### PR TITLE
Add update submitter to the update.comment fedmsg payload.

### DIFF
--- a/bodhi/model.py
+++ b/bodhi/model.py
@@ -1366,7 +1366,8 @@ class Comment(SQLObject):
         return dict(author=self.author_name, group=self.author_group,
                     text=self.text, anonymous=self.anonymous,
                     karma=self.karma, timestamp=self.timestamp,
-                    update_title=self.update.title)
+                    update_title=self.update.title,
+                    update_submitter=self.update.submitter)
 
 
 class CVE(SQLObject):


### PR DESCRIPTION
Add the submitter of the update to the fedmsg message for comments.

This will be nice to have in general, but I want it primarily for this badge:  https://fedorahosted.org/fedora-badges/ticket/153
