### PR TITLE
Improvements to the auto-obsoletion behavior.

### DIFF
--- a/bodhi/controllers.py
+++ b/bodhi/controllers.py
@@ -989,6 +989,10 @@ class Root(controllers.RootController):
                         # Remove inherited builds from the old update and add
                         # them to this new one
                         if not_obsolete:
+                            # If we're inheriting builds from a security
+                            # update, change the type of this update
+                            if update.type == 'security':
+                                type_ = 'security'
                             for _build in not_obsolete:
                                 log.debug('Removing %s from %s' % (_build, update))
                                 update.removePackageBuild(_build)

--- a/bodhi/controllers.py
+++ b/bodhi/controllers.py
@@ -731,6 +731,7 @@ class Root(controllers.RootController):
         # of the builds are tagged as update candidates
         edited_testing_update = False
         removed_builds = []
+        not_obsolete = []
         if edited:
             try:
                 edited = PackageUpdate.byTitle(edited)
@@ -960,33 +961,50 @@ class Root(controllers.RootController):
                     if rpm.labelCompare(util.get_nvr(oldBuild.nvr), nvr) < 0:
                         log.debug("%s is newer than %s" % (nvr, oldBuild.nvr))
                         obsoletable = True
-                    # Ensure the same number of builds are present
-                    if len(update.builds) != len(releases[update.release]):
-                        obsoletable = False
-                        break
-                    # Ensure that all of the packages in the old update are
-                    # present in the new one.
+
+                    # Find builds that are not present in this update that we
+                    # need to inherit.
                     pkgs = [get_nvr(b)[0] for b in releases[update.release]]
                     for _build in update.builds:
                         if _build.package.name not in pkgs:
-                            obsoletable = False
-                            break
+                            log.debug('Inheriting build: %s' % _build.nvr)
+                            not_obsolete.append(_build)
+
                     if update.request == 'testing':
                         # if the update has a testing request, but has yet to
                         # be pushed, obsolete it
                         if update.currently_pushing:
                             obsoletable = False
+
                 if obsoletable:
                     log.info('%s is obsoletable' % oldBuild.nvr)
                     for update in oldBuild.updates:
                         # Have the newer update inherit the older updates bugs
                         for bug in update.bugs:
                             bugs.append(unicode(bug.bz_id))
+
                         # Also inherit the older updates notes as well
                         notes += '\n' + update.notes
+
+                        # Remove inherited builds from the old update and add
+                        # them to this new one
+                        if not_obsolete:
+                            for _build in not_obsolete:
+                                log.debug('Removing %s from %s' % (_build, update))
+                                update.removePackageBuild(_build)
+                                buildinfo[_build.nvr] = {'build': _build, 'release': update.release}
+                                releases[update.release].append(_build.nvr)
+                                # update the old title
+                                title_builds = update.title.replace(',', ' ').split()
+                                title_builds.remove(_build.nvr)
+                                update.title = ','.join(title_builds)
+
                         update.obsolete(newer=build)
+
                     note.append('This update has obsoleted %s, and has '
                                 'inherited its bugs and notes.' % oldBuild.nvr)
+                else:
+                    not_obsolete = []
 
         # Create or modify the necessary PackageUpdate objects
         for release, builds in releases.items():

--- a/bodhi/tests/test_controllers.py
+++ b/bodhi/tests/test_controllers.py
@@ -384,7 +384,7 @@ class TestControllers(testutil.DBTest):
         assert f7up.builds[0].package.name == 'TurboGears'
 
     def test_add_older_build_to_update(self):
-        """ Try adding a newer build an update (#385) """
+        """ Try adding an older build an update (#385) """
         session = login()
         f7 = create_release()
         params = {

--- a/bodhi/tests/test_controllers.py
+++ b/bodhi/tests/test_controllers.py
@@ -24,15 +24,6 @@ from bodhi.util import sort_updates, get_nvr
 import cherrypy
 cherrypy.root = Root()
 
-
-def setUp():
-    turbogears.startup.startTurboGears()
-
-
-def tearDown():
-    turbogears.startup.stopTurboGears()
-
-
 def create_release(num='7', dist='dist-fc', **kw):
     rel = Release(name='F'+num, long_name='Fedora '+num, id_prefix='FEDORA',
                   dist_tag=dist+num, **kw)
@@ -59,14 +50,15 @@ def login(username='guest', display_name='guest', group=None):
     cookiehdr = cookies[0][1].strip()
     return { 'Cookie' : cookiehdr }
 
-
 class TestControllers(testutil.DBTest):
 
     def setUp(self):
         testutil.DBTest.setUp(self)
+        turbogears.startup.startTurboGears()
 
     def tearDown(self):
         testutil.DBTest.tearDown(self)
+        turbogears.startup.stopTurboGears()
 
     def save_update(self, params, session=None):
         if not session: session = {}

--- a/bodhi/tests/test_controllers.py
+++ b/bodhi/tests/test_controllers.py
@@ -3087,7 +3087,7 @@ class TestControllers(testutil.DBTest):
 
     def test_obsoleting_different_batches_of_updates(self):
         """
-        Make sure a batch of builds can't obsolete an update that only has a
+        Make sure a batch of builds can obsolete an update that only has a
         single build
         """
         session = login()
@@ -3125,9 +3125,9 @@ class TestControllers(testutil.DBTest):
         }
         self.save_update(new_params, session)
 
-        # Make sure it doesn't obsolete the older one
+        # Make sure it obsoletes the older one
         assert PackageUpdate.byTitle(new_params['builds']).status == 'pending'
-        assert PackageUpdate.byTitle(params['builds']).status == 'testing'
+        assert PackageUpdate.byTitle(params['builds']).status == 'obsolete'
 
     def test_push_EPEL_before_tested(self):
         """


### PR DESCRIPTION
:warning: experimental feature :construction: 

This allows new updates to obsolete any testing updates containing older versions, along with builds for packages not present in the new update. These non-obsolete builds are then inherited into the new update just like the bugs and notes.