### PR TITLE
Fix changelog handling

### DIFF
--- a/bodhi/mail.py
+++ b/bodhi/mail.py
@@ -411,7 +411,7 @@ def get_template(update, use_template='fedora_errata_template'):
             del oldh
             if not text:
                 oldtime = 0
-            elif len(text) != 1:
+            elif isinstance(oldtime, list):
                 oldtime = oldtime[0]
             info['changelog'] = u"ChangeLog:\n\n%s%s" % \
                     (to_unicode(build.get_changelog(oldtime)), line)

--- a/bodhi/model.py
+++ b/bodhi/model.py
@@ -243,7 +243,7 @@ class PackageBuild(SQLObject):
         when = rpm_header[rpm.RPMTAG_CHANGELOGTIME]
 
         num = len(descrip)
-        if num == 1: when = [when]
+        if not isinstance(when, list): when = [when]
 
         str = ""
         i = 0


### PR DESCRIPTION
The RPM API does not seem to always return a list for the changelog
timestamp(s).

Bodhi has some code trying to identify that and treat it accordingly.

However, it was based on the identified cases where this happened (there
is only one changelog text) instead of just being based on whether or
not the changelog was a list.

It seems that this behaviour in the RPM Python API, as I'm now seeing
cases where Bodhi thinks the timestamp is not in a list, when it
actually is.

This commit fixes this.
