### PR TITLE
Add update_request to bodhi.update.comment fedmsg payload

### DIFF
--- a/bodhi/model.py
+++ b/bodhi/model.py
@@ -1385,7 +1385,8 @@ class Comment(SQLObject):
                     karma=self.karma, timestamp=self.timestamp,
                     update_title=self.update.title,
                     update_submitter=self.update.submitter,
-                    update_status=self.update.status)
+                    update_status=self.update.status,
+                    update_request=self.update.request)
 
 
 class CVE(SQLObject):


### PR DESCRIPTION
The Stop That Update badge [1] requires better logic (as `pending` state currently matches both pending into testing as well as pending into stable). However, this depends on `update_request` being available in each bodhi comment.

[1] http://infrastructure.fedoraproject.org/infra/badges/rules/stop-that-update.yml
