### PR TITLE
Add a way to disable libravatar.

### DIFF
--- a/bodhi/util.py
+++ b/bodhi/util.py
@@ -23,6 +23,7 @@ from datetime import datetime
 from fedora.client import PackageDB
 from sqlalchemy import create_engine
 from pyramid.i18n import TranslationStringFactory
+from pyramid.settings import asbool
 
 from . import log
 from .exceptions import RPMNotFound, RepodataException
@@ -297,12 +298,14 @@ def avatar(context, username, size):
     def work(username, size):
         https = request.registry.settings.get('prefer_ssl'),
         openid = "http://%s.id.fedoraproject.org/" % username
-        return libravatar.libravatar_url(
-            openid=openid,
-            https=https,
-            size=size,
-            default='retro',
-        )
+        if asbool(config.get('libravatar_enabled', True)):
+            return libravatar.libravatar_url(
+                openid=openid,
+                https=https,
+                size=size,
+                default='retro',
+            )
+        return 'libravatar.org'
 
     return work(username, size)
 

--- a/development.ini
+++ b/development.ini
@@ -15,6 +15,10 @@ testing_approval_msg = This update has reached %d days in testing and can be pus
 not_yet_tested_msg = This update has not yet met the minimum testing requirements defined in the <a href="https://fedoraproject.org/wiki/Package_update_acceptance_criteria">Package Update Acceptance Criteria</a>
 stablekarma_comment = This update has reached the stable karma threshold and will be pushed to the stable updates repository
 
+# Libravatar - If this is true libravatar will work as normal. Otherwise, all
+# libravatar links will be replaced with the string "libravatar.org" so that
+# the tests can still pass.
+libravatar_enabled = True
 
 ##
 ## Wiki Test Cases


### PR DESCRIPTION
On connections where we can't hit libravatar for whatever reason, it
is nice to be able to run the tests without having them stall trying to
connect to libravatar.org. This gives us a way to disable it.

Signed-off-by: Ricky Elrod ricky@elrod.me
