### PR TITLE
cabbage: Really be in the background

### DIFF
--- a/bodhi/static/css/site.css
+++ b/bodhi/static/css/site.css
@@ -34,6 +34,7 @@ a:hover {
     zoom: 1;
     filter: alpha(opacity=07);
     opacity: 0.07;
+    z-index: -1;
 }
 
 #ghost-cabbage > img {


### PR DESCRIPTION
Without this, the cabbage tends to intercept clicks from links displayed
on top of it. (e.g "View all X >" updates on a user profile)
