### PR TITLE
Require the pypi importlib on py2.6 or earlier.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -62,6 +62,9 @@ requires = [
     'click',
     ]
 
+if sys.version_info[:3] < (2,7,0):
+    requires.append('importlib')
+
 if sys.version_info[:3] < (2,5,0):
     requires.append('pysqlite')
 


### PR DESCRIPTION
This will hopefully fix the test failures here:
http://jenkins.cloud.fedoraproject.org/job/bodhi/35/console

There's no importlib in the stdlib back on py2.6 but there just so happens to
be a pypi backport.
