### PR TITLE
masher: Compose atomic ostrees after mashing the repos

### DIFF
--- a/bodhi.spec
+++ b/bodhi.spec
@@ -71,6 +71,8 @@ Requires: python-fedora-turbogears
 # 0.3.3+ for thread safety
 Requires: fedmsg >= 0.3.3
 
+Requires: fedmsg-atomic-composer
+
 
 %description server
 Bodhi is a modular framework that facilitates the process of publishing


### PR DESCRIPTION
Uses the https://github.com/fedora-infra/fedmsg-atomic-composer to compose OSTrees during the push process. If the compose fails, the entire push fails.
