### PR TITLE
Construct list of groups for pyramid_fas_openid.

### DIFF
--- a/bodhi/__init__.py
+++ b/bodhi/__init__.py
@@ -114,6 +114,7 @@ def main(global_config, testing=None, **settings):
         'important_groups',
         'admin_packager_groups',
         'mandatory_packager_groups',
+        'admin_groups',
     ]])
     # pyramid_fas_openid looks for this setting
     settings['openid.groups'] = settings.get('openid.groups', default).split()

--- a/bodhi/__init__.py
+++ b/bodhi/__init__.py
@@ -109,6 +109,15 @@ def main(global_config, testing=None, **settings):
     from pyramid.session import SignedCookieSessionFactory
     session_factory = SignedCookieSessionFactory(settings['session.secret'])
 
+    # Construct a list of all groups we're interested in
+    default = ' '.join([settings.get(key, '') for key in [
+        'important_groups',
+        'admin_packager_groups',
+        'mandatory_packager_groups',
+    ]])
+    # pyramid_fas_openid looks for this setting
+    settings['openid.groups'] = settings.get('openid.groups', default).split()
+
     config = Configurator(settings=settings,
                           session_factory=session_factory)
 


### PR DESCRIPTION
This uses fedora-infra/pyramid_fas_openid#3.