### PR TITLE
Add action buttons to the update view page.

### DIFF
--- a/bodhi/models/models.py
+++ b/bodhi/models/models.py
@@ -810,7 +810,7 @@ class Update(Base):
                 # Ensure the same number of builds are present
                 if len(oldBuild.update.builds) != len(self.builds):
                     obsoletable = False
-                    submitter = oldBuild.update.submitter
+                    submitter = oldBuild.update.user
                     if submitter and submitter.name != self.user.name:
                         request.session.flash('Please be aware that %s is'
                                 'part of a multi-build update that is currently '

--- a/bodhi/models/models.py
+++ b/bodhi/models/models.py
@@ -984,7 +984,7 @@ class Update(Base):
             return
         elif action is UpdateRequest.revoke:
             self.revoke()
-            flash_log("%s has been obsoleted" % self.title)
+            flash_log("%s has been revoked" % self.title)
             notifications.publish(topic=topic, msg=dict(
                 update=self, agent=request.user.name))
             return

--- a/bodhi/models/models.py
+++ b/bodhi/models/models.py
@@ -1468,9 +1468,14 @@ class Update(Base):
         """ Remove pending request for this update """
         log.debug("Revoking %s" % self.title)
 
-        if self.status is not UpdateStatus.pending:
-            raise BodhiException("Can only revoke a pending update, not "
-                                 "one that is %s" % self.status.description)
+        if not self.request:
+            raise BodhiException(
+                "Can only revoke an update with an existing request")
+
+        if not self.status in [UpdateStatus.pending, UpdateStatus.testing]:
+            raise BodhiException(
+                "Can only revoke a pending or testing update, not "
+                "one that is %s" % self.status.description)
 
         # Remove the 'pending' koji tags from this update so taskotron stops
         # evalulating them.

--- a/bodhi/models/models.py
+++ b/bodhi/models/models.py
@@ -1479,17 +1479,6 @@ class Update(Base):
         elif self.request is UpdateRequest.stable:
             self.remove_tag(self.release.pending_stable_tag)
 
-        # If we're revoking a request we need to set the status back to what it
-        # was before the request.  The only way to tell what status this update
-        # was in before the request is to look at koji tags.
-        current_tags = self.get_tags()
-        if self.release.testing_tag in current_tags:
-            self.status = UpdateRequest.testing
-        elif self.release.stable_tag in current_tags:
-            self.status = UpdateRequest.stable
-        else:
-            self.status = None
-
         self.request = None
 
         mail.send_admin('revoked', self)

--- a/bodhi/services/updates.py
+++ b/bodhi/services/updates.py
@@ -19,7 +19,7 @@ from pyramid.security import has_permission
 from sqlalchemy.sql import or_
 
 from bodhi import log
-from bodhi.exceptions import LockedUpdateException
+from bodhi.exceptions import BodhiException, LockedUpdateException
 from bodhi.models import Update, Build, Bug, CVE, Package, UpdateRequest
 import bodhi.schemas
 import bodhi.security
@@ -82,7 +82,11 @@ def set_request(request):
                                'Requirement not met %s' % reason)
             return
 
-    update.set_request(action, request)
+    try:
+        update.set_request(action, request)
+    except BodhiException as e:
+        request.errors.add('body', 'request', e.message)
+
     return dict(update=update)
 
 

--- a/bodhi/services/updates.py
+++ b/bodhi/services/updates.py
@@ -43,6 +43,11 @@ update = Service(name='update', path='/updates/{id}',
                  description='Update submission service',
                  acl=bodhi.security.package_maintainers_only_acl)
 
+update_edit = Service(name='update_edit', path='/updates/{id}/edit',
+                 validators=(validate_update_id,),
+                 description='Update submission service',
+                 acl=bodhi.security.package_maintainers_only_acl)
+
 updates = Service(name='updates', path='/updates/',
                   acl=bodhi.security.packagers_allowed_acl,
                   description='Update submission service')
@@ -59,6 +64,17 @@ def get_update(request):
     """Return a single update from an id, title, or alias"""
     can_edit = has_permission('edit', request.context, request)
     return dict(update=request.validated['update'], can_edit=can_edit)
+
+
+@update_edit.get(accept="text/html", renderer="new_update.html")
+def get_update_for_editing(request):
+    """Return a single update from an id, title, or alias for the edit form"""
+    return dict(
+        update=request.validated['update'],
+        types=reversed(bodhi.models.UpdateType.values()),
+        severities=reversed(bodhi.models.UpdateSeverity.values()),
+        suggestions=reversed(bodhi.models.UpdateSuggestion.values()),
+    )
 
 
 @update_request.post(schema=bodhi.schemas.UpdateRequestSchema,

--- a/bodhi/services/updates.py
+++ b/bodhi/services/updates.py
@@ -15,6 +15,7 @@
 import math
 
 from cornice import Service
+from pyramid.security import has_permission
 from sqlalchemy.sql import or_
 
 from bodhi import log
@@ -39,7 +40,8 @@ from bodhi.validators import (
 
 update = Service(name='update', path='/updates/{id}',
                  validators=(validate_update_id,),
-                 description='Update submission service')
+                 description='Update submission service',
+                 acl=bodhi.security.package_maintainers_only_acl)
 
 updates = Service(name='updates', path='/updates/',
                   acl=bodhi.security.packagers_allowed_acl,
@@ -55,7 +57,8 @@ update_request = Service(name='update_request', path='/updates/{id}/request',
 @update.get(accept="text/html", renderer="update.html")
 def get_update(request):
     """Return a single update from an id, title, or alias"""
-    return dict(update=request.validated['update'])
+    can_edit = has_permission('edit', request.context, request)
+    return dict(update=request.validated['update'], can_edit=can_edit)
 
 
 @update_request.post(schema=bodhi.schemas.UpdateRequestSchema,

--- a/bodhi/static/css/site.css
+++ b/bodhi/static/css/site.css
@@ -144,3 +144,7 @@ ul.updateslist li {
     font-size: 0.9em;
     margin-left: 27px; /* avatar + 2px pad */
 }
+
+#preview {
+    padding: 10px;
+}

--- a/bodhi/static/js/update_form.js
+++ b/bodhi/static/js/update_form.js
@@ -199,4 +199,5 @@ $(document).ready(function() {
     // Lastly, hide our warning and show the main form
     $("#js-warning").addClass('hidden');
     $("#new-update-form").removeClass('hidden');
+    update_markdown_preview($("#notes").val());
 });

--- a/bodhi/static/js/update_form.js
+++ b/bodhi/static/js/update_form.js
@@ -193,9 +193,6 @@ $(document).ready(function() {
         theform.submit();
     });
 
-    // Pre-select radio buttons
-    $("#radios dd label:first-child input").attr('checked', true);
-
     // Lastly, hide our warning and show the main form
     $("#js-warning").addClass('hidden');
     $("#new-update-form").removeClass('hidden');

--- a/bodhi/templates/new_update.html
+++ b/bodhi/templates/new_update.html
@@ -96,7 +96,7 @@
             Preview</span>
           </div>
           <div class="panel-body">
-            <span id="preview"><h3><small>Preview</small></h3></span>
+            <div id="preview"><h3><small>Preview</small></h3></div>
           </div>
         </div>
       </div>

--- a/bodhi/templates/new_update.html
+++ b/bodhi/templates/new_update.html
@@ -4,7 +4,13 @@
   <div id='js-warning' class="col-md-6 col-md-offset-3">
     <div class=" panel panel-warning">
       <div class="panel-heading clearfix">
-        <span class="pull-left">New Update Form Requires JavaScript</span>
+        <span class="pull-left">
+          % if not update:
+          New Update Form Requires JavaScript
+          % else:
+          Edit Update Form Requires JavaScript
+          % endif
+        </span>
       </div>
       <div class="panel-body">
         <p class="lead">This page only works with JavaScript enabled.</p>
@@ -23,7 +29,22 @@
 
     <div class="row">
       <div class="col-md-12">
-        <h2 class="pull-left">New Update</span>
+        % if not update:
+          <h2 class="pull-left">New Update</span>
+        % else:
+          <h2 class="pull-left">Edit
+            % if update.alias:
+            ${update.alias}
+            % else:
+            ${update.get_title(', ', 2, ", &hellip;") | n}
+            <div>
+              <span title="${(', ').join(map(lambda x: x.nvr, update.builds[2:]))}">
+                <small>${ "(+ " + str(len(update.builds) - 2) + " more)" if len(update.builds) > 2 else "" }</small>
+              </span>
+            </div>
+          % endif
+        </h2>
+        % endif
       </div>
     </div>
 
@@ -54,7 +75,18 @@
             <input id="builds-adder" class="form-control noui" type="text"
                 placeholder="Add a build, like package-0.2.1-5.fc20">
             <input name="builds" type="hidden"/>
-            <div id="candidate-checkboxes"> </div>
+            <div id="candidate-checkboxes">
+
+              % if update:
+                % for build in update.builds:
+                  <div class="checkbox"><label>
+                      <input name="builds" data-build-nvr="${build.nvr}"
+                      type="checkbox" value="${build.nvr}" checked> ${build.nvr}
+                  </label></div>
+                % endfor
+              % endif
+
+            </div>
           </div>
         </div>
       </div>
@@ -69,7 +101,21 @@
             <input id="bugs-adder" class="form-control noui" type="text"
                    placeholder="Add #RHBZ">
             <input name="bugs" type="hidden"/>
-            <div id="bugs-checkboxes"></div>
+            <div id="bugs-checkboxes">
+
+              % if update:
+                % for bug in update.bugs:
+                <div class="checkbox">
+                  <label>
+                    <input name="bugs" type="checkbox" value="${bug.bug_id}" checked>
+                    <a href="https://bugzilla.redhat.com/show_bug.cgi?id=${bug.bug_id}">
+                      #${bug.bug_id}</a> ${bug.title}
+                  </label>
+                </div>
+                % endfor
+              % endif
+
+            </div>
           </div>
         </div>
       </div>
@@ -84,7 +130,11 @@
           </div>
           <div class="panel-body">
             <textarea class="form-control" id="notes" name="notes" rows="6"
-              placeholder="Update notes go here.  They're really *really* useful, so feel free to write as you please.  You can use **markdown** to make them look nice." required="true"></textarea>
+              placeholder="Update notes go here.  They're really *really* useful, so feel free to write as you please.  You can use **markdown** to make them look nice." required="true">
+% if update:
+${update.notes}
+% endif
+</textarea>
           </div>
         </div>
       </div>
@@ -118,8 +168,11 @@
                   <dd>
                     % for value in types:
                     <label class="radio-inline">
-                      <input type="radio" name="type" value="${value}">
-                      ${value}
+                      <input type="radio" name="type" value="${value}"
+                      % if update and update.type.description == value:
+                      checked="checked"
+                      % endif
+                      > ${value}
                     </label>
                     % endfor
                   </dd>
@@ -129,7 +182,11 @@
                   <dd>
                     % for value in severities:
                     <label class="radio-inline">
-                      <input type="radio" name="severity" value="${value}"> ${value}
+                      <input type="radio" name="severity" value="${value}"
+                      % if update and update.severity.description == value:
+                      checked="checked"
+                      % endif
+                      > ${value}
                     </label>
                     % endfor
                   </dd>
@@ -139,7 +196,11 @@
                   <dd>
                     % for value in suggestions:
                     <label class="radio-inline">
-                      <input type="radio" name="suggest" value="${value}"> ${value}
+                      <input type="radio" name="suggest" value="${value}"
+                      % if update and update.suggest.description == value:
+                      checked="checked"
+                      % endif
+                      > ${value}
                     </label>
                     % endfor
                   </dd>
@@ -148,7 +209,13 @@
 
                   <dt data-toggle="tooltip" title="If checked, then associated bugs in RHBZ will be closed once this update is pushed to the stable repository.">
                   Close bugs on stable?</dt>
-                  <dd> <input type="checkbox" name="close_bugs" checked> </dd>
+                  <dd> <input type="checkbox" name="close_bugs"
+                      % if update and update.close_bugs:
+                      checked
+                      % elif not update:
+                      checked
+                      % endif
+                    ></dd>
                 </dl>
               </div>
 
@@ -156,39 +223,80 @@
                 <dl id='radios' class="dl-horizontal">
                   <dt data-toggle="tooltip" title="If checked, this option allows bodhi to automatically move your update from testing to stable once enough positive karma has been given.">
                   Auto-request stable?</dt>
-                  <dd> <input type="checkbox" name="autokarma" checked> </dd>
-
+                  <dd> <input type="checkbox" name="autokarma"
+                      % if update and update.stable_karma != None and update.unstable_karma != None:
+                      checked
+                      % elif not update:
+                      checked
+                      % endif
+                    ></dd>
                   <dt data-toggle="tooltip" title="This is the threshold of positive karma required to automatically push an update from testing to stable.">
                   Stable karma</dt>
-                  <dd> <input type="number" name="stable_karma" min="1"
-                  required value="3"> </dd>
+                  <dd> <input type="number" name="stable_karma" min="1" required
+                      % if update:
+                      value="${update.stable_karma}"
+                      % elif not update:
+                      value="3"
+                      % endif
+                    ></dd>
 
                   <dt data-toggle="tooltip" title="This is the threshold of negative karma required to automatically unpush an update from testing.">
                   Unstable karma</dt>
-                  <dd> <input type="number" name="unstable_karma" max="-1"
-                  required value="-3"> </dd>
+                  <dd> <input type="number" name="unstable_karma" max="-1" required
+                      % if update:
+                      value="${update.unstable_karma}"
+                      % elif not update:
+                      value="-3"
+                      % endif
+                    ></dd>
 
                   <hr/>
 
                   <dt data-toggle="tooltip" title="If checked, this will require that positive feedback be given on all associated bugs before the update can pass to stable.  If your update has no associated bugs, this option has no effect.">
                   Require bugs
                   </dt>
-                  <dd> <input type="checkbox" name="require_bugs" checked> </dd>
+                  <dd> <input type="checkbox" name="require_bugs"
+                      % if update and update.require_bugs:
+                      checked
+                      % elif not update:
+                      checked
+                      % endif
+                    ></dd>
 
                   <dt data-toggle="tooltip" title="If checked, this will require that positive feedback be given on all associated wiki test cases before the update can pass to stable.  If your update has no associated wiki test cases, this option has no effect.">
                   Require testcases</dt>
-                  <dd> <input type="checkbox" name="require_testcases" checked> </dd>
+                  <dd> <input type="checkbox" name="require_testcases"
+                      % if update and update.require_testcases:
+                      checked
+                      % elif not update:
+                      checked
+                      % endif
+                    ></dd>
 
                   <dt data-toggle="tooltip" title="If specified, the update will be blocked from stable until all of the listed taskotron tests are passing.">
                   Required checks <a target="_blank" href="https://fedoraproject.org/wiki/Taskotron/Tasks"><span class="glyphicon glyphicon-question-sign"></span></a></dt>
                   <dd> <input type="text" name="requirements"
-                  placeholder="Required taskotron tasks"></dd>
+                  placeholder="Required taskotron tasks"
+                      % if update and update.requirements:
+                      value="${update.requirements}"
+                      % endif
+                    ></dd>
 
                 </dl>
               </div>
             </div>
 
-            <button id="submit" class="btn btn-success">Submit</button>
+            % if update:
+            <input type="hidden" name="edited" value="${update.title}">
+            % endif
+
+            <button id="submit" class="btn btn-success">
+              % if update:
+              Edit
+              % else:
+              Submit
+              % endif
+            </button>
           </div>
         </div>
       </div>
@@ -198,3 +306,8 @@
 </div>
 <script src="${request.static_url('bodhi:static/js/update_form.js')}"></script>
 <script> $(document).ready(function() { $('.panel-heading > span, dt').tooltip(); }); </script>
+% if not update:
+<!-- Pre-select the radio buttons -->
+<script> $(document).ready(function() { $("#radios dd label:first-child input").attr('checked', true); }); </script>
+% endif
+

--- a/bodhi/templates/update.html
+++ b/bodhi/templates/update.html
@@ -215,6 +215,41 @@
 </script>
 
 <script type="text/javascript">
+$(document).ready(function() {
+    var messenger = Messenger({theme: 'flat'});
+    var update_id = '${update.title}';
+    $("#updatebuttons #edit").click(function() {
+        alert('not implemented');
+    });
+
+    $.each(['testing', 'stable', 'unpush', 'revoke'], function(i, action) {
+      $("#updatebuttons #" + action).click(function() {
+          var url = '${request.route_url("update_request", id=update.title)}';
+          $.ajax({
+              url: url,
+              data: {request: action},
+              method: 'POST',
+              dataType: 'json',
+              success: function(response) {
+                // Just reload the page if all went well..
+                location.reload();
+              },
+              error: function(response) {
+                $.each(response.responseJSON.errors, function(i, error) {
+                    msg = messenger.post({
+                      message: error.description,
+                      type: "error"
+                    });
+                });
+              },
+          });
+      });
+    });
+
+});
+</script>
+
+<script type="text/javascript">
 var form;
 $(document).ready(function(){
   CommentsForm = function() {};
@@ -407,18 +442,37 @@ $(document).ready(function(){
 
   <div class="col-md-7">
     % if can_edit:
-    % if update.locked:
-    <div class="alert alert-info" role="alert">
-      <span class="glyphicon glyphicon-lock" aria-hidden="true"></span>
-      <span class="sr-only">Locked:</span>
-      This update is currently locked and cannot be modified.
-    </div>
-    % else:
-    TODO - lots of conditionals go into figuring out what buttons get shown here...
-    ${ self.util.request2html('testing', True) | n}
-    ${ self.util.request2html('stable', True) | n}
-    % endif
-    <hr />
+      % if update.locked:
+        <div class="alert alert-info" role="alert">
+          <span class="glyphicon glyphicon-lock" aria-hidden="true"></span>
+          <span class="sr-only">Locked:</span>
+          This update is currently locked and cannot be modified.
+        </div>
+      % else:
+        <div id='updatebuttons' class="btn-group pull-right" role="group" aria-label="...">
+        % if not update.pushed:
+          <a href="#" id='edit' class="btn btn-sm btn-default"><span class="glyphicon glyphicon-edit"></span> Edit</a>
+          % if update.request is None:
+            % if update.status.description != 'testing':
+            <a href="#" id='testing' class="btn btn-sm btn-primary"><span class="glyphicon glyphicon-circle-arrow-right"></span> Push to Testing</a>
+            % endif
+            % if update.status.description != 'stable':
+              <a href="#" id='stable' class="btn btn-sm btn-success"><span class="glyphicon glyphicon-circle-arrow-right"></span> Push to Stable</a>
+            % endif
+          % else:
+            <a href="#" id='revoke' class="btn btn-sm btn-danger"><span class="glyphicon glyphicon-circle-arrow-left"></span> Revoke</a>
+          % endif
+        % elif update.pushed and (update.status.description != 'stable' or (update.status.description == 'stable' and 'releng' in groups)):
+          <a href="#" id='edit' class="btn btn-sm btn-default"><span class="glyphicon glyphicon-edit"></span> Edit</a>
+          % if update.status.description != 'testing':
+            <a href="#" id='stable' class="btn btn-sm btn-success"><span class="glyphicon glyphicon-circle-arrow-right"></span> Push to Stable</a>
+          % endif
+          <a href="#" id='unpush' class="btn btn-sm btn-danger"><span class="glyphicon glyphicon-circle-arrow-left"></span> Unpush</a>
+        % endif
+        </div>
+        <div class="clearfix"></div>
+      % endif
+      <hr />
     % endif
     % if update.notes:
     <h3 class="nomargin">Notes about this update:</h3>

--- a/bodhi/templates/update.html
+++ b/bodhi/templates/update.html
@@ -406,12 +406,25 @@ $(document).ready(function(){
   </div>
 
   <div class="col-md-7">
+    % if can_edit:
+    % if update.locked:
+    <div class="alert alert-info" role="alert">
+      <span class="glyphicon glyphicon-lock" aria-hidden="true"></span>
+      <span class="sr-only">Locked:</span>
+      This update is currently locked and cannot be modified.
+    </div>
+    % else:
+    TODO - lots of conditionals go into figuring out what buttons get shown here...
+    ${ self.util.request2html('testing', True) | n}
+    ${ self.util.request2html('stable', True) | n}
+    % endif
+    <hr />
+    % endif
     % if update.notes:
     <h3 class="nomargin">Notes about this update:</h3>
     ${self.util.markup(update.notes) | n}
-    % endif
-
     <hr />
+    % endif
 
     % if update.bugs:
     <h3>Related Bugs <span class="badge">${len(update.bugs)}</span></h3>

--- a/bodhi/templates/update.html
+++ b/bodhi/templates/update.html
@@ -218,9 +218,8 @@
 $(document).ready(function() {
     var messenger = Messenger({theme: 'flat'});
     var update_id = '${update.title}';
-    $("#updatebuttons #edit").click(function() {
-        alert('not implemented');
-    });
+    $("#updatebuttons #edit").attr('href',
+        '${request.route_url("update_edit", id=update.title)}');
 
     $.each(['testing', 'stable', 'unpush', 'revoke'], function(i, action) {
       $("#updatebuttons #" + action).click(function() {

--- a/bodhi/util.py
+++ b/bodhi/util.py
@@ -435,7 +435,7 @@ def suggestion2html(context, suggestion):
     return "<span class='label label-%s'>%s</span>" % (cls, suggestion)
 
 
-def request2html(context, request, link=False):
+def request2html(context, request):
     request = unicode(request)
     cls = {
         'unpush': 'danger',
@@ -444,10 +444,7 @@ def request2html(context, request, link=False):
         'stable': 'success',
     }.get(request)
 
-    if not link:
-        return "<span class='label label-%s'>%s</span>" % (cls, request)
-    else:
-        return "<a href='#' class='btn btn-%s'>%s</a>" % (cls, request)
+    return "<span class='label label-%s'>%s</span>" % (cls, request)
 
 
 def update2html(context, update):

--- a/bodhi/util.py
+++ b/bodhi/util.py
@@ -435,7 +435,7 @@ def suggestion2html(context, suggestion):
     return "<span class='label label-%s'>%s</span>" % (cls, suggestion)
 
 
-def request2html(context, request):
+def request2html(context, request, link=False):
     request = unicode(request)
     cls = {
         'unpush': 'danger',
@@ -444,7 +444,10 @@ def request2html(context, request):
         'stable': 'success',
     }.get(request)
 
-    return "<span class='label label-%s'>%s</span>" % (cls, request)
+    if not link:
+        return "<span class='label label-%s'>%s</span>" % (cls, request)
+    else:
+        return "<a href='#' class='btn btn-%s'>%s</a>" % (cls, request)
 
 
 def update2html(context, update):

--- a/bodhi/views/generic.py
+++ b/bodhi/views/generic.py
@@ -101,6 +101,7 @@ def new_update(request):
     if not user:
         raise HTTPForbidden("You must be logged in.")
     return dict(
+        update=None,
         types=reversed(bodhi.models.UpdateType.values()),
         severities=reversed(bodhi.models.UpdateSeverity.values()),
         suggestions=reversed(bodhi.models.UpdateSuggestion.values()),


### PR DESCRIPTION
This includes allowing the editing of updates in 2f93ff9, which is essential.

This also adds "revoke" as a possible action on a request which got dropped in
the port from bodhi1 on accident (added back in in e5c248a).