### PR TITLE
mail: Port from turbomail to smtplib

### DIFF
--- a/bodhi/mail.py
+++ b/bodhi/mail.py
@@ -400,18 +400,22 @@ def send_mail(from_addr, to_addr, subject, body_text):
     if not from_addr:
         log.warn('Unable to send mail: bodhi_email not defined in the config')
         return
-    from_addr = to_bytes(from_addr)
-    to_addr = to_bytes(to_addr)
-    subject = to_bytes(subject)
-    body_text = to_bytes(body_text)
-    body = '\r\n'.join((
-        'From: %s' % from_addr,
-        'To: %s' % to_addr,
-        'Subject: %s' % subject,
-        body_text))
-    server = smtplib.SMTP(smtp_server)
-    server.sendmail(from_addr, [to_addr], body)
-    server.quit()
+    try:
+        from_addr = to_bytes(from_addr)
+        to_addr = to_bytes(to_addr)
+        subject = to_bytes(subject)
+        body_text = to_bytes(body_text)
+        body = '\r\n'.join((
+            'From: %s' % from_addr,
+            'To: %s' % to_addr,
+            'Subject: %s' % subject,
+            body_text))
+            server = smtplib.SMTP(smtp_server)
+            server.sendmail(from_addr, [to_addr], body)
+    except:
+        log.exception('Unable to send mail')
+    finally:
+        server.quit()
 
 
 def send(to, msg_type, update, sender=None):

--- a/bodhi/mail.py
+++ b/bodhi/mail.py
@@ -16,7 +16,7 @@ import logging
 import smtplib
 
 from textwrap import wrap
-from kitchen.text.converters import to_unicode
+from kitchen.text.converters import to_unicode, to_bytes
 from kitchen.iterutils import iterate
 
 from .util import get_rpm_header
@@ -400,6 +400,10 @@ def send_mail(from_addr, to_addr, subject, body_text):
     if not from_addr:
         log.warn('Unable to send mail: bodhi_email not defined in the config')
         return
+    from_addr = to_bytes(from_addr)
+    to_addr = to_bytes(to_addr)
+    subject = to_bytes(subject)
+    body_text = to_bytes(body_text)
     body = '\r\n'.join((
         'From: %s' % from_addr,
         'To: %s' % to_addr,

--- a/development.ini
+++ b/development.ini
@@ -121,8 +121,10 @@ update_types = bugfix enhancement security newpackage
 arches = i386 x86_64 armhfp
 
 ##
-## Contact setting
+## Email setting
 ##
+
+smtp_server = bastion
 
 # The updates system itself.  This email address is used in fetching Bugzilla
 # information, as well as email notifications


### PR DESCRIPTION
I'm not porting this to `pyramid_mailer` because we want this API to work from the Pyramid WSGI frontend as well as the Twisted-based masher.