### PR TITLE
Random work with respect to fedmsg messages

### DIFF
--- a/bodhi/__init__.py
+++ b/bodhi/__init__.py
@@ -190,4 +190,8 @@ def main(global_config, testing=None, **settings):
     config.scan('bodhi.services')
     config.scan('bodhi.captcha')
 
+    # Setup fedmsg for this thread
+    import bodhi.notifications
+    bodhi.notifications.init()
+
     return config.make_wsgi_app()

--- a/bodhi/masher.py
+++ b/bodhi/masher.py
@@ -210,8 +210,10 @@ class MasherThread(threading.Thread):
         self.init_state()
         self.init_path()
 
-        notifications.publish(topic="mashtask.mashing", msg=dict(repo=self.id,
-                              updates=self.state['updates']))
+        notifications.publish(topic="mashtask.mashing", msg=dict(
+            repo=self.id,
+            updates=self.state['updates'],
+        ))
 
         success = False
         try:
@@ -325,7 +327,8 @@ class MasherThread(threading.Thread):
             self.state['updates'].remove(update)
         if update in self.updates:
             self.updates.remove(update)
-        notifications.publish(topic="update.ejected", msg=dict(
+        notifications.publish(topic="update.eject", msg=dict(
+            repo=self.id,
             update=update,
             reason=reason,
             request=self.request,
@@ -363,7 +366,7 @@ class MasherThread(threading.Thread):
     def finish(self, success):
         self.log.info('Thread(%s) finished.  Success: %r' % (self.id, success))
         notifications.publish(topic="mashtask.complete", msg=dict(
-            success=success))
+            success=success, repo=self.id))
 
     def update_security_bugs(self):
         """Update the bug titles for security updates"""
@@ -569,7 +572,8 @@ class MasherThread(threading.Thread):
     def wait_for_sync(self):
         """Block until our repomd.xml hits the master mirror"""
         log.info('Waiting for updates to hit the master mirror')
-        notifications.publish(topic="mashtask.sync.wait", msg=dict())
+        notifications.publish(topic="mashtask.sync.wait", msg=dict(
+            repo=self.id))
         arch = os.listdir(self.path)[0]
         release = self.release.id_prefix.lower().replace('-', '_')
         master_repomd = config.get('%s_master_repomd' % release)
@@ -589,7 +593,8 @@ class MasherThread(threading.Thread):
             newsum = hashlib.sha1(masterrepomd.read()).hexdigest()
             if newsum == checksum:
                 log.info("master repomd.xml matches!")
-                notifications.publish(topic="mashtask.sync.done", msg=dict())
+                notifications.publish(topic="mashtask.sync.done", msg=dict(
+                    repo=self.id))
                 return
             log.debug("master repomd.xml doesn't match! %s != %s",
                       checksum, newsum)

--- a/bodhi/masher.py
+++ b/bodhi/masher.py
@@ -597,7 +597,6 @@ class MasherThread(threading.Thread):
                     repo=self.id))
                 return
 
-            # This seems like a pretty big deal..
             log.debug("master repomd.xml doesn't match! %s != %s for %r",
                       checksum, newsum, self.id)
 

--- a/bodhi/masher.py
+++ b/bodhi/masher.py
@@ -596,8 +596,10 @@ class MasherThread(threading.Thread):
                 notifications.publish(topic="mashtask.sync.done", msg=dict(
                     repo=self.id))
                 return
-            log.debug("master repomd.xml doesn't match! %s != %s",
-                      checksum, newsum)
+
+            # This seems like a pretty big deal..
+            log.error("master repomd.xml doesn't match! %s != %s for %r",
+                      checksum, newsum, self.id)
 
     def send_notifications(self):
         log.info('Sending notifications')

--- a/bodhi/masher.py
+++ b/bodhi/masher.py
@@ -300,7 +300,7 @@ class MasherThread(threading.Thread):
         for update in list(self.updates):
             if not update.request is self.request:
                 reason = "Request %s inconsistent with mash request %s" % (
-                    update.request, self.Request)
+                    update.request, self.request)
                 self.eject_from_mash(update, reason)
                 continue
 

--- a/bodhi/masher.py
+++ b/bodhi/masher.py
@@ -598,7 +598,7 @@ class MasherThread(threading.Thread):
                 return
 
             # This seems like a pretty big deal..
-            log.error("master repomd.xml doesn't match! %s != %s for %r",
+            log.debug("master repomd.xml doesn't match! %s != %s for %r",
                       checksum, newsum, self.id)
 
     def send_notifications(self):

--- a/bodhi/models/models.py
+++ b/bodhi/models/models.py
@@ -813,7 +813,7 @@ class Update(Base):
                 # Ensure the same number of builds are present
                 if len(oldBuild.update.builds) != len(self.builds):
                     obsoletable = False
-                    submitter = oldBuild.update.user
+                    submitter = oldBuild.update.submitter
                     if submitter and submitter.name != self.user.name:
                         request.session.flash('Please be aware that %s is'
                                 'part of a multi-build update that is currently '

--- a/bodhi/models/models.py
+++ b/bodhi/models/models.py
@@ -783,6 +783,9 @@ class Update(Base):
 
         up.date_modified = datetime.utcnow()
 
+        notifications.publish(topic='update.edit', msg=dict(
+            update=up, agent=request.user.name))
+
         return up
 
     def obsolete_older_updates(self, request):

--- a/bodhi/models/models.py
+++ b/bodhi/models/models.py
@@ -1492,7 +1492,7 @@ class Update(Base):
 
         self.request = None
 
-        mail.send_admin('revoked', self)
+        mail.send_admin('revoke', self)
 
     def untag(self):
         """ Untag all of the builds in this update """

--- a/bodhi/models/models.py
+++ b/bodhi/models/models.py
@@ -1402,12 +1402,6 @@ class Update(Base):
         session.add(comment)
         session.flush()
 
-        if author not in ('bodhi', 'autoqa'):
-            notifications.publish(topic='update.comment', msg=dict(
-                comment=comment.__json__(anonymize=True),
-                agent=author,
-            ))
-
         for feedback_dict in bug_feedback:
             feedback = BugKarma(**feedback_dict)
             session.add(feedback)
@@ -1432,6 +1426,13 @@ class Update(Base):
         user.comments.append(comment)
         self.comments.append(comment)
         session.flush()
+
+        # Publish to fedmsg
+        if author not in ('bodhi', 'autoqa'):
+            notifications.publish(topic='update.comment', msg=dict(
+                comment=comment.__json__(anonymize=True),
+                agent=author,
+            ))
 
         # Send a notification to everyone that has commented on this update
         people = set()

--- a/bodhi/notifications.py
+++ b/bodhi/notifications.py
@@ -13,8 +13,20 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 import fedmsg
+import fedmsg.config
+
 import bodhi
 import bodhi.config
+
+
+def init():
+    if not bodhi.config.config.get('fedmsg_enabled'):
+        bodhi.log.warn("fedmsg disabled.  not initializing.")
+        return
+
+    fedmsg_config = fedmsg.config.load_config()
+    fedmsg.init(**fedmsg_config)
+    bodhi.log.info("fedmsg initialized")
 
 
 def publish(topic, msg):

--- a/bodhi/static/js/newsfeed.js
+++ b/bodhi/static/js/newsfeed.js
@@ -48,6 +48,7 @@ var generate_newsfeed = function(url, badge_ids) {
             data: $.param({
                 category: 'bodhi',
                 grouped: true,
+                delta: 1209600, // two weeks in seconds (this makes it faster)
             }),
             dataType: 'jsonp',
             success: function(data) { messages.bodhi = data.raw_messages; },
@@ -63,7 +64,8 @@ var generate_newsfeed = function(url, badge_ids) {
                     'org.fedoraproject.prod.fedbadges.badge.award',
                     'org.fedoraproject.stg.fedbadges.badge.award',
                 ],
-                meta: ['subtitle', 'link', 'icon', 'date']
+                meta: ['subtitle', 'link', 'icon', 'date'],
+                delta: 1209600, // two weeks in seconds (this makes it faster)
             }, true),
             dataType: 'jsonp',
             success: function(data) {

--- a/bodhi/tests/test_masher.py
+++ b/bodhi/tests/test_masher.py
@@ -203,7 +203,7 @@ class TestMasher(unittest.TestCase):
         # Also, ensure we reported success
         publish.assert_called_with(
             topic="mashtask.complete",
-            msg=dict(success=True))
+            msg=dict(success=True, repo='f17-updates-testing'))
 
         with self.db_factory() as session:
             # Ensure that the update was locked
@@ -239,7 +239,7 @@ class TestMasher(unittest.TestCase):
         # Also, ensure we reported success
         publish.assert_called_with(
             topic="mashtask.complete",
-            msg=dict(success=True))
+            msg=dict(success=True, repo='f17-updates-testing'))
 
         # Ensure our single update was moved
         self.assertEquals(len(self.koji.__moved__), 1)
@@ -416,13 +416,18 @@ References:
 
         # Ensure that F18 runs before F17
         calls = publish.mock_calls
-        self.assertEquals(calls[1], mock.call(msg={'repo': u'f18-updates',
-            'updates': [u'bodhi-2.0-1.fc18']}, topic='mashtask.mashing'))
-        self.assertEquals(calls[3], mock.call(msg={'success': True},
+        self.assertEquals(calls[1], mock.call(
+            msg={'repo': u'f18-updates', 'updates': [u'bodhi-2.0-1.fc18']},
+            topic='mashtask.mashing'))
+        self.assertEquals(calls[3], mock.call(
+            msg={'success': True, 'repo': 'f18-updates'},
             topic='mashtask.complete'))
-        self.assertEquals(calls[4], mock.call(msg={'repo': u'f17-updates-testing',
-            'updates': [u'bodhi-2.0-1.fc17']}, topic='mashtask.mashing'))
-        self.assertEquals(calls[-1], mock.call(msg={'success': True},
+        self.assertEquals(calls[4], mock.call(
+            msg={'repo': u'f17-updates-testing',
+                 'updates': [u'bodhi-2.0-1.fc17']},
+            topic='mashtask.mashing'))
+        self.assertEquals(calls[-1], mock.call(
+            msg={'success': True, 'repo': 'f17-updates-testing'},
             topic='mashtask.complete'))
 
     @mock.patch(**mock_taskotron_results)
@@ -473,13 +478,19 @@ References:
 
         # Ensure that F17 updates-testing runs before F18
         calls = publish.mock_calls
-        self.assertEquals(calls[1], mock.call(msg={'repo': u'f17-updates-testing',
-            'updates': [u'bodhi-2.0-1.fc17']}, topic='mashtask.mashing'))
-        self.assertEquals(calls[3], mock.call(msg={'success': True},
+        self.assertEquals(calls[1], mock.call(
+            msg={'repo': u'f17-updates-testing',
+                 'updates': [u'bodhi-2.0-1.fc17']},
+            topic='mashtask.mashing'))
+        self.assertEquals(calls[3], mock.call(
+            msg={'success': True, 'repo': 'f17-updates-testing'},
             topic='mashtask.complete'))
-        self.assertEquals(calls[4], mock.call(msg={'repo': u'f18-updates',
-            'updates': [u'bodhi-2.0-1.fc18']}, topic='mashtask.mashing'))
-        self.assertEquals(calls[-1], mock.call(msg={'success': True},
+        self.assertEquals(calls[4], mock.call(
+            msg={'repo': u'f18-updates',
+                 'updates': [u'bodhi-2.0-1.fc18']},
+            topic='mashtask.mashing'))
+        self.assertEquals(calls[-1], mock.call(
+            msg={'success': True, 'repo': 'f18-updates'},
             topic='mashtask.complete'))
 
     @mock.patch(**mock_taskotron_results)
@@ -576,7 +587,7 @@ References:
 
         # Also, ensure we reported success
         publish.assert_called_with(topic="mashtask.complete",
-                                   msg=dict(success=True))
+                                   msg=dict(success=True, repo='f17-updates'))
         publish.assert_any_call(topic='update.complete.stable',
                                 msg=mock.ANY)
 
@@ -606,9 +617,8 @@ References:
 
         # Also, ensure we reported success
         publish.assert_called_with(topic="mashtask.complete",
-                                   msg=dict(success=True))
-        publish.assert_any_call(topic='update.ejected',
-                                msg=mock.ANY)
+                                   msg=dict(success=True, repo='f17-updates'))
+        publish.assert_any_call(topic='update.eject', msg=mock.ANY)
 
         self.assertIn(mock.call(['mash'] + [mock.ANY] * 7), cmd.mock_calls)
         self.assertEquals(len(t.state['completed_repos']), 1)
@@ -635,9 +645,8 @@ References:
 
         # Also, ensure we reported success
         publish.assert_called_with(topic="mashtask.complete",
-                                   msg=dict(success=True))
-        publish.assert_any_call(topic='update.ejected',
-                                msg=mock.ANY)
+                                   msg=dict(success=True, repo='f17-updates'))
+        publish.assert_any_call(topic='update.eject', msg=mock.ANY)
 
         self.assertIn(mock.call(['mash'] + [mock.ANY] * 7), cmd.mock_calls)
         self.assertEquals(len(t.state['completed_repos']), 1)

--- a/bootstrap.py
+++ b/bootstrap.py
@@ -178,6 +178,10 @@ def install_test_deps():
 if __name__ == '__main__':
     print("Bootstrapping bodhi...")
     rebuild()
+    # TODO - yum install
+    #   - pcaro-hermit
+    #   - freetype-devel
+    #   - libjpeg-turbo-devel
     link_system_libs()
     setup_develop()
     install_test_deps()

--- a/development.ini
+++ b/development.ini
@@ -22,6 +22,9 @@ libravatar_enabled = True
 # Set this to true if you want to do federated dns libravatar lookup
 libravatar_dns = False
 
+# Set this to True in order to send fedmsg messages.
+fedmsg_enabled = True
+
 
 # Captcha - if 'captcha.secret' is not None, then it will be used for comments
 # captcha.secret must be 32 url-safe base64-encoded bytes

--- a/development.ini
+++ b/development.ini
@@ -23,7 +23,7 @@ libravatar_enabled = True
 libravatar_dns = False
 
 # Set this to True in order to send fedmsg messages.
-fedmsg_enabled = True
+#fedmsg_enabled = True
 
 
 # Captcha - if 'captcha.secret' is not None, then it will be used for comments

--- a/fedmsg.d/bodhi.py
+++ b/fedmsg.d/bodhi.py
@@ -1,0 +1,15 @@
+# These are general bodhi fedmsg settings, mostly for app dev.
+
+import socket
+hostname = socket.gethostname().split('.')[0]
+
+config = dict(
+    endpoints={
+        "bodhi.%s" % hostname: [
+            'tcp://127.0.0.1:8084',
+            'tcp://127.0.0.1:8085',
+            'tcp://127.0.0.1:8086',
+            'tcp://127.0.0.1:8087',
+        ]
+    }
+)


### PR DESCRIPTION
I went through and tried to trigger each kind of message to make sure that
fedmsg.meta could handle the ones from bodhi2 correctly.  That receiving side
of this is in fedora-infra/fedmsg_meta_fedora_infrastructure#195.

Notably, in 6bc9017 I changed the ``Comment`` json to be backwards compatible
since some things (badges iirc) are looking for certain things there.

Some other things are unrelated but I was too lazy to break them out into their
own pull requests, like:  de9c092 and 8a098e0 and 7aa7c3e and 14cd78f -- sorry
for that.  Long day.