### PR TITLE
Port to createrepo_c

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,7 @@ bodhi v2.0
 
 Setup virtualenvwrapper
 -----------------------
-``sudo yum -y install python-virtualenvwrapper createrepo_c``
+``sudo yum -y install python-virtualenvwrapper python-createrepo_c``
 
 Add the following to your `~/.bashrc`::
 

--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,7 @@ bodhi v2.0
 
 Setup virtualenvwrapper
 -----------------------
-``sudo yum -y install python-virtualenvwrapper``
+``sudo yum -y install python-virtualenvwrapper createrepo_c``
 
 Add the following to your `~/.bashrc`::
 

--- a/bodhi/util.py
+++ b/bodhi/util.py
@@ -21,6 +21,7 @@ import sys
 import arrow
 import socket
 import urllib
+import shutil
 import tempfile
 import markdown
 import requests
@@ -74,30 +75,14 @@ def get_nvr(nvr):
     return ['-'.join(x[:-2]), x[-2], x[-1]]
 
 
-def mkmetadatadir(dir):
+def mkmetadatadir(path):
     """
     Generate package metadata for a given directory; if it doesn't exist, then
     create it.
     """
-    log.debug("mkmetadatadir(%s)" % dir)
-    if not isdir(dir):
-        os.makedirs(dir)
-    cache = config.get('createrepo_cache_dir')
-    try:
-        import createrepo
-        conf = createrepo.MetaDataConfig()
-        conf.cachedir = cache
-        conf.outputdir = dir
-        conf.directory = dir
-        conf.quiet = True
-        mdgen = createrepo.MetaDataGenerator(conf)
-        mdgen.doPkgMetadata()
-        mdgen.doRepoMetadata()
-        mdgen.doFinalMove()
-    except ImportError:
-        sys.path.append('/usr/share/createrepo')
-        import genpkgmetadata
-        genpkgmetadata.main(['--cachedir', str(cache), '-q', str(dir)])
+    if not os.path.isdir(path):
+        os.makedirs(path)
+    subprocess.check_call(['createrepo_c',  '--xz', '--database', '--quiet', path])
 
 
 def get_age(date):

--- a/bootstrap.py
+++ b/bootstrap.py
@@ -90,7 +90,7 @@ def _link_system_lib(lib):
 
 
 def link_system_libs():
-    for mod in ('koji', 'rpm', 'OpenSSL', 'urlgrabber', 'pycurl', 'yum',
+    for mod in ('koji', 'rpm', 'OpenSSL', 'urlgrabber', 'pycurl',
                 'rpmUtils', 'sqlitecachec', '_sqlitecache', 'psycopg2',
                 'krbVmodule', 'createrepo', 'deltarpm', '_deltarpmmodule',
                 'fedora_cert', 'libxml2', 'libxml2mod', 'librepo'):

--- a/bootstrap.py
+++ b/bootstrap.py
@@ -93,7 +93,7 @@ def link_system_libs():
     for mod in ('koji', 'rpm', 'OpenSSL', 'urlgrabber', 'pycurl',
                 'rpmUtils', 'sqlitecachec', '_sqlitecache', 'psycopg2',
                 'krbVmodule', 'createrepo', 'deltarpm', '_deltarpmmodule',
-                'fedora_cert', 'libxml2', 'libxml2mod', 'librepo'):
+                'fedora_cert', 'libxml2', 'libxml2mod', 'librepo', 'createrepo_c'):
         _link_system_lib(mod)
 
 


### PR DESCRIPTION
This ports the code that uses the `yum.update_md` for updateinfo.xml parsing to createrepo_c. It also updates the `bodhi.util.mkmetadatadir` helper for our unit tests as well.