### PR TITLE
Adding long bodhi template to fedmsg

### DIFF
--- a/bodhi/models/models.py
+++ b/bodhi/models/models.py
@@ -1193,6 +1193,8 @@ class Update(Base):
         if mailinglist:
             for subject, body in mail.get_template(self, templatetype):
                 mail.send_mail(sender, mailinglist, subject, body)
+                notifications.publish(topic='errata.publish',
+                    msg=dict(subject=subject, body=body, update=self))
         else:
             log.error("Cannot find mailing list address for update notice")
             log.error("release_name = %r", release_name)


### PR DESCRIPTION
With refence to https://github.com/fedora-infra/fedmsg_meta_fedora_infrastructure/issues/96

@ralphbean , wasn't sure if you wanted to publish to fedmsg for that single template or all the templates. Currently it publishes to fedmsg for that particular template.