### PR TITLE
masher: Gracefully handle exceptions when determing the fedmsg agent

### DIFF
--- a/bodhi/masher.py
+++ b/bodhi/masher.py
@@ -631,8 +631,7 @@ class MasherThread(threading.Thread):
         try:
             agent = os.getlogin()
         except OSError:  # this can happen when building on koji
-            self.log.exception('Skipping notifications')
-            return
+            agent = u'masher'
         for update in self.updates:
             topic = u'update.complete.%s' % update.status
             notifications.publish(topic=topic, msg=dict(

--- a/bodhi/masher.py
+++ b/bodhi/masher.py
@@ -628,11 +628,15 @@ class MasherThread(threading.Thread):
 
     def send_notifications(self):
         self.log.info('Sending notifications')
+        try:
+            agent = os.getlogin()
+        except OSError:  # this can happen when building on koji
+            self.log.exception('Skipping notifications')
+            return
         for update in self.updates:
             topic = u'update.complete.%s' % update.status
             notifications.publish(topic=topic, msg=dict(
-                update=update,
-                agent=os.getlogin(),  # Should almost always be "masher"
+                update=update, agent=agent,
             ))
 
     def modify_bugs(self):


### PR DESCRIPTION
fixes #139 

This happens when we run the test suite during the build process on koji.