### PR TITLE
Be more explicit with Content-Security-Policy

### DIFF
--- a/bodhi/templates/master.html
+++ b/bodhi/templates/master.html
@@ -14,7 +14,7 @@
     <meta name="author" content="Ralph Bean" />
 
     <!-- Only allow websockets connections to fedoraproject.org. -->
-    <meta http-equiv="Content-Security-Policy" content="connect-src '*.fedoraproject.org'">
+    <meta http-equiv="Content-Security-Policy" content="connect-src https://*.fedoraproject.org wss://*.fedoraproject.org">
 
     <link rel="shortcut icon" href="${request.static_url('bodhi:static/ico/favicon.ico')}">
 


### PR DESCRIPTION
Just like in fedora-infra/datagrepper#166, firefox was *okay* with the
CSP we defined before, but chromium didn't like it.  This makes them
both happy by being more explicit.