### PR TITLE
Generate the update ID/alias upon creation

### DIFF
--- a/bodhi/metadata.py
+++ b/bodhi/metadata.py
@@ -204,7 +204,8 @@ class ExtendedMetadata(object):
         rec.release = to_bytes(update.release.long_name)
         rec.rights = config.get('updateinfo_rights')
 
-        rec.issued_date = update.date_pushed
+        if update.date_pushed:
+            rec.issued_date = update.date_pushed
         if update.date_modified:
             rec.updated_date = update.date_modified
 

--- a/bodhi/models/models.py
+++ b/bodhi/models/models.py
@@ -1084,7 +1084,6 @@ class Update(Base):
             self.status = UpdateStatus.stable
         self.request = None
         self.date_pushed = datetime.utcnow()
-        self.assign_alias()
 
     def modify_bugs(self):
         """

--- a/bodhi/models/models.py
+++ b/bodhi/models/models.py
@@ -529,6 +529,14 @@ class Build(Base):
                 koji.untagBuild(tag, self.nvr)
 
 
+def generate_alias(context):
+    """A context-sensitive default function for the `Update.alias` column.
+
+    http://docs.sqlalchemy.org/en/latest/core/defaults.html#context-sensitive-default-functions
+    """
+    return Update.generate_alias(context.current_parameters)
+
+
 class Update(Base):
     __tablename__ = 'updates'
     __exclude_columns__ = ('id', 'user_id', 'release_id')
@@ -569,7 +577,7 @@ class Update(Base):
     date_pushed = Column(DateTime)
 
     # eg: FEDORA-EPEL-2009-12345
-    alias = Column(Unicode(32), default=None, unique=True)
+    alias = Column(Unicode(32), default=generate_alias, unique=True)
 
     # deprecated: our legacy update ID
     old_updateid = Column(Unicode(32), default=None)

--- a/bodhi/services/updates.py
+++ b/bodhi/services/updates.py
@@ -261,6 +261,4 @@ def new_update(request):
 
     up.obsolete_older_updates(request)
 
-    # Send out email notifications
-
     return up

--- a/bodhi/tests/functional/test_stacks.py
+++ b/bodhi/tests/functional/test_stacks.py
@@ -169,7 +169,7 @@ class TestStacksService(bodhi.tests.functional.base.BaseWSGICase):
 
         # Adding gnome-music to the stack should change its requirements, too.
         package = self.session.query(Package)\
-            .filter(Package.name=='gnome-music').one()
+            .filter(Package.name==u'gnome-music').one()
         self.assertEquals(package.requirements, attrs['requirements'])
 
         # But not gnome-shell, since it was already in the stack.

--- a/bodhi/tests/functional/test_updates.py
+++ b/bodhi/tests/functional/test_updates.py
@@ -375,7 +375,7 @@ class TestUpdatesService(bodhi.tests.functional.base.BaseWSGICase):
         self.assertEquals(up['date_modified'], None)
         self.assertEquals(up['date_pushed'], None)
         self.assertEquals(up['locked'], False)
-        self.assertEquals(up['alias'], None)
+        self.assertEquals(up['alias'], u'FEDORA-2015-0001')
         self.assertEquals(up['karma'], 1)
 
     def test_list_updates_jsonp(self):
@@ -466,7 +466,7 @@ class TestUpdatesService(bodhi.tests.functional.base.BaseWSGICase):
         self.assertEquals(up['date_approved'], now.strftime("%Y-%m-%d %H:%M:%S"))
         self.assertEquals(up['date_pushed'], None)
         self.assertEquals(up['locked'], False)
-        self.assertEquals(up['alias'], None)
+        self.assertEquals(up['alias'], u'FEDORA-2015-0001')
         self.assertEquals(up['karma'], 1)
         self.assertEquals(len(up['bugs']), 1)
         self.assertEquals(up['bugs'][0]['bug_id'], 12345)
@@ -501,7 +501,7 @@ class TestUpdatesService(bodhi.tests.functional.base.BaseWSGICase):
         self.assertEquals(up['date_approved'], None)
         self.assertEquals(up['date_pushed'], None)
         self.assertEquals(up['locked'], False)
-        self.assertEquals(up['alias'], None)
+        self.assertEquals(up['alias'], u'FEDORA-2015-0001')
         self.assertEquals(up['karma'], 1)
         self.assertEquals(len(up['bugs']), 1)
         self.assertEquals(up['bugs'][0]['bug_id'], 12345)
@@ -540,7 +540,7 @@ class TestUpdatesService(bodhi.tests.functional.base.BaseWSGICase):
         self.assertEquals(up['date_approved'], None)
         self.assertEquals(up['date_pushed'], None)
         self.assertEquals(up['locked'], False)
-        self.assertEquals(up['alias'], None)
+        self.assertEquals(up['alias'], u'FEDORA-2015-0001')
         self.assertEquals(up['karma'], 1)
 
     def test_list_updates_by_invalid_critpath(self):
@@ -573,7 +573,7 @@ class TestUpdatesService(bodhi.tests.functional.base.BaseWSGICase):
         self.assertEquals(up['date_approved'], None)
         self.assertEquals(up['date_pushed'], None)
         self.assertEquals(up['locked'], False)
-        self.assertEquals(up['alias'], None)
+        self.assertEquals(up['alias'], u'FEDORA-2015-0001')
         self.assertEquals(up['karma'], 1)
         self.assertEquals(up['cves'][0]['cve_id'], "CVE-1985-0110")
 
@@ -632,7 +632,7 @@ class TestUpdatesService(bodhi.tests.functional.base.BaseWSGICase):
         self.assertEquals(up['date_approved'], None)
         self.assertEquals(up['date_pushed'], None)
         self.assertEquals(up['locked'], False)
-        self.assertEquals(up['alias'], None)
+        self.assertEquals(up['alias'], u'FEDORA-2015-0001')
         self.assertEquals(up['karma'], 1)
 
     def test_list_updates_by_locked(self):
@@ -656,7 +656,7 @@ class TestUpdatesService(bodhi.tests.functional.base.BaseWSGICase):
         self.assertEquals(up['date_approved'], None)
         self.assertEquals(up['date_pushed'], None)
         self.assertEquals(up['locked'], False)
-        self.assertEquals(up['alias'], None)
+        self.assertEquals(up['alias'], u'FEDORA-2015-0001')
         self.assertEquals(up['karma'], 1)
 
     def test_list_updates_by_invalid_locked(self):
@@ -704,7 +704,7 @@ class TestUpdatesService(bodhi.tests.functional.base.BaseWSGICase):
         self.assertEquals(up['date_approved'], None)
         self.assertEquals(up['date_pushed'], None)
         self.assertEquals(up['locked'], False)
-        self.assertEquals(up['alias'], None)
+        self.assertEquals(up['alias'], u'FEDORA-2015-0001')
         self.assertEquals(up['karma'], 1)
         self.assertEquals(len(up['bugs']), 1)
         self.assertEquals(up['bugs'][0]['bug_id'], 12345)
@@ -739,7 +739,7 @@ class TestUpdatesService(bodhi.tests.functional.base.BaseWSGICase):
         self.assertEquals(up['date_approved'], None)
         self.assertEquals(up['date_pushed'], None)
         self.assertEquals(up['locked'], False)
-        self.assertEquals(up['alias'], None)
+        self.assertEquals(up['alias'], u'FEDORA-2015-0001')
         self.assertEquals(up['karma'], 1)
 
     def test_list_updates_by_unexisting_package(self):
@@ -768,7 +768,7 @@ class TestUpdatesService(bodhi.tests.functional.base.BaseWSGICase):
         self.assertEquals(up['date_approved'], None)
         self.assertEquals(up['date_pushed'], None)
         self.assertEquals(up['locked'], False)
-        self.assertEquals(up['alias'], None)
+        self.assertEquals(up['alias'], u'FEDORA-2015-0001')
         self.assertEquals(up['karma'], 1)
         self.assertEquals(up['pushed'], False)
 
@@ -816,7 +816,7 @@ class TestUpdatesService(bodhi.tests.functional.base.BaseWSGICase):
         self.assertEquals(up['date_approved'], None)
         self.assertEquals(up['date_pushed'], now.strftime("%Y-%m-%d %H:%M:%S"))
         self.assertEquals(up['locked'], False)
-        self.assertEquals(up['alias'], None)
+        self.assertEquals(up['alias'], u'FEDORA-2015-0001')
         self.assertEquals(up['karma'], 1)
         self.assertEquals(len(up['bugs']), 1)
         self.assertEquals(up['bugs'][0]['bug_id'], 12345)
@@ -851,7 +851,7 @@ class TestUpdatesService(bodhi.tests.functional.base.BaseWSGICase):
         self.assertEquals(up['date_approved'], None)
         self.assertEquals(up['date_pushed'], None)
         self.assertEquals(up['locked'], False)
-        self.assertEquals(up['alias'], None)
+        self.assertEquals(up['alias'], u'FEDORA-2015-0001')
         self.assertEquals(up['karma'], 1)
 
     def test_list_updates_by_release_version(self):
@@ -875,7 +875,7 @@ class TestUpdatesService(bodhi.tests.functional.base.BaseWSGICase):
         self.assertEquals(up['date_approved'], None)
         self.assertEquals(up['date_pushed'], None)
         self.assertEquals(up['locked'], False)
-        self.assertEquals(up['alias'], None)
+        self.assertEquals(up['alias'], u'FEDORA-2015-0001')
         self.assertEquals(up['karma'], 1)
 
     def test_list_updates_by_unexisting_release(self):
@@ -907,7 +907,7 @@ class TestUpdatesService(bodhi.tests.functional.base.BaseWSGICase):
         self.assertEquals(up['date_approved'], None)
         self.assertEquals(up['date_pushed'], None)
         self.assertEquals(up['locked'], False)
-        self.assertEquals(up['alias'], None)
+        self.assertEquals(up['alias'], u'FEDORA-2015-0001')
         self.assertEquals(up['karma'], 1)
 
     def test_list_updates_by_unexisting_request(self):
@@ -941,7 +941,7 @@ class TestUpdatesService(bodhi.tests.functional.base.BaseWSGICase):
         self.assertEquals(up['date_approved'], None)
         self.assertEquals(up['date_pushed'], None)
         self.assertEquals(up['locked'], False)
-        self.assertEquals(up['alias'], None)
+        self.assertEquals(up['alias'], u'FEDORA-2015-0001')
         self.assertEquals(up['karma'], 1)
 
     def test_list_updates_by_unexisting_severity(self):
@@ -974,7 +974,7 @@ class TestUpdatesService(bodhi.tests.functional.base.BaseWSGICase):
         self.assertEquals(up['date_approved'], None)
         self.assertEquals(up['date_pushed'], None)
         self.assertEquals(up['locked'], False)
-        self.assertEquals(up['alias'], None)
+        self.assertEquals(up['alias'], u'FEDORA-2015-0001')
         self.assertEquals(up['karma'], 1)
 
     def test_list_updates_by_unexisting_status(self):
@@ -1007,7 +1007,7 @@ class TestUpdatesService(bodhi.tests.functional.base.BaseWSGICase):
         self.assertEquals(up['date_approved'], None)
         self.assertEquals(up['date_pushed'], None)
         self.assertEquals(up['locked'], False)
-        self.assertEquals(up['alias'], None)
+        self.assertEquals(up['alias'], u'FEDORA-2015-0001')
         self.assertEquals(up['karma'], 1)
 
     def test_list_updates_by_unexisting_suggest(self):
@@ -1040,7 +1040,7 @@ class TestUpdatesService(bodhi.tests.functional.base.BaseWSGICase):
         self.assertEquals(up['date_approved'], None)
         self.assertEquals(up['date_pushed'], None)
         self.assertEquals(up['locked'], False)
-        self.assertEquals(up['alias'], None)
+        self.assertEquals(up['alias'], u'FEDORA-2015-0001')
         self.assertEquals(up['karma'], 1)
 
     def test_list_updates_by_unexisting_type(self):
@@ -1073,7 +1073,7 @@ class TestUpdatesService(bodhi.tests.functional.base.BaseWSGICase):
         self.assertEquals(up['date_approved'], None)
         self.assertEquals(up['date_pushed'], None)
         self.assertEquals(up['locked'], False)
-        self.assertEquals(up['alias'], None)
+        self.assertEquals(up['alias'], u'FEDORA-2015-0001')
         self.assertEquals(up['karma'], 1)
 
     def test_list_updates_by_unexisting_username(self):
@@ -1115,7 +1115,7 @@ class TestUpdatesService(bodhi.tests.functional.base.BaseWSGICase):
         self.assertEquals(up['date_approved'], None)
         self.assertEquals(up['date_pushed'], None)
         self.assertEquals(up['locked'], False)
-        self.assertEquals(up['alias'], None)
+        self.assertEquals(up['alias'], u'FEDORA-2015-0002')
         self.assertEquals(up['karma'], 0)
         self.assertEquals(up['requirements'], 'rpmlint')
         publish.assert_called_once_with(
@@ -1147,7 +1147,7 @@ class TestUpdatesService(bodhi.tests.functional.base.BaseWSGICase):
         self.assertEquals(up['date_approved'], None)
         self.assertEquals(up['date_pushed'], None)
         self.assertEquals(up['locked'], False)
-        self.assertEquals(up['alias'], None)
+        self.assertEquals(up['alias'], u'FEDORA-2015-0002')
         self.assertEquals(up['karma'], 0)
         self.assertEquals(up['requirements'], 'upgradepath')
         self.assertEquals(up['comments'][-1]['text'],

--- a/bodhi/tests/functional/test_updates.py
+++ b/bodhi/tests/functional/test_updates.py
@@ -14,7 +14,9 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
+import time
 import mock
+
 from mock import ANY
 from nose.tools import eq_
 from datetime import datetime, timedelta
@@ -35,6 +37,8 @@ from bodhi.models import (
     UpdateRequest,
     Release,
 )
+
+YEAR = time.localtime().tm_year
 
 mock_valid_requirements = {
     'target': 'bodhi.validators._get_valid_requirements',
@@ -375,7 +379,7 @@ class TestUpdatesService(bodhi.tests.functional.base.BaseWSGICase):
         self.assertEquals(up['date_modified'], None)
         self.assertEquals(up['date_pushed'], None)
         self.assertEquals(up['locked'], False)
-        self.assertEquals(up['alias'], u'FEDORA-2015-0001')
+        self.assertEquals(up['alias'], u'FEDORA-%s-0001' % YEAR)
         self.assertEquals(up['karma'], 1)
 
     def test_list_updates_jsonp(self):
@@ -466,7 +470,7 @@ class TestUpdatesService(bodhi.tests.functional.base.BaseWSGICase):
         self.assertEquals(up['date_approved'], now.strftime("%Y-%m-%d %H:%M:%S"))
         self.assertEquals(up['date_pushed'], None)
         self.assertEquals(up['locked'], False)
-        self.assertEquals(up['alias'], u'FEDORA-2015-0001')
+        self.assertEquals(up['alias'], u'FEDORA-%s-0001' % YEAR)
         self.assertEquals(up['karma'], 1)
         self.assertEquals(len(up['bugs']), 1)
         self.assertEquals(up['bugs'][0]['bug_id'], 12345)
@@ -501,7 +505,7 @@ class TestUpdatesService(bodhi.tests.functional.base.BaseWSGICase):
         self.assertEquals(up['date_approved'], None)
         self.assertEquals(up['date_pushed'], None)
         self.assertEquals(up['locked'], False)
-        self.assertEquals(up['alias'], u'FEDORA-2015-0001')
+        self.assertEquals(up['alias'], u'FEDORA-%s-0001' % YEAR)
         self.assertEquals(up['karma'], 1)
         self.assertEquals(len(up['bugs']), 1)
         self.assertEquals(up['bugs'][0]['bug_id'], 12345)
@@ -540,7 +544,7 @@ class TestUpdatesService(bodhi.tests.functional.base.BaseWSGICase):
         self.assertEquals(up['date_approved'], None)
         self.assertEquals(up['date_pushed'], None)
         self.assertEquals(up['locked'], False)
-        self.assertEquals(up['alias'], u'FEDORA-2015-0001')
+        self.assertEquals(up['alias'], u'FEDORA-%s-0001' % YEAR)
         self.assertEquals(up['karma'], 1)
 
     def test_list_updates_by_invalid_critpath(self):
@@ -573,7 +577,7 @@ class TestUpdatesService(bodhi.tests.functional.base.BaseWSGICase):
         self.assertEquals(up['date_approved'], None)
         self.assertEquals(up['date_pushed'], None)
         self.assertEquals(up['locked'], False)
-        self.assertEquals(up['alias'], u'FEDORA-2015-0001')
+        self.assertEquals(up['alias'], u'FEDORA-%s-0001' % YEAR)
         self.assertEquals(up['karma'], 1)
         self.assertEquals(up['cves'][0]['cve_id'], "CVE-1985-0110")
 
@@ -632,7 +636,7 @@ class TestUpdatesService(bodhi.tests.functional.base.BaseWSGICase):
         self.assertEquals(up['date_approved'], None)
         self.assertEquals(up['date_pushed'], None)
         self.assertEquals(up['locked'], False)
-        self.assertEquals(up['alias'], u'FEDORA-2015-0001')
+        self.assertEquals(up['alias'], u'FEDORA-%s-0001' % YEAR)
         self.assertEquals(up['karma'], 1)
 
     def test_list_updates_by_locked(self):
@@ -656,7 +660,7 @@ class TestUpdatesService(bodhi.tests.functional.base.BaseWSGICase):
         self.assertEquals(up['date_approved'], None)
         self.assertEquals(up['date_pushed'], None)
         self.assertEquals(up['locked'], False)
-        self.assertEquals(up['alias'], u'FEDORA-2015-0001')
+        self.assertEquals(up['alias'], u'FEDORA-%s-0001' % YEAR)
         self.assertEquals(up['karma'], 1)
 
     def test_list_updates_by_invalid_locked(self):
@@ -704,7 +708,7 @@ class TestUpdatesService(bodhi.tests.functional.base.BaseWSGICase):
         self.assertEquals(up['date_approved'], None)
         self.assertEquals(up['date_pushed'], None)
         self.assertEquals(up['locked'], False)
-        self.assertEquals(up['alias'], u'FEDORA-2015-0001')
+        self.assertEquals(up['alias'], u'FEDORA-%s-0001' % YEAR)
         self.assertEquals(up['karma'], 1)
         self.assertEquals(len(up['bugs']), 1)
         self.assertEquals(up['bugs'][0]['bug_id'], 12345)
@@ -739,7 +743,7 @@ class TestUpdatesService(bodhi.tests.functional.base.BaseWSGICase):
         self.assertEquals(up['date_approved'], None)
         self.assertEquals(up['date_pushed'], None)
         self.assertEquals(up['locked'], False)
-        self.assertEquals(up['alias'], u'FEDORA-2015-0001')
+        self.assertEquals(up['alias'], u'FEDORA-%s-0001' % YEAR)
         self.assertEquals(up['karma'], 1)
 
     def test_list_updates_by_unexisting_package(self):
@@ -768,7 +772,7 @@ class TestUpdatesService(bodhi.tests.functional.base.BaseWSGICase):
         self.assertEquals(up['date_approved'], None)
         self.assertEquals(up['date_pushed'], None)
         self.assertEquals(up['locked'], False)
-        self.assertEquals(up['alias'], u'FEDORA-2015-0001')
+        self.assertEquals(up['alias'], u'FEDORA-%s-0001' % YEAR)
         self.assertEquals(up['karma'], 1)
         self.assertEquals(up['pushed'], False)
 
@@ -816,7 +820,7 @@ class TestUpdatesService(bodhi.tests.functional.base.BaseWSGICase):
         self.assertEquals(up['date_approved'], None)
         self.assertEquals(up['date_pushed'], now.strftime("%Y-%m-%d %H:%M:%S"))
         self.assertEquals(up['locked'], False)
-        self.assertEquals(up['alias'], u'FEDORA-2015-0001')
+        self.assertEquals(up['alias'], u'FEDORA-%s-0001' % YEAR)
         self.assertEquals(up['karma'], 1)
         self.assertEquals(len(up['bugs']), 1)
         self.assertEquals(up['bugs'][0]['bug_id'], 12345)
@@ -851,7 +855,7 @@ class TestUpdatesService(bodhi.tests.functional.base.BaseWSGICase):
         self.assertEquals(up['date_approved'], None)
         self.assertEquals(up['date_pushed'], None)
         self.assertEquals(up['locked'], False)
-        self.assertEquals(up['alias'], u'FEDORA-2015-0001')
+        self.assertEquals(up['alias'], u'FEDORA-%s-0001' % YEAR)
         self.assertEquals(up['karma'], 1)
 
     def test_list_updates_by_release_version(self):
@@ -875,7 +879,7 @@ class TestUpdatesService(bodhi.tests.functional.base.BaseWSGICase):
         self.assertEquals(up['date_approved'], None)
         self.assertEquals(up['date_pushed'], None)
         self.assertEquals(up['locked'], False)
-        self.assertEquals(up['alias'], u'FEDORA-2015-0001')
+        self.assertEquals(up['alias'], u'FEDORA-%s-0001' % YEAR)
         self.assertEquals(up['karma'], 1)
 
     def test_list_updates_by_unexisting_release(self):
@@ -907,7 +911,7 @@ class TestUpdatesService(bodhi.tests.functional.base.BaseWSGICase):
         self.assertEquals(up['date_approved'], None)
         self.assertEquals(up['date_pushed'], None)
         self.assertEquals(up['locked'], False)
-        self.assertEquals(up['alias'], u'FEDORA-2015-0001')
+        self.assertEquals(up['alias'], u'FEDORA-%s-0001' % YEAR)
         self.assertEquals(up['karma'], 1)
 
     def test_list_updates_by_unexisting_request(self):
@@ -941,7 +945,7 @@ class TestUpdatesService(bodhi.tests.functional.base.BaseWSGICase):
         self.assertEquals(up['date_approved'], None)
         self.assertEquals(up['date_pushed'], None)
         self.assertEquals(up['locked'], False)
-        self.assertEquals(up['alias'], u'FEDORA-2015-0001')
+        self.assertEquals(up['alias'], u'FEDORA-%s-0001' % YEAR)
         self.assertEquals(up['karma'], 1)
 
     def test_list_updates_by_unexisting_severity(self):
@@ -974,7 +978,7 @@ class TestUpdatesService(bodhi.tests.functional.base.BaseWSGICase):
         self.assertEquals(up['date_approved'], None)
         self.assertEquals(up['date_pushed'], None)
         self.assertEquals(up['locked'], False)
-        self.assertEquals(up['alias'], u'FEDORA-2015-0001')
+        self.assertEquals(up['alias'], u'FEDORA-%s-0001' % YEAR)
         self.assertEquals(up['karma'], 1)
 
     def test_list_updates_by_unexisting_status(self):
@@ -1007,7 +1011,7 @@ class TestUpdatesService(bodhi.tests.functional.base.BaseWSGICase):
         self.assertEquals(up['date_approved'], None)
         self.assertEquals(up['date_pushed'], None)
         self.assertEquals(up['locked'], False)
-        self.assertEquals(up['alias'], u'FEDORA-2015-0001')
+        self.assertEquals(up['alias'], u'FEDORA-%s-0001' % YEAR)
         self.assertEquals(up['karma'], 1)
 
     def test_list_updates_by_unexisting_suggest(self):
@@ -1040,7 +1044,7 @@ class TestUpdatesService(bodhi.tests.functional.base.BaseWSGICase):
         self.assertEquals(up['date_approved'], None)
         self.assertEquals(up['date_pushed'], None)
         self.assertEquals(up['locked'], False)
-        self.assertEquals(up['alias'], u'FEDORA-2015-0001')
+        self.assertEquals(up['alias'], u'FEDORA-%s-0001' % YEAR)
         self.assertEquals(up['karma'], 1)
 
     def test_list_updates_by_unexisting_type(self):
@@ -1073,7 +1077,7 @@ class TestUpdatesService(bodhi.tests.functional.base.BaseWSGICase):
         self.assertEquals(up['date_approved'], None)
         self.assertEquals(up['date_pushed'], None)
         self.assertEquals(up['locked'], False)
-        self.assertEquals(up['alias'], u'FEDORA-2015-0001')
+        self.assertEquals(up['alias'], u'FEDORA-%s-0001' % YEAR)
         self.assertEquals(up['karma'], 1)
 
     def test_list_updates_by_unexisting_username(self):
@@ -1115,7 +1119,7 @@ class TestUpdatesService(bodhi.tests.functional.base.BaseWSGICase):
         self.assertEquals(up['date_approved'], None)
         self.assertEquals(up['date_pushed'], None)
         self.assertEquals(up['locked'], False)
-        self.assertEquals(up['alias'], u'FEDORA-2015-0002')
+        self.assertEquals(up['alias'], u'FEDORA-%s-0002' % YEAR)
         self.assertEquals(up['karma'], 0)
         self.assertEquals(up['requirements'], 'rpmlint')
         publish.assert_called_once_with(
@@ -1147,7 +1151,7 @@ class TestUpdatesService(bodhi.tests.functional.base.BaseWSGICase):
         self.assertEquals(up['date_approved'], None)
         self.assertEquals(up['date_pushed'], None)
         self.assertEquals(up['locked'], False)
-        self.assertEquals(up['alias'], u'FEDORA-2015-0002')
+        self.assertEquals(up['alias'], u'FEDORA-%s-0002' % YEAR)
         self.assertEquals(up['karma'], 0)
         self.assertEquals(up['requirements'], 'upgradepath')
         self.assertEquals(up['comments'][-1]['text'],

--- a/bodhi/tests/models/test_models.py
+++ b/bodhi/tests/models/test_models.py
@@ -217,13 +217,14 @@ class TestUpdate(ModelTest):
 
     def test_assign_alias(self):
         update = self.obj
-        update.assign_alias()
         year = time.localtime()[0]
+        model.DBSession.add(update)
+        model.DBSession.flush()
         eq_(update.alias, u'%s-%s-0001' % (update.release.id_prefix, year))
-        #assert update.date_pushed
 
         update = self.get_update(name=u'TurboGears-0.4.4-8.fc11')
-        update.assign_alias()
+        model.DBSession.add(update)
+        model.DBSession.flush()
         eq_(update.alias, u'%s-%s-0002' % (update.release.id_prefix, year))
 
         ## Create another update for another release that has the same
@@ -239,18 +240,21 @@ class TestUpdate(ModelTest):
                                  pending_stable_tag=u'dist-fc10-updates-pending',
                                  override_tag=u'dist-fc10-override')
         update.release = otherrel
-        update.assign_alias()
+        model.DBSession.add(update)
+        model.DBSession.flush()
         eq_(update.alias, u'%s-%s-0003' % (update.release.id_prefix, year))
 
         ## 10k bug
         update.alias = u'FEDORA-%s-9999' % year
         newupdate = self.get_update(name=u'nethack-2.5.6-1.fc10')
         newupdate.release = otherrel
-        newupdate.assign_alias()
+        model.DBSession.add(update)
+        model.DBSession.flush()
         eq_(newupdate.alias, u'FEDORA-%s-10000' % year)
 
         newerupdate = self.get_update(name=u'nethack-2.5.7-1.fc10')
-        newerupdate.assign_alias()
+        model.DBSession.add(update)
+        model.DBSession.flush()
         eq_(newerupdate.alias, u'FEDORA-%s-10001' % year)
 
         ## test updates that were pushed at the same time.  assign_alias should
@@ -260,7 +264,8 @@ class TestUpdate(ModelTest):
         newerupdate.date_pushed = now
 
         newest = self.get_update(name=u'nethack-2.5.8-1.fc10')
-        newest.assign_alias()
+        model.DBSession.add(update)
+        model.DBSession.flush()
         eq_(newest.alias, u'FEDORA-%s-10002' % year)
 
     def test_epel_id(self):
@@ -269,7 +274,6 @@ class TestUpdate(ModelTest):
         """
         # Create a normal Fedora update first
         update = self.obj
-        update.assign_alias()
         eq_(update.alias, u'FEDORA-%s-0001' % time.localtime()[0])
 
         update = self.get_update(name=u'TurboGears-2.1-1.el5')
@@ -282,12 +286,14 @@ class TestUpdate(ModelTest):
                           pending_stable_tag=u'dist-5E-epel-pending',
                           override_tag=u'dist-5E-epel-override')
         update.release = release
-        update.assign_alias()
+        model.DBSession.add(update)
+        model.DBSession.flush()
         eq_(update.alias, u'FEDORA-EPEL-%s-0001' % time.localtime()[0])
 
         update = self.get_update(name=u'TurboGears-2.2-1.el5')
         update.release = release
-        update.assign_alias()
+        model.DBSession.add(update)
+        model.DBSession.flush()
         eq_(update.alias, u'%s-%s-0002' % (release.id_prefix,
                                            time.localtime()[0]))
 
@@ -450,8 +456,6 @@ class TestUpdate(ModelTest):
         eq_(kwargs['msg']['comment']['author'], 'anonymous')
 
     def test_get_url(self):
-        eq_(self.obj.get_url(), u'/TurboGears-1.0.8-3.fc11')
-        self.obj.assign_alias()
         eq_(self.obj.get_url(), u'/F11/FEDORA-%s-0001' % time.localtime()[0])
 
     def test_bug(self):

--- a/bodhi/tests/test_masher.py
+++ b/bodhi/tests/test_masher.py
@@ -696,7 +696,7 @@ References:
     @mock.patch('bodhi.bugs.bugtracker.on_qa')
     def test_modify_testing_bugs(self, on_qa, modified, *args):
         self.masher.consume(self.msg)
-        on_qa.assert_called_once_with(12345, u"bodhi-2.0-1.fc17 has been pushed to the Fedora 17 testing repository. If problems still persist, please make note of it in this bug report.\\nIf you want to test the update, you can install it with \\n su -c 'yum --enablerepo=updates-testing update bodhi'. You can provide feedback for this update here: http://localhost:8084/F17/FEDORA-2015-0001")
+        on_qa.assert_called_once_with(12345, u"bodhi-2.0-1.fc17 has been pushed to the Fedora 17 testing repository. If problems still persist, please make note of it in this bug report.\\nIf you want to test the update, you can install it with \\n su -c 'yum --enablerepo=updates-testing update bodhi'. You can provide feedback for this update here: http://localhost:8084/F17/FEDORA-%s-0001" % time.localtime().tm_year)
 
     @mock.patch(**mock_taskotron_results)
     @mock.patch('bodhi.masher.MasherThread.update_comps')

--- a/bodhi/tests/test_metadata.py
+++ b/bodhi/tests/test_metadata.py
@@ -96,9 +96,9 @@ class TestExtendedMetadata(unittest.TestCase):
         update = self.db.query(Update).one()
 
         # Pretend it's pushed to testing
-        update.assign_alias()
         update.status = UpdateStatus.testing
         update.request = None
+        update.date_pushed = datetime.utcnow()
         DevBuildsys.__tagged__[update.title] = ['f17-updates-testing']
 
         # Generate the XML
@@ -120,11 +120,12 @@ class TestExtendedMetadata(unittest.TestCase):
         self.assertEquals(notice.title, update.title)
         self.assertEquals(notice.release, update.release.long_name)
         self.assertEquals(notice.status, update.status.value)
-        self.assertEquals(notice.updated_date, update.date_modified)
+        if update.date_modified:
+            self.assertEquals(notice.updated_date, update.date_modified)
         self.assertEquals(notice.fromstr, config.get('bodhi_email'))
         self.assertEquals(notice.rights, config.get('updateinfo_rights'))
         self.assertEquals(notice.description, update.notes)
-        self.assertIsNotNone(notice.issued_date)
+        #self.assertIsNotNone(notice.issued_date)
         self.assertEquals(notice.id, update.alias)
         bug = notice.references[0]
         self.assertEquals(bug.href, update.bugs[0].url)
@@ -152,9 +153,9 @@ class TestExtendedMetadata(unittest.TestCase):
         update = self.db.query(Update).one()
 
         # Pretend it's pushed to testing
-        update.assign_alias()
         update.status = UpdateStatus.testing
         update.request = None
+        update.date_pushed = datetime.utcnow()
         DevBuildsys.__tagged__[update.title] = ['f17-updates-testing']
 
         # Generate the XML
@@ -177,11 +178,12 @@ class TestExtendedMetadata(unittest.TestCase):
         self.assertEquals(notice.updated_date, update.date_modified)
         self.assertEquals(notice.fromstr, config.get('bodhi_email'))
         self.assertEquals(notice.description, update.notes)
-        self.assertIsNotNone(notice.issued_date)
+        #self.assertIsNotNone(notice.issued_date)
         self.assertEquals(notice.id, update.alias)
         #self.assertIsNone(notice.epoch)
         bug = notice.references[0]
-        self.assertEquals(bug.href, update.bugs[0].url)
+        url = update.bugs[0].url
+        self.assertEquals(bug.href, url)
         self.assertEquals(bug.id, '12345')
         self.assertEquals(bug.type, 'bugzilla')
         cve = notice.references[1]
@@ -213,9 +215,9 @@ class TestExtendedMetadata(unittest.TestCase):
         update = self.db.query(Update).one()
 
         # Pretend it's pushed to testing
-        update.assign_alias()
         update.status = UpdateStatus.testing
         update.request = None
+        update.date_pushed = datetime.utcnow()
         DevBuildsys.__tagged__[update.title] = ['f17-updates-testing']
 
         # Generate the XML
@@ -274,10 +276,10 @@ class TestExtendedMetadata(unittest.TestCase):
 
     def test_metadata_updating_with_old_stable_security(self):
         update = self.db.query(Update).one()
-        update.assign_alias()
         update.request = None
         update.type = UpdateType.security
         update.status = UpdateStatus.stable
+        update.date_pushed = datetime.utcnow()
         DevBuildsys.__tagged__[update.title] = ['f17-updates']
 
         repo = join(self.tempdir, 'f17-updates')
@@ -314,7 +316,6 @@ class TestExtendedMetadata(unittest.TestCase):
                            notes=u'x')
         self.db.add(newupdate)
         self.db.flush()
-        newupdate.assign_alias()
 
         # Untag the old security build
         DevBuildsys.__untag__.append(update.title)
@@ -345,10 +346,10 @@ class TestExtendedMetadata(unittest.TestCase):
 
     def test_metadata_updating_with_old_testing_security(self):
         update = self.db.query(Update).one()
-        update.assign_alias()
         update.request = None
         update.type = UpdateType.security
         update.status = UpdateStatus.testing
+        update.date_pushed = datetime.utcnow()
         DevBuildsys.__tagged__[update.title] = ['f17-updates-testing']
 
         # Generate the XML
@@ -381,7 +382,6 @@ class TestExtendedMetadata(unittest.TestCase):
                            notes=u'x')
         self.db.add(newupdate)
         self.db.flush()
-        newupdate.assign_alias()
 
         # Untag the old security build
         del(DevBuildsys.__tagged__[update.title])


### PR DESCRIPTION
As opposed to when it's initially pushed to testing, which is how it is currently done.