### PR TITLE
Use the kitchen unicode/byte converters to mitigate encoding nightmares

### DIFF
--- a/bodhi/model.py
+++ b/bodhi/model.py
@@ -45,6 +45,8 @@ except ImportError:
 
 import fedmsg
 
+from kitchen.text.converters import to_unicode, to_bytes
+
 from bodhi import buildsys, mail
 from bodhi.util import get_nvr, rpm_fileheader, header, get_age, get_age_in_days
 from bodhi.util import Singleton, authorized_user, flash_log, build_evr
@@ -375,7 +377,7 @@ class PackageUpdate(SQLObject):
             kwargs["notes_"] = notes
         return super(PackageUpdate, self).__init__(**kwargs)
     def get_notes(self):
-        return self.notes_.encode('utf-8').decode('string_escape').decode('string_escape').decode('utf-8')
+        return to_unicode(to_bytes(self.notes_).decode('string_escape').decode('string_escape'))
     def set_notes(self, value):
         self.notes_ = value
     def del_notes(self):
@@ -1374,7 +1376,7 @@ class Comment(SQLObject):
             kwargs["text_"] = text
         return super(Comment, self).__init__(**kwargs)
     def get_text(self):
-        return self.text_.encode('utf-8').decode('string_escape').decode('utf-8')
+        return to_unicode(to_bytes(self.text_).decode('string_escape'))
     def set_text(self, value):
         self.text_ = value
     def del_text(self):

--- a/bodhi/tests/test_model.py
+++ b/bodhi/tests/test_model.py
@@ -607,6 +607,13 @@ class TestPackageUpdate(testutil.DBTest):
         u = PackageUpdate.byTitle('foo-1.2.3-4')
         assert u.notes == u'\xb7'
 
+    def test_broken_notes(self):
+        """ Ensure our note encoding works as expected """
+        update = self.get_update(name='foo-1.2.3-4')
+        update.notes_ = u'update to version 3.09\r\n*\xa0Allow regex replacement variables in HAO commands (Roger Bowler)\r\n*\xa0Prevent duplicate EQID (Gordon Bonorchis)\r\n*\xa0Permit concurrent read access to printer and punch files (Roger Bowler)\r\n*\xa0DFP zoned-conversion facility (Roger Bowler)\r\n*\xa0Execution-hint facility (Roger Bowler)\r\n*\xa0Miscellaneous-instruction-extensions facility (Roger Bowler)\r\n*\xa0Load-and-trap facility (Roger Bowler)\r\n*\xa0Fix for VSAM Extended Format (David "Fish" Trout)\r\n*\xa0APL\\360 2741 patch (Max H. Parke)\r\n*\xa0Fix interval timer repeating interrupt (Ivan Warren, Kevin Leonard)\r\n*\xa0Corrections to build procedures (Mike Frysinger, Dan Horak)\r\n*\xa0Miscellaneous bug fixes (Roger Bowler)\r\n'
+        assert False, update.notes
+        assert update.notes
+
     def test_utf8_email(self):
         update = self.get_update(name='TurboGears-1.0.2.2-2.fc7')
         bug = self.get_bug()


### PR DESCRIPTION
This fixes a number of issues that have popped up recently.

https://fedorahosted.org/bodhi/ticket/782
https://fedorahosted.org/bodhi/ticket/783
https://fedorahosted.org/bodhi/ticket/784
