### PR TITLE
compat: Return the 'updateid' as well as the 'alias'

### DIFF
--- a/bodhi/models/models.py
+++ b/bodhi/models/models.py
@@ -1687,6 +1687,13 @@ class Update(Base):
             log.error('Unable to determine requested tag for %s' % self.title)
         return tag
 
+    def __json__(self, *args, **kwargs):
+        result = super(Update, self).__json__(*args, **kwargs)
+        # Duplicate alias as updateid for backwards compat with bodhi1
+        result['updateid'] = result['alias']
+        return result
+
+
 
 # Used for many-to-many relationships between karma and a bug
 class BugKarma(Base):

--- a/bodhi/tests/functional/test_updates.py
+++ b/bodhi/tests/functional/test_updates.py
@@ -1540,3 +1540,9 @@ class TestUpdatesService(bodhi.tests.functional.base.BaseWSGICase):
 
         # Ensure the second update was created successfully
         session.query(Update).filter_by(title=newtitle).one()
+
+    @mock.patch(**mock_valid_requirements)
+    def test_updateid_alias(self, *args):
+        res = self.app.post_json('/updates/', self.get_update(u'bodhi-2.0.0-3.fc17'))
+        json = res.json_body
+        self.assertEquals(json['alias'], json['updateid'])


### PR DESCRIPTION
Things like blockerbugs rely on this, so we might as well remain compatible for now.