### PR TITLE
Declare CORS allowed-origins for cornice.

### DIFF
--- a/bodhi/services/builds.py
+++ b/bodhi/services/builds.py
@@ -39,9 +39,11 @@ from bodhi.validators import (
 
 
 build = Service(name='build', path='/builds/{nvr}',
-                 description='Koji builds')
+                 description='Koji builds',
+                 cors_origins=bodhi.security.cors_origins_ro)
 builds = Service(name='builds', path='/builds/',
-                 description='Koji builds')
+                 description='Koji builds',
+                 cors_origins=bodhi.security.cors_origins_ro)
 
 
 @build.get(renderer='json')

--- a/bodhi/services/comments.py
+++ b/bodhi/services/comments.py
@@ -38,10 +38,14 @@ from bodhi.validators import (
 
 comment = Service(name='comment', path='/comments/{id}',
                  validators=(validate_comment_id,),
-                 description='Comment submission service')
+                 description='Comment submission service',
+                 cors_origins=bodhi.security.cors_origins_ro)
 
 comments = Service(name='comments', path='/comments/',
-                   description='Comment submission service')
+                   description='Comment submission service',
+                   # Note, this 'rw' is not a typo.  the @comments service has
+                   # a ``post`` section at the bottom.
+                   cors_origins=bodhi.security.cors_origins_rw)
 
 
 @comment.get(accept=('application/json', 'text/json'), renderer='json')

--- a/bodhi/services/csrf.py
+++ b/bodhi/services/csrf.py
@@ -14,8 +14,15 @@
 
 from cornice import Service
 
+import bodhi.security
 
-csrf = Service(name='csrf', path='/csrf', description='CSRF Token')
+
+csrf = Service(name='csrf', path='/csrf', description='CSRF Token',
+               # XXX - even though this is really a read-only endpoint,
+               # we're going to **mark** it as read-write to CORS so
+               # that somebody's exploited browser can't make a cross-site
+               # request here to steal the CSRF token and escalate damage.
+               cors_origins=bodhi.security.cors_origins_rw)
 
 
 @csrf.get(accept="text/html", renderer="string")

--- a/bodhi/services/overrides.py
+++ b/bodhi/services/overrides.py
@@ -28,10 +28,14 @@ from bodhi.validators import (validate_override_build, validate_expiration_date,
 
 
 override = Service(name='override', path='/overrides/{nvr}',
-                   description='Buildroot Overrides')
+                   description='Buildroot Overrides',
+                   cors_origins=bodhi.security.cors_origins_ro)
 
 overrides = Service(name='overrides', path='/overrides/',
-                    description='Buildroot Overrides')
+                    description='Buildroot Overrides',
+                    # Note, this 'rw' is not a typo.  the @comments service has
+                    # a ``post`` section at the bottom.
+                    cors_origins=bodhi.security.cors_origins_rw)
 
 
 @override.get(accept=("application/json", "text/json"), renderer="json")

--- a/bodhi/services/releases.py
+++ b/bodhi/services/releases.py
@@ -32,9 +32,13 @@ from bodhi.validators import (
 
 
 release = Service(name='release', path='/releases/{name}',
-                  description='Fedora Releases')
+                  description='Fedora Releases',
+                  cors_origins=bodhi.security.cors_origins_ro)
 releases = Service(name='releases', path='/releases/',
-                   description='Fedora Releases')
+                   description='Fedora Releases',
+                   # Note, this 'rw' is not a typo.  the @comments service has
+                   # a ``post`` section at the bottom.
+                   cors_origins=bodhi.security.cors_origins_rw)
 
 @release.get(accept="text/html", renderer="release.html")
 def get_release_html(request):

--- a/bodhi/services/stacks.py
+++ b/bodhi/services/stacks.py
@@ -34,9 +34,13 @@ from bodhi.validators import (
 
 stack = Service(name='stack', path='/stacks/{name}',
                 validators=(validate_stack,),
-                description='Bodhi Stacks')
+                description='Bodhi Stacks',
+                # Note, this 'rw' is not a typo.  there are deletes and posts.
+                cors_origins=bodhi.security.cors_origins_rw)
 stacks = Service(name='stacks', path='/stacks/',
-                 description='Bodhi Stacks')
+                 description='Bodhi Stacks',
+                 # Not a typo.  there are deletes and posts in here.
+                 cors_origins=bodhi.security.cors_origins_rw)
 
 
 @stack.get(accept="text/html", renderer="new_stack.html")

--- a/bodhi/services/updates.py
+++ b/bodhi/services/updates.py
@@ -42,20 +42,24 @@ from bodhi.validators import (
 update = Service(name='update', path='/updates/{id}',
                  validators=(validate_update_id,),
                  description='Update submission service',
-                 acl=bodhi.security.package_maintainers_only_acl)
+                 acl=bodhi.security.package_maintainers_only_acl,
+                 cors_origins=bodhi.security.cors_origins_ro)
 
 update_edit = Service(name='update_edit', path='/updates/{id}/edit',
                  validators=(validate_update_id,),
                  description='Update submission service',
-                 acl=bodhi.security.package_maintainers_only_acl)
+                 acl=bodhi.security.package_maintainers_only_acl,
+                 cors_origins=bodhi.security.cors_origins_rw)
 
 updates = Service(name='updates', path='/updates/',
                   acl=bodhi.security.packagers_allowed_acl,
-                  description='Update submission service')
+                  description='Update submission service',
+                  cors_origins=bodhi.security.cors_origins_ro)
 
 update_request = Service(name='update_request', path='/updates/{id}/request',
                          description='Update request service',
-                         acl=bodhi.security.package_maintainers_only_acl)
+                         acl=bodhi.security.package_maintainers_only_acl,
+                         cors_origins=bodhi.security.cors_origins_rw)
 
 
 @update.get(accept=('application/json', 'text/json'), renderer='json')

--- a/bodhi/services/user.py
+++ b/bodhi/services/user.py
@@ -28,6 +28,7 @@ from bodhi.models import (
 )
 import bodhi.services.updates
 import bodhi.schemas
+import bodhi.security
 from bodhi.validators import (
     validate_updates,
     validate_packages,
@@ -36,9 +37,13 @@ from bodhi.validators import (
 
 
 user = Service(name='user', path='/users/{name}',
-                 description='Bodhi users')
+                 description='Bodhi users',
+                 # These we leave wide-open since these are only GETs
+                 cors_origins=bodhi.security.cors_origins_ro)
 users = Service(name='users', path='/users/',
-                 description='Bodhi users')
+                 description='Bodhi users',
+                 # These we leave wide-open since these are only GETs
+                 cors_origins=bodhi.security.cors_origins_ro)
 
 
 @user.get(accept=("application/json", "text/json"), renderer="json")

--- a/development.ini
+++ b/development.ini
@@ -366,6 +366,12 @@ openid.provider = https://id.fedoraproject.org/openid/
 openid.url = https://id.fedoraproject.org/
 openid_template = {username}.id.fedoraproject.org
 
+# CORS allowed origins for cornice services
+# This can be wide-open.  read-only, we don't care as much about.
+cors_origins_ro = *
+# This should be more locked down to avoid cross-site request forgery.
+cors_origins_rw = localhost
+
 ##
 ## Pyramid settings
 ##

--- a/production.ini
+++ b/production.ini
@@ -346,6 +346,12 @@ openid.success_callback = bodhi.security:remember_me
 openid.provider = https://id.fedoraproject.org/openid/
 openid_template = {username}.id.fedoraproject.org
 
+# CORS allowed origins for cornice services
+# This can be wide-open.  read-only, we don't care as much about.
+cors_origins_ro = *
+# This should be more locked down to avoid cross-site request forgery.
+cors_origins_rw = bodhi.fedoraproject.org
+
 ##
 ## Pyramid settings
 ##

--- a/staging.ini
+++ b/staging.ini
@@ -347,6 +347,12 @@ openid.provider = https://id.stg.fedoraproject.org/openid/
 openid.url = https://id.stg.fedoraproject.org/
 openid_template = {username}.id.fedoraproject.org
 
+# CORS allowed origins for cornice services
+# This can be wide-open.  read-only, we don't care as much about.
+cors_origins_ro = *
+# This should be more locked down to avoid cross-site request forgery.
+cors_origins_rw = bodhi.stg.fedoraproject.org
+
 ##
 ## Pyramid settings
 ##


### PR DESCRIPTION
This was the root cause of why the typeahead.js search box stopped
working.  Apparently, in the last year browsers got much more strict
about enforcing CORS and ajax requests from typeahead to the server were
failing that policy.

I implemented a proxy class to relay pyramid configuration to cornice.
The docstring of that class details why it is as complicated as it is.