### PR TITLE
Redirect to a package's updates if it exists.

### DIFF
--- a/bodhi/tests/functional/test_updates.py
+++ b/bodhi/tests/functional/test_updates.py
@@ -1554,3 +1554,12 @@ class TestUpdatesService(bodhi.tests.functional.base.BaseWSGICase):
 
         up = body['updates'][0]
         self.assertEquals(up['title'], u'bodhi-2.0-1.fc17')
+
+    def test_redirect_to_package(self):
+        "When you visit /updates/package, redirect to /updates/?packages=..."
+        res = self.app.get('/updates/bodhi', status=302)
+        target = 'http://localhost/updates/?packages=bodhi'
+        self.assertEquals(res.headers['Location'], target)
+
+        # But be sure that we don't redirect if the package doesn't exist
+        res = self.app.get('/updates/non-existant', status=404)

--- a/bodhi/validators.py
+++ b/bodhi/validators.py
@@ -16,6 +16,7 @@ from datetime import datetime, timedelta
 
 from sqlalchemy.sql import or_
 from pyramid.exceptions import HTTPNotFound, HTTPBadRequest
+from pyramid.httpexceptions import HTTPFound
 import pyramid.threadlocal
 
 import colander
@@ -460,6 +461,12 @@ def validate_update_id(request):
     if update:
         request.validated['update'] = update
     else:
+        package = Package.get(request.matchdict['id'], request.db)
+        if package:
+            query = dict(packages=package.name)
+            location = request.route_url('updates', _query=query)
+            raise HTTPFound(location=location)
+
         request.errors.add('url', 'id', 'Invalid update id')
         request.errors.status = HTTPNotFound.code
 


### PR DESCRIPTION
This doesn't fix any bugs, per se.  It's an improvement from a UX perspective.

I realized when working on the bodhi1->bodhi2 redirects that bodhi1 has
a behavior that I use all the time where you can visit
https://admin.fedoraproject.org/updates/nethack and be shown updates of
that package.  In bodhi2, this just gives you a 404, because there's no
update named just "nethack" -- it's a package.

This patch enhances the update_id validator to raise a 302 redirect
*if* the update_id isn't an update id but it *is* a package name.

We could take this or leave it.  It would be nice from a UX point of view, but
maybe confusing to someone if they're trying to use the API and then get a 302
redirect.  On the other hand, I find it hard to imagine somewhere where someone
is programmatically providing a package name where they meant to provide an
update id.  The window of confusion is pretty small.