### PR TITLE
Make our CORS Content-Security-Policy configurable.

### DIFF
--- a/bodhi/__init__.py
+++ b/bodhi/__init__.py
@@ -169,9 +169,6 @@ def main(global_config, testing=None, **settings):
     # Metrics
     config.add_route('metrics', '/metrics')
 
-    # Utils
-    config.add_route('markdowner', '/markdown')
-
     # Auto-completion search
     config.add_route('search_packages', '/search/packages')
     config.add_route('latest_candidates', '/latest_candidates')

--- a/bodhi/services/markdown.py
+++ b/bodhi/services/markdown.py
@@ -1,0 +1,34 @@
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+from cornice import Service
+
+import bodhi.util
+import bodhi.security
+
+
+markdown = Service(name='markdowner', path='/markdown',
+                   description='Markdown service',
+                   cors_origins=bodhi.security.cors_origins_ro)
+
+
+@markdown.get(accept=('application/json', 'text/json'), renderer='json')
+@markdown.get(accept=('application/javascript'), renderer='jsonp')
+def markdowner(request):
+    """ Given some text, return the markdownified html version.
+
+    We use this for "previews" of comments and update notes.
+    """
+    text = request.params.get('text')
+    return dict(html=bodhi.util.markup(request.context, text))

--- a/bodhi/templates/master.html
+++ b/bodhi/templates/master.html
@@ -14,7 +14,7 @@
     <meta name="author" content="Ralph Bean" />
 
     <!-- Only allow websockets connections to fedoraproject.org. -->
-    <meta http-equiv="Content-Security-Policy" content="connect-src https://*.fedoraproject.org wss://*.fedoraproject.org">
+    <meta http-equiv="Content-Security-Policy" content="connect-src ${request.registry.settings['cors_connect_src']}">
 
     <link rel="shortcut icon" href="${request.static_url('bodhi:static/ico/favicon.ico')}">
 

--- a/bodhi/views/generic.py
+++ b/bodhi/views/generic.py
@@ -175,16 +175,6 @@ def latest_builds(request):
     return builds
 
 
-@view_config(route_name='markdowner', renderer='json')
-def markdowner(request):
-    """ Given some text, return the markdownified html version.
-
-    We use this for "previews" of comments and update notes.
-    """
-    text = request.params.get('text')
-    return dict(html=bodhi.util.markup(request.context, text))
-
-
 @view_config(route_name='new_override', renderer='override.html')
 def new_override(request):
     """ Returns the new buildroot override form """

--- a/development.ini
+++ b/development.ini
@@ -372,7 +372,7 @@ cors_origins_ro = *
 # This should be more locked down to avoid cross-site request forgery.
 cors_origins_rw = localhost
 
-cors_connect_src = http://localhost:6543 https://*.fedoraproject.org/ wss://hub.fedoraproject.org:9939/
+cors_connect_src = http://0.0.0.0:6543 http://localhost:6543 https://*.fedoraproject.org/ wss://hub.fedoraproject.org:9939/
 
 ##
 ## Pyramid settings

--- a/development.ini
+++ b/development.ini
@@ -372,6 +372,8 @@ cors_origins_ro = *
 # This should be more locked down to avoid cross-site request forgery.
 cors_origins_rw = localhost
 
+cors_connect_src = http://localhost:6543 https://*.fedoraproject.org/ wss://hub.fedoraproject.org:9939/
+
 ##
 ## Pyramid settings
 ##

--- a/production.ini
+++ b/production.ini
@@ -352,6 +352,8 @@ cors_origins_ro = *
 # This should be more locked down to avoid cross-site request forgery.
 cors_origins_rw = bodhi.fedoraproject.org
 
+cors_connect_src = https://*.fedoraproject.org/ wss://hub.fedoraproject.org:9939/
+
 ##
 ## Pyramid settings
 ##

--- a/staging.ini
+++ b/staging.ini
@@ -353,6 +353,8 @@ cors_origins_ro = *
 # This should be more locked down to avoid cross-site request forgery.
 cors_origins_rw = bodhi.stg.fedoraproject.org
 
+cors_connect_src = https://*.fedoraproject.org/ wss://hub.fedoraproject.org:9939/
+
 ##
 ## Pyramid settings
 ##


### PR DESCRIPTION
Also, move our markdown endpoint to a cornice service so that it gets all the
nice CORS stuff from yesterday.