### PR TITLE
Don't deal with ABORTED taskotron checks.

### DIFF
--- a/bodhi/templates/update.html
+++ b/bodhi/templates/update.html
@@ -79,6 +79,11 @@
       // the latest ones for each arch.  So, prune like this:
       var changed = false;
       $.each(data.data, function(i, result) {
+
+        // However, we want to skip over any ABORTED results:
+        // https://github.com/fedora-infra/bodhi/issues/167
+        if (result.outcome == 'ABORTED') return;
+
         var name = result.testcase.name;
         var arch = result.result_data.arch;
         var submit_time = new Date(result.submit_time);

--- a/bodhi/util.py
+++ b/bodhi/util.py
@@ -547,6 +547,10 @@ def taskotron_results(settings, entity='results', **kwargs):
             json = response.json()
             url, data = json['next'], json['data']
             for datum in data:
+                # Skip ABORTED results
+                # https://github.com/fedora-infra/bodhi/issues/167
+                if entity == 'results' and datum.get('outcome') == 'ABORTED':
+                    continue
                 yield datum
     except Exception:
         log.exception("Problem talking to %r" % url)


### PR DESCRIPTION
As discussed in #167.

- Don't show ABORTED taskotron results in the update UI.
- Hide ABORTED taskotron results from server-side checks.