### PR TITLE
Get captcha working in staging again.

### DIFF
--- a/bodhi/renderers.py
+++ b/bodhi/renderers.py
@@ -1,3 +1,4 @@
+import io
 import operator
 
 from pyramid.exceptions import HTTPNotFound
@@ -79,5 +80,7 @@ def jpeg(info):
             if ct == response.default_content_type:
                 response.content_type = 'image/jpeg'
 
-        return data.tostring('jpeg', 'RGB')
+        b = io.BytesIO()
+        data.save(b, 'jpeg')
+        return b.getvalue()
     return render


### PR DESCRIPTION
Apparently, ``tostring(...)`` is deprecated and this is the way you're
supposed to do this.  It worked in our virtualenvs, but was failing in
staging with the version of PIL in place there.

I was getting this traceback in staging:

```python
mod_wsgi (pid=21696): Exception occurred processing WSGI script '/usr/share/bodhi/bodhi.wsgi'.
Traceback (most recent call last):
  File "/usr/lib/python2.7/site-packages/paste/deploy/config.py", line 291, in __call__
    return self.app(environ, start_response)
  File "/usr/lib/python2.7/site-packages/pyramid/router.py", line 242, in __call__
    response = self.invoke_subrequest(request, use_tweens=True)
  File "/usr/lib/python2.7/site-packages/pyramid/router.py", line 217, in invoke_subrequest
    response = handle_request(request)
  File "/usr/lib/python2.7/site-packages/pyramid/tweens.py", line 46, in excview_tween
    response = view_callable(exc, request)
  File "/usr/lib/python2.7/site-packages/pyramid/config/views.py", line 385, in viewresult_to_response
    result = view(context, request)
  File "/usr/lib/python2.7/site-packages/pyramid/tweens.py", line 21, in excview_tween
    response = handler(request)
  File "/usr/lib/python2.7/site-packages/pyramid_tm/__init__.py", line 82, in tm_tween
    reraise(*exc_info)
  File "/usr/lib/python2.7/site-packages/pyramid_tm/__init__.py", line 63, in tm_tween
    response = handler(request)
  File "/usr/lib/python2.7/site-packages/pyramid/router.py", line 163, in handle_request
    response = view_callable(context, request)
  File "/usr/lib/python2.7/site-packages/pyramid/config/views.py", line 377, in rendered_view
    context)
  File "/usr/lib/python2.7/site-packages/pyramid/renderers.py", line 427, in render_view
    return self.render_to_response(response, system, request=request)
  File "/usr/lib/python2.7/site-packages/pyramid/renderers.py", line 450, in render_to_response
    result = self.render(value, system_values, request=request)
  File "/usr/lib/python2.7/site-packages/pyramid/renderers.py", line 446, in render
    result = renderer(value, system_values)
  File "/usr/lib/python2.7/site-packages/bodhi/renderers.py", line 74, in render
    return data.tostring('jpeg', 'RGB')
  File "/usr/lib64/python2.7/site-packages/PIL/Image.py", line 560, in tostring
    return self.tobytes(*args, **kw)
  File "/usr/lib64/python2.7/site-packages/PIL/Image.py", line 540, in tobytes
    bufsize = max(65536, self.size[0] * 4) # see RawEncode.c
ValueError: Not a valid numbers of quantization tables. Should be between 2 and 4.
```