### PR TITLE
Disable stacks for the initial release.

### DIFF
--- a/bodhi/templates/master.html
+++ b/bodhi/templates/master.html
@@ -91,6 +91,8 @@
                   Override
                 </a>
               </li>
+
+              % if request.registry.settings.get('stacks_enabled') == 'True':
               % if request.matched_route.name == 'stacks':
               <li class="active">
               % else:
@@ -102,6 +104,8 @@
                 </a>
               </li>
               % endif
+              % endif
+
               % if request.matched_route.name == 'metrics':
               <li class="active">
               % else:

--- a/development.ini
+++ b/development.ini
@@ -177,6 +177,14 @@ top_testers_timeframe = 900
 # The email address of the proventesters
 proventesters_email = proventesters-members@fedoraproject.org
 
+
+# This defaults to False.  We're disabling stacks for the initial release
+# because, while you can create stacks, you can't automatically create updates
+# *from* a stack (which was the whole point).  We'll work on that for a later
+# release.
+stacks_enabled = False
+
+
 # These are the default requirements that we apply to stacks, packages, and
 # updates.  Users have free-reign to override them for each kind of entity.  At
 # the end of the day, we only consider the requirements defined by single

--- a/production.ini
+++ b/production.ini
@@ -165,6 +165,13 @@ top_testers_timeframe = 900
 # The email address of the proventesters
 proventesters_email = proventesters-members@fedoraproject.org
 
+# This defaults to False.  We're disabling stacks for the initial release
+# because, while you can create stacks, you can't automatically create updates
+# *from* a stack (which was the whole point).  We'll work on that for a later
+# release.
+stacks_enabled = False
+
+
 # These are the default requirements that we apply to stacks, packages, and
 # updates.  Users have free-reign to override them for each kind of entity.  At
 # the end of the day, we only consider the requirements defined by single

--- a/staging.ini
+++ b/staging.ini
@@ -165,6 +165,13 @@ top_testers_timeframe = 900
 # The email address of the proventesters
 proventesters_email = proventesters-members@fedoraproject.org
 
+# This defaults to False.  We're disabling stacks for the initial release
+# because, while you can create stacks, you can't automatically create updates
+# *from* a stack (which was the whole point).  We'll work on that for a later
+# release.
+stacks_enabled = False
+
+
 # These are the default requirements that we apply to stacks, packages, and
 # updates.  Users have free-reign to override them for each kind of entity.  At
 # the end of the day, we only consider the requirements defined by single


### PR DESCRIPTION
We're disabling stacks for the initial release because, while you can create
stacks, you can't automatically create updates *from* a stack (which was the
whole point).  We'll work on that for a later release.