### PR TITLE
Change default cert_prefix for push tool.

### DIFF
--- a/bodhi/push.py
+++ b/bodhi/push.py
@@ -33,7 +33,7 @@ import bodhi.notifications
 @click.option('--builds', help='Push updates for specific builds')
 @click.option('--username', envvar='USERNAME')
 @click.option('--password', prompt=True, hide_input=True)
-@click.option('--cert-prefix', default="releng",
+@click.option('--cert-prefix', default="shell",
               help="The prefix of a fedmsg cert used to sign the message.")
 @click.option('--staging', help='Use the staging bodhi instance',
               is_flag=True, default=False)


### PR DESCRIPTION
The cert we're going to be using is just called "shell", so we might as well
make that the default to save on typing for releng.