### PR TITLE
Add the 'submitter' field back to Update JSON.

### DIFF
--- a/bodhi/models/models.py
+++ b/bodhi/models/models.py
@@ -1691,6 +1691,9 @@ class Update(Base):
         result = super(Update, self).__json__(*args, **kwargs)
         # Duplicate alias as updateid for backwards compat with bodhi1
         result['updateid'] = result['alias']
+        # Also, put the update submitter's name in the same place we put
+        # it for bodhi1 to make fedmsg.meta compat much more simple.
+        result['submitter'] = result['user']['name']
         return result
 
 

--- a/bodhi/tests/functional/test_updates.py
+++ b/bodhi/tests/functional/test_updates.py
@@ -369,6 +369,7 @@ class TestUpdatesService(bodhi.tests.functional.base.BaseWSGICase):
         self.assertEquals(up['status'], u'pending')
         self.assertEquals(up['request'], u'testing')
         self.assertEquals(up['user']['name'], u'guest')
+        self.assertEquals(up['submitter'], u'guest')
         self.assertEquals(up['release']['name'], u'F17')
         self.assertEquals(up['type'], u'bugfix')
         self.assertEquals(up['severity'], u'unspecified')


### PR DESCRIPTION
This will make fedmsg.meta compatibility between bodhi1 and bodhi2 updates
*much* more simple.