### PR TITLE
Micronap.

### DIFF
--- a/bodhi/masher.py
+++ b/bodhi/masher.py
@@ -452,7 +452,7 @@ class MasherThread(threading.Thread):
                           build, from_tag, to_tag))
             self.koji.moveBuild(from_tag, to_tag, build, force=True)
         results = self.koji.multiCall()
-        failed_tasks = buildsys.wait_for_tasks([task[0] for task in results], self.koji)
+        failed_tasks = buildsys.wait_for_tasks([task[0] for task in results], self.koji, sleep=15)
         if failed_tasks:
             raise Exception("Failed to move builds: %s" % failed_tasks)
 


### PR DESCRIPTION
When we query koji from the masher to figure out if our tag moves are done, no
need to wait 300s (5 minutes!) just wait 15s inbetween polls.