### PR TITLE
Stop validating rpm versions.

### DIFF
--- a/bodhi/services/builds.py
+++ b/bodhi/services/builds.py
@@ -25,7 +25,6 @@ import bodhi.schemas
 import bodhi.security
 from bodhi.validators import (
     validate_nvrs,
-    validate_version,
     validate_uniqueness,
     validate_acls,
     validate_builds,

--- a/bodhi/services/updates.py
+++ b/bodhi/services/updates.py
@@ -26,7 +26,6 @@ import bodhi.schemas
 import bodhi.security
 from bodhi.validators import (
     validate_nvrs,
-    validate_version,
     validate_uniqueness,
     validate_build_tags,
     validate_acls,
@@ -266,7 +265,7 @@ def query_updates(request):
 @updates.post(schema=bodhi.schemas.SaveUpdateSchema,
               permission='create', renderer='json',
               validators=(
-                  validate_nvrs, validate_version, validate_builds,
+                  validate_nvrs, validate_builds,
                   validate_uniqueness, validate_build_tags, validate_acls,
                   validate_enums, validate_requirements))
 def new_update(request):

--- a/bodhi/tests/functional/test_updates.py
+++ b/bodhi/tests/functional/test_updates.py
@@ -115,12 +115,6 @@ class TestUpdatesService(bodhi.tests.functional.base.BaseWSGICase):
     #    assert 'Invalid tag' in res, res
 
     @mock.patch(**mock_valid_requirements)
-    def test_old_build(self, *args):
-        res = self.app.post_json('/updates/', self.get_update(u'bodhi-1.9-1.fc17'),
-                                 status=400)
-        assert 'Invalid build: bodhi-1.9-1.fc17 is older than bodhi-2.0-1.fc17' in res, res
-
-    @mock.patch(**mock_valid_requirements)
     def test_duplicate_build(self, *args):
         res = self.app.post_json('/updates/',
             self.get_update([u'bodhi-2.0-2.fc17', u'bodhi-2.0-2.fc17']),

--- a/bodhi/validators.py
+++ b/bodhi/validators.py
@@ -224,23 +224,6 @@ def validate_acls(request):
                                    "access to {}".format(user.name, package.name))
 
 
-def validate_version(request):
-    """ Ensure no builds are older than any that we know of """
-    db = request.db
-    for build in request.validated.get('builds', []):
-        nvr = request.buildinfo[build]['nvr']
-        pkg = db.query(Package).filter_by(name=nvr[0]).first()
-        if pkg:
-            last = db.query(Build).filter_by(package=pkg) \
-                     .order_by(Build.id.desc()).limit(1).first()
-            if last:
-                if rpm.labelCompare(nvr, get_nvr(last.nvr)) < 0:
-                    request.errors.add('body', 'builds', 'Invalid build: '
-                                       '{} is older than ' '{}'.format(
-                                           '-'.join(nvr), last.nvr))
-                    return
-
-
 def validate_uniqueness(request):
     """ Check for multiple builds from the same package """
     builds = request.validated.get('builds', [])


### PR DESCRIPTION
This check is currently broken, in that it won't let you submit a build of
foo-1.2.3 for F22 if you already submitted foo-1.2.3 for F23(!)  That's
crucial functionality we need in place.

This kind of validator is something that got ported over from bodhi1 which
had years of policy baked on to it.  Now that taskotron is doing depcheck
runs and bodhi2 is using the results of those runs to gate in the mash
process... we don't even need this validator anymore, do we?