### PR TITLE
Catch other bodhi exceptions when commenting.

### DIFF
--- a/bodhi/models/models.py
+++ b/bodhi/models/models.py
@@ -1355,6 +1355,11 @@ class Update(Base):
                     self.check_karma_thresholds(author)
                 except LockedUpdateException:
                     pass
+                except BodhiException as e:
+                    # This gets thrown if the karma is pushed over the
+                    # threshold, but it is a critpath update that is not
+                    # critpath_approved. ... among other cases.
+                    log.exception('Problem checking the karma threshold.')
 
         session = DBSession()
         comment = Comment(


### PR DESCRIPTION
I think some people are hitting this when they comment
on an update that kicks it over the karma threshold, but
that threshold checking raises an exception.  It blocks the
comment from going through all together because the exception
bubbles all the way up to cornice.

This should make it so that the comment can still go through
if karma threshhold checking fails, but it will still log the
exception so we can dig more into them later.