### PR TITLE
validate_build_tags must come before validate_acls.

### DIFF
--- a/bodhi/services/builds.py
+++ b/bodhi/services/builds.py
@@ -26,7 +26,6 @@ import bodhi.security
 from bodhi.validators import (
     validate_nvrs,
     validate_uniqueness,
-    validate_acls,
     validate_builds,
     validate_enums,
     validate_updates,

--- a/bodhi/services/updates.py
+++ b/bodhi/services/updates.py
@@ -90,8 +90,11 @@ def get_update_for_editing(request):
 
 
 @update_request.post(schema=bodhi.schemas.UpdateRequestSchema,
-                     validators=(validate_enums, validate_update_id,
-                                 validate_acls),
+                     validators=(
+                         validate_enums,
+                         validate_update_id,
+                         validate_acls,
+                     ),
                      permission='edit', renderer='json')
 def set_request(request):
     """Sets a specific :class:`bodhi.models.UpdateRequest` on a given update"""
@@ -265,9 +268,14 @@ def query_updates(request):
 @updates.post(schema=bodhi.schemas.SaveUpdateSchema,
               permission='create', renderer='json',
               validators=(
-                  validate_nvrs, validate_builds,
-                  validate_uniqueness, validate_build_tags, validate_acls,
-                  validate_enums, validate_requirements))
+                  validate_nvrs,
+                  validate_builds,
+                  validate_uniqueness,
+                  validate_build_tags,
+                  validate_acls,
+                  validate_enums,
+                  validate_requirements,
+              ))
 def new_update(request):
     """ Save an update.
 

--- a/bodhi/services/updates.py
+++ b/bodhi/services/updates.py
@@ -93,6 +93,7 @@ def get_update_for_editing(request):
                      validators=(
                          validate_enums,
                          validate_update_id,
+                         validate_build_tags,
                          validate_acls,
                      ),
                      permission='edit', renderer='json')


### PR DESCRIPTION
Otherwise, you get the traceback you got in #239.  (This fixes #239.)

validate_build_tags is the one that builds ``request.buildinfo['tags']``.