### PR TITLE
Suppress SAWarnings by using labels.

### DIFF
--- a/bodhi/services/builds.py
+++ b/bodhi/services/builds.py
@@ -88,7 +88,7 @@ def query_builds(request):
 
     # We can't use ``query.count()`` here because it is naive with respect to
     # all the joins that we're doing above.
-    count_query = query.statement\
+    count_query = query.with_labels().statement\
         .with_only_columns([func.count(distinct(Build.nvr))])\
         .order_by(None)
     total = db.execute(count_query).scalar()

--- a/bodhi/services/comments.py
+++ b/bodhi/services/comments.py
@@ -134,7 +134,7 @@ def query_comments(request):
 
     # We can't use ``query.count()`` here because it is naive with respect to
     # all the joins that we're doing above.
-    count_query = query.statement\
+    count_query = query.with_labels().statement\
         .with_only_columns([func.count(distinct(Comment.id))])\
         .order_by(None)
     total = db.execute(count_query).scalar()

--- a/bodhi/services/overrides.py
+++ b/bodhi/services/overrides.py
@@ -112,7 +112,7 @@ def query_overrides(request):
 
     # We can't use ``query.count()`` here because it is naive with respect to
     # all the joins that we're doing above.
-    count_query = query.statement\
+    count_query = query.with_labels().statement\
         .with_only_columns([func.count(distinct(BuildrootOverride.id))])\
         .order_by(None)
     total = db.execute(count_query).scalar()

--- a/bodhi/services/releases.py
+++ b/bodhi/services/releases.py
@@ -132,7 +132,7 @@ def query_releases_json(request):
 
     # We can't use ``query.count()`` here because it is naive with respect to
     # all the joins that we're doing above.
-    count_query = query.statement\
+    count_query = query.with_labels().statement\
         .with_only_columns([func.count(distinct(Release.id))])\
         .order_by(None)
     total = db.execute(count_query).scalar()

--- a/bodhi/services/stacks.py
+++ b/bodhi/services/stacks.py
@@ -78,7 +78,7 @@ def query_stacks(request):
 
     # We can't use ``query.count()`` here because it is naive with respect to
     # all the joins that we're doing above.
-    count_query = query.statement\
+    count_query = query.with_labels().statement\
         .with_only_columns([func.count(distinct(Stack.id))])\
         .order_by(None)
     total = request.db.execute(count_query).scalar()

--- a/bodhi/services/updates.py
+++ b/bodhi/services/updates.py
@@ -245,7 +245,7 @@ def query_updates(request):
 
     # We can't use ``query.count()`` here because it is naive with respect to
     # all the joins that we're doing above.
-    count_query = query.statement\
+    count_query = query.with_labels().statement\
         .with_only_columns([func.count(distinct(Update.id))])\
         .order_by(None)
     total = db.execute(count_query).scalar()

--- a/bodhi/services/user.py
+++ b/bodhi/services/user.py
@@ -118,7 +118,7 @@ def query_users(request):
 
     # We can't use ``query.count()`` here because it is naive with respect to
     # all the joins that we're doing above.
-    count_query = query.statement\
+    count_query = query.with_labels().statement\
         .with_only_columns([func.count(distinct(User.id))])\
         .order_by(None)
     total = request.db.execute(count_query).scalar()


### PR DESCRIPTION
This is used to used to disambiguate columns from multiple tables.

Fixes #179.