### PR TITLE
Display the update in the comment fragment.

### DIFF
--- a/bodhi/models/models.py
+++ b/bodhi/models/models.py
@@ -25,6 +25,13 @@ from textwrap import wrap
 from datetime import datetime
 from collections import defaultdict
 
+try:
+    # python3
+    from urllib.parse import quote
+except ImportError:
+    from urllib import quote
+
+
 from sqlalchemy import Unicode, UnicodeText, Integer, Boolean
 from sqlalchemy import DateTime
 from sqlalchemy import Table, Column, ForeignKey
@@ -1178,13 +1185,19 @@ class Update(Base):
 
     def get_url(self):
         """ Return the relative URL to this update """
-        path = []
+        path = ['updates']
         if self.alias:
-            path.append(self.release.name)
             path.append(self.alias)
         else:
-            path.append(self.get_title())
+            path.append(quote(self.title))
         return os.path.join(*path)
+
+    def abs_url(self):
+        """ Return the absolute URL to this update """
+        base = config['base_address']
+        return os.path.join(base, self.get_url())
+
+    url = abs_url
 
     def __str__(self):
         """

--- a/bodhi/templates/fragments.html
+++ b/bodhi/templates/fragments.html
@@ -1,6 +1,6 @@
 <%namespace name="util" module="bodhi.util"/>
 
-<%def name="comment(comment)">
+<%def name="comment(comment, display_update=True)">
 <div class="row">
   <div class="col-md-12">
     <div class="panel panel-${util.karma2class(comment.karma)}">
@@ -12,11 +12,22 @@
             ${comment.user.name}
           </a>
           % endif
+          % if display_update:
+          <small>on
+            <a href="${comment.update.get_url()}">
+              ${comment.update.get_title(', ', 1, ", &hellip;") | n}
+            </a>
+          </small>
+          % endif
         </span>
 
         <span class="pull-right">
           <a href="${comment.url()}">
+            %if not display_update:
             ${util.age(comment.timestamp)}, <small>${comment.timestamp}</small>
+            % else:
+            ${util.age(comment.timestamp)}
+            % endif
           </a>
         </span>
       </div>

--- a/bodhi/templates/update.html
+++ b/bodhi/templates/update.html
@@ -552,7 +552,7 @@ $(document).ready(function(){
     <ul id="comments" class="linkable">
       % for comment in update.comments:
       <li id="comment-${comment.id}">
-        ${self.fragments.comment(comment)}
+        ${self.fragments.comment(comment, display_update=False)}
       </li>
       % endfor
     </ul>

--- a/bodhi/tests/models/test_models.py
+++ b/bodhi/tests/models/test_models.py
@@ -452,9 +452,10 @@ class TestUpdate(ModelTest):
         eq_(kwargs['msg']['comment']['author'], 'anonymous')
 
     def test_get_url(self):
-        eq_(self.obj.get_url(), u'TurboGears-1.0.8-3.fc11')
+        eq_(self.obj.get_url(), u'updates/TurboGears-1.0.8-3.fc11')
         self.obj.assign_alias()
-        eq_(self.obj.get_url(), u'F11/FEDORA-%s-0001' % time.localtime()[0])
+        expected = u'updates/FEDORA-%s-0001' % time.localtime()[0]
+        eq_(self.obj.get_url(), expected)
 
     def test_bug(self):
         bug = self.obj.bugs[0]

--- a/bodhi/tests/test_masher.py
+++ b/bodhi/tests/test_masher.py
@@ -686,7 +686,7 @@ References:
     @mock.patch('bodhi.bugs.bugtracker.on_qa')
     def test_modify_testing_bugs(self, on_qa, modified, *args):
         self.masher.consume(self.msg)
-        on_qa.assert_called_once_with(12345, u"bodhi-2.0-1.fc17 has been pushed to the Fedora 17 testing repository. If problems still persist, please make note of it in this bug report.\\nIf you want to test the update, you can install it with \\n su -c 'yum --enablerepo=updates-testing update bodhi'. You can provide feedback for this update here: http://0.0.0.0:6543/F17/FEDORA-%s-0001" % time.localtime().tm_year)
+        on_qa.assert_called_once_with(12345, u"bodhi-2.0-1.fc17 has been pushed to the Fedora 17 testing repository. If problems still persist, please make note of it in this bug report.\\nIf you want to test the update, you can install it with \\n su -c 'yum --enablerepo=updates-testing update bodhi'. You can provide feedback for this update here: http://0.0.0.0:6543/updates/FEDORA-%s-0001" % time.localtime().tm_year)
 
     @mock.patch(**mock_taskotron_results)
     @mock.patch('bodhi.masher.MasherThread.update_comps')


### PR DESCRIPTION
But only on the user profile page and the comment list page.

It doesn't make sense to show the name of the update if you're looking
**at** the page for **that** update already... so suppress it there.

Fixes #215.