### PR TITLE
Support multi-release updates.

### DIFF
--- a/bodhi/static/js/update_form.js
+++ b/bodhi/static/js/update_form.js
@@ -4,10 +4,24 @@ $(document).ready(function() {
     UpdatesForm = function() {};
     UpdatesForm.prototype = new Form("#new-update-form", document.baseURI + "updates/");
     UpdatesForm.prototype.success = function(data) {
+        // display caveat popups first
         Form.prototype.success.call(this, data);
-
-        // Now redirect to the update display
-        document.location.href = document.baseURI + "updates/" + data.title;
+        // And then issue a redirect 1 second later.
+        setTimeout(function() {
+            // There are two kinds of success to distinguish:
+            // 1) we submitted a single update
+            // 2) we submitted a multi-release update that created multiple new
+            var base = document.baseURI;
+            if (data.updates != undefined) {
+                // Single-release update
+                // Now redirect to the update display
+                document.location.href = base + "updates/" + data.title;
+            } else {
+                // Multi-release update
+                // Redirect to updates created by *me*
+                document.location.href = base + "users/" + data.user.name;
+            }
+        }, 1000);
     }
 
     var messenger = Messenger({theme: 'flat'});

--- a/bodhi/validators.py
+++ b/bodhi/validators.py
@@ -321,26 +321,30 @@ def validate_acls(request):
 
 
 def validate_uniqueness(request):
-    """ Check for multiple builds from the same package """
+    """ Check for multiple builds from the same package and same release """
     builds = request.validated.get('builds', [])
     if not builds:  # validate_nvr failed
         return
-    for build in builds:
-        nvr = request.buildinfo[build]['nvr']
+    for build1 in builds:
+        nvr1 = request.buildinfo[build1]['nvr']
         seen_build = 0
-        for other_build in builds:
-            other_build_nvr = request.buildinfo[other_build]['nvr']
-            if build == other_build:
+        for build2 in builds:
+            nvr2 = request.buildinfo[build2]['nvr']
+            if build1 == build2:
                 seen_build += 1
                 if seen_build > 1:
                     request.errors.add('body', 'builds', 'Duplicate builds: '
-                                       '{}'.format(build))
+                                       '{}'.format(build1))
                     return
                 continue
-            if nvr[0] == other_build_nvr[0]:
+
+            release1 = nvr1[-1].split('.')[-1]
+            release2 = nvr2[-1].split('.')[-1]
+
+            if nvr1[0] == nvr2[0] and release1 == release2:
                 request.errors.add('body', 'builds', "Multiple {} builds "
-                                   "specified: {} & {}".format(nvr[0], build,
-                                   other_build))
+                                   "specified: {} & {}".format(nvr1[0], build1,
+                                   build2))
                 return
 
 


### PR DESCRIPTION
*Really*, when submitting an update with builds that are in multiple
releases, detect that in the cornice service, split the builds up, and
create multiple updates, one for each release.

This involved moving some logic out of ``Update.new`` and into the cornice
service, so that the cornice service could detect the scenario and call
``Update.new`` multiple times as necessary.

I also took the opportunity to expand the new "caveats" API that
karma/comments has to return some additional information from the updates
service.  Those caveats get rendered as pop-ups after a successful update
submission before you get redirected to a new page.

When submitting a single update, you get redirected to the view page for
that update afterwards.

When submitting multiple updates, you get redirected to the list of updates
submitted by you (so you can see them all).

* Fixes #285
* Fixes #219