### PR TITLE
Surface set_request errors to the user.

### DIFF
--- a/bodhi/services/updates.py
+++ b/bodhi/services/updates.py
@@ -121,6 +121,9 @@ def set_request(request):
         update.set_request(action, request.user.name)
     except BodhiException as e:
         request.errors.add('body', 'request', e.message)
+    except Exception as e:
+        log.exception("Unhandled exception in set_request")
+        request.errors.add('body', 'request', str(e))
 
     return dict(update=update)
 


### PR DESCRIPTION
This is the last pull-request of many that will fix #258.  The others involved
standardizing the error reporting popups and suppressing some errant redirects.