### PR TITLE
Bugfix when redirecting after multi-release update creation.

### DIFF
--- a/bodhi/static/js/update_form.js
+++ b/bodhi/static/js/update_form.js
@@ -19,7 +19,7 @@ $(document).ready(function() {
             } else {
                 // Multi-release update
                 // Redirect to updates created by *me*
-                document.location.href = base + "users/" + data.user.name;
+                document.location.href = base + "users/" + data.updates[0].user.name;
             }
         }, 1000);
     }


### PR DESCRIPTION
This fixes a bug introduced in #304.

When you do multi-release updates, the JSON response that comes back contains
all the created updates in a list.

* Fixes #352.
* Fixes #329.