### PR TITLE
Change the mouse cursor when doing an action

### DIFF
--- a/bodhi/static/js/cabbage.js
+++ b/bodhi/static/js/cabbage.js
@@ -8,6 +8,7 @@ Cabbage.prototype.frequency = 50;
 Cabbage.prototype.finish_time = 400;  // Finish up in 1 second
 
 Cabbage.prototype.spin = function() {
+    document.body.style.cursor = 'wait';
     var self = this;
     self.degrees = self.degrees % 360
     self.stop();
@@ -18,11 +19,13 @@ Cabbage.prototype.spin = function() {
 }
 
 Cabbage.prototype.stop = function() {
+    document.body.style.cursor = 'default';
     var self = this;
     if (self.interval_id != null) { clearInterval(self.interval_id); }
 }
 
 Cabbage.prototype.finish = function() {
+    document.body.style.cursor = 'default';
     var self = this;
 
     // Stop the initial rotation.

--- a/bodhi/static/js/cabbage.js
+++ b/bodhi/static/js/cabbage.js
@@ -8,7 +8,6 @@ Cabbage.prototype.frequency = 50;
 Cabbage.prototype.finish_time = 400;  // Finish up in 1 second
 
 Cabbage.prototype.spin = function() {
-    document.body.style.cursor = 'wait';
     var self = this;
     self.degrees = self.degrees % 360
     self.stop();
@@ -16,16 +15,16 @@ Cabbage.prototype.spin = function() {
         self.degrees = self.degrees + 2;
         $("#ghost-cabbage").css({transform: "rotate(" + self.degrees + "deg)"});
     }, self.frequency);
+
+    $("html,body").css('cursor', 'wait');
 }
 
 Cabbage.prototype.stop = function() {
-    document.body.style.cursor = 'default';
     var self = this;
     if (self.interval_id != null) { clearInterval(self.interval_id); }
 }
 
 Cabbage.prototype.finish = function() {
-    document.body.style.cursor = 'default';
     var self = this;
 
     // Stop the initial rotation.
@@ -50,4 +49,6 @@ Cabbage.prototype.finish = function() {
             $("#ghost-cabbage").css({transform: "rotate(" + self.degrees + "deg)"});
         }
     }, self.frequency);
+
+    $("html,body").css('cursor', 'default');
 }

--- a/bodhi/static/js/forms.js
+++ b/bodhi/static/js/forms.js
@@ -17,13 +17,13 @@ Form.prototype.url = null;
 Form.prototype.start = function() {
     // TODO -- clear all error divs before attempt this,
     // both knock their content, and hide them
-    cabbage.spin();
     $(this.idx + " button").attr("disabled", "disable");
+    cabbage.spin();
 }
 
 Form.prototype.finish = function() {
-    cabbage.finish();
     $(this.idx + " button").attr("disabled", null);
+    cabbage.finish();
 }
 
 Form.prototype.success = function(data) {


### PR DESCRIPTION
Currently after pressing the button to make an update go to testing/stable
the bodhi logo (the cabbage) starts spinning.
This is really nice but easy to miss.
With this change the mouse cursor will also change, making it clearer that
something is going on.

Fixes https://github.com/fedora-infra/bodhi/issues/355