### PR TITLE
Change yum references to dnf

### DIFF
--- a/development.ini
+++ b/development.ini
@@ -268,7 +268,7 @@ pkgdb_url = https://admin.fedoraproject.org/pkgdb
 
 initial_bug_msg = %s has been submitted as an update to %s. %s
 stable_bug_msg = %s has been pushed to the %s repository. If problems still persist, please make note of it in this bug report.
-testing_bug_msg = \nIf you want to test the update, you can install it with \n su -c 'yum --enablerepo=updates-testing update %s'. You can provide feedback for this update here: %s
+testing_bug_msg = \nIf you want to test the update, you can install it with \n su -c 'dnf --enablerepo=updates-testing update %s'. You can provide feedback for this update here: %s
 
 ##
 ## Bugzilla settings.

--- a/production.ini
+++ b/production.ini
@@ -246,7 +246,7 @@ pkgdb_url = https://admin.fedoraproject.org/pkgdb
 
 initial_bug_msg = %s has been submitted as an update to %s. %s
 stable_bug_msg = %s has been pushed to the %s repository. If problems still persist, please make note of it in this bug report.
-testing_bug_msg = \nIf you want to test the update, you can install it with \n su -c 'yum --enablerepo=updates-testing update %s'. You can provide feedback for this update here: %s
+testing_bug_msg = \nIf you want to test the update, you can install it with \n su -c 'dnf --enablerepo=updates-testing update %s'. You can provide feedback for this update here: %s
 
 ##
 ## Bugzilla settings.

--- a/staging.ini
+++ b/staging.ini
@@ -246,7 +246,7 @@ pkgdb_url = https://admin.stg.fedoraproject.org/pkgdb
 
 initial_bug_msg = %s has been submitted as an update to %s. %s
 stable_bug_msg = %s has been pushed to the %s repository. If problems still persist, please make note of it in this bug report.
-testing_bug_msg = \nIf you want to test the update, you can install it with \n su -c 'yum --enablerepo=updates-testing update %s'. You can provide feedback for this update here: %s
+testing_bug_msg = \nIf you want to test the update, you can install it with \n su -c 'dnf --enablerepo=updates-testing update %s'. You can provide feedback for this update here: %s
 
 ##
 ## Bugzilla settings.


### PR DESCRIPTION
Yum is deprecated in Fedora and is replaced by dnf.  We should probably just
reference dnf directly in the bugzilla comments.