### PR TITLE
Assign autokarma credit to 'bodhi' not the comment author.

### DIFF
--- a/bodhi/masher.py
+++ b/bodhi/masher.py
@@ -355,7 +355,7 @@ class MasherThread(threading.Thread):
             success = True
             self.remove_state()
             self.unlock_updates()
-            self.check_karma_thresholds()
+            self.check_all_karma_thresholds()
         except:
             self.log.exception('Exception in MasherThread(%s)' % self.id)
             self.save_state()
@@ -381,7 +381,7 @@ class MasherThread(threading.Thread):
             update.locked = False
         self.db.flush()
 
-    def check_karma_thresholds(self):
+    def check_all_karma_thresholds(self):
         """
         If we just pushed testing updates see if any of them now meet either of
         the karma thresholds

--- a/bodhi/masher.py
+++ b/bodhi/masher.py
@@ -391,7 +391,7 @@ class MasherThread(threading.Thread):
                      'thresholds during the push')
             for update in self.updates:
                 try:
-                    update.check_karma_thresholds(username=u'bodhi')
+                    update.check_karma_thresholds(agent=u'bodhi')
                 except BodhiException:
                     self.log.exception('Problem checking karma thresholds')
 

--- a/bodhi/models/models.py
+++ b/bodhi/models/models.py
@@ -1377,7 +1377,7 @@ class Update(Base):
 
             if check_karma and author not in config.get('system_users').split():
                 try:
-                    self.check_karma_thresholds(author)
+                    self.check_karma_thresholds('bodhi')
                 except LockedUpdateException:
                     pass
                 except BodhiException as e:
@@ -1555,13 +1555,13 @@ class Update(Base):
 
         return True, "All checks pass."
 
-    def check_karma_thresholds(self, username):
+    def check_karma_thresholds(self, agent):
         """Check if we have reached either karma threshold, and call set_request if necessary"""
         if not self.locked:
             if self.status is UpdateStatus.testing:
                 if self.stable_karma not in (0, None) and self.karma >= self.stable_karma:
                     log.info("Automatically marking %s as stable" % self.title)
-                    self.set_request(UpdateRequest.stable, username)
+                    self.set_request(UpdateRequest.stable, agent)
                     self.request = UpdateRequest.stable
                     self.date_pushed = None
                     notifications.publish(


### PR DESCRIPTION
* Fixes #369.
* Fixes #320.

Also, ``MasherThread.check_karma_thresholds`` can be confusing when compared
with ``Update.check_karma_thresholds``, so I renamed it just to differentiate
them for human readers.