### PR TITLE
Remove calendar icon.

### DIFF
--- a/bodhi/templates/override.html
+++ b/bodhi/templates/override.html
@@ -66,7 +66,6 @@
             <span class="pull-left">Expiration date</span>
           </div>
           <div class="form-group noui input-group">
-            <span class="input-group-addon glyphicon glyphicon-calendar"></span>
             <input class="form-control noui" id="expiration_date"
                 name="expiration_date" type="text"
                 %if override is not UNDEFINED:


### PR DESCRIPTION
Super simple.  #374 complains correctly that the calendar icon doesn't do
anything.  The datepicker lib we're using doesn't easily extend to allow being
triggered by a button, so let's just remove the icon so we can move on to
hacking on other bugs/features.

Fixes #374.