### PR TITLE
Add a "Releases" dropdown to the toplevel navbar.

### DIFF
--- a/bodhi/__init__.py
+++ b/bodhi/__init__.py
@@ -12,14 +12,11 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
-import pkg_resources
-
 from collections import defaultdict
 from dogpile.cache import make_region
 from sqlalchemy import engine_from_config
 
 from pyramid.settings import asbool
-from pyramid.decorator import reify
 from pyramid.security import unauthenticated_userid
 from pyramid.config import Configurator
 from pyramid.authentication import AuthTktAuthenticationPolicy

--- a/bodhi/__init__.py
+++ b/bodhi/__init__.py
@@ -75,6 +75,10 @@ def get_buildinfo(request):
     return defaultdict(dict)
 
 
+def get_releases(request):
+    import bodhi.services.releases
+    return bodhi.services.releases.query_releases_html(request)['releases']
+
 #
 # Cornice filters
 #
@@ -130,6 +134,7 @@ def main(global_config, testing=None, **settings):
     config.add_request_method(get_dbsession, 'db', reify=True)
     config.add_request_method(get_cacheregion, 'cache', reify=True)
     config.add_request_method(get_buildinfo, 'buildinfo', reify=True)
+    config.add_request_method(get_releases, 'releases', reify=True)
 
     # Templating
     config.add_mako_renderer('.html', settings_prefix='mako.')

--- a/bodhi/__init__.py
+++ b/bodhi/__init__.py
@@ -76,8 +76,8 @@ def get_buildinfo(request):
 
 
 def get_releases(request):
-    import bodhi.services.releases
-    return bodhi.services.releases.query_releases_html(request)['releases']
+    from bodhi.models import Release
+    return Release.all_releases()
 
 #
 # Cornice filters

--- a/bodhi/models/models.py
+++ b/bodhi/models/models.py
@@ -314,6 +314,17 @@ class Release(Base):
         return ' '.join(self.long_name.split()[:-1])
 
     @classmethod
+    def all_releases(cls):
+        if cls._all_releases:
+            return cls._all_releases
+        releases = defaultdict(list)
+        for release in DBSession.query(cls).order_by(cls.name).all():
+            releases[release.state.value].append(release.__json__())
+        cls._all_releases = releases
+        return cls._all_releases
+    _all_releases = None
+
+    @classmethod
     def get_tags(cls):
         if cls._tag_cache:
             return cls._tag_cache

--- a/bodhi/templates/fragments.html
+++ b/bodhi/templates/fragments.html
@@ -67,7 +67,7 @@
 </div>
 </%def>
 
-<%def name="update(update, display_user=True, display_request=False)">
+<%def name="update(update, display_user=True, display_request=False, display_release=True, display_karma=True)">
   <td>${util.update2html(update) | n}</td>
   <td class="nobreak">
     <span title="${update['date_submitted']} UTC">
@@ -82,6 +82,7 @@
     </a>
   </td>
   %endif
+  %if display_release:
   <td class="hidejs">
     % if update['release']:
     <a href="${request.route_url('release', name=update['release']['name'])}">
@@ -89,9 +90,12 @@
     </a>
     % endif
   </td>
+  %endif
+  %if display_karma:
   <td class="hidejs">
     ${util.karma2html(update['karma']) | n}
   </td>
+  %endif
   %if display_request:
   <td class="hidejs">
     % if update['request']:

--- a/bodhi/templates/master.html
+++ b/bodhi/templates/master.html
@@ -58,6 +58,25 @@
             </form>
 
             <ul class="nav navbar-nav navbar-right">
+              <li class="dropdown">
+                <a class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">
+                  <span class="glyphicon glyphicon-tags"></span>
+                  Releases
+                </a>
+                <ul class="dropdown-menu">
+                  % for state in request.releases:
+                  <li role="separator" class="divider"></li>
+                  % for r in request.releases[state]:
+                  <li>
+                    <a href="${request.route_url('releases')}${r['name']}">
+                      ${r['long_name']}
+                    </a>
+                  </li>
+                  % endfor
+                  % endfor
+                </ul>
+              </li>
+
               % if request.user:
               % if request.matched_route.name == 'user' and request.user and request.user.name == user['name']:
               <li class="active">

--- a/bodhi/templates/release.html
+++ b/bodhi/templates/release.html
@@ -96,7 +96,7 @@
         </span>
       </div>
       <div class="panel-body">
-        ${self.tables.updates(latest_updates)}
+        ${self.tables.updates(latest_updates, display_release=False)}
       </div>
     </div>
   </div>

--- a/bodhi/templates/tables.html
+++ b/bodhi/templates/tables.html
@@ -1,7 +1,7 @@
 <%namespace name="util" module="bodhi.util"/>
 <%namespace name="fragments" file="fragments.html"/>
 
-<%def name="updates(updates, display_user=True, display_request=True)">
+<%def name="updates(updates, display_user=True, display_request=True, display_release=True, display_karma=True)">
   <table class="table">
     <thead><tr>
         <th>Update</th>
@@ -9,8 +9,12 @@
         %if display_user:
         <th class="nobreak">Submitter</th>
         %endif
+        %if display_release:
         <th class="hidejs">Release</th>
+        %endif
+        %if display_karma:
         <th class="hidejs">Karma</th>
+        %endif
         %if display_request:
         <th class="hidejs">Request</th>
         %endif
@@ -19,7 +23,7 @@
     <tbody>
     % for update in updates:
     <tr>
-      ${fragments.update(update, display_user, display_request)}
+      ${fragments.update(update, display_user, display_request, display_release, display_karma)}
     </tr>
     % endfor
     </tbody>

--- a/bodhi/tests/models/test_models.py
+++ b/bodhi/tests/models/test_models.py
@@ -59,6 +59,13 @@ class TestRelease(ModelTest):
     def test_version_int(self):
         eq_(self.obj.version_int, 11)
 
+    def test_all_releases(self):
+        releases = model.Release.all_releases()
+        assert 'current' in releases, releases
+        assert releases['current'][0]['name'] == 'F11', releases
+        # Make sure it's the same cached object
+        assert releases is model.Release.all_releases()
+
 
 class MockWiki(object):
     """ Mocked simplemediawiki.MediaWiki class. """


### PR DESCRIPTION
Provide the data in the template for this by hanging another lazily
evaluated
'reified' property to the request that returns the same data that the
``bodhi.services.releases`` cornice service does.

* Fixes #350.