### PR TITLE
Differentiate singleton and sequence checkboxes(lists).

### DIFF
--- a/bodhi/static/js/forms.js
+++ b/bodhi/static/js/forms.js
@@ -75,7 +75,12 @@ Form.prototype.data = function() {
         if (this.type == 'radio' && ! this.checked) {
             // pass - don't add unchecked radio buttons to the submission
         } else if (this.type == 'checkbox' && ! this.checked) {
-            data[this.name].push(false);
+            // Handle series and singletons differently.
+            // The checkbox lists of bugs and builds are series.
+            // The single checkboxes for require_bugs, etc.. are singletons.
+            if (this['data-singleton'] == true) {
+                data[this.name].push(false);
+            }
         } else {
             var value = $(this).val();
             if (value != "") {

--- a/bodhi/templates/new_update.html
+++ b/bodhi/templates/new_update.html
@@ -223,7 +223,7 @@ ${update.notes}
 
                   <dt data-toggle="tooltip" title="If checked, then associated bugs in RHBZ will be closed once this update is pushed to the stable repository.">
                   Close bugs on stable?</dt>
-                  <dd> <input type="checkbox" name="close_bugs"
+                  <dd> <input type="checkbox" name="close_bugs" data-singleton="true"
                       % if update and update.close_bugs:
                       checked
                       % elif not update:
@@ -237,7 +237,7 @@ ${update.notes}
                 <dl id='radios' class="dl-horizontal">
                   <dt data-toggle="tooltip" title="If checked, this option allows bodhi to automatically move your update from testing to stable once enough positive karma has been given.">
                   Auto-request stable?</dt>
-                  <dd> <input type="checkbox" name="autokarma"
+                  <dd> <input type="checkbox" name="autokarma" data-singleton="true"
                       % if update and update.stable_karma != None and update.unstable_karma != None:
                       checked
                       % elif not update:
@@ -269,7 +269,7 @@ ${update.notes}
                   <dt data-toggle="tooltip" title="If checked, this will require that positive feedback be given on all associated bugs before the update can pass to stable.  If your update has no associated bugs, this option has no effect.">
                   Require bugs
                   </dt>
-                  <dd> <input type="checkbox" name="require_bugs"
+                  <dd> <input type="checkbox" name="require_bugs" data-singleton="true"
                       % if update and update.require_bugs:
                       checked
                       % elif not update:
@@ -279,7 +279,7 @@ ${update.notes}
 
                   <dt data-toggle="tooltip" title="If checked, this will require that positive feedback be given on all associated wiki test cases before the update can pass to stable.  If your update has no associated wiki test cases, this option has no effect.">
                   Require testcases</dt>
-                  <dd> <input type="checkbox" name="require_testcases"
+                  <dd> <input type="checkbox" name="require_testcases" data-singleton="true"
                       % if update and update.require_testcases:
                       checked
                       % elif not update:


### PR DESCRIPTION
This fixes #397.

The bug was introduced in 2c3bba9e when we were trying to fix something else.
The bug stems from the way the list of submitted builds gets generated in
javascript before it is POSTed to the server.  It looks like this when you have
one checkbox unchecked:

```javascript
[
        "foo-1.2.3-1.fc23",
        "bar-0.1.0-1.fc23",
        false,
        "baz-900-2.fc23",
]
```

The code in this patch only pushes that ``false`` value into the list **if**
the checkbox is specially marked with a ``data-singleton`` HTML5 attribute
(which I made up).  So, now:

- lists of checkboxes should *not* get the ``false`` value
  pushed (fixing #397).
- singleton checkboxes will still get their ``false`` value
  included (keeping #348 in good shape).