### PR TITLE
Decorate lists in markdown.

### DIFF
--- a/bodhi/static/css/site.css
+++ b/bodhi/static/css/site.css
@@ -192,3 +192,7 @@ ul.updateslist li {
 #preview {
     padding: 10px;
 }
+
+.markdown ul {
+    list-style-type: circle;
+}


### PR DESCRIPTION
* First, we extend the fedora-flavored markdown hack to add a "surround"
  postprocessor that wraps all markdown returned from our API endpoint with
  ``<div class="markdown">...</div>``.
* Second, we use that new marker to apply list decoration to lists inside that
  container.

Fixes #265.