### PR TITLE
Eject from mash instead of failing when tag actions fail.

### DIFF
--- a/bodhi/consumers/masher.py
+++ b/bodhi/consumers/masher.py
@@ -294,11 +294,7 @@ class MasherThread(threading.Thread):
 
             self.update_security_bugs()
 
-            if not self.state.get('tagged', False):
-                self.determine_tag_actions()
-                self.perform_tag_actions()
-                self.state['tagged'] = True
-                self.save_state()
+            self.determine_and_perform_tag_actions()
 
             self.expire_buildroot_overrides()
             self.remove_pending_tags()
@@ -492,7 +488,12 @@ class MasherThread(threading.Thread):
                 for bug in update.bugs:
                     bug.update_details()
 
-    def determine_tag_actions(self):
+    @checkpoint
+    def determine_and_perform_tag_actions(self):
+        self._determine_tag_actions()
+        self._perform_tag_actions()
+
+    def _determine_tag_actions(self):
         tag_types, tag_rels = Release.get_tags()
         for update in sorted_updates(self.updates):
             if update.status is UpdateStatus.testing:
@@ -518,7 +519,7 @@ class MasherThread(threading.Thread):
                     self.move_tags.append((from_tag, update.requested_tag,
                                            build.nvr))
 
-    def perform_tag_actions(self):
+    def _perform_tag_actions(self):
         self.koji.multicall = True
         for action in self.add_tags:
             tag, build = action

--- a/bodhi/consumers/masher.py
+++ b/bodhi/consumers/masher.py
@@ -292,9 +292,9 @@ class MasherThread(threading.Thread):
             if self.request is UpdateRequest.stable:
                 self.perform_gating()
 
-            self.update_security_bugs()
-
             self.determine_and_perform_tag_actions()
+
+            self.update_security_bugs()
 
             self.expire_buildroot_overrides()
             self.remove_pending_tags()

--- a/bodhi/consumers/masher.py
+++ b/bodhi/consumers/masher.py
@@ -416,6 +416,7 @@ class MasherThread(threading.Thread):
     def eject_from_mash(self, update, reason):
         update.locked = False
         text = '%s ejected from the push because %r' % (update.title, reason)
+        log.warn(text)
         update.comment(text, author=u'bodhi')
         update.request = None
         if update in self.state['updates']:
@@ -509,9 +510,10 @@ class MasherThread(threading.Thread):
                         from_tag = tag
                         break
                 else:
-                    self.log.error('Cannot find relevant tag for %s: %s' % (
-                                   build.nvr, tags))
-                    raise Exception
+                    reason = 'Cannot find relevant tag for %s: %s' % (
+                        build.nvr, tags)
+                    self.eject_from_mash(update, reason)
+                    break
 
                 if self.skip_mash:
                     self.add_tags.append((update.requested_tag, build.nvr))


### PR DESCRIPTION
Potentially fixes #418.  See that issue for more details.

Before accepting this, we need to think if changing the set of updates being
mashed at this point in the mash would be otherwise problematic.  It just seems
like a waste to kill the whole mash if one update has oddball tags at this
point in the process.

If we *don't* want to accept this, we might want to consider cherry-picking
f168b46 and bba5123, which are probably nice on their own.