### PR TITLE
Allow submitting multiple NVRs for an override.

### DIFF
--- a/bodhi/models/models.py
+++ b/bodhi/models/models.py
@@ -1984,7 +1984,8 @@ class BuildrootOverride(Base):
         build = data['build']
 
         if build.override is not None:
-            request.errors.add('body', 'nvr', 'This build already is in a buildroot override')
+            request.errors.add('body', 'nvr',
+                               '%s is already in a override' % build.nvr)
             return
 
         old_build = db.query(Build).filter(and_(

--- a/bodhi/static/js/override_form.js
+++ b/bodhi/static/js/override_form.js
@@ -6,8 +6,21 @@ $(document).ready(function() {
     OverridesForm.prototype.success = function(data) {
         Form.prototype.success.call(this, data);
 
-        // Now redirect to the override display page
-        document.location.href = "/overrides/" + data.build.nvr;
+        setTimeout(function() {
+            // There are two kinds of success to distinguish:
+            // 1) we submitted a single buildroot override
+            // 2) we submitted multiple NVRs that created multiple new overrides
+            var base = document.baseURI;
+            if (data.overrides === undefined) {
+                // Single override
+                // Now redirect to the override display
+                document.location.href = base + "overrides/" + data.build.nvr;
+            } else {
+                // Multi-NVR override.
+                // Redirect to overrides created by *me*
+                document.location.href = base + "users/" + data.overrides[0].submitter.name;
+            }
+        }, 1000);
     };
 
     OverridesForm.prototype.expire = function() {


### PR DESCRIPTION
Under the hood, it creates separate overrides for each NVR
and the JS web client redirects you appropriately.

Added two new tests to cover these cases.  All previous tests cases still pass.

Fixes #415.