### PR TITLE
Indicate that an update is a critpath update.

### DIFF
--- a/bodhi/templates/update.html
+++ b/bodhi/templates/update.html
@@ -511,6 +511,15 @@ $(document).ready(function(){
       % endif
       <hr />
     % endif
+
+    % if update.critpath:
+    <div class="alert alert-danger" role="alert">
+      <span class="glyphicon glyphicon-fire" aria-hidden="true"></span>
+      <span class="sr-only">Critpath:</span>
+      This update contains builds from the <u><a class="text-danger" href="https://fedoraproject.org/wiki/Critical_path_package" target="_blank">critical path</a></u>.
+    </div>
+    % endif
+
     % if update.notes:
     <h3 class="nomargin">Notes about this update:</h3>
     ${self.util.markup(update.notes) | n}


### PR DESCRIPTION
This adds a little alert panel on the update view for critical path updates.

It would show up just below the Locked panel and the Push/Edit buttons, but
above the Update Notes.

Fixes #339.