### PR TITLE
Add a markdown cheat sheet modal.

### DIFF
--- a/bodhi/static/css/site.css
+++ b/bodhi/static/css/site.css
@@ -196,3 +196,11 @@ ul.updateslist li {
 .markdown ul {
     list-style-type: circle;
 }
+
+#markdown-help strong {
+    text-transform: uppercase;
+}
+#markdown-help hr {
+    margin-top: 12px;
+    padding-bottom: 5px;
+}

--- a/bodhi/templates/fragments.html
+++ b/bodhi/templates/fragments.html
@@ -141,3 +141,93 @@
     % endif
   </td>
 </%def>
+
+<%def name="markdown_help_modal()">
+  <div class="modal fade" id="markdown-help" tabindex="-1" role="dialog" aria-labelledby="markdown-help-label">
+    <div class="modal-dialog modal-lg" role="document">
+      <div class="modal-content">
+        <div class="modal-header">
+          <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+          <h4 class="modal-title" id="markdown-help-label">Fedora-Flavored Markdown</h4>
+        </div>
+        <div class="modal-body">
+          <p> Text fields in Bodhi2 support an
+          <a href="https://github.com/fedora-infra/bodhi/blob/develop/bodhi/ffmarkdown.py">enhanced</a>
+          version of <a href="http://daringfireball.net/projects/markdown/syntax" target="_blank">markdown</a>.
+          This is a cheat sheet for your reference.
+          </p>
+          <hr/>
+          <div class="row">
+            <div class="col-md-4">
+              <p>You can do <strong>headers</strong> by underlining or by prefixing with the <code>&#35;</code> character:</p>
+              <pre><code>This is an H1
+=============
+
+This is an H2
+-------------
+
+&#35; This is another H1
+
+&#35;&#35; This is another H2
+</code></pre>
+              <hr/>
+              <p>You can do <strong>blockquotes</strong> using email-style prefixes with the <code>&gt;</code> character:</p>
+              <pre><code>&gt; This is a quotation
+&gt; over many lines
+&gt; &gt; and it can be nested(!)
+</code></pre>
+              <hr/>
+              <p><strong>Lists</strong> work like you'd expect, by prefixing with any of the <code>*</code>, <code>+</code>, or <code>-</code> characters:</p>
+              <pre><code>Check out this list:
+
+* This
+* is
+* a list..
+</code></pre>
+              <p>You need a blank line between a paragraph and the start of a list for the renderer to pick up on it.</p>
+              </div>
+              <div class="col-md-4">
+              <p><strong>Emphasis</strong> can be added like this:</p>
+              <pre><code>*italics*
+_italics_
+**bold**
+__bold__
+</code></pre>
+              <hr/>
+              <p>You can save your <strong>code</strong> references from being misinterpreted as emphasis by surrounding them with backtick characters (<code>`</code>):</p>
+              <pre><code>Use `the_best_function()` and _not_ that crummy one.</code></pre>
+              <hr/>
+              <p><strong>Links</strong> look like this:</p>
+              <pre><code>[text](http://getfedora.org)</code></pre>
+              <p>..but we also support bare links if you just provide a URL.</p>
+              <hr/>
+              <p> You can create <strong>code blocks</strong> by indenting
+              every line of the block by at least 4 spaces or 1 tab. </p>
+              <pre><code>Here is a code block:
+
+    for i in range(4):
+        print i
+    print "done."
+</code></pre>
+            </div>
+            <div class="col-md-4">
+              <p>You can reference <strong>bugzilla tickets</strong> by simply prefixing a ticket id with the <code>&#35;</code> character.</p>
+              <pre><code>We really need #1185409</code></pre>
+              <p>... we will automatically generate a link to the ticket in place.</p>
+              <hr/>
+              <p>And you can refer to <strong>other users</strong> by prefixing their username with the <code>@</code> symbol.</p>
+              <pre><code>Thanks @mattdm!</code></pre>
+              <p>This will generate a link to their profile, but it won't necessarily send them a notification unless they have a special <a href="https://apps.fedoraproject.org/notifications" target="_blank">FMN</a> rule set up to catch it.</p>
+              <hr/>
+              <p>Lastly, you can embed inline <strong>images</strong> with syntax like this:</p>
+              <pre><code>![Alt text](/path/to/img.jpg)</code></pre>
+            </div>
+          </div>
+        </div>
+        <div class="modal-footer">
+          You can read much more about markdown syntax at <a href="http://daringfireball.net/projects/markdown/syntax" target="_blank">daringfireball.net</a>.
+        </div>
+      </div>
+    </div>
+  </div>
+</%def>

--- a/bodhi/templates/new_stack.html
+++ b/bodhi/templates/new_stack.html
@@ -84,10 +84,13 @@
             <textarea class="form-control" id="description" name="description" rows="6"
               placeholder="Stack description goes here. You can use **markdown** to make it look nice."
               required="true">${stack.description if stack is not UNDEFINED else ''}</textarea>
+            <p class="pull-right">Stack descriptions support <a href="#" data-toggle="modal" data-target="#markdown-help">Fedora-Flavored Markdown</a>.</p>
           </div>
         </div>
       </div>
     </div> <!-- end row -->
+
+    ${self.fragments.markdown_help_modal()}
 
     <div class="row">
       <div class="col-md-5">

--- a/bodhi/templates/new_update.html
+++ b/bodhi/templates/new_update.html
@@ -144,14 +144,17 @@
           </div>
           <div class="panel-body">
             <textarea class="form-control" id="notes" name="notes" rows="6"
-              placeholder="Update notes go here.  They're really *really* useful, so feel free to write as you please.  You can use **markdown** to make them look nice." required="true">
+              placeholder="Update notes go here.  They're really *really* useful, so feel free to write as you please." required="true">
 % if update:
 ${update.notes}
 % endif
 </textarea>
+            <p class="pull-right">Update notes support <a href="#" data-toggle="modal" data-target="#markdown-help">Fedora-Flavored Markdown</a>.</p>
           </div>
         </div>
       </div>
+
+      ${self.fragments.markdown_help_modal()}
 
       <div class="col-md-6">
         <div class="panel formpanel panel-default">

--- a/bodhi/templates/override.html
+++ b/bodhi/templates/override.html
@@ -86,10 +86,13 @@
           </div>
           <div class="panel-body">
             <textarea class="form-control" id="notes" name="notes" rows="6"
-              placeholder="Buildroot override notes go here.  They're really *really* useful, so feel free to write as you please.  You can use **markdown** to make them look nice." required="true">${override.notes if override is not UNDEFINED else ''}</textarea>
+              placeholder="Buildroot override notes go here.  They're really *really* useful, so feel free to write as you please." required="true">${override.notes if override is not UNDEFINED else ''}</textarea>
+            <p class="pull-right">Override notes support <a href="#" data-toggle="modal" data-target="#markdown-help">Fedora-Flavored Markdown</a>.</p>
           </div>
         </div>
       </div>
+
+      ${self.fragments.markdown_help_modal()}
 
       <div class="col-md-6">
         <div class="panel panel-default">

--- a/bodhi/templates/update.html
+++ b/bodhi/templates/update.html
@@ -625,7 +625,10 @@ $(document).ready(function(){
                   <strong></strong> <span class="error"></span>
                 </div>
               </div>
+              <p class="pull-right">Comment fields support <a href="#" data-toggle="modal" data-target="#markdown-help">Fedora-Flavored Markdown</a>.</p>
             </div>
+
+            ${self.fragments.markdown_help_modal()}
 
             <div class="row">
               <label for="preview" class="col-sm-2 control-label">Preview</label>


### PR DESCRIPTION
Fixes #286.

![markdown-cheatsheet](https://cloud.githubusercontent.com/assets/331338/9633582/97c0b176-515b-11e5-96fb-00485d244b1e.png)
