### PR TITLE
Add a generic error template and handling.

### DIFF
--- a/bodhi/services/builds.py
+++ b/bodhi/services/builds.py
@@ -23,6 +23,7 @@ from bodhi import log
 from bodhi.models import Update, Build, Bug, CVE, Package, User, Release, Group
 import bodhi.schemas
 import bodhi.security
+import bodhi.services.errors
 from bodhi.validators import (
     validate_nvrs,
     validate_uniqueness,
@@ -45,7 +46,8 @@ builds = Service(name='builds', path='/builds/',
                  cors_origins=bodhi.security.cors_origins_ro)
 
 
-@build.get(renderer='json')
+@build.get(renderer='json',
+           error_handler=bodhi.services.errors.json_handler)
 def get_build(request):
     nvr = request.matchdict.get('nvr')
     build = Build.get(nvr, request.db)
@@ -57,6 +59,7 @@ def get_build(request):
 
 
 @builds.get(schema=bodhi.schemas.ListBuildSchema, renderer='json',
+            error_handler=bodhi.services.errors.json_handler,
             validators=(validate_releases, validate_updates,
                         validate_packages))
 def query_builds(request):

--- a/bodhi/services/csrf.py
+++ b/bodhi/services/csrf.py
@@ -15,6 +15,7 @@
 from cornice import Service
 
 import bodhi.security
+import bodhi.services.errors
 
 
 csrf = Service(name='csrf', path='/csrf', description='CSRF Token',
@@ -25,11 +26,13 @@ csrf = Service(name='csrf', path='/csrf', description='CSRF Token',
                cors_origins=bodhi.security.cors_origins_rw)
 
 
-@csrf.get(accept="text/html", renderer="string")
+@csrf.get(accept="text/html", renderer="string",
+          error_handler=bodhi.services.errors.html_handler)
 def get_csrf_token_html(request):
     return request.session.get_csrf_token()
 
 
-@csrf.get(accept=("application/json", "text/json"), renderer="json")
+@csrf.get(accept=("application/json", "text/json"), renderer="json",
+          error_handler=bodhi.services.errors.json_handler)
 def get_csrf_token_json(request):
     return dict(csrf_token=request.session.get_csrf_token())

--- a/bodhi/services/errors.py
+++ b/bodhi/services/errors.py
@@ -1,0 +1,20 @@
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+import cornice.util
+
+json_handler = cornice.util.json_error
+# TODO -- make these do the right thing..
+jsonp_handler = cornice.util.json_error
+html_handler = cornice.util.json_error

--- a/bodhi/services/errors.py
+++ b/bodhi/services/errors.py
@@ -12,9 +12,75 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
+import logging
+import os
+import re
+
 import cornice.util
 
+import mako.exceptions
+import mako.lookup
+
+import pyramid.httpexceptions
+import pyramid.response
+
+from bodhi.config import config
+
+log = logging.getLogger('bodhi')
+
+
+# First, just re-use cornice's default json handler for our own.  It is fine.
 json_handler = cornice.util.json_error
-# TODO -- make these do the right thing..
+
+# TODO -- make this do the right thing.  Not a big deal for now.
 jsonp_handler = cornice.util.json_error
-html_handler = cornice.util.json_error
+
+
+def camel2space(camel):
+    """ Convert CamelCaseText to Space Separated Text. """
+    regexp = r'([A-Z][a-z0-9]+|[a-z0-9]+|[A-Z0-9]+)'
+    return ' '.join(re.findall(regexp, camel))
+
+
+def status2summary(status):
+    """ Convert 404 the int to "Not Found" the str. """
+    cls = pyramid.httpexceptions.status_map[status]
+    camel = cls.__name__[4:]
+    return camel2space(camel)
+
+
+class html_handler(pyramid.httpexceptions.HTTPError):
+    """ An HTML formatting handler for all our errors. """
+    def __init__(self, errors):
+
+        location = config.get('mako.directories')
+        module, final = location.split(':')
+        base = os.path.dirname(__import__(module).__file__)
+        directory = base + "/" + final
+
+        lookup = mako.lookup.TemplateLookup(
+            directories=[directory],
+            output_encoding='utf-8',
+            input_encoding='utf-8',
+        )
+        template = lookup.get_template('errors.html')
+
+        try:
+            body = template.render(
+                errors=errors,
+                status=errors.status,
+                request=errors.request,
+                summary=status2summary(errors.status),
+            )
+        except:
+            log.error(mako.exceptions.text_error_template().render())
+            raise
+
+        # This thing inherits from both Exception *and* Response, so.. take the
+        # Response path in the diamond inheritance chain and ignore the
+        # exception side.
+        # That turns this thing into a "real boy" like pinnochio.
+        pyramid.response.Response.__init__(self, body)
+
+        self.status = errors.status
+        self.content_type = 'text/html'

--- a/bodhi/services/markdown.py
+++ b/bodhi/services/markdown.py
@@ -16,6 +16,7 @@ from cornice import Service
 
 import bodhi.util
 import bodhi.security
+import bodhi.services.errors
 
 
 markdown = Service(name='markdowner', path='/markdown',
@@ -23,8 +24,10 @@ markdown = Service(name='markdowner', path='/markdown',
                    cors_origins=bodhi.security.cors_origins_ro)
 
 
-@markdown.get(accept=('application/json', 'text/json'), renderer='json')
-@markdown.get(accept=('application/javascript'), renderer='jsonp')
+@markdown.get(accept=('application/json', 'text/json'), renderer='json',
+              error_handler=bodhi.services.errors.json_handler)
+@markdown.get(accept=('application/javascript'), renderer='jsonp',
+              error_handler=bodhi.services.errors.jsonp_handler)
 def markdowner(request):
     """ Given some text, return the markdownified html version.
 

--- a/bodhi/services/packages.py
+++ b/bodhi/services/packages.py
@@ -20,6 +20,7 @@ import math
 from bodhi.models import Package
 import bodhi.schemas
 import bodhi.security
+import bodhi.services.errors
 #from bodhi.validators import (
 #    # None yet...
 #)
@@ -31,6 +32,7 @@ packages = Service(name='packages', path='/packages/',
 
 
 @packages.get(schema=bodhi.schemas.ListPackageSchema, renderer='json',
+              error_handler=bodhi.services.errors.json_handler,
               validators=(
                   # None yet...
               ))

--- a/bodhi/static/css/site.css
+++ b/bodhi/static/css/site.css
@@ -204,3 +204,9 @@ ul.updateslist li {
     margin-top: 12px;
     padding-bottom: 5px;
 }
+
+.error-page-panel {
+    margin-top: 100px;
+    padding: 20px 40px 40px 40px;
+    border: 1px solid;
+}

--- a/bodhi/templates/errors.html
+++ b/bodhi/templates/errors.html
@@ -1,0 +1,12 @@
+<%inherit file="master.html"/>
+
+<div class="row">
+  <div class="col-md-offset-3 col-md-6">
+    <div class="panel error-page-panel">
+      <h1>${status} <small>${summary}</small></h1>
+      % for error in errors:
+      <p class="lead">${error['description']}</p>
+      % endfor
+    </div>
+  </div>
+</div>

--- a/bodhi/templates/master.html
+++ b/bodhi/templates/master.html
@@ -61,7 +61,7 @@
 
             <ul class="nav navbar-nav navbar-right">
               % if request.user:
-              % if request.matched_route.name in ('new_update', 'new_override', 'new_stack'):
+              % if request.matched_route and request.matched_route.name in ('new_update', 'new_override', 'new_stack'):
               <li class="dropdown active">
               % else:
               <li class="dropdown">
@@ -87,7 +87,7 @@
               % endif
 
 
-              % if request.matched_route.name in ('metrics', 'releases', 'release'):
+              % if request.matched_route and request.matched_route.name in ('metrics', 'releases', 'release'):
               <li class="dropdown active">
               % else:
               <li class="dropdown">
@@ -116,7 +116,7 @@
               </li>
 
               % if request.user:
-              % if request.matched_route.name == 'user' and request.user and request.user.name == user['name']:
+              % if request.matched_route and request.matched_route.name == 'user' and request.user and request.user.name == user['name']:
               <li class="dropdown active">
               % else:
               <li class="dropdown">
@@ -147,8 +147,12 @@
                 <a href="${request.route_url('logout')}">
                   <span class="glyphicon glyphicon-log-out"></span>
                   Logout</a>
-                % else:
+                % elif request.matched_route:
                 <a href="${request.route_url('login') + '?came_from=' + request.current_route_url()}">
+                  <span class="glyphicon glyphicon-log-in"></span>
+                  Login</a>
+                % else:
+                <a href="${request.route_url('login')}">
                   <span class="glyphicon glyphicon-log-in"></span>
                   Login</a>
                 % endif


### PR DESCRIPTION
A lot is going on in this one.


- Add cornice error handlers to all of our services.
- A new template is added to show generic errors.
- An HTML error handler is added for cornice views.
- A general exception catcher is installed at the pyramid level, that passes
  errors to the cornice handler for rendering.
- The master template is updated to handle the new special case where there is
  no `matched_route` (a 404 page).

Fixes #432.

![404-page](https://cloud.githubusercontent.com/assets/331338/9649766/622ecbb2-51c7-11e5-8047-d444df20b045.png)
