### PR TITLE
Fix overflow in markdown comment areas.

### DIFF
--- a/bodhi/static/css/site.css
+++ b/bodhi/static/css/site.css
@@ -196,6 +196,13 @@ ul.updateslist li {
 .markdown ul {
     list-style-type: circle;
 }
+.markdown code {
+    white-space: normal !important;
+}
+.markdown p {
+    word-wrap:      break-word; /* old-school */
+    overflow-wrap:  break-word; /* new-school */
+}
 
 #markdown-help strong {
     text-transform: uppercase;


### PR DESCRIPTION
Fixes #459.

![overflow](https://cloud.githubusercontent.com/assets/331338/9659461/b6db686c-521e-11e5-8785-c804ce190057.png)
