### PR TITLE
Adjust the README to document using the latest DB dump

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -21,19 +21,23 @@ Run the test suite
 ------------------
 ``python setup.py test``
 
-Initialize the database
------------------------
-``initialize_bodhi_db``
-
 Migrating Bodhi from v1.0 to v2.0
 ---------------------------------
 ::
 
-    curl -O https://fedorahosted.org/releases/b/o/bodhi/bodhi-pickledb.tar.bz2
-    tar -jxvf bodhi-pickledb.tar.bz2
-    rm bodhi-pickledb.tar.bz2
-    PYTHONPATH=$(pwd) python tools/pickledb.py migrate bodhi-pickledb*
+    curl -O https://infrastructure.fedoraproject.org/infra/db-dumps/bodhi2.dump.xz
+    xzcat bodhi2.dump.xz | psql -U postgres -W
+
+Adjust the development.init file
+--------------------------------
+
+Adjust the configuration key ``sqlalchemy.url`` to point to the postgresql
+database.
+Something like:
+::
+
+    sqlalchemy.url = postgresql://user:password@localhost/bodhi2
 
 Run the web app
 ---------------
-``pserve development.ini``
+``pserve development.ini --reload``

--- a/README.rst
+++ b/README.rst
@@ -28,8 +28,8 @@ Migrating Bodhi from v1.0 to v2.0
     curl -O https://infrastructure.fedoraproject.org/infra/db-dumps/bodhi2.dump.xz
     xzcat bodhi2.dump.xz | psql -U postgres -W
 
-Adjust the development.init file
---------------------------------
+Adjust the development.ini file
+-------------------------------
 
 Adjust the configuration key ``sqlalchemy.url`` to point to the postgresql
 database.

--- a/README.rst
+++ b/README.rst
@@ -28,12 +28,14 @@ Migrating Bodhi from v1.0 to v2.0
     curl -O https://infrastructure.fedoraproject.org/infra/db-dumps/bodhi2.dump.xz
     xzcat bodhi2.dump.xz | psql -U postgres -W
 
+.. note:: If you do not have a PostgreSQL server running, please see the
+          instructions at the bottom of the file.
+
 Adjust the development.ini file
 -------------------------------
 
 Adjust the configuration key ``sqlalchemy.url`` to point to the postgresql
-database.
-Something like:
+database. Something like:
 ::
 
     sqlalchemy.url = postgresql://user:password@localhost/bodhi2
@@ -41,3 +43,57 @@ Something like:
 Run the web app
 ---------------
 ``pserve development.ini --reload``
+
+
+
+Setup the postgresql server
+---------------------------
+
+1. Install postgresql
+~~~~~~~~~~~~~~~~~~~~~
+::
+
+    dnf install postgresql-server
+
+
+2. Setup the Database
+~~~~~~~~~~~~~~~~~~~~~
+
+As a privileged user on a Fedora system run the following:
+
+  sudo postgresql-setup initdb
+
+
+3. Adjust Postgresql Connection Settings
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+As a privileged user on a Fedora system modify the pg_hba.conf file:
+::
+
+  vi /var/lib/pgsql/data/pg_hba.conf
+
+Then adjust the content at the bottom of the file to match the following.
+
+::
+
+  # TYPE  DATABASE    USER        CIDR-ADDRESS          METHOD
+
+  # "local" is for Unix domain socket connections only
+  local   all         all                               ident sameuser
+  # IPv4 local connections:
+  #host    all         all         127.0.0.1/32          ident sameuser
+  # IPv6 local connections:
+  #host    all         all         ::1/128               ident sameuser
+
+  host all all 0.0.0.0 0.0.0.0 md5
+  host all all ::1/128         md5
+
+
+If you need to make other modifications to postgresql please make them now.
+
+4. Start Postgresql
+~~~~~~~~~~~~~~~~~~~
+
+As a privileged user on a Fedora system run the following:
+
+  sudo systemctl start postgresql.service

--- a/README.rst
+++ b/README.rst
@@ -21,8 +21,8 @@ Run the test suite
 ------------------
 ``python setup.py test``
 
-Migrating Bodhi from v1.0 to v2.0
----------------------------------
+Import the bodhi2 database
+--------------------------
 ::
 
     curl -O https://infrastructure.fedoraproject.org/infra/db-dumps/bodhi2.dump.xz

--- a/README.rst
+++ b/README.rst
@@ -38,7 +38,7 @@ Adjust the configuration key ``sqlalchemy.url`` to point to the postgresql
 database. Something like:
 ::
 
-    sqlalchemy.url = postgresql://user:password@localhost/bodhi2
+    sqlalchemy.url = postgresql://postgres:anypasswordworkslocally@localhost/bodhi2
 
 Run the web app
 ---------------
@@ -77,18 +77,14 @@ Then adjust the content at the bottom of the file to match the following.
 
 ::
 
-  # TYPE  DATABASE    USER        CIDR-ADDRESS          METHOD
+  # TYPE  DATABASE        USER            ADDRESS                 METHOD
 
   # "local" is for Unix domain socket connections only
-  local   all         all                               ident sameuser
-  # IPv4 local connections:
-  #host    all         all         127.0.0.1/32          ident sameuser
-  # IPv6 local connections:
-  #host    all         all         ::1/128               ident sameuser
-
-  host all all 0.0.0.0 0.0.0.0 md5
-  host all all ::1/128         md5
-
+  local   all             all                                     peer
+  # IPv4 local connections are *trusted*, any password will work.
+  host    all             all             127.0.0.1/32            trust
+  # IPv6 local connections are *trusted*, any password will work.
+  host    all             all             ::1/128                 trust
 
 If you need to make other modifications to postgresql please make them now.
 

--- a/README.rst
+++ b/README.rst
@@ -60,8 +60,9 @@ Setup the postgresql server
 ~~~~~~~~~~~~~~~~~~~~~
 
 As a privileged user on a Fedora system run the following:
+::
 
-  sudo postgresql-setup initdb
+    sudo postgresql-setup initdb
 
 
 3. Adjust Postgresql Connection Settings
@@ -70,7 +71,7 @@ As a privileged user on a Fedora system run the following:
 As a privileged user on a Fedora system modify the pg_hba.conf file:
 ::
 
-  vi /var/lib/pgsql/data/pg_hba.conf
+    vi /var/lib/pgsql/data/pg_hba.conf
 
 Then adjust the content at the bottom of the file to match the following.
 
@@ -95,5 +96,6 @@ If you need to make other modifications to postgresql please make them now.
 ~~~~~~~~~~~~~~~~~~~
 
 As a privileged user on a Fedora system run the following:
+::
 
-  sudo systemctl start postgresql.service
+    sudo systemctl start postgresql.service


### PR DESCRIPTION
This uses the bodhi2 dump instead of relying on a bodhi1 dump that then
had to be converted for bodhi2.

Fixes https://github.com/fedora-infra/bodhi/issues/466