### PR TITLE
Check the size of the comment before sending it to bugzilla

### DIFF
--- a/bodhi/bugs.py
+++ b/bodhi/bugs.py
@@ -41,6 +41,13 @@ class FakeBugTracker(BugTracker):
     comment = update_details = modified = close = on_qa = __noop__
 
 
+class InvalidComment(Exception):
+    """ Exception thrown when the comment posted is invalid (for example
+    too long.
+    """
+    pass
+
+
 class Bugzilla(BugTracker):
 
     def __init__(self):
@@ -64,8 +71,13 @@ class Bugzilla(BugTracker):
 
     def comment(self, bug_id, comment):
         try:
+            if len(comment) > 65535:
+                raise InvalidComment("Comment is too long: %s" % comment)
             bug = self.bz.getbug(bug_id)
             bug.addcomment(comment)
+        except InvalidComment as err:
+            log.exception("Invalid comment for bug #%d" % bug_id)
+            log.exception(err)
         except:
             log.exception("Unable to add comment to bug #%d" % bug_id)
 

--- a/bodhi/bugs.py
+++ b/bodhi/bugs.py
@@ -75,9 +75,9 @@ class Bugzilla(BugTracker):
                 raise InvalidComment("Comment is too long: %s" % comment)
             bug = self.bz.getbug(bug_id)
             bug.addcomment(comment)
-        except InvalidComment as err:
-            log.exception("Invalid comment for bug #%d" % bug_id)
-            log.exception(err)
+        except InvalidComment:
+            log.exception(
+                "Comment too long for bug #%d:  %s" % (bug_id, comment))
         except:
             log.exception("Unable to add comment to bug #%d" % bug_id)
 


### PR DESCRIPTION
With this commit we won't make the comment but instead we raise an
exception and log it if a comment has more than 65535 characters.

Fixes https://github.com/fedora-infra/bodhi/issues/330