### PR TITLE
Make the link to updates display the title but rely on the alias

### DIFF
--- a/bodhi/util.py
+++ b/bodhi/util.py
@@ -438,7 +438,7 @@ def update2html(context, update):
     title = update.title
     alias = update.alias
 
-    url = request.route_url('update', id=alias)
+    url = request.route_url('update', id=alias or title)
     settings = request.registry.settings
     max_length = int(settings.get('max_update_length_for_ui', 30))
     if len(title) > max_length:

--- a/bodhi/util.py
+++ b/bodhi/util.py
@@ -435,18 +435,10 @@ def request2html(context, request):
 def update2html(context, update):
     request = context.get('request')
 
-    if hasattr(update, 'title'):
-        title = update.title
-    else:
-        title = update['title']
+    title = update.title
+    alias = update.alias
 
-    alias = None
-    if hasattr(update, 'alias'):
-        alias = update.alias
-    else:
-        alias = update.get('alias')
-
-    url = request.route_url('update', id=alias or title)
+    url = request.route_url('update', id=alias)
     settings = request.registry.settings
     max_length = int(settings.get('max_update_length_for_ui', 30))
     if len(title) > max_length:

--- a/bodhi/util.py
+++ b/bodhi/util.py
@@ -435,8 +435,15 @@ def request2html(context, request):
 def update2html(context, update):
     request = context.get('request')
 
-    title = update.title
-    alias = update.alias
+    if hasattr(update, 'title'):
+        title = update.title
+    else:
+        title = update['title']
+
+    if hasattr(update, 'alias'):
+        alias = update.alias
+    else:
+        alias = update['alias']
 
     url = request.route_url('update', id=alias or title)
     settings = request.registry.settings

--- a/bodhi/util.py
+++ b/bodhi/util.py
@@ -440,7 +440,13 @@ def update2html(context, update):
     else:
         title = update['title']
 
-    url = request.route_url('update', id=title)
+    alias = None
+    if hasattr(update, 'alias'):
+        alias = update.alias
+    else:
+        alias = update.get('alias')
+
+    url = request.route_url('update', id=alias)
     settings = request.registry.settings
     max_length = int(settings.get('max_update_length_for_ui', 30))
     if len(title) > max_length:

--- a/bodhi/util.py
+++ b/bodhi/util.py
@@ -446,7 +446,7 @@ def update2html(context, update):
     else:
         alias = update.get('alias')
 
-    url = request.route_url('update', id=alias)
+    url = request.route_url('update', id=alias or title)
     settings = request.registry.settings
     max_length = int(settings.get('max_update_length_for_ui', 30))
     if len(title) > max_length:


### PR DESCRIPTION
This should make sure we do no have unbarrable links anywhere but that
we are using the title instead.

Fixes https://github.com/fedora-infra/bodhi/issues/221