### PR TITLE
Munch it up!

### DIFF
--- a/bodhi/__init__.py
+++ b/bodhi/__init__.py
@@ -14,6 +14,7 @@
 
 from collections import defaultdict
 from dogpile.cache import make_region
+from munch import munchify
 from sqlalchemy import engine_from_config
 
 from pyramid.settings import asbool
@@ -54,7 +55,9 @@ def get_user(request):
     from bodhi.models import User
     userid = unauthenticated_userid(request)
     if userid is not None:
-        return request.db.query(User).filter_by(name=unicode(userid)).first()
+        user = request.db.query(User).filter_by(name=unicode(userid)).first()
+        # Why munch?  https://github.com/fedora-infra/bodhi/issues/473
+        return munchify(user.__json__(request=request))
 
 
 def groupfinder(userid, request):

--- a/bodhi/models/models.py
+++ b/bodhi/models/models.py
@@ -83,7 +83,8 @@ class BodhiBase(object):
     def __json__(self, request=None, anonymize=False):
         return self._to_json(self, request=request, anonymize=anonymize)
 
-    def _to_json(self, obj, seen=None, request=None, anonymize=False):
+    @classmethod
+    def _to_json(cls, obj, seen=None, request=None, anonymize=False):
         if not seen:
             seen = []
         if not obj:
@@ -106,7 +107,7 @@ class BodhiBase(object):
         for attr in rels:
             if attr in exclude:
                 continue
-            d[attr] = self._expand(obj, getattr(obj, attr), seen, request)
+            d[attr] = cls._expand(obj, getattr(obj, attr), seen, request)
 
         for key, value in d.iteritems():
             if isinstance(value, datetime):
@@ -126,14 +127,15 @@ class BodhiBase(object):
 
         return d
 
-    def _expand(self, obj, relation, seen, req):
+    @classmethod
+    def _expand(cls, obj, relation, seen, req):
         """ Return the to_json or id of a sqlalchemy relationship. """
         if hasattr(relation, 'all'):
             relation = relation.all()
         if hasattr(relation, '__iter__'):
-            return [self._expand(obj, item, seen, req) for item in relation]
+            return [cls._expand(obj, item, seen, req) for item in relation]
         if type(relation) not in seen:
-            return self._to_json(relation, seen + [type(obj)], req)
+            return cls._to_json(relation, seen + [type(obj)], req)
         else:
             return relation.id
 

--- a/bodhi/models/models.py
+++ b/bodhi/models/models.py
@@ -1956,8 +1956,8 @@ stack_user_table = Table('stack_user_table', Base.metadata,
 
 class User(Base):
     __tablename__ = 'users'
-    __exclude_columns__ = ('id', 'comments', 'updates', 'groups', 'packages')
-    __include_extras__ = ('avatar',)
+    __exclude_columns__ = ('comments', 'updates', 'groups', 'packages', 'stacks')
+    __include_extras__ = ('avatar', 'openid')
     __get_by__ = ('name',)
 
     name = Column(Unicode(64), unique=True, nullable=False)
@@ -1977,6 +1977,8 @@ class User(Base):
         return get_avatar(context=context, username=self.name, size=24)
 
     def openid(self, request):
+        if not request:
+            return None
         template = request.registry.settings.get('openid_template')
         return template.format(username=self.name)
 

--- a/bodhi/models/models.py
+++ b/bodhi/models/models.py
@@ -628,7 +628,7 @@ class Update(Base):
     def new(cls, request, data):
         """ Create a new update """
         db = request.db
-        user = request.user
+        user = User.get(request.user.name, request.db)
         data['user'] = user
         data['title'] = ' '.join([b.nvr for b in data['builds']])
 
@@ -705,7 +705,6 @@ class Update(Base):
     def edit(cls, request, data):
         db = request.db
         buildinfo = request.buildinfo
-        user = request.user
         koji = request.koji
         up = db.query(Update).filter_by(title=data['edited']).first()
         del(data['edited'])
@@ -765,7 +764,7 @@ class Update(Base):
         del(data['builds'])
 
         # Comment on the update with details of added/removed builds
-        comment = '%s edited this update. ' % user.name
+        comment = '%s edited this update. ' % request.user.name
         if new_builds:
             comment += 'New build(s): %s. ' % ', '.join(new_builds)
         if removed_builds:

--- a/bodhi/services/overrides.py
+++ b/bodhi/services/overrides.py
@@ -21,7 +21,7 @@ from sqlalchemy import func, distinct
 from sqlalchemy.sql import or_
 
 from bodhi import log
-from bodhi.models import Build, BuildrootOverride, Package, Release
+from bodhi.models import Build, BuildrootOverride, Package, Release, User
 import bodhi.schemas
 import bodhi.services.errors
 from bodhi.validators import (
@@ -181,6 +181,7 @@ def save_override(request):
 
     caveats = []
     try:
+        submitter = User.get(request.user.name, request.db)
         if edited is None:
             builds = data['builds']
             overrides = []
@@ -195,7 +196,7 @@ def save_override(request):
                 overrides.append(BuildrootOverride.new(
                     request,
                     build=build,
-                    submitter=request.user,
+                    submitter=submitter,
                     notes=data['notes'],
                     expiration_date=data['expiration_date'],
                 ))
@@ -214,7 +215,7 @@ def save_override(request):
                 return
 
             result = BuildrootOverride.edit(
-                    request, edited=edited, submitter=request.user,
+                    request, edited=edited, submitter=submitter,
                     notes=data["notes"], expired=data["expired"],
                     expiration_date=data["expiration_date"]
                     )

--- a/bodhi/services/stacks.py
+++ b/bodhi/services/stacks.py
@@ -111,7 +111,7 @@ def save_stack(request):
     """Save a stack"""
     data = request.validated
     db = request.db
-    user = request.user
+    user = User.get(request.user.name, db)
 
     # Fetch or create the stack
     stack = Stack.get(data['name'], db)

--- a/bodhi/templates/master.html
+++ b/bodhi/templates/master.html
@@ -116,7 +116,7 @@
               </li>
 
               % if request.user:
-              % if request.matched_route and request.matched_route.name == 'user' and request.user and request.user.name == user['name']:
+              % if request.matched_route and request.matched_route.name == 'user' and request.user and user and request.user.name == user['name']:
               <li class="dropdown active">
               % else:
               <li class="dropdown">
@@ -133,7 +133,7 @@
                     </a>
                   </li>
                   <li>
-                    <a href="${request.registry.settings.get('fmn_url')}${request.user.openid(request)}/">
+                    <a href="${request.registry.settings.get('fmn_url')}${request.user.openid}/">
                       Manage Alerts
                     </a>
                   </li>

--- a/bodhi/templates/user.html
+++ b/bodhi/templates/user.html
@@ -66,7 +66,7 @@
     <div class="pull-left">
       % if request.user and user['name'] == request.user.name:
         <form method="POST" action="https://www.libravatar.org/openid/login/">
-          <input type="hidden" name="openid_identifier" value="${request.user.openid(request)}"/>
+          <input type="hidden" name="openid_identifier" value="${request.user.openid}"/>
           <input type="image" class="img-thumbnail" src="${self.util.avatar(user['name'], size=128)}" style="outline: none;"/>
         </form>
       % else:

--- a/bodhi/tests/functional/test_overrides.py
+++ b/bodhi/tests/functional/test_overrides.py
@@ -489,6 +489,7 @@ class TestOverridesService(bodhi.tests.functional.base.BaseWSGICase):
         self.assertEquals(len(publish.call_args_list), 1)
 
         o = res.json_body
+        self.assertEquals(o['nvr'], nvr)
         self.assertEquals(o['notes'], 'blah blah blah')
         self.assertEquals(o['expiration_date'],
                           expiration_date.strftime("%Y-%m-%d %H:%M:%S"))

--- a/bodhi/validators.py
+++ b/bodhi/validators.py
@@ -67,7 +67,7 @@ def validate_nvrs(request):
 def validate_builds(request):
     edited = request.validated.get('edited')
     settings = request.registry.settings
-    user = request.user
+    user = User.get(request.user.name, request.db)
 
     if not request.validated.get('builds', []):
         request.errors.add('body', 'builds',
@@ -170,7 +170,7 @@ def validate_tags(request):
 def validate_acls(request):
     """Ensure this user has commit privs to these builds or is an admin"""
     db = request.db
-    user = request.user
+    user = User.get(request.user.name, request.db)
     settings = request.registry.settings
     committers = []
     watchers = []


### PR DESCRIPTION
This changeset turns ``request.user`` into a munch object where it used to be a sqlalchemy ``User`` object, mediating the *complex failure scenario* detailed in #473.

It was a little more involved than I thought it would be, but not too bad.  All the tests pass (and I didn't have to modify any of them).