### PR TITLE
Unpush builds when they are removed from an update

### DIFF
--- a/bodhi/models/models.py
+++ b/bodhi/models/models.py
@@ -542,8 +542,9 @@ class Build(Base):
             i += 1
         return str
 
-    def get_tags(self):
-        koji = buildsys.get_session()
+    def get_tags(self, koji=None):
+        if not koji:
+            koji = buildsys.get_session()
         return [tag['name'] for tag in koji.listTags(self.nvr)]
 
     def untag(self, koji):

--- a/bodhi/models/models.py
+++ b/bodhi/models/models.py
@@ -555,6 +555,21 @@ class Build(Base):
                 log.info('Removing %s tag from %s' % (tag, self.nvr))
                 koji.untagBuild(tag, self.nvr)
 
+    def unpush(self, koji):
+        """Move this build back to the candidate tag"""
+        log.info('Unpushing %s' % self.nvr)
+        release = self.update.release
+        for tag in self.get_tags(koji):
+            if tag == release.pending_testing_tag:
+                log.info('Removing %s tag from %s' % (tag, self.nvr))
+                koji.untagBuild(tag, self.nvr)
+            if tag == release.pending_stable_tag:
+                log.info('Removing %s tag from %s' % (tag, self.nvr))
+                koji.untagBuild(tag, self.nvr)
+            elif tag == release.testing_tag:
+                log.info('Moving %s from %s to %s' % (self.nvr, tag,
+                    release.candidate_tag))
+                koji.moveBuild(tag, release.candidate_tag, self.nvr)
 
 class Update(Base):
     __tablename__ = 'updates'

--- a/bodhi/models/models.py
+++ b/bodhi/models/models.py
@@ -763,7 +763,8 @@ class Update(Base):
                 for b in up.builds:
                     if b.nvr == build:
                         break
-                b.untag(koji=request.koji)
+
+                b.unpush(koji=request.koji)
                 up.builds.remove(b)
                 db.delete(b)
 

--- a/bodhi/models/models.py
+++ b/bodhi/models/models.py
@@ -543,6 +543,7 @@ class Build(Base):
         return str
 
     def get_tags(self, koji=None):
+        """ Return a list of koji tags for this build """
         if not koji:
             koji = buildsys.get_session()
         return [tag['name'] for tag in koji.listTags(self.nvr)]
@@ -556,7 +557,9 @@ class Build(Base):
                 koji.untagBuild(tag, self.nvr)
 
     def unpush(self, koji):
-        """Move this build back to the candidate tag"""
+        """
+        Move this build back to the candidate tag and remove any pending tags.
+        """
         log.info('Unpushing %s' % self.nvr)
         release = self.update.release
         for tag in self.get_tags(koji):

--- a/bodhi/tests/models/test_models.py
+++ b/bodhi/tests/models/test_models.py
@@ -210,6 +210,18 @@ class TestUpdate(ModelTest):
         eq_(self.obj.builds[0].release.name, u'F11')
         eq_(self.obj.builds[0].package.name, u'TurboGears')
 
+    def test_unpush_build(self):
+        eq_(len(self.obj.builds), 1)
+        b = self.obj.builds[0]
+        release = self.obj.release
+        koji = buildsys.get_session()
+        koji.clear()
+        koji.__tagged__[b.nvr] = [release.testing_tag,
+                                  release.pending_testing_tag]
+        self.obj.builds[0].unpush(koji)
+        eq_(koji.__moved__, [(u'dist-f11-updates-testing', u'dist-f11-updates-candidate', u'TurboGears-1.0.8-3.fc11')])
+        eq_(koji.__untag__, [(u'dist-f11-updates-testing-pending', u'TurboGears-1.0.8-3.fc11')])
+
     def test_title(self):
         eq_(self.obj.title, u'TurboGears-1.0.8-3.fc11')
 


### PR DESCRIPTION
... as opposed to removing all tags.

This will hopefully work around the following issue we just hit in production:

```
2015-09-06 00:12:05,405 INFO  [bodhi][MainThread] Removing f23-updates-candidate tag from grub2-2.02-0.23.fc23
2015-09-06 00:12:05,526 ERROR [bodhi][MainThread] Failed to create update
Traceback (most recent call last):
  File "/usr/lib/python2.7/site-packages/bodhi/services/updates.py", line 347, in new_update
    result, _caveats = Update.edit(request, data)
  File "/usr/lib/python2.7/site-packages/bodhi/models/models.py", line 750, in edit
    b.untag(koji=request.koji)
  File "/usr/lib/python2.7/site-packages/bodhi/models/models.py", line 555, in untag
    koji.untagBuild(tag, self.nvr)
  File "/usr/lib/python2.7/site-packages/koji/__init__.py", line 1556, in __call__
    return self.__func(self.__name,args,opts)
  File "/usr/lib/python2.7/site-packages/koji/__init__.py", line 1918, in _callMethod
    raise err
ActionNotAllowed: policy violation (tag)
```