### PR TITLE
Include meets_testing_requirements in Update JSON.

### DIFF
--- a/bodhi/models/models.py
+++ b/bodhi/models/models.py
@@ -579,6 +579,7 @@ class Build(Base):
 class Update(Base):
     __tablename__ = 'updates'
     __exclude_columns__ = ('id', 'user_id', 'release_id')
+    __include_extras__ = ('meets_testing_requirements',)
     __get_by__ = ('title', 'alias')
 
     title = Column(UnicodeText, default=None, index=True)

--- a/bodhi/tests/functional/test_updates.py
+++ b/bodhi/tests/functional/test_updates.py
@@ -1919,3 +1919,10 @@ class TestUpdatesService(bodhi.tests.functional.base.BaseWSGICase):
         self.assertEquals(up['status'], u'testing')
         self.assertEquals(up['request'], None)
         self.assertEquals(up['type'], u'bugfix')
+
+    def test_update_meeting_requirements_present(self):
+        """ Check that the requirements boolean is present in our JSON """
+        res = self.app.get('/updates/bodhi-2.0-1.fc17')
+        actual = res.json_body['update']['meets_testing_requirements']
+        expected = False
+        self.assertEquals(actual, expected)


### PR DESCRIPTION
This is for my personal use.

It would be cool if Update JSON included a True/False of whether or not updates
are ready to be pushed to stable or not.  I would use this from local scripts
to figure out what updates I need to go push to stable.  Historically, I would
scrape the comment history looking for bodhi to tell me its good to go.