### PR TITLE
Correctly map builds to bugs when closing.

### DIFF
--- a/bodhi/bugs.py
+++ b/bodhi/bugs.py
@@ -93,12 +93,12 @@ class Bugzilla(BugTracker):
         except:
             log.exception("Unable to alter bug #%d" % bug_id)
 
-    def close(self, bug_id, fixedin=None):
+    def close(self, bug_id, versions):
         args = {}
-        if fixedin:
-            args['fixedin'] = fixedin
         try:
             bug = self.bz.getbug(bug_id)
+            if bug.component in versions:
+                args['fixedin'] = versions[bug.component]
             bug.close('NEXTRELEASE', **args)
         except xmlrpclib.Fault:
             log.exception("Unable to close bug #%d" % bug_id)

--- a/bodhi/models/models.py
+++ b/bodhi/models/models.py
@@ -1957,8 +1957,12 @@ class Bug(Base):
             bugtracker.on_qa(self.bug_id, comment)
 
     def close_bug(self, update):
-        ver = '-'.join(get_nvr(update.builds[0].nvr)[-2:])
-        bugtracker.close(self.bug_id, fixedin=ver)
+        # Build a mapping of package names to build versions
+        # so that .close() can figure out which build version fixes which bug.
+        versions = dict([
+            (get_nvr(b.nvr)[0], b.nvr) for b in update.builds
+        ])
+        bugtracker.close(self.bug_id, versions=versions)
 
     def modified(self, update):
         """ Change the status of this bug to MODIFIED """

--- a/bodhi/tests/test_masher.py
+++ b/bodhi/tests/test_masher.py
@@ -731,7 +731,8 @@ References:
             t.db = session
             t.work()
             t.db = None
-        close.assert_called_with(12345, fixedin=u'2.0-1.fc17')
+        close.assert_called_with(12345, versions=dict(
+            bodhi=u'bodhi-2.0-1.fc17'))
         comment.assert_called_with(12345, u'bodhi-2.0-1.fc17 has been pushed to the Fedora 17 stable repository. If problems still persist, please make note of it in this bug report.')
 
     @mock.patch(**mock_taskotron_results)


### PR DESCRIPTION
It used to be that we would take the version of the first build in a
multi-build update and use it everywhere for the "fixed in version" field.
This should more correctly map builds to bugs.

Fixes #513.