### PR TITLE
Flip the order of the feedback items.

### DIFF
--- a/bodhi/models/models.py
+++ b/bodhi/models/models.py
@@ -957,7 +957,7 @@ class Update(Base):
                         good += 1
                     elif feedback.karma < 0:
                         bad += 1
-        return good, bad * -1
+        return bad * -1, good
 
     def get_testcase_karma(self, testcase):
         good, bad, seen = 0, 0, set()
@@ -971,7 +971,7 @@ class Update(Base):
                         good += 1
                     elif feedback.karma < 0:
                         bad += 1
-        return good, bad * -1
+        return bad * -1, good
 
     def assign_alias(self):
         """Return the next available update ID.

--- a/bodhi/templates/update.html
+++ b/bodhi/templates/update.html
@@ -542,8 +542,8 @@ $(document).ready(function(){
       <colgroup span="1"></colgroup>
       <thead>
         <tr>
-          <th class='icon'><span data-toggle="tooltip" data-placement="top" title="PASS - Passes the test case." class="glyphicon glyphicon-ok-circle"></span></th>
           <th class='icon'><span data-toggle="tooltip" data-placement="top" title="FAIL - Does not fix the bug." class="glyphicon glyphicon-remove-circle"></span></th>
+          <th class='icon'><span data-toggle="tooltip" data-placement="top" title="PASS - Passes the test case." class="glyphicon glyphicon-ok-circle"></span></th>
           <th></th>
         </tr>
       </thead>
@@ -564,8 +564,8 @@ $(document).ready(function(){
       <colgroup span="1"></colgroup>
       <thead>
         <tr>
-          <th><span data-toggle="tooltip" data-placement="top" title="PASS - Fixes the bug or passes the test case." class="glyphicon glyphicon-ok-circle"></span></th>
           <th><span data-toggle="tooltip" data-placement="top" title="FAIL - Does not fix the bug or pass the test case." class="glyphicon glyphicon-remove-circle"></span></th>
+          <th><span data-toggle="tooltip" data-placement="top" title="PASS - Fixes the bug or passes the test case." class="glyphicon glyphicon-ok-circle"></span></th>
           <th></th>
         </tr>
       </thead>


### PR DESCRIPTION
So that they are in the same order as in the comment form at the bottom of the page.

Fixes #498.