### PR TITLE
Make the fixedin field additive.

### DIFF
--- a/bodhi/bugs.py
+++ b/bodhi/bugs.py
@@ -97,8 +97,18 @@ class Bugzilla(BugTracker):
         args = {}
         try:
             bug = self.bz.getbug(bug_id)
+            # If this bug is for one of these builds...
             if bug.component in versions:
-                args['fixedin'] = versions[bug.component]
+                version = versions[bug.component]
+                # Get the existing list
+                fixedin = [v.strip() for v in bug.fixed_in.split(',')]
+                # Strip out any empty strings
+                fixedin = [v for v in fixedin if v.strip()]
+                # And add our build if its not already there
+                if version not in fixedin:
+                    fixedin.append(version)
+                args['fixedin'] = ", ".join(fixedin)
+
             bug.close('NEXTRELEASE', **args)
         except xmlrpclib.Fault:
             log.exception("Unable to close bug #%d" % bug_id)

--- a/bodhi/models/models.py
+++ b/bodhi/models/models.py
@@ -1960,9 +1960,12 @@ class Bug(Base):
     def close_bug(self, update):
         # Build a mapping of package names to build versions
         # so that .close() can figure out which build version fixes which bug.
-        versions = dict([
-            (get_nvr(b.nvr)[0], b.nvr) for b in update.builds
-        ])
+        versions = dict([(
+            get_nvr(b.nvr)[0],
+            # Strip off the .fc23 at the end of the nvr to try and match the
+            # way the anaconda team uses the fixedin field.
+            b.nvr.rsplit('.', 1)[0]
+        ) for b in update.builds])
         bugtracker.close(self.bug_id, versions=versions)
 
     def modified(self, update):

--- a/bodhi/tests/test_masher.py
+++ b/bodhi/tests/test_masher.py
@@ -731,8 +731,7 @@ References:
             t.db = session
             t.work()
             t.db = None
-        close.assert_called_with(12345, versions=dict(
-            bodhi=u'bodhi-2.0-1.fc17'))
+        close.assert_called_with(12345, versions=dict(bodhi=u'bodhi-2.0-1'))
         comment.assert_called_with(12345, u'bodhi-2.0-1.fc17 has been pushed to the Fedora 17 stable repository. If problems still persist, please make note of it in this bug report.')
 
     @mock.patch(**mock_taskotron_results)


### PR DESCRIPTION
This should fix #428.

Furthermore, I try here to stick with how the anaconda team uses the fixedin
field by hand so that we don't disrupt their workflow.  See this bug for an
example:  https://bugzilla.redhat.com/show_bug.cgi?id=1256072