### PR TITLE
metadata: Use GZ compression for the updateinfo on RHEL5 (fixes #534)

### DIFF
--- a/bodhi/metadata.py
+++ b/bodhi/metadata.py
@@ -66,10 +66,11 @@ class ExtendedMetadata(object):
             # yum on py2.4 doesn't support sha256 (#1080373)
             if 'el5' in self.repo or '5E' in self.repo:
                 self.hash_type = cr.SHA1
-
-            # FIXME: I'm not sure which versions of RHEL support xz metadata
-            # compression, so use the lowest common denominator for now.
-            self.comp_type = cr.BZ2
+                self.comp_type = cr.GZ
+            else:
+                # FIXME: I'm not sure which versions of RHEL support xz metadata
+                # compression, so use the lowest common denominator for now.
+                self.comp_type = cr.BZ2
 
         # Load from the cache if it exists
         self.cached_repodata = os.path.join(self.repo, '..', self.tag +


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1256336