### PR TITLE
Add tests for commenting on locked updates.

### DIFF
--- a/bodhi/tests/functional/test_updates.py
+++ b/bodhi/tests/functional/test_updates.py
@@ -1425,7 +1425,7 @@ class TestUpdatesService(bodhi.tests.functional.base.BaseWSGICase):
 
         up = DBSession.query(Update).filter_by(title=nvr).one()
         up.locked = True
-        up.status = UpdateRequest.testing
+        up.status = UpdateStatus.testing
         up.request = None
         up_id = up.id
 


### PR DESCRIPTION
- Ensure you can comment on a locked update.
- Ensure that the comment won't trigger threshold action if your comment
takes
 things over or under the stable/unstable karma thresholds.

Relates to #539.