### PR TITLE
Added link to developement.ini and sqlalchemy.url

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -31,10 +31,10 @@ Import the bodhi2 database
 .. note:: If you do not have a PostgreSQL server running, please see the
           instructions at the bottom of the file.
 
-Adjust the development.ini file
+Adjust the `development.ini <https://github.com/fedora-infra/bodhi/blob/develop/development.ini>`_ file
 -------------------------------
 
-Adjust the configuration key ``sqlalchemy.url`` to point to the postgresql
+Adjust the configuration key `sqlalchemy.url <https://github.com/fedora-infra/bodhi/blob/02d0a883c156d9a27a4dbac994409ecf726d00a9/development.ini#L413>`_ to point to the postgresql
 database. Something like:
 ::
 


### PR DESCRIPTION
Improved [README.rst](https://github.com/fedora-infra/bodhi/blob/develop/README.rst) by adding the links. Presently the user would have to search for them especially [sqlalchemy.url](https://github.com/fedora-infra/bodhi/blob/02d0a883c156d9a27a4dbac994409ecf726d00a9/development.ini#L413)