### PR TITLE
Use email over username here (if we have it).

### DIFF
--- a/bodhi/models/models.py
+++ b/bodhi/models/models.py
@@ -1497,7 +1497,10 @@ class Update(Base):
         for comment in self.comments:
             if comment.anonymous or comment.user.name == u'bodhi':
                 continue
-            people.add(comment.user.name)
+            if comment.user.email:
+                people.add(comment.user.email)
+            else:
+                people.add(comment.user.name)
         mail.send(people, 'comment', self, author, author)
         return comment, caveats
 


### PR DESCRIPTION
We did this just a few lines above for all of the package maintainers, but we
forgot to do it here for all the people who commented on the bug.  This should
cut down on superfluous warnings in our logs *and* get more email to people who
should be getting it.