### PR TITLE
Use validate_acls to produce the can_edit value.

### DIFF
--- a/bodhi/security.py
+++ b/bodhi/security.py
@@ -14,14 +14,13 @@
 
 from cornice.errors import Errors
 
-from pyramid.security import (Allow, Deny, Everyone, Authenticated,
-                              ALL_PERMISSIONS, DENY_ALL)
+from pyramid.security import (Allow, ALL_PERMISSIONS, DENY_ALL)
 from pyramid.security import remember, forget
 from pyramid.httpexceptions import HTTPFound
 from pyramid.threadlocal import get_current_registry
 
 from . import log
-from .models import User, Group, Update
+from .models import User, Group
 
 
 #
@@ -37,19 +36,10 @@ def admin_only_acl(request):
 
 def packagers_allowed_acl(request):
     """Generate an ACL for update submission"""
-    return [(Allow, 'group:' + group, ALL_PERMISSIONS) for group in
-            request.registry.settings['mandatory_packager_groups'].split()] + \
-           [DENY_ALL]
-
-
-def package_maintainers_only_acl(request):
-    """An ACL that only allows package maintainers for a given package"""
-    acl = admin_only_acl(request)
-    update = Update.get(request.matchdict['id'], request.db)
-    if update:
-        for committer in update.get_maintainers():
-            acl.insert(0, (Allow, committer.name, ALL_PERMISSIONS))
-    return acl
+    groups = request.registry.settings['mandatory_packager_groups'].split()
+    return [
+        (Allow, 'group:' + group, ALL_PERMISSIONS) for group in groups
+    ] + [DENY_ALL]
 
 
 #

--- a/bodhi/security.py
+++ b/bodhi/security.py
@@ -12,6 +12,8 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
+from cornice.errors import Errors
+
 from pyramid.security import (Allow, Deny, Everyone, Authenticated,
                               ALL_PERMISSIONS, DENY_ALL)
 from pyramid.security import remember, forget
@@ -189,3 +191,19 @@ class CorsOrigins(object):
 
 cors_origins_ro = CorsOrigins('cors_origins_ro')
 cors_origins_rw = CorsOrigins('cors_origins_rw')
+
+
+class ProtectedRequest(object):
+    """ A proxy to the request object.
+
+    The point here is that you can set 'errors' on this request, but they
+    will be sent to /dev/null and hidden from cornice.  Otherwise, this
+    object behaves just like a normal request object.
+    """
+    def __init__(self, real_request):
+        # Hide errors added to this from the real request
+        self.errors = Errors()
+        # But proxy other attributes to the real request
+        self.real_request = real_request
+        for attr in ['db', 'registry', 'validated', 'buildinfo', 'user']:
+            setattr(self, attr, getattr(self.real_request, attr))

--- a/bodhi/services/updates.py
+++ b/bodhi/services/updates.py
@@ -16,7 +16,6 @@ import copy
 import math
 
 from cornice import Service
-from pyramid.security import has_permission
 from sqlalchemy import func, distinct
 from sqlalchemy.sql import or_
 
@@ -45,18 +44,12 @@ from bodhi.validators import (
 update = Service(name='update', path='/updates/{id}',
                  validators=(validate_update_id,),
                  description='Update submission service',
-                 # This acl only checks if the user is an admin or a commiters to the packages,
-                 # where as the validate_acls method which is attached to the @post on this
-                 # services does this as well as checking against the groups. So, this acl
-                 # should be unnecessary at the moment.
-                 #acl=bodhi.security.package_maintainers_only_acl,
                  acl=bodhi.security.packagers_allowed_acl,
                  cors_origins=bodhi.security.cors_origins_ro)
 
 update_edit = Service(name='update_edit', path='/updates/{id}/edit',
                  validators=(validate_update_id,),
                  description='Update submission service',
-                 #acl=bodhi.security.package_maintainers_only_acl,
                  acl=bodhi.security.packagers_allowed_acl,
                  cors_origins=bodhi.security.cors_origins_rw)
 
@@ -67,10 +60,8 @@ updates = Service(name='updates', path='/updates/',
 
 update_request = Service(name='update_request', path='/updates/{id}/request',
                          description='Update request service',
-                         #acl=bodhi.security.package_maintainers_only_acl,
                          acl=bodhi.security.packagers_allowed_acl,
                          cors_origins=bodhi.security.cors_origins_rw)
-
 
 @update.get(accept=('application/json', 'text/json'), renderer='json',
             error_handler=bodhi.services.errors.json_handler)

--- a/bodhi/services/updates.py
+++ b/bodhi/services/updates.py
@@ -80,7 +80,12 @@ update_request = Service(name='update_request', path='/updates/{id}/request',
             error_handler=bodhi.services.errors.html_handler)
 def get_update(request):
     """Return a single update from an id, title, or alias"""
-    can_edit = bool(has_permission('edit', request.context, request))
+
+    proxy_request = bodhi.security.ProtectedRequest(request)
+    validate_acls(proxy_request)
+    # If validate_acls produced 0 errors, then we can edit this update.
+    can_edit = len(proxy_request.errors) == 0
+
     return dict(update=request.validated['update'], can_edit=can_edit)
 
 

--- a/bodhi/tests/functional/test_updates.py
+++ b/bodhi/tests/functional/test_updates.py
@@ -248,6 +248,7 @@ class TestUpdatesService(bodhi.tests.functional.base.BaseWSGICase):
         user = User(name=u'bob')
         session.add(user)
         session.add(User(name=u'ralph'))  # Add a non proventester
+        session.add(User(name=u'someuser'))  # An unrelated user with no privs
         session.flush()
         group = session.query(Group).filter_by(name=u'provenpackager').one()
         user.groups.append(group)
@@ -319,6 +320,22 @@ class TestUpdatesService(bodhi.tests.functional.base.BaseWSGICase):
         eq_(res.json_body['update']['request'], None)
         eq_(update.request, None)
         eq_(update.status, UpdateStatus.obsolete)
+
+        # Test that bob has can_edit True, provenpackager
+        app = TestApp(main({}, testing=u'bob', **self.app_settings))
+        res = app.get('/updates/%s' % nvr, status=200)
+        eq_(res.json_body['can_edit'], True)
+
+        # Test that ralph has can_edit True, they submitted it.
+        app = TestApp(main({}, testing=u'ralph', **self.app_settings))
+        res = app.get('/updates/%s' % nvr, status=200)
+        eq_(res.json_body['can_edit'], True)
+
+        # Test that someuser has can_edit False, they are unrelated
+        # This check *failed* with the old acls code.
+        app = TestApp(main({}, testing=u'someuser', **self.app_settings))
+        res = app.get('/updates/%s' % nvr, status=200)
+        eq_(res.json_body['can_edit'], False)
 
     @mock.patch(**mock_valid_requirements)
     def test_pkgdb_outage(self, *args):

--- a/bodhi/validators.py
+++ b/bodhi/validators.py
@@ -721,7 +721,6 @@ def validate_override_builds(request):
 def _validate_override_build(request, nvr, db):
     """ Workhorse function for validate_override_builds """
     build = Build.get(nvr, db)
-    print "in _validate with build", build
     if build is not None:
         if not build.release:
             # Oddly, the build has no associated release.  Let's try to figure

--- a/bodhi/validators.py
+++ b/bodhi/validators.py
@@ -285,10 +285,10 @@ def validate_acls(request):
         admin_groups = settings['admin_packager_groups'].split()
         for group in admin_groups:
             if group in user_groups:
-                log.debug(
-                    '{} is in {} admin group'.format(user.name, group))
+                log.debug('{} is in {} admin group'.format(user.name, group))
                 has_access = True
                 break
+
         if has_access:
             continue
 


### PR DESCRIPTION
* Fixes #190
* Fixes #321

This didn't go the way I expected.  I expected to make the ``bodhi.security.package_maintainers_only_acl`` acl smarter by moving some of the logic over from ``validate_acls``, and then rewriting  ``validate_acls`` to use that pyramid acl.  This turned out to not be the best idea.

First, pyramid acls must return a list of principals indicating who is and who isn't allowed to access a resource.  For us, that would mean returning a list of *all* proven packagers and *all* people with commit access (by querying pkgdb) every time we load a page.  `validate_acls` is smarter than this in that it first checks for provenpackager status and then skips querying pkgdb if the person is in that group.  I thought about trying to be clever by returning a *generator* from our acl function there, so that pyramid would only evaluate the first few items before saying "okay", but it is not written to be able to handle that.  I then thought about replacing pyramid ACLAuthorizationPolicy object with our own, but then things got out of hand.

Before this patch, we were querying pkgdb *twice* (in some cases, three times) for all the people with commit on *all the builds in an update*.  Now we should be doing that *at most once*, and sometimes not at all (in the case of provenpackager).

Furthermore, in fixing #321, the buttons that show up at the top of the update page should make a lot more sense.