### PR TITLE
Cut down on recursive data in the JSON api.

### DIFF
--- a/bodhi/models/models.py
+++ b/bodhi/models/models.py
@@ -107,6 +107,9 @@ class BodhiBase(object):
         for attr in rels:
             if attr in exclude:
                 continue
+            target = getattr(type(obj), attr).property.mapper.class_
+            if target in seen:
+                continue
             d[attr] = cls._expand(obj, getattr(obj, attr), seen, request)
 
         for key, value in d.iteritems():


### PR DESCRIPTION
This removes a *ton* of stuff that isn't needed.

Right now we return something like this:

```javascript
{
  update: {
    user: {
      groups: [{
        name: "packagers",
        users: [
          id1,
          id2,
          id3,
          id4,
          ...
        ],
      }],
    }
  }
}
```

Previously, we would notice that we have already ``seen`` the ``User`` model in
the json recursion, and turn that list of users into just a list of IDs... but
this is still way too much data.  If you are getting a *list of updates*, you
get the owner of every update, and every group their in, and the id of every
user in every one of those groups *over and over* for every update in the list
you retrieved.

With this code change, we detect that we have already ``seen`` the ``User``
model before diving into the ``_expand(..)`` recursion, and we just drop that
innermost user list all together.

```javascript
{
  update: {
    user: {
      groups: [{
        name: "packagers",
      }],
    }
  }
}
```

This reduces the number of bytes returned by a typical query by about 1/2::

  ❯ # Before
  ❯ http get http://0.0.0.0:6543/updates/ | wc
        0  191134 1661397
  ❯ # After
  ❯ http get http://0.0.0.0:6543/updates/ | wc
        0   85607 1087158