### PR TITLE
bugzilla ticket number have 6+ digits

### DIFF
--- a/bodhi/ffmarkdown.py
+++ b/bodhi/ffmarkdown.py
@@ -62,7 +62,7 @@ def inject():
             return el
 
     MENTION_RE = r'(@\w+)'
-    BUGZILLA_RE = r'(#[0-9]{5,})'
+    BUGZILLA_RE = r'(#[0-9]{6,})'
 
     class SurroundProcessor(markdown.postprocessors.Postprocessor):
         def run(self, text):


### PR DESCRIPTION
Ticker 99999 is >8 years old.

This is mostly useful to avoid the pattern to be raised when update description is a copy/paste from upstream changelog, with upstream bug ref.

And I think most projects have bug < 100,000 (e.g. PHP is ~70,000)

See https://bodhi.fedoraproject.org/updates/FEDORA-2015-14978