### PR TITLE
Markdown bugurls

### DIFF
--- a/bodhi/ffmarkdown.py
+++ b/bodhi/ffmarkdown.py
@@ -29,8 +29,16 @@ def user_url(name):
     return request.route_url('user', name=name)
 
 
-def bugzilla_url(idx):
-    return "https://bugzilla.redhat.com/show_bug.cgi?id=%s" % idx
+def bug_url(tracker, idx):
+    try:
+        return {
+            'fedora': "https://bugzilla.redhat.com/show_bug.cgi?id=%s",
+            'rh': "https://bugzilla.redhat.com/show_bug.cgi?id=%s",
+            'rhbz': "https://bugzilla.redhat.com/show_bug.cgi?id=%s",
+            }[tracker.lower()] % idx
+
+    except KeyError:
+        return None
 
 
 def inject():
@@ -55,14 +63,20 @@ def inject():
 
     class BugzillaPattern(markdown.inlinepatterns.Pattern):
         def handleMatch(self, m):
+            tracker = markdown.util.AtomicString(m.group(2))
+            idx = markdown.util.AtomicString(m.group(3))
+            url = bug_url(tracker, idx[1:])
+
+            if url is None:
+                return tracker + idx
+
             el = markdown.util.etree.Element("a")
-            idx = markdown.util.AtomicString(m.group(2))
-            el.set('href', bugzilla_url(idx[1:]))
+            el.set('href', url)
             el.text = idx
             return el
 
     MENTION_RE = r'(@\w+)'
-    BUGZILLA_RE = r'(#[0-9]{5,})'
+    BUGZILLA_RE = r'([\S]+)(#[0-9]{5,})'
 
     class SurroundProcessor(markdown.postprocessors.Postprocessor):
         def run(self, text):

--- a/bodhi/ffmarkdown.py
+++ b/bodhi/ffmarkdown.py
@@ -33,6 +33,12 @@ def bug_url(tracker, idx):
     try:
         return {
             'fedora': "https://bugzilla.redhat.com/show_bug.cgi?id=%s",
+            'gnome': "https://bugzilla.gnome.org/show_bug.cgi?id=%s",
+            'kde': "https://bugs.kde.org/show_bug.cgi?id=%s",
+            'mozilla': "https://bugzilla.mozilla.org/show_bug.cgi?id=%s",
+            'pear': "http://pear.php.net/bugs/bug.php?id=%s",
+            'php': "https://bugs.php.net/bug.php?id=%s",
+            'python': "https://bugs.python.org/issue%s",
             'rh': "https://bugzilla.redhat.com/show_bug.cgi?id=%s",
             'rhbz': "https://bugzilla.redhat.com/show_bug.cgi?id=%s",
             }[tracker.lower()] % idx

--- a/bodhi/templates/fragments.html
+++ b/bodhi/templates/fragments.html
@@ -211,9 +211,18 @@ __bold__
 </code></pre>
             </div>
             <div class="col-md-4">
-              <p>You can reference <strong>bugzilla tickets</strong> by simply prefixing a ticket id with the <code>&#35;</code> character.</p>
-              <pre><code>We really need #1185409</code></pre>
-              <p>... we will automatically generate a link to the ticket in place.</p>
+              <p>You can reference <strong>bug reports</strong> by simply writing something of the form <code>tracker&#35;ticketid</code>.</p>
+              <pre><code>This fixes PHP#1234 and Python#2345</code></pre>
+              <p>... we will automatically generate links to the tickets in the appropriate trackers in place.</p>
+              <p>The supported bug tracker prefixes are: (these are all case-insensitive)</p>
+              <ul>
+                <li><code>Fedora</code>, <code>RHBZ</code> and <code>RH</code> (all point to the Red Hat Bugzilla)</li>
+                <li><code>GNOME</code></li>
+                <li><code>KDE</code></li>
+                <li><code>PEAR</code></li>
+                <li><code>PHP</code></li>
+                <li><code>Python</code></li>
+              </ul>
               <hr/>
               <p>And you can refer to <strong>other users</strong> by prefixing their username with the <code>@</code> symbol.</p>
               <pre><code>Thanks @mattdm!</code></pre>

--- a/bodhi/tests/functional/test_generic.py
+++ b/bodhi/tests/functional/test_generic.py
@@ -169,9 +169,20 @@ class TestGenericViews(bodhi.tests.functional.base.BaseWSGICase):
             "</div>"
         )
 
-    def test_markdown_with_bugzilla(self):
+    def test_markdown_with_unprefixed_bugzilla(self):
         res = self.app.get('/markdown', {
             'text': 'Crazy.  #12345 is still busted.',
+        }, status=200)
+        self.assertEquals(
+            res.json_body['html'],
+            "<div class='markdown'>"
+            '<p>Crazy.  #12345 is still busted.</p>'
+            "</div>"
+        )
+
+    def test_markdown_with_prefixed_bugzilla(self):
+        res = self.app.get('/markdown', {
+            'text': 'Crazy.  RHBZ#12345 is still busted.',
         }, status=200)
         self.assertEquals(
             res.json_body['html'],
@@ -179,6 +190,17 @@ class TestGenericViews(bodhi.tests.functional.base.BaseWSGICase):
             '<p>Crazy.  '
             '<a href="https://bugzilla.redhat.com/show_bug.cgi?id=12345">'
             '#12345</a> is still busted.</p>'
+            "</div>"
+        )
+
+    def test_markdown_with_unknown_prefixed_bugzilla(self):
+        res = self.app.get('/markdown', {
+            'text': 'Crazy.  upstream#12345 is still busted.',
+        }, status=200)
+        self.assertEquals(
+            res.json_body['html'],
+            "<div class='markdown'>"
+            '<p>Crazy.  upstream#12345 is still busted.</p>'
             "</div>"
         )
 


### PR DESCRIPTION
This allows writing things like `python#12345` and get it markdownified into a link to bug 12345 in the upstream Python bug tracker.