### PR TITLE
Suppress "Caveats:" text if there are no caveats.

### DIFF
--- a/bodhi/cli.py
+++ b/bodhi/cli.py
@@ -228,7 +228,7 @@ def print_resp(resp, client):
     else:
         click.echo(resp)
 
-    if 'caveats' in resp:
+    if resp.get('caveats', None):
         click.echo('Caveats:')
         for caveat in resp.caveats:
             click.echo(caveat.description)


### PR DESCRIPTION
Otherwise, it prints that header out every time.