### PR TITLE
Restructure the way we assign aliases.

### DIFF
--- a/bodhi/tests/__init__.py
+++ b/bodhi/tests/__init__.py
@@ -1,3 +1,5 @@
+import mock
+
 from datetime import datetime, timedelta
 from bodhi.models import (
     Base,
@@ -77,7 +79,8 @@ def populate(db):
     db.add(comment)
     update.comments.append(comment)
 
-    update.assign_alias()
+    with mock.patch(target='uuid.uuid4', return_value='wat'):
+        update.assign_alias()
     db.add(update)
 
     expiration_date = datetime.utcnow()

--- a/bodhi/tests/functional/test_updates.py
+++ b/bodhi/tests/functional/test_updates.py
@@ -46,6 +46,15 @@ mock_valid_requirements = {
     'return_value': ['rpmlint', 'upgradepath'],
 }
 
+mock_uuid4_version1 = {
+    'target': 'uuid.uuid4',
+    'return_value': 'this is a consistent string',
+}
+mock_uuid4_version2 = {
+    'target': 'uuid.uuid4',
+    'return_value': 'this is another consistent string',
+}
+
 mock_taskotron_results = {
     'target': 'bodhi.util.taskotron_results',
     'return_value': [{
@@ -408,7 +417,7 @@ class TestUpdatesService(bodhi.tests.functional.base.BaseWSGICase):
         self.assertEquals(up['date_modified'], None)
         self.assertEquals(up['date_pushed'], None)
         self.assertEquals(up['locked'], False)
-        self.assertEquals(up['alias'], u'FEDORA-%s-0001' % YEAR)
+        self.assertEquals(up['alias'], u'FEDORA-%s-a3bbe1a8f2' % YEAR)
         self.assertEquals(up['karma'], 1)
 
     def test_list_updates_jsonp(self):
@@ -499,7 +508,7 @@ class TestUpdatesService(bodhi.tests.functional.base.BaseWSGICase):
         self.assertEquals(up['date_approved'], now.strftime("%Y-%m-%d %H:%M:%S"))
         self.assertEquals(up['date_pushed'], None)
         self.assertEquals(up['locked'], False)
-        self.assertEquals(up['alias'], u'FEDORA-%s-0001' % YEAR)
+        self.assertEquals(up['alias'], u'FEDORA-%s-a3bbe1a8f2' % YEAR)
         self.assertEquals(up['karma'], 1)
         self.assertEquals(len(up['bugs']), 1)
         self.assertEquals(up['bugs'][0]['bug_id'], 12345)
@@ -538,7 +547,7 @@ class TestUpdatesService(bodhi.tests.functional.base.BaseWSGICase):
         self.assertEquals(up['date_approved'], None)
         self.assertEquals(up['date_pushed'], None)
         self.assertEquals(up['locked'], False)
-        self.assertEquals(up['alias'], u'FEDORA-%s-0001' % YEAR)
+        self.assertEquals(up['alias'], u'FEDORA-%s-a3bbe1a8f2' % YEAR)
         self.assertEquals(up['karma'], 1)
         self.assertEquals(len(up['bugs']), 1)
         self.assertEquals(up['bugs'][0]['bug_id'], 12345)
@@ -577,7 +586,7 @@ class TestUpdatesService(bodhi.tests.functional.base.BaseWSGICase):
         self.assertEquals(up['date_approved'], None)
         self.assertEquals(up['date_pushed'], None)
         self.assertEquals(up['locked'], False)
-        self.assertEquals(up['alias'], u'FEDORA-%s-0001' % YEAR)
+        self.assertEquals(up['alias'], u'FEDORA-%s-a3bbe1a8f2' % YEAR)
         self.assertEquals(up['karma'], 1)
 
     def test_list_updates_by_invalid_critpath(self):
@@ -610,7 +619,7 @@ class TestUpdatesService(bodhi.tests.functional.base.BaseWSGICase):
         self.assertEquals(up['date_approved'], None)
         self.assertEquals(up['date_pushed'], None)
         self.assertEquals(up['locked'], False)
-        self.assertEquals(up['alias'], u'FEDORA-%s-0001' % YEAR)
+        self.assertEquals(up['alias'], u'FEDORA-%s-a3bbe1a8f2' % YEAR)
         self.assertEquals(up['karma'], 1)
         self.assertEquals(up['cves'][0]['cve_id'], "CVE-1985-0110")
 
@@ -669,7 +678,7 @@ class TestUpdatesService(bodhi.tests.functional.base.BaseWSGICase):
         self.assertEquals(up['date_approved'], None)
         self.assertEquals(up['date_pushed'], None)
         self.assertEquals(up['locked'], False)
-        self.assertEquals(up['alias'], u'FEDORA-%s-0001' % YEAR)
+        self.assertEquals(up['alias'], u'FEDORA-%s-a3bbe1a8f2' % YEAR)
         self.assertEquals(up['karma'], 1)
 
     def test_list_updates_by_locked(self):
@@ -693,7 +702,7 @@ class TestUpdatesService(bodhi.tests.functional.base.BaseWSGICase):
         self.assertEquals(up['date_approved'], None)
         self.assertEquals(up['date_pushed'], None)
         self.assertEquals(up['locked'], False)
-        self.assertEquals(up['alias'], u'FEDORA-%s-0001' % YEAR)
+        self.assertEquals(up['alias'], u'FEDORA-%s-a3bbe1a8f2' % YEAR)
         self.assertEquals(up['karma'], 1)
 
     def test_list_updates_by_invalid_locked(self):
@@ -741,7 +750,7 @@ class TestUpdatesService(bodhi.tests.functional.base.BaseWSGICase):
         self.assertEquals(up['date_approved'], None)
         self.assertEquals(up['date_pushed'], None)
         self.assertEquals(up['locked'], False)
-        self.assertEquals(up['alias'], u'FEDORA-%s-0001' % YEAR)
+        self.assertEquals(up['alias'], u'FEDORA-%s-a3bbe1a8f2' % YEAR)
         self.assertEquals(up['karma'], 1)
         self.assertEquals(len(up['bugs']), 1)
         self.assertEquals(up['bugs'][0]['bug_id'], 12345)
@@ -776,7 +785,7 @@ class TestUpdatesService(bodhi.tests.functional.base.BaseWSGICase):
         self.assertEquals(up['date_approved'], None)
         self.assertEquals(up['date_pushed'], None)
         self.assertEquals(up['locked'], False)
-        self.assertEquals(up['alias'], u'FEDORA-%s-0001' % YEAR)
+        self.assertEquals(up['alias'], u'FEDORA-%s-a3bbe1a8f2' % YEAR)
         self.assertEquals(up['karma'], 1)
 
     def test_list_updates_by_builds(self):
@@ -804,7 +813,7 @@ class TestUpdatesService(bodhi.tests.functional.base.BaseWSGICase):
         self.assertEquals(up['date_approved'], None)
         self.assertEquals(up['date_pushed'], None)
         self.assertEquals(up['locked'], False)
-        self.assertEquals(up['alias'], u'FEDORA-%s-0001' % YEAR)
+        self.assertEquals(up['alias'], u'FEDORA-%s-a3bbe1a8f2' % YEAR)
         self.assertEquals(up['karma'], 1)
 
     def test_list_updates_by_unexisting_package(self):
@@ -833,7 +842,7 @@ class TestUpdatesService(bodhi.tests.functional.base.BaseWSGICase):
         self.assertEquals(up['date_approved'], None)
         self.assertEquals(up['date_pushed'], None)
         self.assertEquals(up['locked'], False)
-        self.assertEquals(up['alias'], u'FEDORA-%s-0001' % YEAR)
+        self.assertEquals(up['alias'], u'FEDORA-%s-a3bbe1a8f2' % YEAR)
         self.assertEquals(up['karma'], 1)
         self.assertEquals(up['pushed'], False)
 
@@ -881,7 +890,7 @@ class TestUpdatesService(bodhi.tests.functional.base.BaseWSGICase):
         self.assertEquals(up['date_approved'], None)
         self.assertEquals(up['date_pushed'], now.strftime("%Y-%m-%d %H:%M:%S"))
         self.assertEquals(up['locked'], False)
-        self.assertEquals(up['alias'], u'FEDORA-%s-0001' % YEAR)
+        self.assertEquals(up['alias'], u'FEDORA-%s-a3bbe1a8f2' % YEAR)
         self.assertEquals(up['karma'], 1)
         self.assertEquals(len(up['bugs']), 1)
         self.assertEquals(up['bugs'][0]['bug_id'], 12345)
@@ -916,7 +925,7 @@ class TestUpdatesService(bodhi.tests.functional.base.BaseWSGICase):
         self.assertEquals(up['date_approved'], None)
         self.assertEquals(up['date_pushed'], None)
         self.assertEquals(up['locked'], False)
-        self.assertEquals(up['alias'], u'FEDORA-%s-0001' % YEAR)
+        self.assertEquals(up['alias'], u'FEDORA-%s-a3bbe1a8f2' % YEAR)
         self.assertEquals(up['karma'], 1)
 
     def test_list_updates_by_release_version(self):
@@ -940,7 +949,7 @@ class TestUpdatesService(bodhi.tests.functional.base.BaseWSGICase):
         self.assertEquals(up['date_approved'], None)
         self.assertEquals(up['date_pushed'], None)
         self.assertEquals(up['locked'], False)
-        self.assertEquals(up['alias'], u'FEDORA-%s-0001' % YEAR)
+        self.assertEquals(up['alias'], u'FEDORA-%s-a3bbe1a8f2' % YEAR)
         self.assertEquals(up['karma'], 1)
 
     def test_list_updates_by_unexisting_release(self):
@@ -972,7 +981,7 @@ class TestUpdatesService(bodhi.tests.functional.base.BaseWSGICase):
         self.assertEquals(up['date_approved'], None)
         self.assertEquals(up['date_pushed'], None)
         self.assertEquals(up['locked'], False)
-        self.assertEquals(up['alias'], u'FEDORA-%s-0001' % YEAR)
+        self.assertEquals(up['alias'], u'FEDORA-%s-a3bbe1a8f2' % YEAR)
         self.assertEquals(up['karma'], 1)
 
     def test_list_updates_by_unexisting_request(self):
@@ -1006,7 +1015,7 @@ class TestUpdatesService(bodhi.tests.functional.base.BaseWSGICase):
         self.assertEquals(up['date_approved'], None)
         self.assertEquals(up['date_pushed'], None)
         self.assertEquals(up['locked'], False)
-        self.assertEquals(up['alias'], u'FEDORA-%s-0001' % YEAR)
+        self.assertEquals(up['alias'], u'FEDORA-%s-a3bbe1a8f2' % YEAR)
         self.assertEquals(up['karma'], 1)
 
     def test_list_updates_by_unexisting_severity(self):
@@ -1039,7 +1048,7 @@ class TestUpdatesService(bodhi.tests.functional.base.BaseWSGICase):
         self.assertEquals(up['date_approved'], None)
         self.assertEquals(up['date_pushed'], None)
         self.assertEquals(up['locked'], False)
-        self.assertEquals(up['alias'], u'FEDORA-%s-0001' % YEAR)
+        self.assertEquals(up['alias'], u'FEDORA-%s-a3bbe1a8f2' % YEAR)
         self.assertEquals(up['karma'], 1)
 
     def test_list_updates_by_unexisting_status(self):
@@ -1072,7 +1081,7 @@ class TestUpdatesService(bodhi.tests.functional.base.BaseWSGICase):
         self.assertEquals(up['date_approved'], None)
         self.assertEquals(up['date_pushed'], None)
         self.assertEquals(up['locked'], False)
-        self.assertEquals(up['alias'], u'FEDORA-%s-0001' % YEAR)
+        self.assertEquals(up['alias'], u'FEDORA-%s-a3bbe1a8f2' % YEAR)
         self.assertEquals(up['karma'], 1)
 
     def test_list_updates_by_unexisting_suggest(self):
@@ -1105,7 +1114,7 @@ class TestUpdatesService(bodhi.tests.functional.base.BaseWSGICase):
         self.assertEquals(up['date_approved'], None)
         self.assertEquals(up['date_pushed'], None)
         self.assertEquals(up['locked'], False)
-        self.assertEquals(up['alias'], u'FEDORA-%s-0001' % YEAR)
+        self.assertEquals(up['alias'], u'FEDORA-%s-a3bbe1a8f2' % YEAR)
         self.assertEquals(up['karma'], 1)
 
     def test_list_updates_by_unexisting_type(self):
@@ -1138,7 +1147,7 @@ class TestUpdatesService(bodhi.tests.functional.base.BaseWSGICase):
         self.assertEquals(up['date_approved'], None)
         self.assertEquals(up['date_pushed'], None)
         self.assertEquals(up['locked'], False)
-        self.assertEquals(up['alias'], u'FEDORA-%s-0001' % YEAR)
+        self.assertEquals(up['alias'], u'FEDORA-%s-a3bbe1a8f2' % YEAR)
         self.assertEquals(up['karma'], 1)
 
     def test_list_updates_by_unexisting_username(self):
@@ -1160,6 +1169,7 @@ class TestUpdatesService(bodhi.tests.functional.base.BaseWSGICase):
         publish.assert_called_once_with(
             topic='update.request.testing', msg=mock.ANY)
 
+    @mock.patch(**mock_uuid4_version1)
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.notifications.publish')
     def test_new_update(self, publish, *args):
@@ -1180,7 +1190,7 @@ class TestUpdatesService(bodhi.tests.functional.base.BaseWSGICase):
         self.assertEquals(up['date_approved'], None)
         self.assertEquals(up['date_pushed'], None)
         self.assertEquals(up['locked'], False)
-        self.assertEquals(up['alias'], u'FEDORA-%s-0002' % YEAR)
+        self.assertEquals(up['alias'], u'FEDORA-%s-033713b73b' % YEAR)
         self.assertEquals(up['karma'], 0)
         self.assertEquals(up['requirements'], 'rpmlint')
         publish.assert_called_once_with(
@@ -1219,6 +1229,7 @@ class TestUpdatesService(bodhi.tests.functional.base.BaseWSGICase):
         self.assertEquals(up['errors'][0]['description'],
                           "Invalid bug ID specified: [u'1234', u'blargh']")
 
+    @mock.patch(**mock_uuid4_version1)
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.notifications.publish')
     def test_edit_update(self, publish, *args):
@@ -1245,7 +1256,7 @@ class TestUpdatesService(bodhi.tests.functional.base.BaseWSGICase):
         self.assertEquals(up['date_approved'], None)
         self.assertEquals(up['date_pushed'], None)
         self.assertEquals(up['locked'], False)
-        self.assertEquals(up['alias'], u'FEDORA-%s-0002' % YEAR)
+        self.assertEquals(up['alias'], u'FEDORA-%s-033713b73b' % YEAR)
         self.assertEquals(up['karma'], 0)
         self.assertEquals(up['requirements'], 'upgradepath')
         comment = textwrap.dedent("""
@@ -1507,7 +1518,8 @@ class TestUpdatesService(bodhi.tests.functional.base.BaseWSGICase):
     def test_obsoletion(self, publish, *args):
         nvr = 'bodhi-2.0.0-2.fc17'
         args = self.get_update(nvr)
-        self.app.post_json('/updates/', args)
+        with mock.patch(**mock_uuid4_version1):
+            self.app.post_json('/updates/', args)
         publish.assert_called_once_with(
             topic='update.request.testing', msg=mock.ANY)
         publish.call_args_list = []
@@ -1517,7 +1529,8 @@ class TestUpdatesService(bodhi.tests.functional.base.BaseWSGICase):
         up.request = None
 
         args = self.get_update('bodhi-2.0.0-3.fc17')
-        r = self.app.post_json('/updates/', args).json_body
+        with mock.patch(**mock_uuid4_version2):
+            r = self.app.post_json('/updates/', args).json_body
         self.assertEquals(r['request'], 'testing')
 
         # Since we're obsoleting something owned by someone else.
@@ -1529,7 +1542,7 @@ class TestUpdatesService(bodhi.tests.functional.base.BaseWSGICase):
         # Note that caveats above don't support markdown, but comments do.
         self.assertEquals(r['comments'][-1]['text'],
                           u'This update has obsoleted [bodhi-2.0.0-2.fc17]'
-                          '(http://0.0.0.0:6543/updates/FEDORA-2015-0002), '
+                          '(http://0.0.0.0:6543/updates/FEDORA-2015-033713b73b), '
                           'and has inherited its bugs and notes.')
         publish.assert_called_with(
             topic='update.request.testing', msg=mock.ANY)
@@ -1539,7 +1552,7 @@ class TestUpdatesService(bodhi.tests.functional.base.BaseWSGICase):
         self.assertEquals(up.comments[-1].text,
                           u'This update has been obsoleted by '
                           '[bodhi-2.0.0-3.fc17](http://0.0.0.0:6543/'
-                          'updates/FEDORA-2015-0003).')
+                          'updates/FEDORA-2015-53345602d5).')
 
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.notifications.publish')

--- a/bodhi/tests/models/test_models.py
+++ b/bodhi/tests/models/test_models.py
@@ -237,13 +237,17 @@ class TestUpdate(ModelTest):
 
     def test_assign_alias(self):
         update = self.obj
-        update.assign_alias()
+        with mock.patch(target='uuid.uuid4', return_value='wat'):
+            update.assign_alias()
         year = time.localtime()[0]
-        eq_(update.alias, u'%s-%s-0001' % (update.release.id_prefix, year))
+        idx = 'a3bbe1a8f2'
+        eq_(update.alias, u'%s-%s-%s' % (update.release.id_prefix, year, idx))
 
         update = self.get_update(name=u'TurboGears-0.4.4-8.fc11')
-        update.assign_alias()
-        eq_(update.alias, u'%s-%s-0002' % (update.release.id_prefix, year))
+        with mock.patch(target='uuid.uuid4', return_value='wat2'):
+            update.assign_alias()
+        idx = '016462d41f'
+        eq_(update.alias, u'%s-%s-%s' % (update.release.id_prefix, year, idx))
 
         ## Create another update for another release that has the same
         ## Release.id_prefix.  This used to trigger a bug that would cause
@@ -259,29 +263,16 @@ class TestUpdate(ModelTest):
                                  override_tag=u'dist-fc10-override',
                                  branch=u'fc10', version=u'10')
         update.release = otherrel
-        update.assign_alias()
-        eq_(update.alias, u'%s-%s-0003' % (update.release.id_prefix, year))
-
-        ## 10k bug
-        update.alias = u'FEDORA-%s-9999' % year
-        newupdate = self.get_update(name=u'nethack-2.5.6-1.fc10')
-        newupdate.release = otherrel
-        newupdate.assign_alias()
-        eq_(newupdate.alias, u'FEDORA-%s-10000' % year)
-
-        newerupdate = self.get_update(name=u'nethack-2.5.7-1.fc10')
-        newerupdate.assign_alias()
-        eq_(newerupdate.alias, u'FEDORA-%s-10001' % year)
-
-        ## test updates that were pushed at the same time.  assign_alias should
-        ## be able to figure out which one has the highest id.
-        now = datetime.utcnow()
-        newupdate.date_pushed = now
-        newerupdate.date_pushed = now
+        with mock.patch(target='uuid.uuid4', return_value='wat3'):
+            update.assign_alias()
+        idx = '0efffa96f7'
+        eq_(update.alias, u'%s-%s-%s' % (update.release.id_prefix, year, idx))
 
         newest = self.get_update(name=u'nethack-2.5.8-1.fc10')
-        newest.assign_alias()
-        eq_(newest.alias, u'FEDORA-%s-10002' % year)
+        with mock.patch(target='uuid.uuid4', return_value='wat4'):
+            newest.assign_alias()
+        idx = '0efffa96f7'
+        eq_(update.alias, u'%s-%s-%s' % (update.release.id_prefix, year, idx))
 
     def test_epel_id(self):
         """ Make sure we can handle id_prefixes that contain dashes.
@@ -289,8 +280,10 @@ class TestUpdate(ModelTest):
         """
         # Create a normal Fedora update first
         update = self.obj
-        update.assign_alias()
-        eq_(update.alias, u'FEDORA-%s-0001' % time.localtime()[0])
+        with mock.patch(target='uuid.uuid4', return_value='wat'):
+            update.assign_alias()
+        idx = 'a3bbe1a8f2'
+        eq_(update.alias, u'FEDORA-%s-%s' % (time.localtime()[0], idx))
 
         update = self.get_update(name=u'TurboGears-2.1-1.el5')
         release = model.Release(name=u'EL-5', long_name=u'Fedora EPEL 5',
@@ -303,14 +296,18 @@ class TestUpdate(ModelTest):
                           override_tag=u'dist-5E-epel-override',
                           branch=u'el5', version=u'5')
         update.release = release
-        update.assign_alias()
-        eq_(update.alias, u'FEDORA-EPEL-%s-0001' % time.localtime()[0])
+        idx = 'a3bbe1a8f2'
+        with mock.patch(target='uuid.uuid4', return_value='wat'):
+            update.assign_alias()
+        eq_(update.alias, u'FEDORA-EPEL-%s-%s' % (time.localtime()[0], idx))
 
         update = self.get_update(name=u'TurboGears-2.2-1.el5')
         update.release = release
-        update.assign_alias()
-        eq_(update.alias, u'%s-%s-0002' % (release.id_prefix,
-                                           time.localtime()[0]))
+        idx = '016462d41f'
+        with mock.patch(target='uuid.uuid4', return_value='wat2'):
+            update.assign_alias()
+        eq_(update.alias, u'%s-%s-%s' % (
+            release.id_prefix, time.localtime()[0], idx))
 
     @raises(IntegrityError)
     def test_dupe(self):
@@ -482,8 +479,10 @@ class TestUpdate(ModelTest):
 
     def test_get_url(self):
         eq_(self.obj.get_url(), u'updates/TurboGears-1.0.8-3.fc11')
-        self.obj.assign_alias()
-        expected = u'updates/FEDORA-%s-0001' % time.localtime()[0]
+        idx = 'a3bbe1a8f2'
+        with mock.patch(target='uuid.uuid4', return_value='wat'):
+            self.obj.assign_alias()
+        expected = u'updates/FEDORA-%s-%s' % (time.localtime()[0], idx)
         eq_(self.obj.get_url(), expected)
 
     def test_bug(self):

--- a/bodhi/tests/test_masher.py
+++ b/bodhi/tests/test_masher.py
@@ -309,7 +309,7 @@ class TestMasher(unittest.TestCase):
             t.db = None
         self.assertEquals(t.testing_digest[u'Fedora 17'][u'bodhi-2.0-1.fc17'], """\
 ================================================================================
- libseccomp-2.1.0-1.fc20 (FEDORA-%s-0001)
+ libseccomp-2.1.0-1.fc20 (FEDORA-%s-a3bbe1a8f2)
  Enhanced seccomp library
 --------------------------------------------------------------------------------
 Update Information:
@@ -329,7 +329,7 @@ References:
         mail.assert_called_with(config.get('bodhi_email'), config.get('fedora_test_announce_list'), mock.ANY)
         assert len(mail.mock_calls) == 2, len(mail.mock_calls)
         body = mail.mock_calls[1][1][2]
-        assert body.startswith('From: updates@fedoraproject.org\r\nTo: %s\r\nSubject: Fedora 17 updates-testing report\r\n\r\nThe following builds have been pushed to Fedora 17 updates-testing\n\n    bodhi-2.0-1.fc17\n\nDetails about builds:\n\n\n================================================================================\n libseccomp-2.1.0-1.fc20 (FEDORA-%s-0001)\n Enhanced seccomp library\n--------------------------------------------------------------------------------\nUpdate Information:\n\nUseful details!\n--------------------------------------------------------------------------------\nReferences:\n\n  [ 1 ] Bug #12345 - None\n        https://bugzilla.redhat.com/show_bug.cgi?id=12345\n  [ 2 ] CVE-1985-0110\n        http://www.cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-1985-0110\n--------------------------------------------------------------------------------\n\n' % (config.get('fedora_test_announce_list'), time.strftime('%Y'))), repr(body)
+        assert body.startswith('From: updates@fedoraproject.org\r\nTo: %s\r\nSubject: Fedora 17 updates-testing report\r\n\r\nThe following builds have been pushed to Fedora 17 updates-testing\n\n    bodhi-2.0-1.fc17\n\nDetails about builds:\n\n\n================================================================================\n libseccomp-2.1.0-1.fc20 (FEDORA-%s-a3bbe1a8f2)\n Enhanced seccomp library\n--------------------------------------------------------------------------------\nUpdate Information:\n\nUseful details!\n--------------------------------------------------------------------------------\nReferences:\n\n  [ 1 ] Bug #12345 - None\n        https://bugzilla.redhat.com/show_bug.cgi?id=12345\n  [ 2 ] CVE-1985-0110\n        http://www.cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-1985-0110\n--------------------------------------------------------------------------------\n\n' % (config.get('fedora_test_announce_list'), time.strftime('%Y'))), repr(body)
 
     def test_sanity_check(self):
         t = MasherThread(u'F17', u'testing', [u'bodhi-2.0-1.fc17'],
@@ -709,7 +709,7 @@ References:
     @mock.patch('bodhi.bugs.bugtracker.on_qa')
     def test_modify_testing_bugs(self, on_qa, modified, *args):
         self.masher.consume(self.msg)
-        on_qa.assert_called_once_with(12345, u"bodhi-2.0-1.fc17 has been pushed to the Fedora 17 testing repository. If problems still persist, please make note of it in this bug report.\nIf you want to test the update, you can install it with\n$ su -c 'dnf --enablerepo=updates-testing update bodhi'\nYou can provide feedback for this update here: http://0.0.0.0:6543/updates/FEDORA-%s-0001" % time.localtime().tm_year)
+        on_qa.assert_called_once_with(12345, u"bodhi-2.0-1.fc17 has been pushed to the Fedora 17 testing repository. If problems still persist, please make note of it in this bug report.\nIf you want to test the update, you can install it with\n$ su -c 'dnf --enablerepo=updates-testing update bodhi'\nYou can provide feedback for this update here: http://0.0.0.0:6543/updates/FEDORA-%s-a3bbe1a8f2" % time.localtime().tm_year)
 
     @mock.patch(**mock_taskotron_results)
     @mock.patch('bodhi.consumers.masher.MasherThread.update_comps')


### PR DESCRIPTION
Fixes #567.

Before this change, they were ``<PREFIX>-<YEAR>-<INTEGER>``, where the last
part grows monotonically with each new update.

This commit changes that to ``<PREFIX>-<YEAR>-<HASH>``, where hash is the first
10 characters of a hash of a random uuid.

The problem with the way things are now is that:

- we have a race condition.  If you try to submit two updates at the same time
  (via a script, this is easy to do), then they both go into the code where
  their alias is assigned at the same time, they both get the same integer, and
  then when they try to commit their database transactions, one wins and the
  other fails.
- the alias-assigning code is one of the slower parts of the new update
  process.  It takes 1-2s iirc (because it has to query for the latest update
  before it and figure out its id).

The downside here is that the update aliases will no longer be meaningful like
they were.  You won't be able to look at the latest one and instantly know how
many updates there have been so far in 2015, for instance.  IMHO, this isn't
worth the trouble they're causing us.  Up for discussion!