### PR TITLE
Collapse these two emails into one.

### DIFF
--- a/bodhi/metadata.py
+++ b/bodhi/metadata.py
@@ -87,8 +87,8 @@ class ExtendedMetadata(object):
                     self.missing_ids.append(update.title)
 
         if self.missing_ids:
-            log.error("%d updates with missing ID!" % len(self.missing_ids))
-            log.error(self.missing_ids)
+            log.error("%d updates with missing ID: %r" % (
+                len(self.missing_ids), self.missing_ids))
 
     def _load_cached_updateinfo(self):
         """


### PR DESCRIPTION
There's no need to get two errors emails here.

Are these even actionable?  Should we further demote this to a warning?
Does it indicate a serious underlying bug that needs to be fixed?

If it's not serious, let's demote it to a warning.  Otherwise, it will
contribute to error-fatigue.  We'll stop paying attention... ;)