### PR TITLE
don't validate username when querying updates

### DIFF
--- a/bodhi/services/updates.py
+++ b/bodhi/services/updates.py
@@ -140,7 +140,6 @@ validators = (
     validate_release,
     validate_releases,
     validate_enums,
-    validate_username,
     validate_bugs,
 )
 @updates_rss.get(schema=bodhi.schemas.ListUpdateSchema, renderer='rss',


### PR DESCRIPTION
This should fix things like running 'bodhi -D' if your system
user name is not the same as your FAS ID and you do not
have the FAS_USERNAME env var set.

I had to dig through a ton of history to find it, but this
was added in commit 81a2380e4e4c34092035282b97fc21ac7ec8a939 .
I'm fairly sure it's bogus. The point of that commit was to
allow querying updates by user - it added the 'user' arg.
But validate_username doesn't check that the 'user' arg in
the query terms is valid, it checks if the username on the
request is valid, so this isn't doing anything to validate
the query, it's just causing queries to fail for no particular
reason. Querying updates is not a privileged operation and
doesn't require a valid username (or any username).