### PR TITLE
initialize fedmsg off of the main thread.

### DIFF
--- a/bodhi/__init__.py
+++ b/bodhi/__init__.py
@@ -198,8 +198,4 @@ def main(global_config, testing=None, **settings):
     config.scan('bodhi.captcha')
     config.scan('bodhi.events')
 
-    # Setup fedmsg for this thread
-    import bodhi.notifications
-    bodhi.notifications.init()
-
     return config.make_wsgi_app()


### PR DESCRIPTION
we're getting tracebacks in production from the mod_wsgi sub-interpreters.

- we used to manually initialize fedmsg on the main thread in ``main()``.
- the child threads however would just secretly re-initialize themselves under
  the hood when .publish was called.  this worked fine for a long time and we
  had no idea.
- it only became a problem when we added code that checked to see if we were
  explicitly initialized before we published.  then the child threads all
  crashed at this point.
- this now *explicitly* initializes all threads whenever they call publish for
  the first time.
- it also removes the red herring initialization from ``main()``.