### PR TITLE
Port everything to a request-local db session.

### DIFF
--- a/bodhi/consumers/updates.py
+++ b/bodhi/consumers/updates.py
@@ -67,9 +67,8 @@ class UpdatesHandler(fedmsg.consumers.FedmsgConsumer):
             config_uri = '/etc/bodhi/production.ini'
             self.settings = get_appsettings(config_uri)
             engine = engine_from_config(self.settings, 'sqlalchemy.')
-            DBSession.configure(bind=engine)
             Base.metadata.create_all(engine)
-            self.db_factory = transactional_session_maker
+            self.db_factory = transactional_session_maker(engine)
         else:
             self.db_factory = db_factory
 

--- a/bodhi/services/comments.py
+++ b/bodhi/services/comments.py
@@ -181,7 +181,7 @@ def new_comment(request):
 
     try:
         comment, caveats = update.comment(
-            author=author, anonymous=anonymous, **data)
+            session=request.db, author=author, anonymous=anonymous, **data)
     except Exception as e:
         log.exception(e)
         request.errors.add('body', 'comment', 'Unable to create comment')

--- a/bodhi/services/updates.py
+++ b/bodhi/services/updates.py
@@ -125,7 +125,7 @@ def set_request(request):
             return
 
     try:
-        update.set_request(action, request.user.name)
+        update.set_request(request.db, action, request.user.name)
     except BodhiException as e:
         log.exception("Failed to set the request")
         request.errors.add('body', 'request', str(e))

--- a/bodhi/tests/__init__.py
+++ b/bodhi/tests/__init__.py
@@ -8,7 +8,6 @@ from bodhi.models import (
     BuildrootOverride,
     Comment,
     CVE,
-    DBSession,
     Group,
     Package,
     Release,

--- a/bodhi/tests/functional/test_builds.py
+++ b/bodhi/tests/functional/test_builds.py
@@ -23,7 +23,6 @@ from bodhi.models import (
     Bug,
     Build,
     CVE,
-    DBSession,
     Group,
     Package,
     Release,
@@ -52,7 +51,7 @@ class TestBuildsService(bodhi.tests.functional.base.BaseWSGICase):
     def test_list_builds_pagination(self):
 
         # First, stuff a second build in there
-        session = DBSession()
+        session = self.db
         build = Build(nvr=u'bodhi-3.0-1.fc21')
         session.add(build)
         session.flush()

--- a/bodhi/tests/functional/test_generic.py
+++ b/bodhi/tests/functional/test_generic.py
@@ -15,7 +15,7 @@
 import bodhi.tests.functional.base
 
 from bodhi.security import remember_me
-from bodhi.models import DBSession, User, Group
+from bodhi.models import User, Group
 
 from pyramid.testing import DummyRequest
 
@@ -34,11 +34,10 @@ class TestGenericViews(bodhi.tests.functional.base.BaseWSGICase):
 
     def test_remember_me(self):
         """Test the post-login hook"""
-        db = DBSession()
         req = DummyRequest(params={
             'openid.op_endpoint': self.app_settings['openid.provider'],
         })
-        req.db = db
+        req.db = self.db
         req.session = {'came_from': '/'}
         info = {
             'identity_url': 'http://lmacken.id.fedoraproject.org',
@@ -48,13 +47,13 @@ class TestGenericViews(bodhi.tests.functional.base.BaseWSGICase):
         req.registry.settings = self.app_settings
 
         # Ensure the user doesn't exist yet
-        self.assertIsNone(User.get(u'lmacken', db))
-        self.assertIsNone(Group.get(u'releng', db))
+        self.assertIsNone(User.get(u'lmacken', self.db))
+        self.assertIsNone(Group.get(u'releng', self.db))
 
         resp = remember_me(None, req, info)
 
         # The user should now exist, and be a member of the releng group
-        user = User.get(u'lmacken', db)
+        user = User.get(u'lmacken', self.db)
         self.assertEquals(user.name, u'lmacken')
         self.assertEquals(user.email, u'lmacken@fp.o')
         self.assertEquals(len(user.groups), 1)
@@ -66,18 +65,17 @@ class TestGenericViews(bodhi.tests.functional.base.BaseWSGICase):
 
         resp = remember_me(None, req, info)
 
-        user = User.get(u'lmacken', db)
+        user = User.get(u'lmacken', self.db)
         self.assertEquals(len(user.groups), 0)
-        self.assertEquals(len(Group.get(u'releng', db).users), 0)
+        self.assertEquals(len(Group.get(u'releng', self.db).users), 0)
 
 
     def test_remember_me_with_bad_endpoint(self):
         """Test the post-login hook with a bad openid endpoint"""
-        db = DBSession()
         req = DummyRequest(params={
             'openid.op_endpoint': 'bad_endpoint',
         })
-        req.db = db
+        req.db = self.db
         def flash(msg):
             pass
         req.session.flash = flash
@@ -96,7 +94,7 @@ class TestGenericViews(bodhi.tests.functional.base.BaseWSGICase):
             pass
 
         # The user should not exist
-        self.assertIsNone(User.get(u'lmacken', db))
+        self.assertIsNone(User.get(u'lmacken', self.db))
 
     def test_home(self):
         res = self.app.get('/', status=200)

--- a/bodhi/tests/functional/test_overrides.py
+++ b/bodhi/tests/functional/test_overrides.py
@@ -17,8 +17,7 @@ from datetime import datetime, timedelta
 import mock
 
 import bodhi.tests.functional.base
-from bodhi.models import (DBSession, Build, Package,
-                          Release, User)
+from bodhi.models import (Build, Package, Release, User)
 
 
 class TestOverridesService(bodhi.tests.functional.base.BaseWSGICase):
@@ -93,9 +92,8 @@ class TestOverridesService(bodhi.tests.functional.base.BaseWSGICase):
         self.assertEquals(override['notes'], 'blah blah blah')
 
     def test_list_overrides_by_packages_without_override(self):
-        session = DBSession()
-        session.add(Package(name=u'python'))
-        session.flush()
+        self.db.add(Package(name=u'python'))
+        self.db.flush()
 
         res = self.app.get('/overrides/', {'packages': 'python'})
 
@@ -125,8 +123,7 @@ class TestOverridesService(bodhi.tests.functional.base.BaseWSGICase):
         self.assertEquals(override['notes'], 'blah blah blah')
 
     def test_list_overrides_by_releases_without_override(self):
-        session = DBSession()
-        session.add(Release(name=u'F42', long_name=u'Fedora 42',
+        self.db.add(Release(name=u'F42', long_name=u'Fedora 42',
                             id_prefix=u'FEDORA', version=u'42',
                             dist_tag=u'f42', stable_tag=u'f42-updates',
                             testing_tag=u'f42-updates-testing',
@@ -135,7 +132,7 @@ class TestOverridesService(bodhi.tests.functional.base.BaseWSGICase):
                             pending_stable_tag=u'f42-updates-pending',
                             override_tag=u'f42-override',
                             branch=u'f42'))
-        session.flush()
+        self.db.flush()
 
         res = self.app.get('/overrides/', {'releases': 'F42'})
 
@@ -164,9 +161,8 @@ class TestOverridesService(bodhi.tests.functional.base.BaseWSGICase):
         self.assertEquals(override['notes'], 'blah blah blah')
 
     def test_list_overrides_by_username_without_override(self):
-        session = DBSession()
-        session.add(User(name=u'bochecha'))
-        session.flush()
+        self.db.add(User(name=u'bochecha'))
+        self.db.flush()
 
         res = self.app.get('/overrides/', {'user': 'bochecha'})
 
@@ -185,16 +181,14 @@ class TestOverridesService(bodhi.tests.functional.base.BaseWSGICase):
 
     @mock.patch('bodhi.notifications.publish')
     def test_create_override(self, publish):
-        session = DBSession()
-
-        release = Release.get(u'F17', session)
+        release = Release.get(u'F17', self.db)
 
         package = Package(name=u'not-bodhi')
-        session.add(package)
+        self.db.add(package)
         build = Build(nvr=u'not-bodhi-2.0-2.fc17', package=package,
                       release=release)
-        session.add(build)
-        session.flush()
+        self.db.add(build)
+        self.db.flush()
 
         expiration_date = datetime.utcnow() + timedelta(days=1)
 
@@ -216,22 +210,20 @@ class TestOverridesService(bodhi.tests.functional.base.BaseWSGICase):
 
     @mock.patch('bodhi.notifications.publish')
     def test_create_override_multiple_nvr(self, publish):
-        session = DBSession()
-
-        release = Release.get(u'F17', session)
+        release = Release.get(u'F17', self.db)
         package = Package(name=u'not-bodhi')
-        session.add(package)
+        self.db.add(package)
         build1 = Build(nvr=u'not-bodhi-2.0-2.fc17', package=package,
                       release=release)
-        session.add(build1)
-        session.flush()
+        self.db.add(build1)
+        self.db.flush()
 
         package = Package(name=u'another-not-bodhi')
-        session.add(package)
+        self.db.add(package)
         build2 = Build(nvr=u'another-not-bodhi-2.0-2.fc17', package=package,
                       release=release)
-        session.add(build2)
-        session.flush()
+        self.db.add(build2)
+        self.db.flush()
 
         expiration_date = datetime.utcnow() + timedelta(days=1)
 
@@ -263,16 +255,14 @@ class TestOverridesService(bodhi.tests.functional.base.BaseWSGICase):
 
     @mock.patch('bodhi.notifications.publish')
     def test_create_override_too_long(self, publish):
-        session = DBSession()
-
-        release = Release.get(u'F17', session)
+        release = Release.get(u'F17', self.db)
 
         package = Package(name=u'not-bodhi')
-        session.add(package)
+        self.db.add(package)
         build = Build(nvr=u'not-bodhi-2.0-2.fc17', package=package,
                       release=release)
-        session.add(build)
-        session.flush()
+        self.db.add(build)
+        self.db.flush()
 
         expiration_date = datetime.utcnow() + timedelta(days=60)
 
@@ -283,13 +273,12 @@ class TestOverridesService(bodhi.tests.functional.base.BaseWSGICase):
 
     @mock.patch('bodhi.notifications.publish')
     def test_create_override_for_newer_build(self, publish):
-        session = DBSession()
-        old_build = Build.get(u'bodhi-2.0-1.fc17', session)
+        old_build = Build.get(u'bodhi-2.0-1.fc17', self.db)
 
         build = Build(nvr=u'bodhi-2.0-2.fc17', package=old_build.package,
                       release=old_build.release)
-        session.add(build)
-        session.flush()
+        self.db.add(build)
+        self.db.flush()
 
         expiration_date = datetime.utcnow() + timedelta(days=1)
 
@@ -309,15 +298,13 @@ class TestOverridesService(bodhi.tests.functional.base.BaseWSGICase):
                           expiration_date.strftime("%Y-%m-%d %H:%M:%S"))
         self.assertEquals(o['expired_date'], None)
 
-        old_build = Build.get(u'bodhi-2.0-1.fc17', session)
+        old_build = Build.get(u'bodhi-2.0-1.fc17', self.db)
 
         self.assertNotEquals(old_build.override['expired_date'], None)
 
     @mock.patch('bodhi.notifications.publish')
     def test_cannot_edit_override_build(self, publish):
-        session = DBSession()
-
-        release = Release.get(u'F17', session)
+        release = Release.get(u'F17', self.db)
 
         old_nvr = u'bodhi-2.0-1.fc17'
 
@@ -327,8 +314,8 @@ class TestOverridesService(bodhi.tests.functional.base.BaseWSGICase):
         old_build_id = o['build_id']
 
         build = Build(nvr=u'bodhi-2.0-2.fc17', release=release)
-        session.add(build)
-        session.flush()
+        self.db.add(build)
+        self.db.flush()
 
         o.update({
             'nvr': build.nvr,
@@ -345,12 +332,11 @@ class TestOverridesService(bodhi.tests.functional.base.BaseWSGICase):
         self.assertEquals(len(publish.call_args_list), 0)
 
     def test_edit_unexisting_override(self):
-        session = DBSession()
-        release = Release.get(u'F17', session)
+        release = Release.get(u'F17', self.db)
 
         build = Build(nvr=u'bodhi-2.0-2.fc17', release=release)
-        session.add(build)
-        session.flush()
+        self.db.add(build)
+        self.db.flush()
 
         expiration_date = datetime.utcnow() + timedelta(days=1)
 
@@ -441,14 +427,12 @@ class TestOverridesService(bodhi.tests.functional.base.BaseWSGICase):
 
     @mock.patch('bodhi.notifications.publish')
     def test_unexpire_override(self, publish):
-        session = DBSession()
-
         # First expire a buildroot override
         old_nvr = u'bodhi-2.0-1.fc17'
-        override = Build.get(old_nvr, session).override
+        override = Build.get(old_nvr, self.db).override
         override.expire()
-        session.add(override)
-        session.flush()
+        self.db.add(override)
+        self.db.flush()
 
         publish.assert_called_once_with(
             topic='buildroot_override.untag', msg=mock.ANY)

--- a/bodhi/tests/functional/test_packages.py
+++ b/bodhi/tests/functional/test_packages.py
@@ -18,7 +18,6 @@
 import bodhi.tests.functional.base
 
 from bodhi.models import (
-    DBSession,
     Package,
 )
 
@@ -26,7 +25,7 @@ from bodhi.models import (
 class TestPackagesService(bodhi.tests.functional.base.BaseWSGICase):
     def test_basic_json(self):
         """ Test querying with no arguments... """
-        DBSession.add(Package(name='a_second_package'))
+        self.db.add(Package(name='a_second_package'))
         resp = self.app.get('/packages/')
         body = resp.json_body
         self.assertEquals(len(body['packages']), 2)
@@ -34,7 +33,7 @@ class TestPackagesService(bodhi.tests.functional.base.BaseWSGICase):
     def test_filter_by_name(self):
         """ Test that filtering by name returns one package and not the other.
         """
-        DBSession.add(Package(name='a_second_package'))
+        self.db.add(Package(name='a_second_package'))
         resp = self.app.get('/packages/', dict(name='bodhi'))
         body = resp.json_body
         self.assertEquals(len(body['packages']), 1)
@@ -42,7 +41,7 @@ class TestPackagesService(bodhi.tests.functional.base.BaseWSGICase):
     def test_filter_by_like(self):
         """ Test that filtering by like returns one package and not the other.
         """
-        DBSession.add(Package(name='a_second_package'))
+        self.db.add(Package(name='a_second_package'))
         resp = self.app.get('/packages/', dict(like='odh'))
         body = resp.json_body
         self.assertEquals(len(body['packages']), 1)

--- a/bodhi/tests/functional/test_releases.py
+++ b/bodhi/tests/functional/test_releases.py
@@ -15,7 +15,6 @@
 import bodhi.tests.functional.base
 
 from bodhi.models import (
-    DBSession,
     Release,
     ReleaseState,
     Update,
@@ -27,7 +26,6 @@ class TestReleasesService(bodhi.tests.functional.base.BaseWSGICase):
     def setUp(self):
         super(TestReleasesService, self).setUp()
 
-        session = DBSession()
         release = Release(
             name=u'F22', long_name=u'Fedora 22',
             id_prefix=u'FEDORA', version=u'22',
@@ -39,8 +37,8 @@ class TestReleasesService(bodhi.tests.functional.base.BaseWSGICase):
             override_tag=u'f22-override',
             branch=u'f22')
 
-        session.add(release)
-        session.flush()
+        self.db.add(release)
+        self.db.flush()
 
     def test_404(self):
         self.app.get('/releases/watwatwat', status=404)
@@ -103,10 +101,9 @@ class TestReleasesService(bodhi.tests.functional.base.BaseWSGICase):
         self.assertEquals(body['releases'][0]['name'], 'F17')
 
     def test_list_releases_by_update_alias(self):
-        session = DBSession()
-        update = session.query(Update).first()
+        update = self.db.query(Update).first()
         update.alias = u'some_alias'
-        session.flush()
+        self.db.flush()
 
         res = self.app.get('/releases/', {"updates": 'some_alias'})
         body = res.json_body
@@ -146,7 +143,7 @@ class TestReleasesService(bodhi.tests.functional.base.BaseWSGICase):
 
         attrs.pop('csrf_token')
 
-        r = DBSession().query(Release).filter(Release.name==attrs["name"]).one()
+        r = self.db.query(Release).filter(Release.name==attrs["name"]).one()
 
         for k, v in attrs.items():
             self.assertEquals(getattr(r, k), v)
@@ -180,7 +177,7 @@ class TestReleasesService(bodhi.tests.functional.base.BaseWSGICase):
 
         res = self.app.post("/releases/", r, status=200)
 
-        r = DBSession().query(Release).filter(Release.name==name).one()
+        r = self.db.query(Release).filter(Release.name==name).one()
         self.assertEquals(r.state, ReleaseState.current)
 
     def test_get_single_release_html(self):

--- a/bodhi/tests/functional/test_users.py
+++ b/bodhi/tests/functional/test_users.py
@@ -18,7 +18,6 @@ import bodhi.tests.functional.base
 
 from bodhi.config import config
 from bodhi.models import (
-    DBSession,
     Update,
     User,
 )
@@ -29,10 +28,9 @@ class TestUsersService(bodhi.tests.functional.base.BaseWSGICase):
     def setUp(self):
         super(TestUsersService, self).setUp()
 
-        session = DBSession()
         user = User(name=u'bodhi')
-        session.add(user)
-        session.flush()
+        self.db.add(user)
+        self.db.flush()
 
     def test_404(self):
         self.app.get('/users/watwatwat', status=404)
@@ -192,10 +190,9 @@ class TestUsersService(bodhi.tests.functional.base.BaseWSGICase):
         self.assertEquals(body['users'][0]['name'], 'guest')
 
     def test_list_users_by_update_alias(self):
-        session = DBSession()
-        update = session.query(Update).first()
+        update = self.db.query(Update).first()
         update.alias = u'some_alias'
-        session.flush()
+        self.db.flush()
 
         res = self.app.get('/users/', {"updates": 'some_alias'})
         body = res.json_body

--- a/bodhi/tests/test_utils.py
+++ b/bodhi/tests/test_utils.py
@@ -13,7 +13,7 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 from bodhi.models import Update
-from bodhi.util import (get_db_from_config, get_critpath_pkgs, markup,
+from bodhi.util import (get_critpath_pkgs, markup,
                         get_rpm_header, cmd)
 from bodhi.config import config
 
@@ -23,11 +23,6 @@ class TestUtils(object):
     def test_config(self):
         assert config.get('sqlalchemy.url'), config
         assert config['sqlalchemy.url'], config
-
-    def test_get_db_from_config(self):
-        db = get_db_from_config(dev=True)
-        num = db.query(Update).count()
-        assert num == 0, num
 
     def test_get_critpath_pkgs(self):
         """Ensure the pkgdb's critpath API works"""

--- a/bodhi/validators.py
+++ b/bodhi/validators.py
@@ -102,7 +102,7 @@ def validate_builds(request):
 
 def validate_build_tags(request):
     """ Ensure that all of the builds are tagged as candidates """
-    tag_types, tag_rels = Release.get_tags()
+    tag_types, tag_rels = Release.get_tags(request.db)
     edited = request.validated.get('edited')
     release = None
     if edited:
@@ -165,7 +165,7 @@ def validate_build_tags(request):
 
 def validate_tags(request):
     """Ensure that all the tags are valid Koji tags"""
-    tag_types, tag_rels = Release.get_tags()
+    tag_types, tag_rels = Release.get_tags(request.db)
 
     for tag_type in tag_types:
         tag_name = request.validated.get("%s_tag" % tag_type)
@@ -742,7 +742,7 @@ def _validate_override_build(request, nvr, db):
         if not build.release:
             # Oddly, the build has no associated release.  Let's try to figure
             # that out and apply it.
-            tag_types, tag_rels = Release.get_tags()
+            tag_types, tag_rels = Release.get_tags(request.db)
             valid_tags = tag_types['candidate'] + tag_types['testing']
 
             tags = [tag['name'] for tag in request.koji.listTags(nvr)
@@ -770,7 +770,7 @@ def _validate_override_build(request, nvr, db):
             return
 
     else:
-        tag_types, tag_rels = Release.get_tags()
+        tag_types, tag_rels = Release.get_tags(request.db)
         valid_tags = tag_types['candidate'] + tag_types['testing']
 
         try:

--- a/bodhi/views/generic.py
+++ b/bodhi/views/generic.py
@@ -168,7 +168,7 @@ def latest_builds(request):
     builds = {}
     koji = request.koji
     package = request.params.get('package')
-    for tag_type, tags in bodhi.models.Release.get_tags()[0].iteritems():
+    for tag_type, tags in bodhi.models.Release.get_tags(request.db)[0].iteritems():
         for tag in tags:
             try:
                 for build in koji.getLatestBuilds(tag, package=package):

--- a/tools/metrics.py
+++ b/tools/metrics.py
@@ -29,9 +29,13 @@ from datetime import timedelta
 from collections import defaultdict
 
 from sqlalchemy.sql import and_
+from sqlalchemy.orm import scoped_session, sessionmaker
+from zope.sqlalchemy import ZopeTransactionExtension
 
-from bodhi.util import get_db_from_config, header, get_critpath_pkgs
+from bodhi.util import header, get_critpath_pkgs
 from bodhi.models import Update, Release, UpdateStatus, UpdateType
+
+import bodhi
 
 statuses = ('stable', 'testing', 'pending', 'obsolete')
 types = ('bugfix', 'enhancement', 'security', 'newpackage')
@@ -46,7 +50,10 @@ def short_url(update):
 
 
 def main(releases=None):
-    db = get_db_from_config()
+    engine = bodhi.config['sqlalchemy.url']
+    Session = scoped_session(sessionmaker(extension=ZopeTransactionExtension()))
+    Session.configure(bind=engine)
+    db = Session()
 
     stats = {}  # {release: {'stat': ...}}
     feedback = 0  # total number of updates that received feedback

--- a/tools/pickledb.py
+++ b/tools/pickledb.py
@@ -32,7 +32,11 @@ from progressbar import ProgressBar, SimpleProgress, Percentage, Bar
 from pyramid.paster import setup_logging
 setup_logging('/etc/bodhi/production.ini')
 
-from bodhi.util import get_db_from_config, get_critpath_pkgs
+from sqlalchemy.orm import scoped_session, sessionmaker
+from zope.sqlalchemy import ZopeTransactionExtension
+
+from bodhi.util import get_critpath_pkgs
+import bodhi
 
 
 def load_sqlalchemy_db():
@@ -56,7 +60,10 @@ def load_sqlalchemy_db():
 
     aliases = []
 
-    db = get_db_from_config()
+    engine = bodhi.config['sqlalchemy.url']
+    Session = scoped_session(sessionmaker(extension=ZopeTransactionExtension()))
+    Session.configure(bind=engine)
+    db = Session()
 
     # Allow filtering of releases to load
     whitelist = []


### PR DESCRIPTION
.. in a quest to kill the memory leak.

One thing we get out of this is the ability to explicitly close the sessions that we open.

For some context:

- We used to use global dbsessions for everything.  This is a habit we learned from TurboGears back in the day and it turns out to be a bad one.  With the rewrite to Bodhi2, we ported *most all* instances of that to instead rely on a request-local db session which is nicely scoped, more testable, etc.  This 27-file change ports over the *last* of those old global session references and it removes the global session all together.  Starting this I thought it would be easy since there were only a few instances, but it turned out to be more involved.  These last spots were some of the more tangled places in the code.

The test suite is all passing and smoke-testing with a local instance works (submitting comments, poking around, etc...).