### PR TITLE
Improve the perftest tool to compare different commits.

### DIFF
--- a/tools/perf-test.py
+++ b/tools/perf-test.py
@@ -40,7 +40,7 @@ def clock_url(url, tries=4):
         start = time.time()
         response = requests.get(url)
         if not bool(response):
-            raise IOError("Failed to talk to pserve.")
+            raise IOError("pserve failure: %r" % response.status_code)
         values.append(time.time() - start)
     values.remove(max(values))
     values.remove(min(values))

--- a/tools/perf-test.py
+++ b/tools/perf-test.py
@@ -55,6 +55,21 @@ def do_scan():
         results[name] = duration
     return results
 
+
+def loop_over_refs(refs):
+    print "Checking %r" % refs
+    response = raw_input("Is that okay? ")
+    if response != 'y':
+        sys.exit(0)
+    for ref in refs:
+        time.sleep(3)
+        ref = ref[:reflength]
+        commands.getstatus('git checkout %s' % ref)
+        print "Running on", ref
+        results[ref] = do_scan()
+    return results
+
+
 def print_table(table):
     width = max(map(len, items.keys()))
     headers = [' ' * width] + [ref.ljust(reflength) for ref in table.keys()]
@@ -69,27 +84,19 @@ def print_table(table):
     for row in rows:
         print "|" + "|".join(row) + "|"
 
+
 if __name__ == '__main__':
-    refs = sys.argv[1:]
 
     results = collections.OrderedDict()
-    head = commands.getoutput('git rev-parse --abbrev-ref HEAD')[:reflength]
-    if not refs:
-        time.sleep(3)
-        print "Running on", head
-        results[head] = do_scan()
-    else:
-        print "Checking %r" % refs
-        response = raw_input("Is that okay? ")
-        if response != 'y':
-            sys.exit(0)
-        for ref in refs:
-            time.sleep(3)
-            ref = ref[:reflength]
-            commands.getstatus('git checkout %s' % ref)
-            print "Running on", ref
-            results[ref] = do_scan()
+    head = commands.getoutput('git rev-parse --abbrev-ref HEAD')
 
+    refs = sys.argv[1:]
+    if not refs:
+        refs = [head]
+
+    try:
+        results = loop_over_refs(refs)
+    finally:
         print "Returning you to %s" % head
         commands.getstatus('git checkout %s' % head)
 

--- a/tools/perf-test.py
+++ b/tools/perf-test.py
@@ -31,10 +31,21 @@ items = collections.OrderedDict([
 
 
 
-def clock_url(url):
-    start = time.time()
-    requests.get(url)
-    return time.time() - start
+def clock_url(url, tries=5):
+    """ Return the average time taken to query a URL.
+    Throw out the max and min values to avoid startup skew.
+    """
+    values = []
+    for i in range(tries):
+        start = time.time()
+        response = requests.get(url)
+        if not bool(response):
+            raise IOError("Failed to talk to pserve.")
+        values.append(time.time() - start)
+    values.remove(max(values))
+    values.remove(min(values))
+    return sum(values) / len(values)
+
 
 def do_scan():
     results = collections.OrderedDict()

--- a/tools/perf-test.py
+++ b/tools/perf-test.py
@@ -31,7 +31,7 @@ items = collections.OrderedDict([
 
 
 
-def clock_url(url, tries=5):
+def clock_url(url, tries=4):
     """ Return the average time taken to query a URL.
     Throw out the max and min values to avoid startup skew.
     """

--- a/tools/perf-test.py
+++ b/tools/perf-test.py
@@ -86,9 +86,9 @@ def print_table(table):
 
 
 if __name__ == '__main__':
-
     results = collections.OrderedDict()
     head = commands.getoutput('git rev-parse --abbrev-ref HEAD')
+    reflength = max([reflength, len(head)])
 
     refs = sys.argv[1:]
     if not refs:

--- a/tools/perf-test.py
+++ b/tools/perf-test.py
@@ -23,7 +23,7 @@ items = collections.OrderedDict([
     ('release_list', 'http://0.0.0.0:6543/releases/'),
     ('release_view', 'http://0.0.0.0:6543/releases/f22'),
     ('comment_list', 'http://0.0.0.0:6543/comments/'),
-    ('comment_view', 'http://0.0.0.0:6543/comments/2'),
+    ('comment_view', 'http://0.0.0.0:6543/comments/328597'),
     ('user_list', 'http://0.0.0.0:6543/users/'),
     ('user_view', 'http://0.0.0.0:6543/users/adamwill'),
     ('f-e-k-query', 'http://0.0.0.0:6543/updates/?status=testing&release=F22&limit=100')


### PR DESCRIPTION
The output looks kind of like this:

```bash
❯ python tools/perf-test.py e6190c6 7f5e89a 65f319c
Checking ['e6190c6', '7f5e89a', '65f319c']
Is that okay? y
Running on e6190c6
Crunching frontpage http://0.0.0.0:6543/
Crunching update_list http://0.0.0.0:6543/updates/
Crunching update_list_gnome http://0.0.0.0:6543/updates/?packages=gnome-2048
Crunching update_view http://0.0.0.0:6543/updates/FEDORA-2015-13946
Crunching update_view_gnome http://0.0.0.0:6543/updates/FEDORA-2015-16555
Crunching release_list http://0.0.0.0:6543/releases/
Crunching release_view http://0.0.0.0:6543/releases/f22
Crunching comment_list http://0.0.0.0:6543/comments/
Crunching comment_view http://0.0.0.0:6543/comments/2
Crunching user_list http://0.0.0.0:6543/users/
Crunching user_view http://0.0.0.0:6543/users/adamwill
Crunching f-e-k-query http://0.0.0.0:6543/updates/?status=testing&release=F22&limit=100
Running on 7f5e89a
Crunching frontpage http://0.0.0.0:6543/
Crunching update_list http://0.0.0.0:6543/updates/
Crunching update_list_gnome http://0.0.0.0:6543/updates/?packages=gnome-2048
Crunching update_view http://0.0.0.0:6543/updates/FEDORA-2015-13946
Crunching update_view_gnome http://0.0.0.0:6543/updates/FEDORA-2015-16555
Crunching release_list http://0.0.0.0:6543/releases/
Crunching release_view http://0.0.0.0:6543/releases/f22
Crunching comment_list http://0.0.0.0:6543/comments/
Crunching comment_view http://0.0.0.0:6543/comments/2
Crunching user_list http://0.0.0.0:6543/users/
Crunching user_view http://0.0.0.0:6543/users/adamwill
Crunching f-e-k-query http://0.0.0.0:6543/updates/?status=testing&release=F22&limit=100
Running on 65f319c
Crunching frontpage http://0.0.0.0:6543/
Crunching update_list http://0.0.0.0:6543/updates/
Crunching update_list_gnome http://0.0.0.0:6543/updates/?packages=gnome-2048
Crunching update_view http://0.0.0.0:6543/updates/FEDORA-2015-13946
Crunching update_view_gnome http://0.0.0.0:6543/updates/FEDORA-2015-16555
Crunching release_list http://0.0.0.0:6543/releases/
Crunching release_view http://0.0.0.0:6543/releases/f22
Crunching comment_list http://0.0.0.0:6543/comments/
Crunching comment_view http://0.0.0.0:6543/comments/2
Crunching user_list http://0.0.0.0:6543/users/
Crunching user_view http://0.0.0.0:6543/users/adamwill
Crunching f-e-k-query http://0.0.0.0:6543/updates/?status=testing&release=F22&limit=100
Returning you to feature/pe
|                   | e6190c6    | 7f5e89a    | 65f319c    |
| ----------------- | ---------- | ---------- | ---------- |
| frontpage         | 2.76s      | 0.05s      | 0.05s      |
| update_list       | 1.60s      | 1.56s      | 1.65s      |
| update_list_gnome | 2.32s      | 2.29s      | 2.34s      |
| update_view       | 0.68s      | 0.63s      | 0.68s      |
| update_view_gnome | 1.14s      | 1.14s      | 1.12s      |
| release_list      | 0.02s      | 0.02s      | 0.02s      |
| release_view      | 0.02s      | 0.02s      | 0.02s      |
| comment_list      | 3.34s      | 1.70s      | 1.78s      |
| comment_view      | 0.06s      | 0.05s      | 0.05s      |
| user_list         | 0.33s      | 0.19s      | 0.19s      |
| user_view         | 0.09s      | 0.09s      | 0.09s      |
| f-e-k-query       | 2.80s      | 3.83s      | 3.81s      |
````

And the table it produces looks like this when rendered with markdown.

|                   | e6190c6    | 7f5e89a    | 65f319c    |
| ----------------- | ---------- | ---------- | ---------- |
| frontpage         | 2.76s      | 0.05s      | 0.05s      |
| update_list       | 1.60s      | 1.56s      | 1.65s      |
| update_list_gnome | 2.32s      | 2.29s      | 2.34s      |
| update_view       | 0.68s      | 0.63s      | 0.68s      |
| update_view_gnome | 1.14s      | 1.14s      | 1.12s      |
| release_list      | 0.02s      | 0.02s      | 0.02s      |
| release_view      | 0.02s      | 0.02s      | 0.02s      |
| comment_list      | 3.34s      | 1.70s      | 1.78s      |
| comment_view      | 0.06s      | 0.05s      | 0.05s      |
| user_list         | 0.33s      | 0.19s      | 0.19s      |
| user_view         | 0.09s      | 0.09s      | 0.09s      |
| f-e-k-query       | 2.80s      | 3.83s      | 3.81s      |