### PR TITLE
Use https for comps Repo

### DIFF
--- a/bodhi/consumers/masher.py
+++ b/bodhi/consumers/masher.py
@@ -596,10 +596,10 @@ class MasherThread(threading.Thread):
         comps_url = config.get('comps_url')
         if not os.path.exists(comps_dir):
             util.cmd(['git', 'clone', comps_url], os.path.dirname(comps_dir))
-        if comps_url.startswith('git://'):
+        if comps_url.startswith('https://'):
             util.cmd(['git', 'pull'], comps_dir)
         else:
-            self.log.error('comps_url must start with git://')
+            self.log.error('comps_url must start with https://')
             return
         util.cmd(['make'], comps_dir)
 

--- a/development.ini
+++ b/development.ini
@@ -105,7 +105,7 @@ jobs = cache_release_data refresh_metrics approve_testing_updates
 ## Comps configuration
 #comps_dir = /usr/share/bodhi/
 comps_dir = %(here)s/masher/comps
-comps_url = git://git.fedorahosted.org/comps.git
+comps_url = https://git.fedorahosted.org/comps.git
 
 ##
 ## Mirror settings

--- a/production.ini
+++ b/production.ini
@@ -96,7 +96,7 @@ jobs = cache_release_data refresh_metrics approve_testing_updates
 
 ## Comps configuration
 comps_dir = /usr/share/bodhi/
-comps_url = git://git.fedorahosted.org/comps.git
+comps_url = https://git.fedorahosted.org/comps.git
 
 ##
 ## Mirror settings

--- a/staging.ini
+++ b/staging.ini
@@ -96,7 +96,7 @@ jobs = cache_release_data refresh_metrics approve_testing_updates
 
 ## Comps configuration
 comps_dir = /usr/share/bodhi/
-comps_url = git://git.fedorahosted.org/comps.git
+comps_url = https://git.fedorahosted.org/comps.git
 
 ##
 ## Mirror settings


### PR DESCRIPTION
git:// is insecure, therefore do not use it.

Plase also remove the old comps repo on the systems bodhi runs since bodhi will not update the comps URL afaics.