### PR TITLE
Clarify ejection reason.

### DIFF
--- a/bodhi/consumers/masher.py
+++ b/bodhi/consumers/masher.py
@@ -530,8 +530,10 @@ class MasherThread(threading.Thread):
                         from_tag = tag
                         break
                 else:
-                    reason = 'Cannot find relevant tag for %s: %s' % (
-                        build.nvr, tags)
+                    reason = (
+                        'Cannot find relevant tag for %s.  '
+                        'None of %s are in %s.') % (
+                            build.nvr, tags, tag_types[status])
                     self.eject_from_mash(update, reason)
                     break
 


### PR DESCRIPTION
This should help to make the reason for cases like #666 more self-evident in the future.