### PR TITLE
Remove extra unnecessary float class from the build list.

### DIFF
--- a/bodhi/templates/update.html
+++ b/bodhi/templates/update.html
@@ -357,7 +357,7 @@ $(document).ready(function(){
           <ul>
             % for build in update.builds:
             <li>
-              <span class="pull-left">${build.nvr}</span>
+              <span>${build.nvr}</span>
               <span class="pull-right">
                 <a href='${request.route_url("updates_rss") + "?packages=" + build.package.name}'>
                   <span class="fa fa-rss" data-toggle="tooltip" data-placement="top" title="RSS feed for new Bodhi updates containing ${build.package.name}"></span>


### PR DESCRIPTION
This fixes #665 which got introduced in b7690dcc496d60c4b4bb8f30c321fb9d6e010abb.

Things are automatically left-aligned.  No need to introduce some floatery.  It makes things weird at various sizes.