### PR TITLE
Explicitly namespace the white-space css rule.

### DIFF
--- a/bodhi/static/css/site.css
+++ b/bodhi/static/css/site.css
@@ -196,7 +196,7 @@ ul.updateslist li {
 .markdown ul {
     list-style-type: circle;
 }
-.markdown code {
+.markdown > p > code {
     white-space: normal !important;
 }
 .markdown p {


### PR DESCRIPTION
This fixes an issue with the way code-blocks are rendered while maintaining the
behavior we want introduced in #464.

I noticed it while trying to reproduce #671.