### PR TITLE
Add convenience links from the update page to override management.

### DIFF
--- a/bodhi/templates/override.html
+++ b/bodhi/templates/override.html
@@ -49,8 +49,14 @@
           </div>
           <div id="candidates-search" class="form-group noui">
             %if override is UNDEFINED:
-            <input class="typeahead form-control noui" id="nvr" name="nvr" type="text"
-                placeholder="Add a build, like package-0.2.1-5.fc20">
+              %if nvr is UNDEFINED or nvr is None:
+              <input class="typeahead form-control noui" id="nvr" name="nvr" type="text"
+                  placeholder="Add a build, like package-0.2.1-5.fc20">
+              %else:
+              <input class="typeahead form-control noui" id="nvr" name="nvr" type="text"
+                  placeholder="Add a build, like package-0.2.1-5.fc20"
+                  value="${nvr}">
+              %endif
             %else:
             <input class="typeahead form-control noui" id="nvr" name="nvr" type="text"
                 placeholder="Add a build, like package-0.2.1-5.fc20"

--- a/bodhi/templates/update.html
+++ b/bodhi/templates/update.html
@@ -365,6 +365,17 @@ $(document).ready(function(){
                 <a href='${request.route_url("updates") + "?packages=" + build.package.name}'>
                   <span class="glyphicon glyphicon-list" data-toggle="tooltip" data-placement="top" title="Show other Bodhi updates for ${build.package.name}"></span>
                 </a>
+                % if can_edit:
+                % if build.override:
+                <a href="${request.route_url('override', nvr=build.nvr)}">
+                  <span class="glyphicon glyphicon-edit" data-toggle="tooltip" data-placement="top" title="Edit the buildroot override for ${build.nvr}"/>
+                </a>
+                % else:
+                <a href='${request.route_url("new_override")}?nvr=${build.nvr}'>
+                  <span class="glyphicon glyphicon-plus" data-toggle="tooltip" data-placement="top" title="Create a buildroot override for ${build.nvr}"/>
+                </a>
+                % endif
+                % endif
                 <a href="http://koji.fedoraproject.org/koji/search?terms=${build.nvr}&type=build&match=glob" target="_blank">
                   <span class="glyphicon glyphicon-new-window" data-toggle="tooltip" data-placement="top" title="Show the ${build.nvr} build in Koji"></span>
                 </a>

--- a/bodhi/views/generic.py
+++ b/bodhi/views/generic.py
@@ -186,10 +186,11 @@ def masher_status(request):
 @view_config(route_name='new_override', renderer='override.html')
 def new_override(request):
     """ Returns the new buildroot override form """
+    nvr = request.params.get('nvr')
     user = authenticated_userid(request)
     if not user:
         raise HTTPForbidden("You must be logged in.")
-    return dict()
+    return dict(nvr=nvr)
 
 
 @view_config(route_name='api_version', renderer='json')


### PR DESCRIPTION
- If an override exists for each build, add a link to go and edit each one.
- If an override does not exist, add a link to go and create each one.
- If you cannot edit the update, do not show those links.

Fixes #661.