### PR TITLE
Log a little more information about unhandled errors.

### DIFF
--- a/bodhi/__init__.py
+++ b/bodhi/__init__.py
@@ -109,7 +109,7 @@ def get_releases(request):
 def exception_filter(response, request):
     """Log exceptions that get thrown up to cornice"""
     if isinstance(response, Exception):
-        log.exception('Unhandled exception raised')
+        log.exception('Unhandled exception raised:  %r' % response)
     return response
 
 from cornice.validators import DEFAULT_FILTERS


### PR DESCRIPTION
What's weird is that we have *two* other error catchers.  In total:

- We have a *per-service* cornice error handler, defined in ``bodhi/services/errors.py``.
- We have a *pyramid-wide* handler in `bodhi/views/generic.py`.
- Lastly, this *cornice-wide* error handler.

In local testing, I can introduce errors that get handled by the first and
second handlers, but not this one.  Oddly, it seems we're hitting it in
production all the time with that ``None`` error mentioned in #624.

So, I'm not sure what's going on, but hopefully this patch will help us figure
out what's happening, fixing #624.