### PR TITLE
Hide the js warning as early as possible.

### DIFF
--- a/bodhi/static/js/override_form.js
+++ b/bodhi/static/js/override_form.js
@@ -84,7 +84,6 @@ $(document).ready(function() {
         theform.expire();
     });
 
-    // Lastly, hide our warning and show the main form
-    $("#js-warning").addClass('hidden');
+    // Lastly show the main form
     $("#new-override-form").removeClass('hidden');
 });

--- a/bodhi/static/js/stack_form.js
+++ b/bodhi/static/js/stack_form.js
@@ -108,7 +108,6 @@ $(document).ready(function() {
       });
     });
 
-    // Lastly, hide our warning and show the main form
-    $("#js-warning").addClass('hidden');
+    // Lastly show the main form
     $("#new-stack-form").removeClass('hidden');
 });

--- a/bodhi/static/js/update_form.js
+++ b/bodhi/static/js/update_form.js
@@ -240,8 +240,7 @@ $(document).ready(function() {
         theform.submit();
     });
 
-    // Lastly, hide our warning and show the main form
-    $("#js-warning").addClass('hidden');
+    // Lastly show the main form
     $("#new-update-form").removeClass('hidden');
     update_markdown_preview($("#notes").val());
 });

--- a/bodhi/templates/new_stack.html
+++ b/bodhi/templates/new_stack.html
@@ -19,6 +19,8 @@
     </div>
   </div>
 
+  <script>$("#js-warning").addClass('hidden');</script>
+
   <div id="new-stack-form" class="col-md-12 hidden">
 
     <div class="row">

--- a/bodhi/templates/new_update.html
+++ b/bodhi/templates/new_update.html
@@ -25,6 +25,8 @@
     </div>
   </div>
 
+  <script>$("#js-warning").addClass('hidden');</script>
+
   <div id="new-update-form" class="col-md-12 hidden">
 
     <div class="row">

--- a/bodhi/templates/override.html
+++ b/bodhi/templates/override.html
@@ -20,6 +20,8 @@
     </div>
   </div>
 
+  <script>$("#js-warning").addClass('hidden');</script>
+
   <div id="new-override-form" class="col-md-12 hidden">
 
     <div class="row">


### PR DESCRIPTION
Fixes #627, by not waiting for ``$(document).ready(...);``.