### PR TITLE
Allow users to disable global popups.

### DIFF
--- a/alembic/versions/6383ec38980_add_a_show_popups_attribute_for_users.py
+++ b/alembic/versions/6383ec38980_add_a_show_popups_attribute_for_users.py
@@ -1,0 +1,24 @@
+"""Add a show_popups attribute for users.
+
+Revision ID: 6383ec38980
+Revises: 2defe1107259
+Create Date: 2015-10-27 13:33:34.193337
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '6383ec38980'
+down_revision = '2defe1107259'
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.sql import text
+
+
+def upgrade():
+    op.add_column('users', sa.Column(
+        'show_popups', sa.Boolean(), server_default=text('TRUE')))
+
+
+def downgrade():
+    op.drop_column('users', 'show_popups')

--- a/bodhi/__init__.py
+++ b/bodhi/__init__.py
@@ -211,6 +211,9 @@ def main(global_config, testing=None, session=None, **settings):
 
     config.add_route('api_version', '/api_version')
 
+    # The only user preference we have.
+    config.add_route('popup_toggle', '/popup_toggle')
+
     config.scan('bodhi.views')
     config.scan('bodhi.services')
     config.scan('bodhi.captcha')

--- a/bodhi/models/models.py
+++ b/bodhi/models/models.py
@@ -37,6 +37,7 @@ from sqlalchemy import Unicode, UnicodeText, Integer, Boolean
 from sqlalchemy import DateTime
 from sqlalchemy import Table, Column, ForeignKey
 from sqlalchemy import and_, or_
+from sqlalchemy.sql import text
 from sqlalchemy.orm import relationship, backref
 from sqlalchemy.orm import class_mapper
 from sqlalchemy.orm.properties import RelationshipProperty
@@ -2006,6 +2007,9 @@ class User(Base):
 
     name = Column(Unicode(64), unique=True, nullable=False)
     email = Column(UnicodeText, unique=True)
+
+    # A preference
+    show_popups = Column(Boolean, default=True, server_default=text('TRUE'))
 
     # One-to-many relationships
     comments = relationship(Comment, backref=backref('user'), lazy='dynamic')

--- a/bodhi/templates/master.html
+++ b/bodhi/templates/master.html
@@ -89,7 +89,6 @@
               </li>
               % endif
 
-
               % if request.matched_route and request.matched_route.name in ('metrics', 'releases', 'release', 'overrides'):
               <li class="dropdown active">
               % else:
@@ -143,6 +142,20 @@
                   <li>
                     <a href="${request.registry.settings.get('fmn_url')}${request.user.openid}/">
                       Manage Alerts
+                    </a>
+                  </li>
+                  <li>
+                    <form id="popup_toggle" action="${request.route_url('popup_toggle')}" method="POST">
+                      % if request.matched_route:
+                      <input type="hidden" name="next" value="${request.current_route_url()}">
+                      % endif
+                    </form>
+                    <a href="javascript:$('#popup_toggle').submit();">
+                      % if request.user.show_popups:
+                      Disable popups
+                      % else:
+                      Enable popups
+                      % endif
                     </a>
                   </li>
                 </ul>
@@ -203,7 +216,9 @@
     <script src="${request.static_url('bodhi:static/js/cabbage.js')}"></script>
     <script src="${request.static_url('bodhi:static/js/forms.js')}"></script>
     <script src="${request.static_url('bodhi:static/js/site.js')}"></script>
+    % if request.user.show_popups:
     <script src="${request.static_url('bodhi:static/js/live.js')}"></script>
+    % endif
     <script src="${request.static_url('bodhi:static/messenger/js/messenger.min.js')}"></script>
     <script src="${request.static_url('bodhi:static/messenger/js/messenger-theme-flat.js')}"></script>
     <link href="${request.static_url('bodhi:static/messenger/css/messenger.css') }" rel="stylesheet" />

--- a/bodhi/views/generic.py
+++ b/bodhi/views/generic.py
@@ -20,7 +20,8 @@ import cornice.errors
 from pyramid.security import authenticated_userid
 from pyramid.settings import asbool
 from pyramid.view import view_config, notfound_view_config
-from pyramid.exceptions import HTTPForbidden
+from pyramid.exceptions import HTTPForbidden, HTTPBadRequest
+from pyramid.httpexceptions import HTTPFound
 
 from bodhi import log
 import bodhi.models
@@ -191,6 +192,25 @@ def new_override(request):
     if not user:
         raise HTTPForbidden("You must be logged in.")
     return dict(nvr=nvr)
+
+
+@view_config(route_name='popup_toggle', request_method='POST')
+def popup_toggle(request):
+    # Get the user
+    from bodhi.models import User
+    userid = authenticated_userid(request)
+    if userid is None:
+        raise HTTPForbidden("You must be logged in.")
+    user = request.db.query(User).filter_by(name=unicode(userid)).first()
+    if user is None:
+        raise HTTPBadRequest("For some reason, user does not exist.")
+
+    # Toggle the value.
+    user.show_popups = not user.show_popups
+
+    # And send the user back
+    return_to = request.params.get('next', request.route_url('home'))
+    return HTTPFound(location=return_to)
 
 
 @view_config(route_name='api_version', renderer='json')


### PR DESCRIPTION
Fixes #660.

People will still get popups about actions they're undertaking (like,
commenting on an update or error messages when they submit an incomplete form).