### PR TITLE
Add perl# schema for bug links

### DIFF
--- a/bodhi/ffmarkdown.py
+++ b/bodhi/ffmarkdown.py
@@ -37,6 +37,7 @@ def bug_url(tracker, idx):
             'kde': "https://bugs.kde.org/show_bug.cgi?id=%s",
             'mozilla': "https://bugzilla.mozilla.org/show_bug.cgi?id=%s",
             'pear': "http://pear.php.net/bugs/bug.php?id=%s",
+            'perl': "https://rt.cpan.org/Public/Bug/Display.html?id=%s",
             'php': "https://bugs.php.net/bug.php?id=%s",
             'python': "https://bugs.python.org/issue%s",
             'rh': "https://bugzilla.redhat.com/show_bug.cgi?id=%s",


### PR DESCRIPTION
Perl change often use RT#123456 (e.g. http://cpansearch.perl.org/src/SULLR/Net-SSLGlue-1.055/Changes) but perhaps "RT" is too generic, reason why I use "perl" here.