### PR TITLE
Couple of fixes regarding sending emails.

### DIFF
--- a/bodhi/mail.py
+++ b/bodhi/mail.py
@@ -432,6 +432,7 @@ def send_mail(from_addr, to_addr, subject, body_text, headers=None):
     if headers:
         for key, value in headers.items():
             msg.append('%s: %s' % (key, to_bytes(value)))
+    msg.append('X-Bodhi: %s' % config.get('default_email_domain'))
     msg += ['Subject: %s' % subject, '', body_text]
     body = to_bytes('\r\n'.join(msg))
 

--- a/bodhi/models/models.py
+++ b/bodhi/models/models.py
@@ -1482,7 +1482,7 @@ class Update(Base):
                 people.add(comment.user.email)
             else:
                 people.add(comment.user.name)
-        mail.send(people, 'comment', self, author, author)
+        mail.send(people, 'comment', self, sender=None, agent=author)
         return comment, caveats
 
     def unpush(self):


### PR DESCRIPTION
This pull-request addresses the first two points mentioned by @nirik in 
https://github.com/fedora-infra/bodhi/issues/626

- Emails are all sent using the sender email set in the configuration file
- All emails sent by Bodhi have a X-Bodhi header