### PR TITLE
query: add _before params matching the _since params

### DIFF
--- a/bodhi/schemas.py
+++ b/bodhi/schemas.py
@@ -403,6 +403,12 @@ class ListUpdateSchema(PaginatedSchema, SearchableSchema, Cosmetics):
         missing=None,
     )
 
+    approved_before = colander.SchemaNode(
+        colander.DateTime(),
+        location="querystring",
+        missing=None,
+    )
+
     bugs = Bugs(
         colander.Sequence(accept_scalar=True),
         location="querystring",
@@ -442,6 +448,12 @@ class ListUpdateSchema(PaginatedSchema, SearchableSchema, Cosmetics):
         missing=None,
     )
 
+    modified_before = colander.SchemaNode(
+        colander.DateTime(),
+        location="querystring",
+        missing=None,
+    )
+
     packages = Packages(
         colander.Sequence(accept_scalar=True),
         location="querystring",
@@ -456,6 +468,12 @@ class ListUpdateSchema(PaginatedSchema, SearchableSchema, Cosmetics):
     )
 
     pushed_since = colander.SchemaNode(
+        colander.DateTime(),
+        location="querystring",
+        missing=None,
+    )
+
+    pushed_before = colander.SchemaNode(
         colander.DateTime(),
         location="querystring",
         missing=None,
@@ -498,6 +516,12 @@ class ListUpdateSchema(PaginatedSchema, SearchableSchema, Cosmetics):
     )
 
     submitted_since = colander.SchemaNode(
+        colander.DateTime(),
+        location="querystring",
+        missing=None,
+    )
+
+    submitted_before = colander.SchemaNode(
         colander.DateTime(),
         location="querystring",
         missing=None,

--- a/bodhi/services/updates.py
+++ b/bodhi/services/updates.py
@@ -167,6 +167,10 @@ def query_updates(request):
     if approved_since is not None:
         query = query.filter(Update.date_approved >= approved_since)
 
+    approved_before = data.get('approved_before')
+    if approved_before is not None:
+        query = query.filter(Update.date_approved < approved_before)
+
     bugs = data.get('bugs')
     if bugs is not None:
         query = query.join(Update.bugs)
@@ -195,6 +199,10 @@ def query_updates(request):
     if modified_since is not None:
         query = query.filter(Update.date_modified >= modified_since)
 
+    modified_before = data.get('modified_before')
+    if modified_before is not None:
+        query = query.filter(Update.date_modified < modified_before)
+
     packages = data.get('packages')
     if packages is not None:
         query = query.join(Update.builds).join(Build.package)
@@ -212,6 +220,10 @@ def query_updates(request):
     pushed_since = data.get('pushed_since')
     if pushed_since is not None:
         query = query.filter(Update.date_pushed >= pushed_since)
+
+    pushed_before = data.get('pushed_before')
+    if pushed_before is not None:
+        query = query.filter(Update.date_pushed < pushed_before)
 
     releases = data.get('releases')
     if releases is not None:
@@ -238,6 +250,10 @@ def query_updates(request):
     submitted_since = data.get('submitted_since')
     if submitted_since is not None:
         query = query.filter(Update.date_submitted >= submitted_since)
+
+    submitted_before = data.get('submitted_before')
+    if submitted_before is not None:
+        query = query.filter(Update.date_submitted < submitted_before)
 
     suggest = data.get('suggest')
     if suggest is not None:


### PR DESCRIPTION
Bodhi 1 accepted 'start_date' and 'end_date' query params
(BodhiClient didn't actually allow you to submit them, but
they worked on the server end and we have a QA script that
subclassed BodhiClient and fixed the query method to pass
those parameters). 'start_date' worked like 'pushed_since'
in Bodhi 2, but there is no Bodhi 2 equivalent of 'end_date'.
This commit adds pushed_before, and also the _before
equivalent for all the other _since params (approved_since,
modified_since, and submitted_since). If it's approved I'll
send a follow-up which adds them to the client.