### PR TITLE
masher: Iterate over the status results generator

### DIFF
--- a/bodhi/consumers/masher.py
+++ b/bodhi/consumers/masher.py
@@ -204,7 +204,8 @@ Once mash is done:
                         thread.start()
                 for thread in threads:
                     thread.join()
-                results.extend([thread.results() for thread in threads])
+                    for result in thread.results():
+                        results.append(result)
 
         self.log.info('Push complete!  Summary follows:')
         for result in results:


### PR DESCRIPTION
This fixes a bug where the current masher summary looks like:
```
    PoolThread-twisted.internet.reactor-1 <generator object results at 0x7ff99a30d9b0>
```