### PR TITLE
models: Don't reset the `pushed` and `date_pushed` flags upon request.

### DIFF
--- a/bodhi/metadata.py
+++ b/bodhi/metadata.py
@@ -206,6 +206,7 @@ class ExtendedMetadata(object):
         rec.rights = config.get('updateinfo_rights')
 
         if update.date_pushed:
+            log.warning('No date_pushed set for %s' % update.title)
             rec.issued_date = update.date_pushed
         if update.date_modified:
             rec.updated_date = update.date_modified

--- a/bodhi/models/models.py
+++ b/bodhi/models/models.py
@@ -1112,7 +1112,6 @@ class Update(Base):
                 self.add_tag(self.release.candidate_tag)
 
         self.request = action
-        self.pushed = False
 
         notes = notes and '. '.join(notes) + '.' or ''
         flash_notes = flash_notes and '. %s' % flash_notes
@@ -1122,9 +1121,6 @@ class Update(Base):
             action.description, username, notes), author=u'bodhi')
         topic = u'update.request.%s' % action
         notifications.publish(topic=topic, msg=dict(update=self, agent=username))
-
-        # FIXME: track date pushed to testing & stable in different fields
-        self.date_pushed = None
 
     def add_tag(self, tag):
         """ Add a koji tag to all builds in this update """


### PR DESCRIPTION
If a testing update gets a request for stable, currently it will nullify the
`pushed` and `date_pushed` fields. I don't see any reason why we shouldn't keep
these intact, especially considering the fact that we now have `date_stable` and
`date_testing` timestamps. Also, with `date_pushed` set to None, the
`<issued/>` tag in the updateinfo.xml will be omitted, which can lead to other
problems (see
issue #718).