### PR TITLE
ini: Link to wiki page for how to get updates instead of inline cmd

### DIFF
--- a/development.ini
+++ b/development.ini
@@ -269,12 +269,12 @@ pkgdb_url = https://admin.fedoraproject.org/pkgdb
 initial_bug_msg = %s has been submitted as an update to %s. %s
 stable_bug_msg = %s has been pushed to the %s repository. If problems still persist, please make note of it in this bug report.
 testing_bug_msg =
-    If you want to test the update, you can install it with
-    $ su -c 'dnf --enablerepo=updates-testing update %s'
+    See https://fedoraproject.org/wiki/QA:Updates_Testing for
+    instructions on how to install test updates.
     You can provide feedback for this update here: %s
 testing_bug_epel_msg =
-    If you want to test the update, you can install it with
-    $ su -c 'yum --enablerepo=epel-testing update %s'
+    See https://fedoraproject.org/wiki/QA:Updates_Testing for
+    instructions on how to install test updates.
     You can provide feedback for this update here: %s
 
 ##

--- a/production.ini
+++ b/production.ini
@@ -247,12 +247,12 @@ pkgdb_url = https://admin.fedoraproject.org/pkgdb
 initial_bug_msg = %s has been submitted as an update to %s. %s
 stable_bug_msg = %s has been pushed to the %s repository. If problems still persist, please make note of it in this bug report.
 testing_bug_msg =
-    If you want to test the update, you can install it with
-    $ su -c 'dnf --enablerepo=updates-testing update %s'
+    See https://fedoraproject.org/wiki/QA:Updates_Testing for
+    instructions on how to install test updates.
     You can provide feedback for this update here: %s
 testing_bug_epel_msg =
-    If you want to test the update, you can install it with
-    $ su -c 'yum --enablerepo=epel-testing update %s'
+    See https://fedoraproject.org/wiki/QA:Updates_Testing for
+    instructions on how to install test updates.
     You can provide feedback for this update here: %s
 
 ##

--- a/staging.ini
+++ b/staging.ini
@@ -248,12 +248,12 @@ pkgdb_url = https://admin.stg.fedoraproject.org/pkgdb
 initial_bug_msg = %s has been submitted as an update to %s. %s
 stable_bug_msg = %s has been pushed to the %s repository. If problems still persist, please make note of it in this bug report.
 testing_bug_msg =
-    If you want to test the update, you can install it with
-    $ su -c 'dnf --enablerepo=updates-testing update %s'
+    See https://fedoraproject.org/wiki/QA:Updates_Testing for
+    instructions on how to install test updates.
     You can provide feedback for this update here: %s
 testing_bug_epel_msg =
-    If you want to test the update, you can install it with
-    $ su -c 'yum --enablerepo=epel-testing update %s'
+    See https://fedoraproject.org/wiki/QA:Updates_Testing for
+    instructions on how to install test updates.
     You can provide feedback for this update here: %s
 
 ##


### PR DESCRIPTION
Fedora Atomic host uses the `atomic` command and not `dnf` - the wiki
page has more information in either case, at the small cost of
indirection.