### PR TITLE
Remove unnecessary encoding of bug titles.

### DIFF
--- a/bodhi/tests/models/test_models.py
+++ b/bodhi/tests/models/test_models.py
@@ -386,7 +386,7 @@ class TestUpdate(ModelTest):
         bug.title = u'foo\xe9bar'
         from bodhi.util import bug_link
         link = bug_link(None, bug)
-        eq_(link, "<a target='_blank' href='https://bugzilla.redhat.com/show_bug.cgi?id=1'>#1</a> foo\xc3\xa9bar")
+        eq_(link, u"<a target='_blank' href='https://bugzilla.redhat.com/show_bug.cgi?id=1'>#1</a> foo\xe9bar")
 
     def test_set_request_untested_stable(self):
         """

--- a/bodhi/util.py
+++ b/bodhi/util.py
@@ -41,7 +41,6 @@ from sqlalchemy.orm import scoped_session, sessionmaker
 from zope.sqlalchemy import ZopeTransactionExtension
 from pyramid.i18n import TranslationStringFactory
 from pyramid.settings import asbool
-from kitchen.text.converters import to_bytes
 
 from . import log, buildsys
 from .exceptions import RepodataException
@@ -477,7 +476,7 @@ def bug_link(context, bug, short=False):
     if not short:
         if bug.title:
             # We're good...
-            link = link + " " + to_bytes(bug.title)
+            link = link + " " + bug.title
         else:
             # Otherwise, the backend is async grabbing the title from rhbz, so
             link = link + " <img class='spinner' src='static/img/spinner.gif'>"


### PR DESCRIPTION
Ok, so this fixes a bug that showed up first as #366, was partway fixed, but
then it showed up again as #705.

We were originally casting bug titles to a ``str`` (to ``bytes`` in python3
terminology) which caused (of course) some encoding errors.  We then addressed
this in 06476bf1 by using's kitchen's ``to_bytes`` which still forces things to
bytes, but does so in a graceful way.

The problem is that we're using mako's ``render_unicode(...)`` function at the
end of the day, which looks for things like bytes and has to force them *back*
to unicode before rendering everything out and giving it a final encoding once
done.  It's that re-decoding that caused the issue in #705.  By just keeping
everything as unicode and letting mako deal with it, this fixes #705.  (I
checked, and ``bug.title`` is indeed a ``unicode`` object).

I hacked this in place in staging to figure it out.  Compare:

- Working in stg - https://bodhi.stg.fedoraproject.org/updates/FEDORA-2015-67b99c3223
- Broken in prod - https://bodhi.fedoraproject.org/updates/FEDORA-2015-67b99c3223