### PR TITLE
validators: Gracefully handle attempts to edit updates that don't exist

### DIFF
--- a/bodhi/tests/functional/test_updates.py
+++ b/bodhi/tests/functional/test_updates.py
@@ -2198,6 +2198,18 @@ class TestUpdatesService(bodhi.tests.functional.base.BaseWSGICase):
 
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.notifications.publish')
+    def test_edit_missing_update(self, publish, *args):
+        """ Attempt to edit an update that doesn't exist """
+        build = 'bodhi-2.0.0-2.fc17'
+        edited = 'bodhi-1.0-1.fc17'
+        args = self.get_update(build)
+        args['edited'] = edited
+        r = self.app.post_json('/updates/', args, status=400).json_body
+        self.assertEquals(r['status'], 'error')
+        self.assertEquals(r['errors'][0]['description'], 'Cannot find update to edit: %s' % edited)
+
+    @mock.patch(**mock_valid_requirements)
+    @mock.patch('bodhi.notifications.publish')
     def test_edit_update_and_disable_features(self, publish, *args):
         build = 'bodhi-2.0.0-2.fc17'
         args = self.get_update('bodhi-2.0.0-2.fc17')

--- a/bodhi/validators.py
+++ b/bodhi/validators.py
@@ -112,10 +112,15 @@ def validate_build_tags(request):
     release = None
     if edited:
         valid_tags = tag_types['candidate'] + tag_types['testing']
-        release = request.db.query(Update)\
+        update = request.db.query(Update)\
                          .filter_by(title=edited)\
-                         .first()\
-                         .release
+                         .first()
+        if not update:
+            # No need to tack on any more errors here, since they should have
+            # already been added by `validate_builds`
+            return
+
+        release = update.release
         if not release:
             # If the edited update has no release, something went wrong a while
             # ago.  We're already in a corrupt state.  We can't perform the


### PR DESCRIPTION
Fixes #766