### PR TITLE
push: Only attempt to push unlocked updates

### DIFF
--- a/bodhi/push.py
+++ b/bodhi/push.py
@@ -46,6 +46,9 @@ def push(username, password, cert_prefix, **kwargs):
     client = Bodhi2Client(username=username, password=password,
                           staging=staging)
 
+    # Don't try and push locked updates
+    kwargs['locked'] = False
+
     # If we're resuming a push
     if resume:
         updates = []


### PR DESCRIPTION
We just hit an issue where a second push was queued up containing locked updates from the first. This lead to a bunch of ejection messages.