### PR TITLE
Hide "Push to Stable" if request is already "stable".

### DIFF
--- a/bodhi/templates/update.html
+++ b/bodhi/templates/update.html
@@ -522,11 +522,11 @@ $(document).ready(function(){
           % endif
         % elif update.pushed and (update.status.description != 'stable' or (update.status.description == 'stable' and 'releng' in [group.name for group in request.user.groups])):
           <a id='edit' class="btn btn-sm btn-default"><span class="glyphicon glyphicon-edit"></span> Edit</a>
-          % if update.critpath:
+          % if update.critpath and update.request.description != 'stable':
             % if update.critpath_approved:
               <a id='stable' class="btn btn-sm btn-success"><span class="glyphicon glyphicon-circle-arrow-right"></span> Push to Stable</a>
             % endif
-          % elif update.meets_testing_requirements:
+          % elif update.meets_testing_requirements and update.request.description != 'stable':
             <a id='stable' class="btn btn-sm btn-success"><span class="glyphicon glyphicon-circle-arrow-right"></span> Push to Stable</a>
           % endif
           <a id='unpush' class="btn btn-sm btn-danger"><span class="glyphicon glyphicon-circle-arrow-left"></span> Unpush</a>


### PR DESCRIPTION
Whenever I request an update go to stable, it then reloads the page for the
update.. but the button is still there.  It should be hidden after you click
it.  This should handle that.