### PR TITLE
Remove microsecond from timestamp

### DIFF
--- a/bodhi/templates/fragments.html
+++ b/bodhi/templates/fragments.html
@@ -24,7 +24,7 @@
         <span class="pull-right">
           <a href="${comment.url()}">
             %if not display_update:
-            ${util.age(comment.timestamp)}, <small>${comment.timestamp} (UTC)</small>
+            ${util.age(comment.timestamp)}, <small>${str(comment.timestamp).split('.')[0]} (UTC)</small>
             % else:
             ${util.age(comment.timestamp)}
             % endif

--- a/bodhi/templates/update.html
+++ b/bodhi/templates/update.html
@@ -444,14 +444,14 @@ $(document).ready(function(){
       <tr>
         <td>Submitted</td>
         <td>${self.util.age(update.date_submitted)},
-          <small>${update.date_submitted} (UTC)</small></td>
+          <small>${str(update.date_submitted).split('.')[0]} (UTC)</small></td>
       </tr>
 
       % if update.date_testing:
       <tr>
         <td>In Testing</td>
         <td>${self.util.age(update.date_testing)},
-          <small>${update.date_testing} (UTC)</small></td>
+          <small>${str(update.date_testing).split('.')[0]} (UTC)</small></td>
       </tr>
       % endif
 
@@ -459,7 +459,7 @@ $(document).ready(function(){
       <tr>
         <td>In Stable</td>
         <td>${self.util.age(update.date_stable)},
-          <small>${update.date_stable} (UTC)</small></td>
+          <small>${str(update.date_stable).split('.')[0]} (UTC)</small></td>
       </tr>
       % endif
 
@@ -474,7 +474,7 @@ $(document).ready(function(){
       <tr>
         <td>Modified</td>
         <td>${self.util.age(update.date_modified)},
-          <small>${update.date_modified} (UTC)</small></td>
+          <small>${str(update.date_modified).split('.')[0]} (UTC)</small></td>
       </tr>
       % endif
 
@@ -482,7 +482,7 @@ $(document).ready(function(){
       <tr>
         <td>approved</td>
         <td>${self.util.age(update.date_approved)},
-          <small>${update.date_approved} (UTC)</small></td>
+          <small>${str(update.date_approved).split('.')[0]} (UTC)</small></td>
       </tr>
       % endif
 


### PR DESCRIPTION
Fixes #802 
Here are the screenshots:

![screenshot from 2016-03-11 23-32-34](https://cloud.githubusercontent.com/assets/13337039/13711598/7dbb3d3e-e7e5-11e5-93c4-7be93a248c7f.png)

![screenshot from 2016-03-11 23-32-45](https://cloud.githubusercontent.com/assets/13337039/13711605/852ed1de-e7e5-11e5-95ff-ec3de86495d9.png)




