### PR TITLE
Bundle Bugzilla comments with the close command.

### DIFF
--- a/bodhi/bugs.py
+++ b/bodhi/bugs.py
@@ -102,8 +102,12 @@ class Bugzilla(BugTracker):
         except:
             log.exception("Unable to alter bug #%d" % bug_id)
 
-    def close(self, bug_id, versions):
-        args = {}
+    def close(self, bug_id, versions, comment):
+        """
+        Close the bug given by bug_id, mark it as fixed in the given versions,
+        and add a comment.
+        """
+        args = {'comment': comment}
         try:
             bug = self.bz.getbug(bug_id)
             # If this bug is for one of these builds...

--- a/bodhi/models/models.py
+++ b/bodhi/models/models.py
@@ -1203,11 +1203,11 @@ class Update(Base):
                 log.debug('Adding testing comment to bugs for %s', self.title)
                 bug.testing(self)
         elif self.status is UpdateStatus.stable:
-            for bug in self.bugs:
-                log.debug('Adding stable comment to bugs for %s', self.title)
-                bug.add_comment(self)
-
-            if self.close_bugs:
+            if not self.close_bugs:
+                for bug in self.bugs:
+                    log.debug('Adding stable comment to bugs for %s', self.title)
+                    bug.add_comment(self)
+            else:
                 if self.type is UpdateType.security:
                     # Only close the tracking bugs
                     # https://github.com/fedora-infra/bodhi/issues/368#issuecomment-135155215
@@ -2027,7 +2027,7 @@ class Bug(Base):
         versions = dict([
             (get_nvr(b.nvr)[0], b.nvr) for b in update.builds
         ])
-        bugtracker.close(self.bug_id, versions=versions)
+        bugtracker.close(self.bug_id, versions=versions, comment=self.default_message(update))
 
     def modified(self, update):
         """ Change the status of this bug to MODIFIED """


### PR DESCRIPTION
Bodhi used to add a comment to a Bugzilla that the ticket was
resolved, and then close it in a separate transation. This commit
adjusts Bodhi to close and comment in the same Bugzilla transaction
to reduce the number of e-mails that users receive.

closes #404
