### PR TITLE
Disallow re-use of solved captchas.

### DIFF
--- a/bodhi/captcha.py
+++ b/bodhi/captcha.py
@@ -93,6 +93,7 @@ def generate_captcha(context, request):
     plainkey, value = math_generator(plainkey=None, settings=settings)
     cipherkey = encrypt(plainkey, settings)
     url = request.route_url('captcha_image', cipherkey=cipherkey)
+    request.session['captcha'] = cipherkey  # Remember this to stop replay.
     return cipherkey, url
 
 


### PR DESCRIPTION
If someone solved a captcha, they could re-use it over and over again for 5 minutes.  Let's not let them do that.  ;)

This adds the cipherkey of the captcha to the session as a kind of sentinel.  We remove that flag once the captcha is used once.  If they try to use their answer again, it will fail since the flag for that captcha is no longer in the session.

Fixes CVE-2016-1000008.
