### PR TITLE
conditional for RHEL7 distro fixed

### DIFF
--- a/bodhi.spec
+++ b/bodhi.spec
@@ -72,7 +72,7 @@ BuildRequires:   python-sphinx
 # For the bodhi-client
 BuildRequires:   python-click
 
-%if 0%{?rhel} <= 7
+%if 0%{?rhel} >= 7
 BuildRequires:   python-webob1.4
 Requires:        python-webob1.4
 %endif


### PR DESCRIPTION
I think the operator should be 'greater than or equal' if we check for RHEL7 distro (the python-webob1.4 package inside the conditional exists only for EPEL7).
