### PR TITLE
Add dependency postgresql-devel

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -24,7 +24,7 @@ Virtualenv is another option for building a development environment.
 
 Dependencies
 ------------
-``sudo dnf install libffi-devel openssl-devel koji pcaro-hermit-fonts freetype-devel libjpeg-turbo-devel python-pillow zeromq-devel``
+``sudo dnf install libffi-devel postgresql-devel openssl-devel koji pcaro-hermit-fonts freetype-devel libjpeg-turbo-devel python-pillow zeromq-devel``
 
 Setup virtualenvwrapper
 -----------------------


### PR DESCRIPTION
I was getting this issue when setting up development environment.
This patch fixes this.

```
(bodhi-python2.7) [trishna@trishnag bodhi]$ pip install psycopg2
Collecting psycopg2
  Downloading psycopg2-2.6.2.tar.gz (376kB)
    100% |████████████████████████████████| 378kB 211kB/s 
    Complete output from command python setup.py egg_info:
    running egg_info
    creating pip-egg-info/psycopg2.egg-info
    writing pip-egg-info/psycopg2.egg-info/PKG-INFO
    writing top-level names to pip-egg-info/psycopg2.egg-info/top_level.txt
    writing dependency_links to pip-egg-info/psycopg2.egg-info/dependency_links.txt
    writing manifest file 'pip-egg-info/psycopg2.egg-info/SOURCES.txt'
    warning: manifest_maker: standard file '-c' not found

    Error: pg_config executable not found.

    Please add the directory containing pg_config to the PATH
    or specify the full executable path with the option:

        python setup.py build_ext --pg-config /path/to/pg_config build ...

    or with the pg_config option in 'setup.cfg'.

    ----------------------------------------
Command "python setup.py egg_info" failed with error code 1 in /tmp/pip-build-5JKlVh/psycopg2
```
