### PR TITLE
Remove cornice from the Sphinx project.

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -23,13 +23,9 @@ import sys, os
 # If your documentation needs a minimal Sphinx version, state it here.
 #needs_sphinx = '1.0'
 
-import cornice
-
-sys.path.insert(0, os.path.abspath(cornice.__file__))
-
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
-extensions = ['sphinx.ext.autodoc', 'cornice.ext.sphinxext',
+extensions = ['sphinx.ext.autodoc',
               #'sphinx.ext.intersphinx',
               'sphinx.ext.todo', 'sphinx.ext.coverage', 'sphinx.ext.viewcode']
 

--- a/docs/services.rst
+++ b/docs/services.rst
@@ -4,27 +4,11 @@ Bodhi API
 /updates
 --------
 
-.. cornice-autodoc::
-   :modules: bodhi.services.updates
-   :services: updates, update, update_request
-
 /releases
 ---------
-
-.. cornice-autodoc::
-   :modules: bodhi.services.releases
-   :services: releases, release
 
 /builds
 -------
 
-.. cornice-autodoc::
-   :modules: bodhi.services.builds
-   :services: builds, build
-
 /users
 ------
-
-.. cornice-autodoc::
-   :modules: bodhi.services.user
-   :services: users, user


### PR DESCRIPTION
The docs project currently does not build with a mysterious error
message. Removing cornice from the project seems to remove this
error message, though currently the entirety of the Sphinx project
is the cornice generated documentation. However, I am working on
using Sphinx to build a man page for the new bodhi 2 CLI, and so
the docs failing to build is a blocker for the work I need to do.

I will file an issue to re-examine cornice in the future when we
have time to determine what the issue was.
