### PR TITLE
Provide URL link to feedback guidelines

### DIFF
--- a/bodhi/templates/update.html
+++ b/bodhi/templates/update.html
@@ -713,7 +713,7 @@ $(document).ready(function(){
                   <th class='icon'><span data-toggle="tooltip" data-placement="top" title="FAIL - Does not fix the bug or pass the test case." class="glyphicon glyphicon-remove-circle"></span></th>
                   <th class='icon'><span data-toggle="tooltip" data-placement="top" title="Untested." class="glyphicon glyphicon-unchecked"></span></th>
                   <th class='icon'><span data-toggle="tooltip" data-placement="top" title="PASS - Fixes the bug or passes the test case." class="glyphicon glyphicon-ok-circle"></span></th>
-                  <th><a href="https://fedoraproject.org/wiki/QA:Update_feedback_guidelines" target="blank">Feedback Guidelines</a></th>
+                  <th><a href="https://fedoraproject.org/wiki/QA:Update_feedback_guidelines" target="_blank">Feedback Guidelines</a></th>
                 </tr>
               </thead>
 

--- a/bodhi/templates/update.html
+++ b/bodhi/templates/update.html
@@ -713,7 +713,7 @@ $(document).ready(function(){
                   <th class='icon'><span data-toggle="tooltip" data-placement="top" title="FAIL - Does not fix the bug or pass the test case." class="glyphicon glyphicon-remove-circle"></span></th>
                   <th class='icon'><span data-toggle="tooltip" data-placement="top" title="Untested." class="glyphicon glyphicon-unchecked"></span></th>
                   <th class='icon'><span data-toggle="tooltip" data-placement="top" title="PASS - Fixes the bug or passes the test case." class="glyphicon glyphicon-ok-circle"></span></th>
-                  <th></th>
+                  <th><a href="https://fedoraproject.org/wiki/QA:Update_feedback_guidelines" target="blank">Feedback Guidelines</a></th>
                 </tr>
               </thead>
 


### PR DESCRIPTION
In the section for delivering karma/feedback, it would be useful to provide a link to guidelines for providing feedback. Fixes issue no = #865
![screen](https://cloud.githubusercontent.com/assets/3798130/17613504/d0d3d1d4-607b-11e6-9ab9-680397ce286f.png)
