### PR TITLE
Bring the Vagrantfile into the bodhi repository.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -5,22 +5,46 @@ bodhi v2.0 development environment
 There are two ways to bootstrap a Bodhi development environment. You can use Vagrant, or you can use
 virtualenv on an existing host.
 
+
 Vagrant
 =======
 
-To use Vagrant, please read the instructions at
-https://pagure.io/fedora-apps-vagrantfiles/blob/master/f/bodhi/README.md
+[Vagrant](https://www.vagrantup.com/) allows contributors to get quickly up and running with a Bodhi
+development environment by automatically configuring a virtual machine. To get started, simply use
+these commands::
 
-Run test suite for Vagrant setup
--------------------------------
+    # This won't be necessary once https://bugzilla.redhat.com/show_bug.cgi?id=1343814 is done
+    $ sudo dnf copr enable dustymabe/vagrant-sshfs
+    $ sudo dnf install vagrant-libvirt vagrant-sshfs
+    $ cp Vagrantfile.example Vagrantfile
+    # Make sure your bodhi checkout is your shell's cwd
+    $ vagrant up
 
-The code from your development host will be mounted in /vagrant in the guest, and you can run the
-unit tests with nosetests::
 
-    vagrant up
-    vagrant ssh
-    cd /vagrant
-    nosetests -v
+Quick tips about the Bodhi Vagrant environment
+----------------------------------------------
+
+
+You can ssh into your running Vagrant box like this::
+
+    # Make sure your bodhi checkout is your shell's cwd
+    $ vagrant ssh
+
+Keep in mind that all ``vagrant`` commands should be run with your current working directory set to
+your Bodhi checkout. The code from your development host will be mounted in ``/vagrant`` in the
+guest. You can edit this code on the host, and the vagrant-sshfs plugin will cause the changes to
+automatically be reflected in the guest's ``/vagrant`` folder.
+
+You can run the unit tests within the guest with nosetests::
+
+    $ cd /vagrant
+    $ nosetests -v
+
+When you are done with your Vagrant guest, you can destroy it permanently by running this command on
+the host::
+
+    $ vagrant destroy
+
 
 Virtualenv
 ==========

--- a/Vagrantfile.example
+++ b/Vagrantfile.example
@@ -1,0 +1,51 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# On your host:
+# git clone https://github.com/fedora-infra/bodhi.git
+# cd bodhi
+# cp Vagrantfile.example Vagrantfile
+# vagrant up
+# vagrant ssh -c "cd /vagrant/; pserve development.ini --reload"
+
+Vagrant.configure(2) do |config|
+  config.vm.box_url = "https://download.fedoraproject.org/pub/fedora/linux/releases/23/Cloud/x86_64/Images/Fedora-Cloud-Base-Vagrant-23-20151030.x86_64.vagrant-libvirt.box"
+  config.vm.box = "f23-cloud-libvirt"
+  config.vm.network "forwarded_port", guest: 6543, host: 5000
+  config.vm.synced_folder ".", "/vagrant", type: "sshfs"
+
+  config.vm.provider :libvirt do |domain|
+      domain.cpus = 4
+      domain.graphics_type = "spice"
+      # The unit tests use a lot of RAM.
+      domain.memory = 4096
+      domain.video_type = "qxl"
+  end
+
+  config.vm.provision "shell", inline: "sudo dnf -y install python python-webob libjpeg-devel zlib-devel gcc redhat-rpm-config python-devel libffi-devel openssl-devel python-zmq koji pcaro-hermit-fonts freetype-devel libjpeg-turbo-devel python-pillow postgresql-devel postgresql-server rpl python2-createrepo_c createrepo_c python-librepo python-alembic"
+
+  # For unit tests
+  config.vm.provision "shell", inline: "sudo dnf install -y python-nose python-mock python-webtest"
+
+  config.vm.provision "shell", inline: "pushd /vagrant/; sudo python setup.py develop; popd;"
+  config.vm.provision "shell", inline: "sudo dnf -y install python-psycopg2"
+  config.vm.provision "shell", inline: "sudo postgresql-setup initdb"
+
+  config.vm.provision "shell", inline: "sudo rpl 'host    all             all             127.0.0.1/32            ident' 'host    all             all             127.0.0.1/32            trust' /var/lib/pgsql/data/pg_hba.conf"
+  config.vm.provision "shell", inline: "sudo rpl 'host    all             all             ::1/128                 ident' 'host    all             all             ::1/128                 trust' /var/lib/pgsql/data/pg_hba.conf"
+
+  config.vm.provision "shell", inline: "sudo systemctl enable postgresql.service"
+  config.vm.provision "shell", inline: "sudo systemctl start postgresql.service"
+
+  config.vm.provision "shell", inline: "pushd /tmp/; curl -O https://infrastructure.fedoraproject.org/infra/db-dumps/bodhi2.dump.xz; popd;"
+  config.vm.provision "shell", inline: "sudo runuser -l postgres -c 'createdb bodhi2'"
+
+  config.vm.provision "shell", inline: "xzcat /tmp/bodhi2.dump.xz | sudo runuser -l postgres -c 'psql bodhi2'"
+
+  # Set up development.ini
+  config.vm.provision "shell", inline: "pushd /vagrant/; cp development.ini.example development.ini; popd;"
+  config.vm.provision "shell", inline: "pushd /vagrant/; rpl 'sqlalchemy.url = sqlite:///%(here)s/bodhi.db' 'sqlalchemy.url = postgresql://postgres:anypasswordworkslocally@localhost/bodhi2' development.ini; popd;"
+
+  # Run the migrations
+  config.vm.provision "shell", inline: "pushd /vagrant/; alembic upgrade head; popd;"
+end


### PR DESCRIPTION
This commit brings Ryan Lerch's Vagrantfile from
https://pagure.io/fedora-apps-vagrantfiles/ into the Bodhi main
repository. It also adjusts the Readme to be a little more thorough
and to reflect this change.

By bringing the Vagrantfile into the Bodhi repository, we will be
able to easily convert it to use Ansible for provisioning instead
of shell commands. This will help us manage the development
environment more easily in the future.
