### PR TITLE
Always use utf8 for mashing threads

### DIFF
--- a/bodhi/server/consumers/masher.py
+++ b/bodhi/server/consumers/masher.py
@@ -29,6 +29,7 @@ import hashlib
 import threading
 import fedmsg.consumers
 from datetime import datetime
+import sys
 
 from collections import defaultdict
 from pyramid.paster import get_appsettings
@@ -248,6 +249,9 @@ class MasherThread(threading.Thread):
             'completed_repos': []
         }
         self.success = False
+
+        reload(sys)
+        sys.setdefaultencoding('utf8')
 
     def run(self):
         try:


### PR DESCRIPTION
This change makes sure that the encoding during mashing is utf8 by default.
This fixes running on Fedora, since Fedora's systemd on server starts processes
with an empty LC_ALL, defaulting to LC_ALL=C, which breaks almost all unicode.

Signed-off-by: Patrick Uiterwijk puiterwijk@redhat.com
