### PR TITLE
Remove vagrant-sshfs copr from the readme.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -13,8 +13,6 @@ Vagrant
 Bodhi development environment by automatically configuring a virtual machine. To get started, simply
 use these commands::
 
-    # This won't be necessary once https://bugzilla.redhat.com/show_bug.cgi?id=1343814 is done
-    $ sudo dnf copr enable dustymabe/vagrant-sshfs
     $ sudo dnf install ansible vagrant-libvirt vagrant-sshfs
     $ cp Vagrantfile.example Vagrantfile
     # Make sure your bodhi checkout is your shell's cwd


### PR DESCRIPTION
vagrant-sshfs is now in Fedora, so we don't need to tell devs to
enable the copr for it anymore.
