### PR TITLE
Change port forwarding in Vagrantfile.example, actualise README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -13,12 +13,11 @@ Vagrant
 Bodhi development environment by automatically configuring a virtual machine. To get started, simply
 use these commands::
 
-    # This won't be necessary once https://bugzilla.redhat.com/show_bug.cgi?id=1343814 is done
-    $ sudo dnf copr enable dustymabe/vagrant-sshfs
     $ sudo dnf install ansible vagrant-libvirt vagrant-sshfs
     $ cp Vagrantfile.example Vagrantfile
     # Make sure your bodhi checkout is your shell's cwd
     $ vagrant up
+    $ vagrant ssh -c "cd /vagrant/; pserve development.ini --reload"
 
 
 Quick tips about the Bodhi Vagrant environment

--- a/Vagrantfile.example
+++ b/Vagrantfile.example
@@ -11,7 +11,7 @@
 Vagrant.configure(2) do |config|
   config.vm.box_url = "https://download.fedoraproject.org/pub/fedora/linux/releases/23/Cloud/x86_64/Images/Fedora-Cloud-Base-Vagrant-23-20151030.x86_64.vagrant-libvirt.box"
   config.vm.box = "f23-cloud-libvirt"
-  config.vm.network "forwarded_port", guest: 6543, host: 5000
+  config.vm.network "forwarded_port", guest: 6543, host: 6543
   config.vm.synced_folder ".", "/vagrant", type: "sshfs"
 
   config.vm.provider :libvirt do |domain|


### PR DESCRIPTION
- forward to the same port 6543 -> 6543 (as discussed on IRC with @bowlofeggs )
- remove vagrant-sshfs copr instructions from the readme (new package tested on F23 / F24 / F25)
- add missing command to the get started "quick" overview in the readme
