### PR TITLE
Remove mention of 2.0 from README.rst.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,6 @@
-==================================
-bodhi v2.0 development environment
-==================================
+=============================
+bodhi development environment
+=============================
 
 There are two ways to bootstrap a Bodhi development environment. You can use Vagrant, or you can use
 virtualenv on an existing host.


### PR DESCRIPTION
The current stable version of Bodhi is 2.1.8, so it doesn't make
sense for the README to refer to the development environment as
2.0.
