### PR TITLE
Update email templates to point users to dnf instead of yum

### DIFF
--- a/bodhi/server/mail.py
+++ b/bodhi/server/mail.py
@@ -252,12 +252,12 @@ Description :
 
 --------------------------------------------------------------------------------
 %(notes)s%(changelog)s%(references)s
-This update can be installed with the "yum" update program. Use
-su -c 'yum%(yum_repository)s update %(name)s' at the command line.
-For more information, refer to "Managing Software with yum",
-available at https://docs.fedoraproject.org/yum/.
+This update can be installed with the "dnf" update program. Use
+su -c 'dnf%(yum_repository)s upgrade %(name)s' at the command line.
+For more information, refer to the dnf documentation available at
+http://dnf.readthedocs.io/en/latest/command_ref.html#upgrade-command-label
 
-All packages are signed with the Fedora Project GPG key.  More details on the
+All packages are signed with the Fedora Project GPG key. More details on the
 GPG keys used by the Fedora Project can be found at
 https://fedoraproject.org/keys
 --------------------------------------------------------------------------------
@@ -281,10 +281,41 @@ Description :
 
 --------------------------------------------------------------------------------
 %(notes)s%(changelog)s%(references)s
+This update can be installed with the "dnf" update programs.  Use
+su -c 'dnf%(yum_repository)s upgrade %(name)s' at the command line.
+For more information, refer to the dnf documentation available at
+http://dnf.readthedocs.io/en/latest/command_ref.html#upgrade-command-label
+
+All packages are signed with the Fedora EPEL GPG key. More details on the
+GPG keys used by the Fedora Project can be found at
+https://fedoraproject.org/keys
+--------------------------------------------------------------------------------
+"""
+
+# message template for legacy systems, still pointing users to use "yum"
+fedora_epel_legacy_errata_template = u"""\
+--------------------------------------------------------------------------------
+Fedora EPEL%(testing)s Update Notification
+%(updateid)s
+%(date)s
+--------------------------------------------------------------------------------
+
+Name        : %(name)s
+Product     : %(product)s
+Version     : %(version)s
+Release     : %(release)s
+URL         : %(url)s
+Summary     : %(summary)s
+Description :
+%(description)s
+
+--------------------------------------------------------------------------------
+%(notes)s%(changelog)s%(references)s
 This update can be installed with the "yum" update programs.  Use
 su -c 'yum%(yum_repository)s update %(name)s' at the command line.
-For more information, refer to "Managing Software with yum",
-available at https://docs.fedoraproject.org/yum/.
+For more information, refer to "YUM", available at
+https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7\
+/html/System_Administrators_Guide/ch-yum.html
 
 All packages are signed with the Fedora EPEL GPG key.  More details on the
 GPG keys used by the Fedora Project can be found at

--- a/bodhi/server/models/models.py
+++ b/bodhi/server/models/models.py
@@ -1247,7 +1247,13 @@ class Update(Base):
             mailinglist = config.get('%s_announce_list' % release_name)
         elif self.status is UpdateStatus.testing:
             mailinglist = config.get('%s_test_announce_list' % release_name)
-        templatetype = '%s_errata_template' % release_name
+        
+        # switch email template to legacy if update aims to EPEL <= 7
+        if release_name == 'fedora_epel' and self.release.version_int <= 7:
+            templatetype = '%s_errata_legacy_template' % release_name
+        else:
+            templatetype = '%s_errata_template' % release_name
+
         if mailinglist:
             for subject, body in mail.get_template(self, templatetype):
                 mail.send_mail(sender, mailinglist, subject, body)
@@ -1256,6 +1262,7 @@ class Update(Base):
         else:
             log.error("Cannot find mailing list address for update notice")
             log.error("release_name = %r", release_name)
+
 
     def get_url(self):
         """ Return the relative URL to this update """

--- a/bodhi/tests/server/models/test_models.py
+++ b/bodhi/tests/server/models/test_models.py
@@ -598,6 +598,44 @@ class TestUpdate(ModelTest):
         for value in mail.MESSAGES.values():
             value['body'] % value['fields']('guest', self.obj)
 
+    @mock.patch('bodhi.server.mail.get_template')
+    def test_send_update_notice_message_template(self, get_template):
+        """Ensure update message template reflects aimed distribution"""
+        update = self.obj
+        update.status = UpdateStatus.stable
+        update.send_update_notice()
+        get_template.assert_called_with(update, u'fedora_errata_template')
+
+        update = self.get_update(name=u'TurboGears-3.1-1.el7')
+        release = model.Release(name=u'EL-7', long_name=u'Fedora EPEL 7',
+                          id_prefix=u'FEDORA-EPEL', dist_tag=u'dist-7E-epel',
+                          stable_tag=u'dist-7E-epel',
+                          testing_tag=u'dist-7E-epel-testing',
+                          candidate_tag=u'dist-7E-epel-testing-candidate',
+                          pending_testing_tag=u'dist-7E-epel-testing-pending',
+                          pending_stable_tag=u'dist-7E-epel-pending',
+                          override_tag=u'dist-7E-epel-override',
+                          branch=u'el7', version=u'7')
+        update.release = release
+        update.status = UpdateStatus.stable
+        update.send_update_notice()
+        get_template.assert_called_with(update, u'fedora_epel_errata_legacy_template')
+
+        update = self.get_update(name=u'TurboGears-4.1-1.el8')
+        release = model.Release(name=u'EL-8', long_name=u'Fedora EPEL 8',
+                          id_prefix=u'FEDORA-EPEL', dist_tag=u'dist-8E-epel',
+                          stable_tag=u'dist-8E-epel',
+                          testing_tag=u'dist-8E-epel-testing',
+                          candidate_tag=u'dist-8E-epel-testing-candidate',
+                          pending_testing_tag=u'dist-8E-epel-testing-pending',
+                          pending_stable_tag=u'dist-8E-epel-pending',
+                          override_tag=u'dist-8E-epel-override',
+                          branch=u'el8', version=u'8')
+        update.release = release
+        update.status = UpdateStatus.stable
+        update.send_update_notice()
+        get_template.assert_called_with(update, u'fedora_epel_errata_template')
+
 
 class TestUser(ModelTest):
     klass = model.User


### PR DESCRIPTION
fixes #927 
- update template texts to not use outdated informations
- add legacy template pointing to yum and use it with updates for EPEL <= 7 distributions
