### PR TITLE
Change the development base_address to be localhost.

### DIFF
--- a/bodhi/tests/server/test_masher.py
+++ b/bodhi/tests/server/test_masher.py
@@ -15,6 +15,7 @@
 import os
 import mock
 import time
+import urlparse
 import json
 import shutil
 import unittest
@@ -781,8 +782,15 @@ References:
     @mock.patch('bodhi.server.bugs.bugtracker.on_qa')
     def test_modify_testing_bugs(self, on_qa, modified, *args):
         self.masher.consume(self.msg)
-        on_qa.assert_called_once_with(12345,
-                u'bodhi-2.0-1.fc17 has been pushed to the Fedora 17 testing repository. If problems still persist, please make note of it in this bug report.\nSee https://fedoraproject.org/wiki/QA:Updates_Testing for\ninstructions on how to install test updates.\nYou can provide feedback for this update here: http://0.0.0.0:6543/updates/FEDORA-2016-a3bbe1a8f2')
+
+        expected_message = (
+            u'bodhi-2.0-1.fc17 has been pushed to the Fedora 17 testing repository. If problems '
+            u'still persist, please make note of it in this bug report.\nSee '
+            u'https://fedoraproject.org/wiki/QA:Updates_Testing for\ninstructions on how to '
+            u'install test updates.\nYou can provide feedback for this update here: {}')
+        expected_message = expected_message.format(
+            urlparse.urljoin(config['base_address'], '/updates/FEDORA-2016-a3bbe1a8f2'))
+        on_qa.assert_called_once_with(12345, expected_message)
 
     @mock.patch(**mock_taskotron_results)
     @mock.patch('bodhi.server.consumers.masher.MasherThread.update_comps')

--- a/development.ini.example
+++ b/development.ini.example
@@ -123,7 +123,7 @@ fedora_epel_testing_master_repomd = https://download.fedoraproject.org/pub/epel/
 
 ## The base url of this application
 ## Used as the <base/> tag in the master template.
-base_address = http://0.0.0.0:6543/
+base_address = http://localhost:6543/
 #base_address = https://admin.stg.fedoraproject.org/updates/
 
 ## Supported update types


### PR DESCRIPTION
Most developers are likely to develop by pointing their browsers
at localhost, rather than 0.0.0.0. This commit sets the
base_address to use the name "localhost" by default for new
developers.
