### PR TITLE
Only put the comment through markdown if there is a comment

### DIFF
--- a/bodhi/server/templates/fragments.html
+++ b/bodhi/server/templates/fragments.html
@@ -34,7 +34,9 @@
 
       <div class="panel-body">
         <div class="col-md-8">
+          %if comment.text:
           ${util.markup(comment.text) | n}
+          $endif
         </div>
         <div class="col-md-4 text-right">
           % if comment.karma:


### PR DESCRIPTION
Because sometimes, the contents are None (null in the database), which
breaks the markdown processing.

Signed-off-by: Patrick Uiterwijk puiterwijk@redhat.com
