### PR TITLE
Fix the Ansible replace statement to match the sqlite default.

### DIFF
--- a/devel/ansible/roles/dev/tasks/main.yml
+++ b/devel/ansible/roles/dev/tasks/main.yml
@@ -49,9 +49,10 @@
   args:
       creates: /vagrant/development.ini
 
-- replace:
+- name: Switch the database connection to postgres
+  replace:
     dest: /vagrant/development.ini
-    regexp: "sqlalchemy.url = sqlite:///%(here)s/bodhi.db"
+    regexp: "^sqlalchemy.url = sqlite.*$"
     replace: "sqlalchemy.url = postgresql://postgres:anypasswordworkslocally@localhost/bodhi2"
 
 - name: Apply database migrations


### PR DESCRIPTION
New Bodhi developers would not have had their development.ini
configured properly by Ansible prior to this fix. The regex failed
to match the sqlalchemy.url setting in the development.ini.example
file, and thus did not properly change that setting to connect to
postgres. This commit adjusts the regex to match the sqlite setting
and replace with postgres.
