### PR TITLE
Sometimes we have no mash, so dont wait for mash_thread if we dont

### DIFF
--- a/bodhi/server/consumers/masher.py
+++ b/bodhi/server/consumers/masher.py
@@ -685,6 +685,9 @@ class MasherThread(threading.Thread):
         return mash_thread
 
     def wait_for_mash(self, mash_thread):
+        if mash_thread is None:
+            self.log.info('Not waiting for mash thread, as there was no mash')
+            return
         self.log.debug('Waiting for mash thread to finish')
         mash_thread.join()
         if mash_thread.success:


### PR DESCRIPTION
If self.state['completed_repos'] is True, we don't kick off a mash thread, and
def mash() returns nothing (None).

Signed-off-by: Patrick Uiterwijk puiterwijk@redhat.com
