### PR TITLE
Do not allow NULL values to be stored in the Comment.text column.

### DIFF
--- a/alembic/versions/37f38ddc4c8d_.py
+++ b/alembic/versions/37f38ddc4c8d_.py
@@ -1,0 +1,32 @@
+"""Do not allow NULL values in the text column of the comments table.
+
+Revision ID: 37f38ddc4c8d
+Revises: 4df1fcd59050
+Create Date: 2016-09-21 19:51:04.946521
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '37f38ddc4c8d'
+down_revision = '4df1fcd59050'
+
+
+def upgrade():
+    """
+    We will need to set all existing NULL comments to "", then change the column to disallow NULL comments.
+    """
+    # Build a fake mini version of the comments table so we can form an UPDATE statement.
+    comments = sa.sql.table('comments', sa.sql.column('text', sa.UnicodeText))
+    # Set existing NULL comments to "".
+    op.execute(comments.update().where(comments.c.text==None).values({'text': op.inline_literal('')}))
+
+    # Disallow new NULL comments.
+    op.alter_column('comments', 'text', existing_type=sa.TEXT(), nullable=False)
+
+
+def downgrade():
+    op.alter_column('comments', 'text', existing_type=sa.TEXT(), nullable=True)

--- a/bodhi/server/models/models.py
+++ b/bodhi/server/models/models.py
@@ -1925,7 +1925,7 @@ class Comment(Base):
 
     karma = Column(Integer, default=0)
     karma_critpath = Column(Integer, default=0)
-    text = Column(UnicodeText)
+    text = Column(UnicodeText, nullable=False)
     anonymous = Column(Boolean, default=False)
     timestamp = Column(DateTime, default=datetime.utcnow)
 


### PR DESCRIPTION
This commit disallows the Comment.text column to contain NULL
values. Additionally, it contains a data migration to convert all
NULL values to the empty string.

fixes #949
