### PR TITLE
Split a test into three and remove a space for PEP-8.

### DIFF
--- a/bodhi/server/models/models.py
+++ b/bodhi/server/models/models.py
@@ -1267,7 +1267,6 @@ class Update(Base):
             log.error("Cannot find mailing list address for update notice")
             log.error("release_name = %r", release_name)
 
-
     def get_url(self):
         """ Return the relative URL to this update """
         path = ['updates']

--- a/bodhi/tests/server/models/test_models.py
+++ b/bodhi/tests/server/models/test_models.py
@@ -614,43 +614,49 @@ class TestUpdate(ModelTest):
             value['body'] % value['fields']('guest', self.obj)
 
     @mock.patch('bodhi.server.mail.get_template')
-    def test_send_update_notice_message_template(self, get_template):
-        """Ensure update message template reflects aimed distribution"""
+    def test_send_update_notice_message_template_fedora(self, get_template):
+        """Ensure update message template reflects fedora when it should"""
         update = self.obj
         update.status = UpdateStatus.stable
+
         update.send_update_notice()
+
         get_template.assert_called_with(update, u'fedora_errata_template')
 
+    @mock.patch('bodhi.server.mail.get_template')
+    def test_send_update_notice_message_template_el7(self, get_template):
+        """Ensure update message template reflects EL <= 7 when it should"""
         update = self.get_update(name=u'TurboGears-3.1-1.el7')
-        release = model.Release(name=u'EL-7', long_name=u'Fedora EPEL 7',
-                          id_prefix=u'FEDORA-EPEL', dist_tag=u'dist-7E-epel',
-                          stable_tag=u'dist-7E-epel',
-                          testing_tag=u'dist-7E-epel-testing',
-                          candidate_tag=u'dist-7E-epel-testing-candidate',
-                          pending_signing_tag=u'dist-7E-epel-signing-pending',
-                          pending_testing_tag=u'dist-7E-epel-testing-pending',
-                          pending_stable_tag=u'dist-7E-epel-pending',
-                          override_tag=u'dist-7E-epel-override',
-                          branch=u'el7', version=u'7')
+        release = model.Release(
+            name=u'EL-7', long_name=u'Fedora EPEL 7', id_prefix=u'FEDORA-EPEL',
+            dist_tag=u'dist-7E-epel', stable_tag=u'dist-7E-epel',
+            testing_tag=u'dist-7E-epel-testing', candidate_tag=u'dist-7E-epel-testing-candidate',
+            pending_testing_tag=u'dist-7E-epel-testing-pending',
+            pending_stable_tag=u'dist-7E-epel-pending', override_tag=u'dist-7E-epel-override',
+            branch=u'el7', version=u'7')
         update.release = release
         update.status = UpdateStatus.stable
+
         update.send_update_notice()
+
         get_template.assert_called_with(update, u'fedora_epel_errata_legacy_template')
 
+    @mock.patch('bodhi.server.mail.get_template')
+    def test_send_update_notice_message_template_el8(self, get_template):
+        """Ensure update message template reflects EL >= 8 when it should"""
         update = self.get_update(name=u'TurboGears-4.1-1.el8')
-        release = model.Release(name=u'EL-8', long_name=u'Fedora EPEL 8',
-                          id_prefix=u'FEDORA-EPEL', dist_tag=u'dist-8E-epel',
-                          stable_tag=u'dist-8E-epel',
-                          testing_tag=u'dist-8E-epel-testing',
-                          candidate_tag=u'dist-8E-epel-testing-candidate',
-                          pending_signing_tag=u'dist-8E-epel-signing-pending',
-                          pending_testing_tag=u'dist-8E-epel-testing-pending',
-                          pending_stable_tag=u'dist-8E-epel-pending',
-                          override_tag=u'dist-8E-epel-override',
-                          branch=u'el8', version=u'8')
+        release = model.Release(
+            name=u'EL-8', long_name=u'Fedora EPEL 8', id_prefix=u'FEDORA-EPEL',
+            dist_tag=u'dist-8E-epel', stable_tag=u'dist-8E-epel',
+            testing_tag=u'dist-8E-epel-testing', candidate_tag=u'dist-8E-epel-testing-candidate',
+            pending_testing_tag=u'dist-8E-epel-testing-pending',
+            pending_stable_tag=u'dist-8E-epel-pending', override_tag=u'dist-8E-epel-override',
+            branch=u'el8', version=u'8')
         update.release = release
         update.status = UpdateStatus.stable
+
         update.send_update_notice()
+
         get_template.assert_called_with(update, u'fedora_epel_errata_template')
 
 


### PR DESCRIPTION
This commit splits a test into three tests, and removes a space to
conform to PEP-8. These changes are made in response to my review
comments on https://github.com/fedora-infra/bodhi/pull/929
