### PR TITLE
metrics: 'releases' always must be sorted in all loops.

### DIFF
--- a/bodhi/server/views/metrics.py
+++ b/bodhi/server/views/metrics.py
@@ -23,8 +23,10 @@ def compute_ticks_and_data(db, releases, update_types):
     """ Return the data and ticks to make the stats graph. """
     data, ticks = [], []
 
-    for i, release in enumerate(sorted(releases, cmp=lambda x, y:
-            cmp(int(x.version_int), int(y.version_int)))):
+    releases = sorted(releases, cmp=lambda x, y:
+            cmp(int(x.version_int), int(y.version_int)))
+
+    for i, release in enumerate(releases):
         ticks.append([i, release.name])
 
     for update_type, label in update_types.items():


### PR DESCRIPTION
Depending on the tag that you are using, the data may be inconsistent
with the labels. So, all releases lists needs to be sorted in all loops.

Example:
Data stored in my database:
- Fedora 23: 3 bugfixes
- Fedora 24: 2 bugfixes
- Fedora 22: 5 bugfixes

Sorted label array:
- Fedora 22
- Fedora 23
- Fedora 24

Chart result (wrong results):
- Fedora 22: 3 bugfixes
- Fedora 23: 2 bugfixes
- Fedora 24: 5 bugfixes

After this patch:
- Fedora 22: 5 bugfixes
- Fedora 23: 3 bugfixes
- Fedora 24: 2 bugfixes

Signed-off-by: Julio Faracco jfaracco@br.ibm.com
