### PR TITLE
Karma comments should not set request to None when autopush is off.

### DIFF
--- a/bodhi/server/models/models.py
+++ b/bodhi/server/models/models.py
@@ -1697,7 +1697,6 @@ class Update(Base):
                         # Add the 'testing_approval_msg_based_on_karma' message now
                         log.info("%s update has reached the stable karma threshold and can be pushed to "\
                         "stable now if the maintainer wishes" % self.title)
-                        self.request = None
                 elif self.unstable_karma not in (0, None) and self.karma <= self.unstable_karma:
                     log.info("Automatically unpushing %s" % self.title)
                     self.obsolete(db)

--- a/bodhi/tests/server/functional/test_updates.py
+++ b/bodhi/tests/server/functional/test_updates.py
@@ -2900,14 +2900,17 @@ class TestUpdatesService(bodhi.tests.server.functional.base.BaseWSGICase):
 
         self.assertEquals(up.karma, 3)
         self.assertEquals(up.autokarma, False)
+        # The request should still be at testing. This assertion tests for
+        # https://github.com/fedora-infra/bodhi/issues/989 where karma comments were resetting the
+        # request to None.
+        self.assertEquals(up.request, UpdateRequest.testing)
+        self.assertEquals(up.status, UpdateStatus.testing)
 
-        # Checks Push to Stable text in the html page for this update
         id = 'kernel-3.11.5-300.fc17'
         resp = self.app.get('/updates/%s' % id,
                             headers={'Accept': 'text/html'})
         self.assertIn('text/html', resp.headers['Content-Type'])
         self.assertIn(id, resp)
-        self.assertIn('Push to Stable', resp)
 
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
@@ -2946,14 +2949,17 @@ class TestUpdatesService(bodhi.tests.server.functional.base.BaseWSGICase):
 
         self.assertEquals(up.karma, 3)
         self.assertEquals(up.autokarma, False)
+        # The request should still be at testing. This assertion tests for
+        # https://github.com/fedora-infra/bodhi/issues/989 where karma comments were resetting the
+        # request to None.
+        self.assertEquals(up.request, UpdateRequest.testing)
+        self.assertEquals(up.status, UpdateStatus.testing)
 
-        # Checks Push to Stable text in the html page for this update
         id = 'kernel-3.11.5-300.fc17'
         resp = self.app.get('/updates/%s' % id,
                             headers={'Accept': 'text/html'})
         self.assertIn('text/html', resp.headers['Content-Type'])
         self.assertIn(id, resp)
-        self.assertIn('Push to Stable', resp)
 
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')


### PR DESCRIPTION
fixes #989
