### PR TITLE
Use a different method to find the bodhi.server Python packages.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -143,6 +143,12 @@ setup(name='bodhi-client',
 
 
 setuptools.command.egg_info.manifest_maker.template = 'SERVER_MANIFEST.in'
+# Due to https://github.com/pypa/setuptools/issues/808, we need to include the bodhi superpackage
+# and then remove it if we want find_packages() to find the bodhi.server package and its
+# subpackages without including the bodhi top level package.
+server_packages = find_packages(
+    exclude=['bodhi.client', 'bodhi.client.*', 'bodhi.tests', 'bodhi.tests.*'])
+server_packages.remove('bodhi')
 
 
 setup(name='bodhi-server',
@@ -160,8 +166,7 @@ setup(name='bodhi-server',
       platforms=PLATFORMS,
       url=URL,
       keywords='web fedora pyramid',
-      packages=find_packages(
-          exclude=['bodhi', 'bodhi.client', 'bodhi.client.*', 'bodhi.tests', 'bodhi.tests.*']),
+      packages=server_packages,
       include_package_data=True,
 #      script_args=sys.argv.extend(['--template', 'TEST']),
       zip_safe=False,


### PR DESCRIPTION
setuptools-28.0 changed the behavior of the exclude argument of
find_packages() such that it does not search for subpackages
inside of any excluded package. Bodhi's setup.py had been relying
on the former behavior and so it now needs to find a method that
will work with setuptools-28.0 as well as setuptools < 28.

Unfortunately, that same change also broke backwards compatibility
on the include argument to the same function, and a package's
subpackages cannot be included without including the superpackage:

https://github.com/pypa/setuptools/issues/808

To work around the above, the server packages are now searched
with
find_packages(include=['bodhi', 'bodhi.server', 'bodhi.server.*'])
and then the 'bodhi' string is removed from the resulting list.
This way we can still find bodhi.server and its subpackages
automatically in both setuptools-28.0 and setuptools < 28.

fixes #994
