### PR TITLE
Fixes untagging buildroot override unexpectedly

### DIFF
--- a/bodhi/server/models/models.py
+++ b/bodhi/server/models/models.py
@@ -2233,12 +2233,13 @@ class BuildrootOverride(Base):
         if self.expired_date is not None:
             return
 
-        koji_session = buildsys.get_session()
-        try:
-            koji_session.untagBuild(self.build.release.override_tag,
-                                    self.build.nvr, strict=True)
-        except Exception, e:
-            log.error('Unable to untag override %s: %s' % (self.build.nvr, e))
+        if datetime.utcnow() >= self.expiration_date:
+            koji_session = buildsys.get_session()
+            try:
+                koji_session.untagBuild(self.build.release.override_tag,
+                                        self.build.nvr, strict=True)
+            except Exception, e:
+                log.error('Unable to untag override %s: %s' % (self.build.nvr, e))
         self.expired_date = datetime.utcnow()
 
         notifications.publish(


### PR DESCRIPTION
Work on #798 Testcases on the way.
