### PR TITLE
Display buttons on override template to users who belong to packager/provenpackager group 

### DIFF
--- a/bodhi/server/templates/override.html
+++ b/bodhi/server/templates/override.html
@@ -138,6 +138,7 @@
 
     <input type="hidden" name="csrf_token" value="${request.session.get_csrf_token()}"/>
 
+    %if request.user and ('provenpackager' or 'packager' in request.user.groups):
     <div class="row">
       <div class="col-md-12">
         <div class="panel panel-default">
@@ -157,6 +158,7 @@
         </div>
       </div>
     </div> <!-- end row -->
+    %endif
 
   </div>
 </div>


### PR DESCRIPTION
Fixes #1008 
Here is the screenshot:

![screenshot from 2016-10-07 11-28-45](https://cloud.githubusercontent.com/assets/13337039/19180179/401dd586-8c81-11e6-851a-45bb37e07401.png)
