### PR TITLE
approve_testing: use required testing time when update can be pushed to stable

### DIFF
--- a/bodhi/server/scripts/approve_testing.py
+++ b/bodhi/server/scripts/approve_testing.py
@@ -62,7 +62,7 @@ def main(argv=sys.argv):
                 continue
             if update.meets_testing_requirements:
                 print('%s now meets testing requirements' % update.title)
-                text = config.get('testing_approval_msg') % update.days_in_testing
+                text = config.get('testing_approval_msg') % update.release.mandatory_days_in_testing
                 update.comment(db, text, author='bodhi')
 
             # Approval message when testing based on karma threshold


### PR DESCRIPTION
The script currently uses the number of days that the update has been in testing. This can lead to comments like the one seen here:

  https://bodhi.fedoraproject.org/updates/FEDORA-2016-c22fffe3da

...where the comment says the update "has reached 9 days in testing", because the script ran 9 days after the update entered testing. For this (F24) update it's better to say it's reached 7 days in testing, since that's the mandatory testing time for this release.

This fixes #1017.
