### PR TITLE
Remove bodhi.server.models.DBSession from development.ini.example.

### DIFF
--- a/development.ini.example
+++ b/development.ini.example
@@ -449,7 +449,6 @@ port = 6543
 
 [pshell]
 m = bodhi.server.models
-db = bodhi.server.models.DBSession
 t = transaction
 
 # Begin logging configuration


### PR DESCRIPTION
There is no bodhi.server.models.DBSession, and its presence in the
example development.ini file causes pshell to fail.
