### PR TITLE
Allow shelldb to detect its settings from argv and document it.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -43,6 +43,34 @@ You can run the development server from inside the Vagrant environment::
 
     $ pserve /vagrant/development.ini --reload
 
+You can use ``pshell`` and ``tools/shelldb.py`` to get a Python shell quickly set up with a nice
+environment for you to hack in::
+
+	[vagrant@localhost vagrant]$ pshell development.ini
+	Python 2.7.12 (default, Sep 29 2016, 13:30:34)
+	[GCC 6.2.1 20160916 (Red Hat 6.2.1-2)] on linux2
+	Type "help" for more information.
+
+	Environment:
+	  app          The WSGI application.
+	  registry     Active Pyramid registry.
+	  request      Active request object.
+	  root         Root of the default resource tree.
+	  root_factory Default root factory used to create `root`.
+
+	Custom Variables:
+	  m            bodhi.server.models
+	  t            transaction
+
+	>>> execfile('tools/shelldb.py')
+
+Once you've run that ``execfile('tools/shelldb.py')`` tools command, it's pretty easy to run
+database queries::
+
+	>>> db.query(m.Update).filter_by(alias='FEDORA-2016-840ff89708').one().title
+	<output trimmed>
+	u'gtk3-3.22.1-1.fc25'
+
 It is possible to connect your Vagrant box to the staging Koji instance for testing, which can be
 handy at times. You will need to copy your ``.fedora.cert`` and ``.fedora-server-ca.cert`` that you
 normally use to connect to Koji into your Vagrant box, storing them in ``/home/vagrant``. Once you

--- a/tools/shelldb.py
+++ b/tools/shelldb.py
@@ -8,13 +8,24 @@ from pyramid.paster import get_appsettings, setup_logging
 from sqlalchemy import engine_from_config
 from sqlalchemy.orm import scoped_session, sessionmaker
 from zope.sqlalchemy import ZopeTransactionExtension
+import sys
 import transaction
-config_uri = '/etc/bodhi/production.ini'
+
+
+config_uri = None
+for arg in sys.argv:
+    if arg.endswith('.ini'):
+        config_uri = arg
+if not config_uri:
+    config_uri = '/etc/bodhi/production.ini'
+
+
 settings = get_appsettings(config_uri)
 engine = engine_from_config(settings, 'sqlalchemy.')
 Session = scoped_session(sessionmaker(extension=ZopeTransactionExtension()))
 Session.configure(bind=engine)
 db = Session()
+
 
 def delete_update(up):
         for b in up.builds:


### PR DESCRIPTION
This commit adjusts the small shelldb.py utility to be a little
more flexible and allow it to detect which settings files should be
used by inspecting sys.argv for any arguments that end in .ini.
Though this is a "simpleton" approach and normally I'd want
something more robust, it does work and this is just a development
tool.
