### PR TITLE
Display Autopush on Update page

### DIFF
--- a/bodhi/server/templates/update.html
+++ b/bodhi/server/templates/update.html
@@ -428,6 +428,15 @@ $(document).ready(function(){
         </td>
       </tr>
 
+      <tr>
+        <td>Autopush</td>
+          % if update.autokarma is True:
+          <td><span class='label label-success'>Enabled</span></td>
+          % elif update.autokarma is False:
+          <td><span class='label label-danger'>Disabled</span></td>
+          % endif
+      </tr>
+
       % if update.type:
       <tr>
         <td>Type</td><td>${self.util.type2html(update.type) | n}</td>

--- a/bodhi/tests/server/functional/test_updates.py
+++ b/bodhi/tests/server/functional/test_updates.py
@@ -1876,6 +1876,34 @@ class TestUpdatesService(bodhi.tests.server.functional.base.BaseWSGICase):
         self.assertIn(id, resp)
         self.assertNotIn('Push to Stable', resp)
 
+    @mock.patch(**mock_valid_requirements)
+    def test_enabled_button_for_autopush(self, *args):
+        """Test Enabled button on Update page when autopush is True"""
+        nvr = 'bodhi-2.0.0-2.fc17'
+        args = self.get_update(nvr)
+        args['autokarma'] = True
+        resp = self.app.post_json('/updates/', args)
+
+        resp = self.app.get('/updates/%s' % nvr,
+                        headers={'Accept': 'text/html'})
+        self.assertIn('text/html', resp.headers['Content-Type'])
+        self.assertIn(nvr, resp)
+        self.assertIn('Enabled', resp)
+
+    @mock.patch(**mock_valid_requirements)
+    def test_disabled_button_for_autopush(self, *args):
+        """Test Disabled button on Update page when autopush is False"""
+        nvr = 'bodhi-2.0.0-2.fc17'
+        args = self.get_update(nvr)
+        args['autokarma'] = False
+        resp = self.app.post_json('/updates/', args)
+
+        resp = self.app.get('/updates/%s' % nvr,
+                        headers={'Accept': 'text/html'})
+        self.assertIn('text/html', resp.headers['Content-Type'])
+        self.assertIn(nvr, resp)
+        self.assertIn('Disabled', resp)
+
     @mock.patch(**mock_taskotron_results)
     @mock.patch(**mock_valid_requirements)
     def test_invalid_request(self, *args):


### PR DESCRIPTION
Fixes #999 . This might also fix #1032 by displaying autopush on the UI. 
Screenshot uploaded:

![screenshot from 2016-10-13 17-13-55](https://cloud.githubusercontent.com/assets/13337039/19347898/d6f67922-9168-11e6-8266-51d4128e2898.jpg)
