### PR TITLE
Send one comment when non-autokarma updates hit the threshold.

### DIFF
--- a/bodhi/server/models/models.py
+++ b/bodhi/server/models/models.py
@@ -1783,16 +1783,28 @@ class Update(Base):
                     return False
             num_days = int(config.get('critpath.stable_after_days_without_negative_karma'))
             return self.days_in_testing >= num_days
+
         num_days = self.release.mandatory_days_in_testing
         if not num_days:
             return True
+
+        # non-autokarma updates have met the testing requirements if they've reached the karma
+        # threshold.
+        if not self.autokarma and self.stable_karma not in (0, None)\
+                and self.karma >= self.stable_karma:
+            return True
+
+        # Any update that reaches num_days has met the testing requirements.
         return self.days_in_testing >= num_days
 
     @property
     def met_testing_requirements(self):
         """
         Return whether or not this update has already met the testing
-        requirements.
+        requirements and bodhi has commented on the update that the
+        requirements have been met. This is used to determine whether bodhi
+        should add the comment about the Update's eligibility to be pushed,
+        as we only want Bodhi to add the comment once.
 
         If this release does not have a mandatory testing requirement, then
         simply return True.
@@ -1806,7 +1818,7 @@ class Update(Base):
         for comment in self.comments:
             if comment.user.name == 'bodhi' and \
                comment.text.startswith('This update has reached') and \
-               'days in testing and can be pushed to stable now if the ' \
+               'and can be pushed to stable now if the ' \
                'maintainer wishes' in comment.text:
                 return True
         return False

--- a/bodhi/tests/server/base.py
+++ b/bodhi/tests/server/base.py
@@ -1,0 +1,59 @@
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+"""
+This module contains a useful base test class that helps with common testing needs when testing
+bodhi.server modules.
+"""
+
+import unittest
+
+from sqlalchemy import create_engine
+from sqlalchemy import event
+from sqlalchemy.orm import scoped_session, sessionmaker
+from zope.sqlalchemy import ZopeTransactionExtension
+
+from bodhi.server import log
+from bodhi.tests.server import populate
+from bodhi.server.models import (
+    Base,
+)
+
+DB_PATH = 'sqlite://'
+DB_NAME = None
+
+
+class BaseTestCase(unittest.TestCase):
+    def setUp(self):
+        engine = create_engine(DB_PATH)
+        # We want a special session that lasts longer than a transaction
+        Session = scoped_session(
+            sessionmaker(bind=engine, extension=ZopeTransactionExtension(keep_session=True)))
+        log.debug('Creating all models for %s' % engine)
+        Base.metadata.bind = engine
+        Base.metadata.create_all(engine)
+        self.db = Session()
+        populate(self.db)
+
+        # Track sql statements in every test
+        self.sql_statements = []
+
+        def track(conn, cursor, statement, param, ctx, many):
+            self.sql_statements.append(statement)
+
+        event.listen(engine, "before_cursor_execute", track)
+
+    def tearDown(self):
+        log.debug('Removing session')
+        self.db.close()
+        del self.sql_statements

--- a/bodhi/tests/server/functional/test_updates.py
+++ b/bodhi/tests/server/functional/test_updates.py
@@ -3025,6 +3025,7 @@ class TestUpdatesService(bodhi.tests.server.functional.base.BaseWSGICase):
         upd = Update.get(nvr, self.db)
         upd.status = UpdateStatus.testing
         upd.request = None
+        upd.date_testing = datetime.now() - timedelta(days=1)
         self.db.flush()
 
         # Checks karma threshold is reached

--- a/bodhi/tests/server/models/__init__.py
+++ b/bodhi/tests/server/models/__init__.py
@@ -32,9 +32,10 @@ class ModelTest(object):
     klass = None
     attrs = {}
 
-    def setup(self):
+    def setUp(self):
         engine = create_engine('sqlite://')
-        Session = scoped_session(sessionmaker(extension=ZopeTransactionExtension()))
+        Session = scoped_session(
+            sessionmaker(extension=ZopeTransactionExtension(keep_session=True)))
         Session.configure(bind=engine)
         self.db = Session()
         Base.metadata.create_all(engine)

--- a/bodhi/tests/server/scripts/test_approve_testing.py
+++ b/bodhi/tests/server/scripts/test_approve_testing.py
@@ -1,0 +1,237 @@
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+"""
+This module contains tests for the bodhi.server.scripts.approve_testing module.
+"""
+from datetime import datetime, timedelta
+
+from mock import patch
+import transaction
+
+from bodhi.server.config import config
+from bodhi.server.models import models
+from bodhi.server.scripts import approve_testing
+from bodhi.tests.server.base import BaseTestCase
+
+
+class TestMain(BaseTestCase):
+    """
+    This class contains tests for the main() function.
+    """
+    def test_autokarma_update_meeting_time_requirements_gets_one_comment(self):
+        """
+        Ensure that an update that meets the required time in testing gets only one comment from
+        Bodhi to that effect, even on subsequent runs of main().
+        """
+        update = self.db.query(models.Update).all()[0]
+        update.autokarma = True
+        update.request = None
+        update.stable_karma = 10
+        update.status = models.UpdateStatus.testing
+        update.date_testing = datetime.now() - timedelta(days=7)
+        self.db.flush()
+
+        with patch(
+                'bodhi.server.scripts.approve_testing._get_db_session', return_value=self.db):
+            approve_testing.main(['nosetests', 'some_config.ini'])
+
+            # Now we will run main() again, but this time we expect Bodhi not to add any further
+            # comments.
+            approve_testing.main(['nosetests', 'some_config.ini'])
+
+        bodhi = self.db.query(models.User).filter_by(name=u'bodhi').one()
+        comment_q = self.db.query(models.Comment).filter_by(update_id=update.id, user_id=bodhi.id)
+        self.assertEqual(comment_q.count(), 1)
+        self.assertEqual(
+            comment_q[0].text,
+            config.get('testing_approval_msg') % update.release.mandatory_days_in_testing)
+
+    # Set the release's mandatory days in testing to 0 to set up the condition for this test.
+    @patch.dict(config, [('fedora.mandatory_days_in_testing', 0)])
+    def test_autokarma_update_without_mandatory_days_in_testing(self):
+        """
+        If the Update's release doesn't have a mandatory days in testing, main() should ignore it
+        (and should not comment on the update at all, even if it does reach karma levels.)
+        """
+        update = self.db.query(models.Update).all()[0]
+        update.autokarma = True
+        update.request = None
+        update.status = models.UpdateStatus.testing
+        update.date_testing = datetime.now() - timedelta(days=7)
+        # Let's delete all the comments to make our assertion at the end of this simpler.
+        for c in update.comments:
+            self.db.delete(c)
+        transaction.commit()
+
+        with patch(
+                'bodhi.server.scripts.approve_testing._get_db_session', return_value=self.db):
+            approve_testing.main(['nosetests', 'some_config.ini'])
+
+        # The bodhi user shouldn't exist, since it shouldn't have made any comments
+        self.assertEqual(self.db.query(models.User).filter_by(name=u'bodhi').count(), 0)
+        self.assertEqual(self.db.query(models.Comment).count(), 0)
+
+    def test_autokarma_update_not_meeting_testing_requirments(self):
+        """
+        If an autokarma update has not met the testing requirements, bodhi should not comment on the
+        update.
+        """
+        update = self.db.query(models.Update).all()[0]
+        update.autokarma = True
+        update.request = None
+        update.status = models.UpdateStatus.testing
+        # 6 days isn't enough time to meet the testing requirements.
+        update.date_testing = datetime.now() - timedelta(days=6)
+        # Let's delete all the comments to make our assertion at the end of this simpler.
+        for c in update.comments:
+            self.db.delete(c)
+        transaction.commit()
+
+        with patch(
+                'bodhi.server.scripts.approve_testing._get_db_session', return_value=self.db):
+            approve_testing.main(['nosetests', 'some_config.ini'])
+
+        # The bodhi user shouldn't exist, since it shouldn't have made any comments
+        self.assertEqual(self.db.query(models.User).filter_by(name=u'bodhi').count(), 0)
+        self.assertEqual(self.db.query(models.Comment).count(), 0)
+
+    def test_non_autokarma_update_meeting_karma_requirements_gets_one_comment(self):
+        """
+        Ensure that a non-autokarma update that meets the required karma threshold gets only one
+        comment from Bodhi to that effect, even on subsequent runs of main(). There was an issue[0]
+        where Bodhi wasn't correctly detected that it has already commented on updates, and would
+        repeatedly comment that non-autokarma updates could be pushed. This test ensures that issue
+        stays fixed.
+
+        [0] https://github.com/fedora-infra/bodhi/issues/1009
+        """
+        update = self.db.query(models.Update).all()[0]
+        update.autokarma = False
+        update.request = None
+        update.stable_karma = 1
+        update.status = models.UpdateStatus.testing
+        update.comment(self.db, 'testing', author='hunter2', anonymous=False, karma=1)
+
+        with patch(
+                'bodhi.server.scripts.approve_testing._get_db_session', return_value=self.db):
+            approve_testing.main(['nosetests', 'some_config.ini'])
+
+            # Now we will run main() again, but this time we expect Bodhi not to add any further
+            # comments.
+            approve_testing.main(['nosetests', 'some_config.ini'])
+
+        bodhi = self.db.query(models.User).filter_by(name=u'bodhi').one()
+        comment_q = self.db.query(models.Comment).filter_by(update_id=update.id, user_id=bodhi.id)
+        self.assertEqual(comment_q.count(), 1)
+        self.assertEqual(comment_q[0].text, config.get('testing_approval_msg_based_on_karma'))
+
+    def test_non_autokarma_update_with_stable_karma_0(self):
+        """
+        A non-autokarma update with a stable_karma set to 0 should not get comments from Bodhi.
+        """
+        update = self.db.query(models.Update).all()[0]
+        update.autokarma = False
+        update.request = None
+        update.stable_karma = 0
+        update.status = models.UpdateStatus.testing
+        update.comment(self.db, 'testing', author='hunter2', anonymous=False, karma=1)
+
+        with patch(
+                'bodhi.server.scripts.approve_testing._get_db_session', return_value=self.db):
+            approve_testing.main(['nosetests', 'some_config.ini'])
+
+        # The bodhi user shouldn't exist, since it shouldn't have made any comments
+        self.assertEqual(self.db.query(models.User).filter_by(name=u'bodhi').count(), 0)
+        # There are three comments, but none from the non-existing bodhi user.
+        self.assertEqual(self.db.query(models.Comment).count(), 3)
+        usernames = [
+            c.user.name
+            for c in self.db.query(models.Comment).order_by(models.Comment.timestamp).all()]
+        self.assertEqual(usernames, [u'guest', u'anonymous', u'hunter2'])
+
+    def test_non_autokarma_update_with_stable_karma_None(self):
+        """
+        A non-autokarma update with a stable_karma set to None should not get comments from Bodhi.
+        """
+        update = self.db.query(models.Update).all()[0]
+        update.autokarma = False
+        update.request = None
+        update.stable_karma = None
+        update.status = models.UpdateStatus.testing
+        update.comment(self.db, 'testing', author='hunter2', anonymous=False, karma=1)
+
+        with patch(
+                'bodhi.server.scripts.approve_testing._get_db_session', return_value=self.db):
+            approve_testing.main(['nosetests', 'some_config.ini'])
+
+        # The bodhi user shouldn't exist, since it shouldn't have made any comments
+        self.assertEqual(self.db.query(models.User).filter_by(name=u'bodhi').count(), 0)
+        # There are three comments, but none from the non-existing bodhi user.
+        self.assertEqual(self.db.query(models.Comment).count(), 3)
+        usernames = [
+            c.user.name
+            for c in self.db.query(models.Comment).order_by(models.Comment.timestamp).all()]
+        self.assertEqual(usernames, [u'guest', u'anonymous', u'hunter2'])
+
+    def test_non_autokarma_update_with_unmet_karma_requirement(self):
+        """
+        A non-autokarma update without enough karma should not get comments from Bodhi.
+        """
+        update = self.db.query(models.Update).all()[0]
+        update.autokarma = False
+        update.request = None
+        update.stable_karma = 10
+        update.status = models.UpdateStatus.testing
+        update.comment(self.db, 'testing', author='hunter2', anonymous=False, karma=1)
+
+        with patch(
+                'bodhi.server.scripts.approve_testing._get_db_session', return_value=self.db):
+            approve_testing.main(['nosetests', 'some_config.ini'])
+
+        # The bodhi user shouldn't exist, since it shouldn't have made any comments
+        self.assertEqual(self.db.query(models.User).filter_by(name=u'bodhi').count(), 0)
+        # There are three comments, but none from the non-existing bodhi user.
+        self.assertEqual(self.db.query(models.Comment).count(), 3)
+        usernames = [
+            c.user.name
+            for c in self.db.query(models.Comment).order_by(models.Comment.timestamp).all()]
+        self.assertEqual(usernames, [u'guest', u'anonymous', u'hunter2'])
+
+    # Set the release's mandatory days in testing to 0 to set up the condition for this test.
+    @patch.dict(config, [('fedora.mandatory_days_in_testing', 0)])
+    def test_non_autokarma_update_without_mandatory_days_in_testing(self):
+        """
+        If the Update's release doesn't have a mandatory days in testing, main() should ignore it
+        (and should not comment on the update at all, even if it does reach karma levels.)
+        """
+        update = self.db.query(models.Update).all()[0]
+        update.autokarma = False
+        update.request = None
+        update.stable_karma = 1
+        update.status = models.UpdateStatus.testing
+        update.comment(self.db, 'testing', author='hunter2', anonymous=False, karma=1)
+        transaction.commit()
+
+        with patch(
+                'bodhi.server.scripts.approve_testing._get_db_session', return_value=self.db):
+            approve_testing.main(['nosetests', 'some_config.ini'])
+
+        # The bodhi user shouldn't exist, since it shouldn't have made any comments
+        self.assertEqual(self.db.query(models.User).filter_by(name=u'bodhi').count(), 0)
+        # There are three comments, but none from the non-existing bodhi user.
+        self.assertEqual(self.db.query(models.Comment).count(), 3)
+        usernames = [
+            c.user.name
+            for c in self.db.query(models.Comment).order_by(models.Comment.timestamp).all()]
+        self.assertEqual(usernames, [u'guest', u'anonymous', u'hunter2'])

--- a/bodhi/tests/server/test_metadata.py
+++ b/bodhi/tests/server/test_metadata.py
@@ -49,7 +49,7 @@ class TestExtendedMetadata(unittest.TestCase):
 
     def setUp(self):
         engine = create_engine(DB_PATH)
-        Session = scoped_session(sessionmaker(extension=ZopeTransactionExtension()))
+        Session = scoped_session(sessionmaker(extension=ZopeTransactionExtension(keep_session=True)))
         Session.configure(bind=engine)
         log.debug('Creating all models for %s' % engine)
         Base.metadata.bind = engine


### PR DESCRIPTION
The approve_testing script did not work properly with the new
autokarma feature. For updates that had autokarma set to False, the
approve_testing script would add a bodhi comment every time it ran
to say that the update could be pushed to stable. This commit
adjusts that script, the Update.meets_testing_requirements method,
and the Update.met_testing_requirements method so that only one
comment is left.

Additionally, it was noted that there was not testing coverage on
the approve_testing script so a new test module was created to
cover the script. In order to save some testing effort, a new base
test class was created to perform some common functions.
Additionally, this commit adds several new tests on
Update.meets_testing_requirements and
Update.met_testing_requirements.

fixes #1009
