### PR TITLE
Add route to allow trailing slash on masher url

### DIFF
--- a/bodhi/server/__init__.py
+++ b/bodhi/server/__init__.py
@@ -191,7 +191,7 @@ def main(global_config, testing=None, session=None, **settings):
 
     # Metrics
     config.add_route('metrics', '/metrics')
-    config.add_route('masher_status', '/masher')
+    config.add_route('masher_status', '/masher/')
 
     # Auto-completion search
     config.add_route('search_packages', '/search/packages')


### PR DESCRIPTION
Fixes #1041 
This would allow `302` URL redirection from `/masher` to `/masher/`.
