### PR TITLE
Configure nosetests to require 77% coverage and document its usage.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -46,7 +46,7 @@ automatically be reflected in the guest's ``/vagrant`` folder.
 You can run the unit tests within the guest with nosetests::
 
     $ cd /vagrant
-    $ nosetests -v
+    $ python setup.py nosetests
 
 You can run the development server from inside the Vagrant environment::
 
@@ -122,7 +122,7 @@ Copy ``development.ini.example`` to ``development.ini``:
     
 Run the test suite
 ------------------
-``python setup.py test``
+``python setup.py nosetests``
 
 Import the bodhi2 database
 --------------------------

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,9 +1,9 @@
 [nosetests]
-#match=^test
-#nocapture=1
+cover-erase=TRUE
+cover-inclusive=TRUE
+cover-min-percentage=77
 cover-package=bodhi
-#with-coverage=0
-#cover-erase=1
+with-coverage=TRUE
 
 [compile_catalog]
 directory = bodhi/server/locale


### PR DESCRIPTION
Though we should and do have the goal of higher test coverage,
bodhi currently only has 77% coverage. This commit alters the
nosetests configuration so that the coverage will not be allowed to
regress and documents that nose should be used to run the tests.

Over time I plan to slowly increase our test coverage and will
adjust these settings as I go.
