### PR TITLE
PEP-8 bodhi.server.models.__init__.

### DIFF
--- a/bodhi/server/models/__init__.py
+++ b/bodhi/server/models/__init__.py
@@ -12,4 +12,4 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
-from models import *
+from models import *  # noqa

--- a/bodhi/tests/test_style.py
+++ b/bodhi/tests/test_style.py
@@ -34,8 +34,8 @@ class TestStyle(unittest.TestCase):
         slowly. This test enforces only modules that have been corrected to comply with flake8. The
         goal is that this test would one day check the entire codebase.
         """
-        enforced_paths = ['bodhi/server/models/models.py', 'bodhi/server/services/updates.py',
-                          'bodhi/server/views/admin.py']
+        enforced_paths = ['bodhi/server/models/__init__.py', 'bodhi/server/models/models.py',
+                          'bodhi/server/services/updates.py', 'bodhi/server/views/admin.py']
 
         enforced_paths = [os.path.join(REPO_PATH, p) for p in enforced_paths]
 


### PR DESCRIPTION
Frankly I was tempted to just get rid of the `from models import *` because I don't generally like that pattern. I'd prefer to either move all the models into `__init__.py` or just fix all the things that import from the `__init__.py`. However, I didn't want to make either of those drastic moves at this time, so I'm just slapping a `# noqa` on it for now. I filed https://github.com/fedora-infra/bodhi/issues/1057 to track getting rid of this line so we remember to do that later.
