### PR TITLE
Add python-cornice to the development environment.

### DIFF
--- a/devel/ansible/roles/dev/tasks/main.yml
+++ b/devel/ansible/roles/dev/tasks/main.yml
@@ -17,6 +17,7 @@
       - postgresql-devel
       - python
       - python-alembic
+      - python-cornice
       - python-devel
       - python-librepo
       - python-mock


### PR DESCRIPTION
During the Cloud test day today, I found that the unit tests for
Bodhi did not pass with the Fedora 25 Vagrant image. It turned out
that python-cornice was not getting installed anymore. I didn't
determine exactly which change between Fedora 24 and 25 caused
this, but I suspect something that we were installing stopped
depending on it.
