### PR TITLE
Drop the Update.karma column and replace it with a property.

### DIFF
--- a/alembic/versions/06aa0e8aa5d2_drop_the_update_karma_column.py
+++ b/alembic/versions/06aa0e8aa5d2_drop_the_update_karma_column.py
@@ -1,0 +1,30 @@
+"""Drop the Update.karma column.
+
+Revision ID: 06aa0e8aa5d2
+Revises: 3cde3882442a
+Create Date: 2016-10-26 16:55:54.875994
+
+"""
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = '06aa0e8aa5d2'
+down_revision = '3cde3882442a'
+
+
+def upgrade():
+    """
+    Drop the karma column from the updates table.
+    """
+    op.drop_column('updates', 'karma')
+
+
+def downgrade():
+    """
+    Downgrade is not supported. If we ever do want to do this for some reason, we can use the
+    code from the bodhi.server.models.models.Update.karma() property that was written in the same
+    commit that introduced this migration as a guide for how to calculate the karma column. As it is
+    highly unlikely that will ever be needed, this function simply raises an Exception for now.
+    """
+    raise NotImplemented('Downgrade not supported')

--- a/bodhi/tests/server/__init__.py
+++ b/bodhi/tests/server/__init__.py
@@ -72,7 +72,6 @@ def populate(db):
     db.add(comment)
     comment.user = user
     update.comments.append(comment)
-    update.karma = 1
 
     comment = Comment(karma=0, text=u"srsly.  pretty good.", anonymous=True)
     comment.user = anonymous


### PR DESCRIPTION
Prior to this commit Update karma had been denormalized, but that
led to a few issues with keeping the karma column correctly in sync
with the Comments in an Update. In one case, a user was able to
double +1 an Update, causing the karma column to contain an
incorrect value. The code that managed the karma column was
complicated and it was determined that the denormalized column did
not provide a significant enough performance gain to justify the
complex code it takes to maintain correct values in the database.
Nearly all views on Updates need to load the associated Comments
from the database, so calculating the Update.karma property
dynamically will not introduce any new queries in most cases.

This commit drops the karma column and replaces it with two
properties. The first calculates the sums of positive and negative
karma separately, and the second uses the first to generate and
return the overall karma. The first property was created to replace
the has_negative_karma() method, which had an issue where it failed
to correctly filter out karma before karma reset events. Rather
than fix that method, it was determined that it would be simpler to
drop it and rework the caller to use the new _composite_karma()
property to determine if there is negative karma.

This commit also addresses a third issue with karma counting where
users who changed their mind more than once would no longer be able
to change the karma of an Update.

fixes #1018
fixes #1064
fixes #1065
