### PR TITLE
Tests server.consumers.updates

### DIFF
--- a/bodhi/server/__init__.py
+++ b/bodhi/server/__init__.py
@@ -38,11 +38,18 @@ log = logging.getLogger(__name__)
 from bodhi.server import ffmarkdown
 ffmarkdown.inject()
 
+
 #
 # Request methods
 #
 
-def get_dbsession(request):
+def get_db_session_for_request(request=None):
+    """
+    This function returns a database session that is meant to be used for the given request. It sets
+    up the Zope transaction manager and configures the request to close the session when it is
+    completed. If you need a database session that is not tied to a request, you can use
+    bodhi.server.models.models.get_db_factory() to return a session generator.
+    """
     engine = engine_from_config(request.registry.settings, 'sqlalchemy.')
     Sess = scoped_session(sessionmaker(extension=ZopeTransactionExtension()))
     Sess.configure(bind=engine)
@@ -149,7 +156,7 @@ def main(global_config, testing=None, session=None, **settings):
     if session:
         config.add_request_method(lambda _: session, 'db', reify=True)
     else:
-        config.add_request_method(get_dbsession, 'db', reify=True)
+        config.add_request_method(get_db_session_for_request, 'db', reify=True)
 
     config.add_request_method(get_user, 'user', reify=True)
     config.add_request_method(get_koji, 'koji', reify=True)

--- a/bodhi/server/consumers/updates.py
+++ b/bodhi/server/consumers/updates.py
@@ -61,15 +61,12 @@ class UpdatesHandler(fedmsg.consumers.FedmsgConsumer):
     """
     config_key = 'updates_handler'
 
-    def __init__(self, hub, db_factory=None, *args, **kwargs):
-        if not db_factory:
-            config_uri = '/etc/bodhi/production.ini'
-            self.settings = get_appsettings(config_uri)
-            engine = engine_from_config(self.settings, 'sqlalchemy.')
-            Base.metadata.create_all(engine)
-            self.db_factory = transactional_session_maker(engine)
-        else:
-            self.db_factory = db_factory
+    def __init__(self, hub, *args, **kwargs):
+        config_uri = '/etc/bodhi/production.ini'
+        self.settings = get_appsettings(config_uri)
+        engine = engine_from_config(self.settings, 'sqlalchemy.')
+        Base.metadata.create_all(engine)
+        self.db_factory = transactional_session_maker(engine)
 
         prefix = hub.config.get('topic_prefix')
         env = hub.config.get('environment')

--- a/bodhi/server/consumers/updates.py
+++ b/bodhi/server/consumers/updates.py
@@ -35,11 +35,7 @@ import pprint
 
 import fedmsg.consumers
 
-from pyramid.paster import get_appsettings
-from sqlalchemy import engine_from_config
-
 from bodhi.server.exceptions import BodhiException
-from bodhi.server.util import transactional_session_maker
 from bodhi.server.models import (
     Bug,
     Update,
@@ -48,6 +44,8 @@ from bodhi.server.models import (
 )
 
 from bodhi.server.bugs import bugtracker
+from bodhi.server.config import config
+from bodhi.server.models import models
 
 import logging
 log = logging.getLogger('bodhi')
@@ -62,11 +60,7 @@ class UpdatesHandler(fedmsg.consumers.FedmsgConsumer):
     config_key = 'updates_handler'
 
     def __init__(self, hub, *args, **kwargs):
-        config_uri = '/etc/bodhi/production.ini'
-        self.settings = get_appsettings(config_uri)
-        engine = engine_from_config(self.settings, 'sqlalchemy.')
-        Base.metadata.create_all(engine)
-        self.db_factory = transactional_session_maker(engine)
+        self.db_factory = models.get_db_factory()
 
         prefix = hub.config.get('topic_prefix')
         env = hub.config.get('environment')
@@ -75,7 +69,7 @@ class UpdatesHandler(fedmsg.consumers.FedmsgConsumer):
             prefix + '.' + env + '.bodhi.update.edit',
         ]
 
-        self.handle_bugs = bool(self.settings.get('bodhi_email'))
+        self.handle_bugs = bool(config.get('bodhi_email'))
         if not self.handle_bugs:
             log.warn("No bodhi_email defined; not fetching bug details")
 
@@ -150,7 +144,7 @@ class UpdatesHandler(fedmsg.consumers.FedmsgConsumer):
                     update.type = UpdateType.security
 
                 log.info("Commenting on %r" % bug.bug_id)
-                comment = self.settings['initial_bug_msg'] % (
+                comment = config['initial_bug_msg'] % (
                     update.title, update.release.long_name, update.abs_url())
                 bug.add_comment(update, comment)
 

--- a/bodhi/server/models/models.py
+++ b/bodhi/server/models/models.py
@@ -34,7 +34,7 @@ except ImportError:
 
 
 from sqlalchemy import Unicode, UnicodeText, Integer, Boolean
-from sqlalchemy import DateTime
+from sqlalchemy import DateTime, engine_from_config
 from sqlalchemy import Table, Column, ForeignKey
 from sqlalchemy import and_, or_
 from sqlalchemy.sql import text
@@ -55,6 +55,8 @@ from bodhi.server.models.enum import DeclEnum, EnumSymbol
 from bodhi.server.exceptions import BodhiException, LockedUpdateException
 from bodhi.server.config import config
 from bodhi.server.bugs import bugtracker
+from bodhi.server.util import transactional_session_maker
+
 
 try:
     import rpm
@@ -2282,3 +2284,15 @@ class Stack(Base):
     # Many-to-many relationships
     groups = relationship("Group", secondary=stack_group_table, backref='stacks')
     users = relationship("User", secondary=stack_user_table, backref='stacks')
+
+
+def get_db_factory():
+    """
+    This function generates and returns a database factory that can be used for non-request
+    transactions. You can instantiate the class returned by this function to get a database
+    session that you can use with a context manager. If you wish to get a database session for a
+    request, see bodhi.server.get_db_session_for_request().
+    """
+    engine = engine_from_config(config, 'sqlalchemy.')
+    Base.metadata.create_all(engine)
+    return transactional_session_maker(engine)

--- a/bodhi/tests/server/consumers/test_updates.py
+++ b/bodhi/tests/server/consumers/test_updates.py
@@ -1,0 +1,87 @@
+# -*- coding: utf-8 -*-
+
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+"""This test suite contains tests for the bodhi.server.consumers.updates module."""
+
+import copy
+import unittest
+
+import mock
+
+from bodhi.server import util
+from bodhi.server.consumers import updates
+
+
+class TestUpdatesHandlerInit(unittest.TestCase):
+    """This test class contains tests for the UpdatesHandler.__init__() method."""
+    def test_handle_bugs_bodhi_email_falsy(self):
+        """
+        Assert that bug handling is disabled when bodhi_email is configured "falsy".
+        """
+        hub = mock.MagicMock()
+        hub.config = {'environment': 'environment',
+                      'topic_prefix': 'topic_prefix'}
+
+        with mock.patch.dict(updates.config, {'bodhi_email': ''}):
+            h = updates.UpdatesHandler(hub)
+
+        self.assertEqual(h.handle_bugs, False)
+
+    def test_handle_bugs_bodhi_email_missing(self):
+        """
+        Assert that bug handling is disabled when bodhi_email is not configured.
+        """
+        hub = mock.MagicMock()
+        hub.config = {'environment': 'environment',
+                      'topic_prefix': 'topic_prefix'}
+        replacement_config = copy.deepcopy(updates.config)
+        del replacement_config['bodhi_email']
+
+        with mock.patch.dict(updates.config, replacement_config, clear=True):
+            h = updates.UpdatesHandler(hub)
+
+        self.assertEqual(h.handle_bugs, False)
+
+    @mock.patch('bodhi.server.consumers.updates.fedmsg.consumers.FedmsgConsumer.__init__')
+    def test_super___init___called(self, __init__):
+        """
+        Make sure the superclass's __init__() was called.
+        """
+        hub = mock.MagicMock()
+        hub.config = {'environment': 'environment',
+                      'topic_prefix': 'topic_prefix'}
+
+        with mock.patch.dict(updates.config, {'bodhi_email': 'bowlofeggs@fpo.org'}):
+            h = updates.UpdatesHandler(hub)
+
+        __init__.assert_called_once_with(hub)
+
+    def test_typical_config(self):
+        """
+        Test the method with a typical config.
+        """
+        hub = mock.MagicMock()
+        hub.config = {'environment': 'environment',
+                      'topic_prefix': 'topic_prefix'}
+
+        with mock.patch.dict(updates.config, {'bodhi_email': 'bowlofeggs@fpo.org'}):
+            h = updates.UpdatesHandler(hub)
+
+        self.assertEqual(h.handle_bugs, True)
+        self.assertEqual(type(h.db_factory), util.TransactionalSessionMaker)
+        self.assertEqual(
+            h.topic,
+            ['topic_prefix.environment.bodhi.update.request.testing',
+             'topic_prefix.environment.bodhi.update.edit'])

--- a/bodhi/tests/server/models/test_models.py
+++ b/bodhi/tests/server/models/test_models.py
@@ -26,8 +26,8 @@ from datetime import datetime, timedelta
 from sqlalchemy.exc import IntegrityError
 from pyramid.testing import DummyRequest
 
-from bodhi.server import models as model, buildsys, mail
-from bodhi.server.models import (UpdateStatus, UpdateType, UpdateRequest,
+from bodhi.server import models as model, buildsys, mail, util
+from bodhi.server.models import (get_db_factory, UpdateStatus, UpdateType, UpdateRequest,
                           UpdateSeverity, UpdateSuggestion, ReleaseState,
                           BugKarma)
 from bodhi.tests.server.models import ModelTest
@@ -47,6 +47,18 @@ class TestComment(unittest.TestCase):
         https://github.com/fedora-infra/bodhi/issues/949.
         """
         self.assertEqual(model.Comment.__table__.columns['text'].nullable, False)
+
+
+class TestGetDBFactory(unittest.TestCase):
+    """
+    This class contains tests for the get_db_factory() function.
+    """
+    def test_return_type(self):
+        """
+        """
+        Session = get_db_factory()
+
+        self.assertEqual(type(Session), util.TransactionalSessionMaker)
 
 
 class TestRelease(ModelTest):


### PR DESCRIPTION
The overall goal of this pull request is to add some test coverage for ```bodhi.server.consumers.updates.UpdatesHandler.__init__```. However, that code was more difficult to test because it failed to separate concerns and reuse code, so this pull request also contains three more commits that refactor that code and other related code to make it more suitable for testing.