### PR TITLE
Add Tests for bodhi.server.consumers.signed.SignedHandler.__init__()

### DIFF
--- a/bodhi/server/consumers/signed.py
+++ b/bodhi/server/consumers/signed.py
@@ -22,11 +22,8 @@ import logging
 import pprint
 
 import fedmsg.consumers
-from pyramid.paster import get_appsettings
-from sqlalchemy import engine_from_config
 
-from bodhi.server.models import Base, Build, Release
-from bodhi.server.util import transactional_session_maker
+from bodhi.server.models import Base, Build, get_db_factory, Release
 
 log = logging.getLogger('bodhi')
 
@@ -40,11 +37,7 @@ class SignedHandler(fedmsg.consumers.FedmsgConsumer):
     config_key = 'signed_handler'
 
     def __init__(self, hub, *args, **kwargs):
-        config_uri = '/etc/bodhi/production.ini'
-        self.settings = get_appsettings(config_uri)
-        engine = engine_from_config(self.settings, 'sqlalchemy.')
-        Base.metadata.create_all(engine)
-        self.db_factory = transactional_session_maker(engine)
+        self.db_factory = get_db_factory()
 
         prefix = hub.config.get('topic_prefix')
         env = hub.config.get('environment')

--- a/bodhi/tests/server/consumers/test_signed.py
+++ b/bodhi/tests/server/consumers/test_signed.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+"""This test suite contains tests for the bodhi.server.consumers.signed module."""
+
+import unittest
+
+import mock
+
+from bodhi.server.consumers import signed
+
+
+class TestSignedHandler___init__(unittest.TestCase):
+    """This test class contains tests for the SignedHandler.__init__() method."""
+    def test___init__(self):
+        """Test __init__() with a manufactured hub config."""
+        hub = mock.MagicMock()
+        hub.config = {'environment': 'environment', 'topic_prefix': 'topic_prefix'}
+
+        handler = signed.SignedHandler(hub)
+
+        self.assertEqual(handler.topic, ['topic_prefix.environment.buildsys.tag'])
+
+    @mock.patch('bodhi.server.consumers.signed.fedmsg.consumers.FedmsgConsumer.__init__')
+    def test_calls_super(self, __init__):
+        """Assert that __init__() calls the superclass __init__()."""
+        hub = mock.MagicMock()
+        hub.config = {'environment': 'environment', 'topic_prefix': 'topic_prefix'}
+
+        handler = signed.SignedHandler(hub)
+
+        self.assertEqual(handler.topic, ['topic_prefix.environment.buildsys.tag'])
+        __init__.assert_called_once_with(hub)


### PR DESCRIPTION
This pull request contains two commits. The first commit refactors the signed handler so that it uses ```get_db_factory()``` instead of repeating code. This is needed for two reasons: it reduced repeated code, and it makes the ```__init__()``` method significantly easier to test. The second commit adds tests for the ```__init__()``` method.