### PR TITLE
Fix a failing test.

### DIFF
--- a/bodhi/tests/server/services/test_updates.py
+++ b/bodhi/tests/server/services/test_updates.py
@@ -651,10 +651,11 @@ class TestUpdatesService(bodhi.tests.server.functional.base.BaseWSGICase):
         body = res.json_body
         self.assertEquals(len(body['updates']), 0)
 
-    def test_list_updates_pagination(self):
+    @mock.patch(**mock_valid_requirements)
+    def test_list_updates_pagination(self, *args):
 
         # First, stuff a second update in there
-        self.test_new_update()
+        self.app.post_json('/updates/', self.get_update('bodhi-2.0.0-2.fc17'))
 
         # Then, test pagination
         res = self.app.get('/updates/',


### PR DESCRIPTION
During my last commit, I had assumed that tests didn't depend on
other tests when I shuffled them around. I discovered that one test
was failing because it was running another test to avoid copying a
line of code and a mock.

This commit adjusts the failing test to be isolated.