### PR TITLE
Add tests, drop unreachable code, and fix #1111

### DIFF
--- a/bodhi/server/services/updates.py
+++ b/bodhi/server/services/updates.py
@@ -351,11 +351,8 @@ def new_update(request):
         # Create the Package and Build entities
         for nvr in data['builds']:
             name, version, release = request.buildinfo[nvr]['nvr']
-            package = request.db.query(Package).filter_by(name=name).first()
-            if not package:
-                package = Package(name=name)
-                request.db.add(package)
-                request.db.flush()
+            # The package will have been created by validate_acls
+            package = request.db.query(Package).filter_by(name=name).one()
 
             build = Build.get(nvr, request.db)
 

--- a/bodhi/tests/server/services/test_updates.py
+++ b/bodhi/tests/server/services/test_updates.py
@@ -404,6 +404,19 @@ class TestNewUpdate(bodhi.tests.server.functional.base.BaseWSGICase):
             urlparse.urljoin(config['base_address'], '/updates/FEDORA-2016-53345602d5'))
         self.assertEquals(up.comments[-1].text, expected_comment)
 
+    @mock.patch(**mock_valid_requirements)
+    @mock.patch('bodhi.server.notifications.publish')
+    @mock.patch('bodhi.server.services.updates.Update.new', side_effect=IOError('oops!'))
+    def test_unexpected_exception(self, publish, *args):
+        """Ensure that an unexpected Exception is handled by new_update()."""
+        update = self.get_update('bodhi-2.0.0-2.fc17')
+
+        r = self.app.post_json('/updates/', update, status=400)
+
+        self.assertEquals(r.json_body['status'], 'error')
+        self.assertEquals(r.json_body['errors'][0]['description'],
+                          "Unable to create update.  oops!")
+
 
 class TestUpdatesService(bodhi.tests.server.functional.base.BaseWSGICase):
 


### PR DESCRIPTION
This pull request contains four commits. Each commit is atomic and is desirable to go in by itself (i.e., we shouldn't squash this pull request), but they are also all needed for the final commit which fixes #1111.

Incidentally, the last commit's addition of transactions (and in particular, the abortion of transactions) has reduced the test suite's memory usage by about 50%!