### PR TITLE
Disable caching koji sessions during mashing process

### DIFF
--- a/bodhi/server/consumers/masher.py
+++ b/bodhi/server/consumers/masher.py
@@ -278,7 +278,6 @@ class MasherThread(threading.Thread):
         #        src=src, dest=dest, nvr=nvr)
 
     def work(self):
-        self.koji = buildsys.get_session()
         self.release = self.db.query(Release)\
                               .filter_by(name=self.release).one()
         self.id = getattr(self.release, '%s_tag' % self.request.value)
@@ -454,10 +453,10 @@ class MasherThread(threading.Thread):
         # Remove the pending tag as well
         if update.request is UpdateRequest.stable:
             update.remove_tag(update.release.pending_stable_tag,
-                              koji=self.koji)
+                              koji=buildsys.get_session())
         elif update.request is UpdateRequest.testing:
             update.remove_tag(update.release.pending_testing_tag,
-                              koji=self.koji)
+                              koji=buildsys.get_session())
         update.request = None
         if update in self.state['updates']:
             self.state['updates'].remove(update)
@@ -584,27 +583,28 @@ class MasherThread(threading.Thread):
                         self.move_tags_async.extend(move_tags)
 
     def _perform_tag_actions(self):
+        koji = buildsys.get_session()
         for i, batches in enumerate([(self.add_tags_sync, self.move_tags_sync),
                                      (self.add_tags_async, self.move_tags_async)]):
             add, move = batches
             if i == 0:
-                self.koji.multicall = False
+                koji.multicall = False
             else:
-                self.koji.multicall = True
+                koji.multicall = True
             for action in add:
                 tag, build = action
                 self.log.info("Adding tag %s to %s" % (tag, build))
-                self.koji.tagBuild(tag, build, force=True)
+                koji.tagBuild(tag, build, force=True)
             for action in move:
                 from_tag, to_tag, build = action
                 self.log.info('Moving %s from %s to %s' % (
                               build, from_tag, to_tag))
-                self.koji.moveBuild(from_tag, to_tag, build, force=True)
+                koji.moveBuild(from_tag, to_tag, build, force=True)
 
             if i != 0:
-                results = self.koji.multiCall()
+                results = koji.multiCall()
                 failed_tasks = buildsys.wait_for_tasks([task[0] for task in results],
-                                                       self.koji, sleep=15)
+                                                       koji, sleep=15)
                 if failed_tasks:
                     raise Exception("Failed to move builds: %s" % failed_tasks)
 
@@ -622,15 +622,16 @@ class MasherThread(threading.Thread):
     def remove_pending_tags(self):
         """ Remove all pending tags from these updates """
         self.log.debug("Removing pending tags from builds")
-        self.koji.multicall = True
+        koji = buildsys.get_session()
+        koji.multicall = True
         for update in self.updates:
             if update.request is UpdateRequest.stable:
                 update.remove_tag(update.release.pending_stable_tag,
-                                  koji=self.koji)
+                                  koji=koji)
             elif update.request is UpdateRequest.testing:
                 update.remove_tag(update.release.pending_testing_tag,
-                                  koji=self.koji)
-        result = self.koji.multiCall()
+                                  koji=koji)
+        result = koji.multiCall()
         self.log.debug('remove_pending_tags koji.multiCall result = %r',
                        result)
 

--- a/bodhi/server/metadata.py
+++ b/bodhi/server/metadata.py
@@ -54,7 +54,6 @@ class ExtendedMetadata(object):
         self.builds = {}
         self.missing_ids = []
         self._from = config.get('bodhi_email')
-        self.koji = get_session()
         self._fetch_updates()
 
         self.uinfo = cr.UpdateInfo()
@@ -177,7 +176,7 @@ class ExtendedMetadata(object):
     def _fetch_updates(self):
         """Based on our given koji tag, populate a list of Update objects"""
         log.debug("Fetching builds tagged with '%s'" % self.tag)
-        kojiBuilds = self.koji.listTagged(self.tag, latest=True)
+        kojiBuilds = get_session().listTagged(self.tag, latest=True)
         nonexistent = []
         log.debug("%d builds found" % len(kojiBuilds))
         for build in kojiBuilds:
@@ -218,13 +217,14 @@ class ExtendedMetadata(object):
         col.name = to_bytes(update.release.long_name)
         col.shortname = to_bytes(update.release.name)
 
+        koji = get_session()
         for build in update.builds:
             try:
                 kojiBuild = self.builds[build.nvr]
             except:
-                kojiBuild = self.koji.getBuild(build.nvr)
+                kojiBuild = koji.getBuild(build.nvr)
 
-            rpms = self.koji.listBuildRPMs(kojiBuild['id'])
+            rpms = koji.listBuildRPMs(kojiBuild['id'])
             for rpm in rpms:
                 pkg = cr.UpdateCollectionPackage()
                 pkg.name = rpm['name']


### PR DESCRIPTION
The mashing process takes a very long time: longer than the session timeout for the
bodhi user in koji.
Since a koji session is started on buildsys.get_session(), that means the koji session
often times out if the mash takes too long.
This patch makes us get a new session for each batch of koji operations.

This will incur a slight performance impact, but that should not be too big, since most
of the koji operations are batched, and this change gets a new session on each batch.

Signed-off-by: Patrick Uiterwijk <puiterwijk@redhat.com>