### PR TITLE
Fail horribly if we forget to setup the build system

### DIFF
--- a/bodhi/server/buildsys.py
+++ b/bodhi/server/buildsys.py
@@ -315,10 +315,15 @@ def get_krb_conf(config):
 def get_session():
     """ Get a new buildsystem instance """
     global _buildsystem
-    if not _buildsystem:
-        log.warning('No buildsystem configured; assuming testing')
-        return DevBuildsys()
+    if _buildsystem is None:
+        raise RuntimeError('Buildsys needs to be setup')
     return _buildsystem()
+
+
+def teardown_buildsystem():
+    global _buildsystem
+    _buildsystem = None
+    DevBuildsys.clear()
 
 
 def setup_buildsystem(settings):
@@ -336,6 +341,9 @@ def setup_buildsystem(settings):
     elif buildsys in ('dev', 'dummy', None):
         log.debug('Using DevBuildsys')
         _buildsystem = DevBuildsys
+
+    else:
+        raise ValueError('Buildsys %s not known' % buildsys)
 
 
 def wait_for_tasks(tasks, session=None, sleep=300):

--- a/bodhi/server/buildsys.py
+++ b/bodhi/server/buildsys.py
@@ -337,11 +337,9 @@ def setup_buildsystem(settings):
     if buildsys == 'koji':
         log.debug('Using Koji Buildsystem')
         _buildsystem = lambda: koji_login(config=settings)
-
     elif buildsys in ('dev', 'dummy', None):
         log.debug('Using DevBuildsys')
         _buildsystem = DevBuildsys
-
     else:
         raise ValueError('Buildsys %s not known' % buildsys)
 

--- a/bodhi/tests/server/consumers/test_masher.py
+++ b/bodhi/tests/server/consumers/test_masher.py
@@ -95,6 +95,8 @@ def makemsg(body=None):
 class TestMasher(unittest.TestCase):
 
     def setUp(self):
+        buildsys.setup_buildsystem({'buildsystem': 'dev'})
+
         fd, self.db_filename = tempfile.mkstemp(prefix='bodhi-testing-', suffix='.db')
         db_path = 'sqlite:///%s' % self.db_filename
         # The BUILD_ID environment variable is set by Jenkins and allows us to
@@ -133,6 +135,7 @@ class TestMasher(unittest.TestCase):
             os.remove(self.db_filename)
         except:
             pass
+        buildsys.teardown_buildsystem()
 
     def set_stable_request(self, title):
         with self.db_factory() as session:
@@ -1107,6 +1110,7 @@ class MasherThreadBaseTestCase(base.BaseTestCase):
         Set up the test conditions.
         """
         super(MasherThreadBaseTestCase, self).setUp()
+        buildsys.setup_buildsystem({'buildsystem': 'dev'})
         self.tempdir = tempfile.mkdtemp()
 
     def tearDown(self):
@@ -1115,7 +1119,7 @@ class MasherThreadBaseTestCase(base.BaseTestCase):
         """
         super(MasherThreadBaseTestCase, self).tearDown()
         shutil.rmtree(self.tempdir)
-        buildsys.DevBuildsys.clear()
+        buildsys.teardown_buildsystem()
 
 
 class TestMasherThread__perform_tag_actions(MasherThreadBaseTestCase):

--- a/bodhi/tests/server/test_buildsys.py
+++ b/bodhi/tests/server/test_buildsys.py
@@ -38,6 +38,20 @@ class TestBuildsystem(unittest.TestCase):
                 bs.multiCall, bs.getTag):
             self.assertRaises(NotImplementedError, method)
 
+    def test_raises_not_configured(self):
+        """
+        buildsys.get_session requires buildsys.setup_buildsystem to be called first. Ensure
+        that if not, we crash hard.
+        """
+        buildsys.teardown_buildsystem()
+        self.assertRaises(AssertionError, buildsys.get_session)
+
+    def test_raises_unknown_buildsys(self):
+        """
+        Ensure that we crash if we try to configure an invalid buildsys.
+        """
+        self.assertRaises(ValueError, buildsys.setup_buildsystem, {'buildsystem': 'invalid'})
+
 
 class TestGetKrbConf(unittest.TestCase):
     """This class contains tests for the get_krb_conf() function."""

--- a/bodhi/tests/server/test_buildsys.py
+++ b/bodhi/tests/server/test_buildsys.py
@@ -44,7 +44,7 @@ class TestBuildsystem(unittest.TestCase):
         that if not, we crash hard.
         """
         buildsys.teardown_buildsystem()
-        self.assertRaises(AssertionError, buildsys.get_session)
+        self.assertRaises(RuntimeError, buildsys.get_session)
 
     def test_raises_unknown_buildsys(self):
         """

--- a/bodhi/tests/server/test_metadata.py
+++ b/bodhi/tests/server/test_metadata.py
@@ -32,7 +32,8 @@ from bodhi.server.config import config
 from bodhi.server.util import mkmetadatadir
 from bodhi.server.models import (Package, Update, Build, Base,
         UpdateRequest, UpdateStatus, UpdateType)
-from bodhi.server.buildsys import get_session, DevBuildsys
+from bodhi.server.buildsys import (setup_buildsystem, teardown_buildsystem,
+                                   get_session, DevBuildsys)
 from bodhi.server.metadata import ExtendedMetadata
 from bodhi.tests.server import base
 from bodhi.tests.server.functional.base import DB_PATH
@@ -49,6 +50,7 @@ class TestAddUpdate(base.BaseTestCase):
         Initialize our temporary repo.
         """
         super(TestAddUpdate, self).setUp()
+        setup_buildsystem({'buildsystem': 'dev'})
         self.tempdir = tempfile.mkdtemp('bodhi')
         self.temprepo = join(self.tempdir, 'f17-updates-testing')
         mkmetadatadir(join(self.temprepo, 'f17-updates-testing', 'i386'))
@@ -58,6 +60,7 @@ class TestAddUpdate(base.BaseTestCase):
         Clean up the tempdir.
         """
         super(TestAddUpdate, self).tearDown()
+        teardown_buildsystem()
         shutil.rmtree(self.tempdir)
 
     def test_build_not_in_builds(self):
@@ -128,6 +131,7 @@ class TestExtendedMetadata(unittest.TestCase):
             os.makedirs(repo_path)
 
     def setUp(self):
+        setup_buildsystem({'buildsystem': 'dev'})
         engine = create_engine(DB_PATH)
         Session = scoped_session(sessionmaker(extension=ZopeTransactionExtension(keep_session=True)))
         Session.configure(bind=engine)
@@ -162,6 +166,7 @@ class TestExtendedMetadata(unittest.TestCase):
         self.db.close()
         get_session().clear()
         shutil.rmtree(self.tempdir)
+        teardown_buildsystem()
 
     def _verify_updateinfo(self, repodata):
         updateinfos = glob.glob(join(repodata, "*-updateinfo.xml*"))

--- a/bodhi/tests/server/test_utils.py
+++ b/bodhi/tests/server/test_utils.py
@@ -12,6 +12,7 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
+from bodhi.server.buildsys import setup_buildsystem, teardown_buildsystem
 from bodhi.server.models import Update
 from bodhi.server.util import (get_critpath_pkgs, markup,
                                get_rpm_header, cmd, sorted_builds, sorted_updates)
@@ -19,6 +20,12 @@ from bodhi.server.config import config
 
 
 class TestUtils(object):
+
+    def setUp(self):
+        setup_buildsystem({'buildsystem': 'dev'})
+
+    def tearDown(self):
+        teardown_buildsystem()
 
     def test_config(self):
         assert config.get('sqlalchemy.url'), config


### PR DESCRIPTION
Currently, if someone forgets to set the buildsys, we will silently (because who
ever sets up logging for "bodhi" if they're working in a shell?).
This commit makes sure that we require people to have setup a buildsys before we
will allow them to get a session.

Signed-off-by: Patrick Uiterwijk <puiterwijk@redhat.com>