### PR TITLE
Display autokarma and thresholds when the CLI prints updates.

### DIFF
--- a/bodhi/client/bindings.py
+++ b/bodhi/client/bindings.py
@@ -426,8 +426,10 @@ class BodhiClient(OpenIdBaseClient):
         val += """    Release: %s
      Status: %s
        Type: %s
-      Karma: %d""" % (update['release']['long_name'], update['status'],
-                      update['type'], update['karma'])
+      Karma: %d
+  Autokarma: %s  [%d, %d]""" % (update['release']['long_name'], update['status'],
+                      update['type'], update['karma'], update['autokarma'],
+                      update['unstable_karma'], update['stable_karma'])
         if update['request'] is not None:
             val += "\n    Request: %s" % update['request']
         if len(update['bugs']):

--- a/bodhi/tests/client/test___init__.py
+++ b/bodhi/tests/client/test___init__.py
@@ -33,6 +33,7 @@ EXAMPLE_UPDATE_OUTPUT = u"""====================================================
      Status: stable
        Type: bugfix
       Karma: 0
+  Autokarma: True  [-3, 3]
       Notes: Update to 2.2.4. Release notes available at https://github.com
            : /fedora-infra/bodhi/releases/tag/2.2.4
   Submitter: bowlofeggs


### PR DESCRIPTION
Updates are now printed like this:

```
[vagrant@localhost vagrant]$ bodhi updates query --updateid FEDORA-2016-bf2a514f37
================================================================================
     python-fedmsg-atomic-composer-2016.3-1.fc25
================================================================================
  Update ID: FEDORA-2016-bf2a514f37
    Release: Fedora 25
     Status: unpushed
       Type: enhancement
      Karma: 0
  Autokarma: False  [-3, 3]
      Notes: Update to 2016.3 https://github.com/fedora-infra/fedmsg-atomic-
           : composer/releases/tag/2016.3
  Submitter: bowlofeggs
  Submitted: 2016-10-27 15:30:45
   Comments: bodhi - 2016-10-27 15:30:45 (karma 0)
             This update has been submitted for testing by
             bowlofeggs.
             bodhi - 2016-10-28 14:56:17 (karma 0)
             This update has been pushed to testing.
             bowlofeggs - 2016-11-26 03:19:36 (karma 0)
             This update has been unpushed.

  https://bodhi.fedoraproject.org/updates/FEDORA-2016-bf2a514f37

1 updates found (1 shown)
```

The bit that is new/different is the ```Autokarma: False  [-3, 3]``` line. To be honest, I couldn't decide whether the thresholds should be where I put them, on the Karma line, or on their own line. Input on that welcome!