### PR TITLE
Test for repomd.xml instead of repodata directory

### DIFF
--- a/bodhi/server/metadata.py
+++ b/bodhi/server/metadata.py
@@ -74,7 +74,7 @@ class ExtendedMetadata(object):
         # Load from the cache if it exists
         self.cached_repodata = os.path.join(self.repo, '..', self.tag +
                                             '.repocache', 'repodata/')
-        if os.path.isdir(self.cached_repodata):
+        if os.path.isfile(os.path.join(self.cached_repodata, 'repomd.xml')):
             log.info('Loading cached updateinfo.xml')
             self._load_cached_updateinfo()
         else:


### PR DESCRIPTION
This pull request contains two commits. The first is from @k3rn3l3rr0r and fixes #908. The second is from me and tests the fix to ensure it works properly.