### PR TITLE
Raise Bodhi's test coverage to 78%

### DIFF
--- a/bodhi/tests/server/test_captcha.py
+++ b/bodhi/tests/server/test_captcha.py
@@ -18,8 +18,65 @@
 import unittest
 
 import mock
+import PIL.Image
 
 from bodhi.server import captcha
+
+
+class TestJPEGGenerator(unittest.TestCase):
+    """This test class contains tests for the jpeg_generator() function."""
+    def test_with_defaults(self):
+        """Test the jpeg_generator with default settings."""
+        img = captcha.jpeg_generator('42 + 7', {})
+
+        img.verify()
+        self.assertTrue(isinstance(img, PIL.Image.Image))
+        # Ensure the image is the default size
+        self.assertEqual(img.size, (300, 80))
+        self.assertEqual(img.mode, 'RGB')
+
+    @mock.patch('bodhi.server.captcha.ImageDraw.Draw')
+    @mock.patch('bodhi.server.captcha.ImageFont.truetype')
+    @mock.patch('bodhi.server.captcha.random.randint')
+    def test_with_heavy_mocking(self, randint, truetype, Draw):
+        """
+        Test the generator with heavy mocking so we can make sure all the right calls were made.
+        """
+        randint.side_effect = [52, 78]
+        truetype.return_value.getsize = mock.MagicMock(return_value=(100, 80))
+
+        settings = {
+            'captcha.image_width': 1920, 'captcha.image_height': 1080,
+            'captcha.font_path': '/path/to/cool/font',
+            'captcha.font_size': 24, 'captcha.font_color': '#012345', 'captcha.padding': 6}
+
+        img = captcha.jpeg_generator('42 + 7', settings)
+
+        truetype.assert_called_once_with('/path/to/cool/font', 24)
+        truetype.return_value.getsize.assert_called_once_with('42 + 7')
+        Draw.assert_called_once_with(img)
+        Draw.return_value.text.assert_called_once_with((52, 78), '42 + 7',
+                                                       font=truetype.return_value, fill='#012345')
+        img.verify()
+        self.assertTrue(isinstance(img, PIL.Image.Image))
+        # Ensure the image is the default size
+        self.assertEqual(img.size, (1920, 1080))
+        self.assertEqual(img.mode, 'RGB')
+
+    def test_with_specified_parameters(self):
+        """Test the generator with specified dimensions."""
+        settings = {
+            'captcha.image_width': 1920, 'captcha.image_height': 1080,
+            'captcha.font_path': '/usr/share/fonts/liberation/LiberationMono-Bold.ttf',
+            'captcha.font_size': 24, 'captch.font_color': '#012345', 'captcha.padding': 6}
+
+        img = captcha.jpeg_generator('42 + 7', settings)
+
+        img.verify()
+        self.assertTrue(isinstance(img, PIL.Image.Image))
+        # Ensure the image is the default size
+        self.assertEqual(img.size, (1920, 1080))
+        self.assertEqual(img.mode, 'RGB')
 
 
 class TestMathGenerator(unittest.TestCase):

--- a/devel/ansible/roles/dev/tasks/main.yml
+++ b/devel/ansible/roles/dev/tasks/main.yml
@@ -9,6 +9,7 @@
       - gcc
       - git
       - koji
+      - liberation-mono-fonts
       - libffi-devel
       - libjpeg-devel
       - libjpeg-turbo-devel

--- a/docs/developer_docs.rst
+++ b/docs/developer_docs.rst
@@ -120,7 +120,7 @@ Virtualenv is another option for building a development environment.
 
 Dependencies
 ^^^^^^^^^^^^
-``sudo dnf install libffi-devel postgresql-devel openssl-devel koji pcaro-hermit-fonts freetype-devel libjpeg-turbo-devel python-pillow zeromq-devel``
+``sudo dnf install libffi-devel postgresql-devel openssl-devel koji pcaro-hermit-fonts freetype-devel libjpeg-turbo-devel python-pillow zeromq-devel liberation-mono-fonts``
 
 Setup virtualenvwrapper
 ^^^^^^^^^^^^^^^^^^^^^^^

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 [nosetests]
 cover-erase=TRUE
 cover-inclusive=TRUE
-cover-min-percentage=77
+cover-min-percentage=78
 cover-package=bodhi
 cover-xml=TRUE
 with-coverage=TRUE


### PR DESCRIPTION
This pull request contains two commits. The first commit adds three new tests on ```bodhi.server.captcha.jpeg_generator```. Those tests happen to raise the overall test coverage to 78% so the second commit adjusts the test suite to require 78% coverage so we don't slip back down in the future.