### PR TITLE
Refactor and test push.py

### DIFF
--- a/bodhi/server/push.py
+++ b/bodhi/server/push.py
@@ -72,7 +72,6 @@ def push(username, cert_prefix, **kwargs):
                 for update in lockfiles[lockfile]:
                     update = session.query(Update).filter(Update.title==update).first()
                     updates.append(update)
-                    click.echo(update)
         else:
             # Accept both comma and space separated request list
             requests = kwargs['request'].replace(',', ' ').split(' ')

--- a/bodhi/server/push.py
+++ b/bodhi/server/push.py
@@ -108,18 +108,14 @@ def push(username, cert_prefix, **kwargs):
         for update in updates:
             print update.title
 
-        doit = raw_input('Push these %d updates? (y/n) ' % len(updates)).lower().strip()
-        if doit == 'y':
-            click.echo('\nLocking updates...')
-            for update in updates:
-                update.locked = True
-                update.date_locked = datetime.utcnow()
+        click.confirm('Push these {:d} updates?'.format(len(updates)), abort=True)
 
-            update_titles = list([update.title for update in updates])
-        else:
-            click.echo('\nAborting push')
-            raise Exception('Aborting push')
+        click.echo('\nLocking updates...')
+        for update in updates:
+            update.locked = True
+            update.date_locked = datetime.utcnow()
 
+        update_titles = list([update.title for update in updates])
 
     if update_titles:
         click.echo('\nSending masher.start fedmsg')

--- a/bodhi/server/push.py
+++ b/bodhi/server/push.py
@@ -107,12 +107,14 @@ def push(username, cert_prefix, **kwargs):
         for update in updates:
             print update.title
 
-        click.confirm('Push these {:d} updates?'.format(len(updates)), abort=True)
-
-        click.echo('\nLocking updates...')
-        for update in updates:
-            update.locked = True
-            update.date_locked = datetime.utcnow()
+        if updates:
+            click.confirm('Push these {:d} updates?'.format(len(updates)), abort=True)
+            click.echo('\nLocking updates...')
+            for update in updates:
+                update.locked = True
+                update.date_locked = datetime.utcnow()
+        else:
+            click.echo('\nThere are no updates to push.')
 
         update_titles = list([update.title for update in updates])
 

--- a/bodhi/tests/server/test_push.py
+++ b/bodhi/tests/server/test_push.py
@@ -17,7 +17,10 @@
 
 from datetime import datetime
 
+from click.testing import CliRunner
 import click
+import mock
+import transaction
 
 from bodhi.server import push
 from bodhi.server.models import models
@@ -152,3 +155,626 @@ class TestFilterReleases(base.BaseTestCase):
         with self.assertRaises(click.BadParameter) as ex:
             push._filter_releases(self.db, query, u'RELEASE WITH NO NAME')
             self.assertEqual(str(ex.exception), 'Unknown release: RELEASE WITH NO NAME')
+
+
+TEST_ABORT_PUSH_EXPECTED_OUTPUT = """Warning: bodhi-2.0-1.fc17 is locked but not in a push
+Warning: bodhi-2.0-1.fc17 has unsigned builds and has been skipped
+python-nose-1.3.7-11.fc17
+python-paste-deploy-1.5.2-8.fc17
+Push these 2 updates? (y/n) 
+Aborting push
+"""
+
+TEST_BUILDS_FLAG_EXPECTED_OUTPUT = """ejabberd-16.09-4.fc17
+python-nose-1.3.7-11.fc17
+Push these 2 updates? (y/n) 
+Locking updates...
+
+Sending masher.start fedmsg
+"""
+
+TEST_CERT_PREFIX_FLAG_EXPECTED_OUTPUT = """Warning: bodhi-2.0-1.fc17 is locked but not in a push
+Warning: bodhi-2.0-1.fc17 has unsigned builds and has been skipped
+python-nose-1.3.7-11.fc17
+python-paste-deploy-1.5.2-8.fc17
+Push these 2 updates? (y/n) 
+Locking updates...
+
+Sending masher.start fedmsg
+"""
+
+TEST_LOCKED_UPDATES_EXPECTED_OUTPUT = """Warning: bodhi-2.0-1.fc17 is locked but not in a push
+Warning: bodhi-2.0-1.fc17 has unsigned builds and has been skipped
+python-nose-1.3.7-11.fc17
+python-paste-deploy-1.5.2-8.fc17
+Push these 2 updates? (y/n) 
+Locking updates...
+
+Sending masher.start fedmsg
+"""
+
+TEST_LOCKED_UPDATES_NOT_IN_A_PUSH_EXPECTED_OUTPUT = """Warning: ejabberd-16.09-4.fc17 is locked but not in a push
+python-nose-1.3.7-11.fc17
+python-paste-deploy-1.5.2-8.fc17
+ejabberd-16.09-4.fc17
+Push these 3 updates? (y/n) 
+Locking updates...
+
+Sending masher.start fedmsg
+"""
+
+TEST_NO_UPDATES_TO_PUSH_EXPECTED_OUTPUT = """Warning: python-nose-1.3.7-11.fc17 has unsigned builds and has been skipped
+Warning: python-paste-deploy-1.5.2-8.fc17 has unsigned builds and has been skipped
+Warning: bodhi-2.0-1.fc17 is locked but not in a push
+Warning: bodhi-2.0-1.fc17 has unsigned builds and has been skipped
+Push these 0 updates? (y/n) 
+Locking updates...
+"""
+
+TEST_RELEASES_FLAG_EXPECTED_OUTPUT = """python-nose-1.3.7-11.fc25
+python-paste-deploy-1.5.2-8.fc26
+Push these 2 updates? (y/n) 
+Locking updates...
+
+Sending masher.start fedmsg
+"""
+
+TEST_REQUEST_FLAG_EXPECTED_OUTPUT = """Warning: bodhi-2.0-1.fc17 is locked but not in a push
+Warning: bodhi-2.0-1.fc17 has unsigned builds and has been skipped
+python-paste-deploy-1.5.2-8.fc17
+Push these 1 updates? (y/n) 
+Locking updates...
+
+Sending masher.start fedmsg
+"""
+
+TEST_RESUME_FLAG_EXPECTED_OUTPUT = """Resume /mnt/koji/mash/updates/MASHING-f17-updates? (y/n) ================================================================================
+     ejabberd-16.09-4.fc17
+================================================================================
+    Release: Fedora 17
+     Status: pending
+       Type: bugfix
+      Karma: 0
+    Request: testing
+      Notes: Useful details!
+  Submitter: guest
+  Submitted: 1984-11-02 00:00:00
+
+  http://localhost:6543/updates/ejabberd-16.09-4.fc17
+
+ejabberd-16.09-4.fc17
+Push these 1 updates? (y/n) 
+Locking updates...
+
+Sending masher.start fedmsg
+"""
+
+TEST_RESUME_HUMAN_SAYS_NO_EXPECTED_OUTPUT = """Resume /mnt/koji/mash/updates/MASHING-f17-testing? (y/n) Resume /mnt/koji/mash/updates/MASHING-f17-updates? (y/n) ================================================================================
+     ejabberd-16.09-4.fc17
+================================================================================
+    Release: Fedora 17
+     Status: pending
+       Type: bugfix
+      Karma: 0
+    Request: testing
+      Notes: Useful details!
+  Submitter: guest
+  Submitted: 1984-11-02 00:00:00
+
+  http://localhost:6543/updates/ejabberd-16.09-4.fc17
+
+ejabberd-16.09-4.fc17
+Push these 1 updates? (y/n) 
+Locking updates...
+
+Sending masher.start fedmsg
+"""
+
+TEST_STAGING_FLAG_EXPECTED_OUTPUT = """Warning: bodhi-2.0-1.fc17 is locked but not in a push
+Warning: bodhi-2.0-1.fc17 has unsigned builds and has been skipped
+python-nose-1.3.7-11.fc17
+python-paste-deploy-1.5.2-8.fc17
+Push these 2 updates? (y/n) 
+Locking updates...
+
+Sending masher.start fedmsg
+"""
+
+TEST_UNSIGNED_UPDATES_SKIPPED_EXPECTED_OUTPUT = """Warning: python-nose-1.3.7-11.fc17 has unsigned builds and has been skipped
+Warning: bodhi-2.0-1.fc17 is locked but not in a push
+Warning: bodhi-2.0-1.fc17 has unsigned builds and has been skipped
+python-paste-deploy-1.5.2-8.fc17
+Push these 1 updates? (y/n) 
+Locking updates...
+
+Sending masher.start fedmsg
+"""
+
+
+class TestPush(base.BaseTestCase):
+    """
+    This class contains tests for the push() function.
+    """
+    def setUp(self):
+        """
+        Make some updates that can be pushed.
+        """
+        super(TestPush, self).setUp()
+        python_nose = self.create_update([u'python-nose-1.3.7-11.fc17'])
+        python_paste_deploy = self.create_update([u'python-paste-deploy-1.5.2-8.fc17'])
+        # Make it so we have two builds to push out
+        python_nose.builds[0].signed = True
+        python_paste_deploy.builds[0].signed = True
+        self.db.flush()
+
+    @mock.patch('bodhi.server.push.bodhi.server.notifications.publish')
+    def test_abort_push(self, publish):
+        """
+        Ensure that the push gets aborted if the user types 'n' when asked if they want to push.
+        """
+        cli = CliRunner()
+        transaction.commit()
+
+        with mock.patch('bodhi.server.push.get_db_factory',
+                        return_value=base.TransactionalSessionMaker(self.Session)):
+            result = cli.invoke(push.push, ['--username', 'bowlofeggs'], input='n')
+
+        # The exit code is -1 when the push is aborted.
+        self.assertEqual(result.exit_code, -1)
+        self.assertEqual(result.output, TEST_ABORT_PUSH_EXPECTED_OUTPUT)
+        self.assertEqual(publish.call_count, 0)
+
+        # The updates should not be locked
+        python_nose = self.db.query(models.Update).filter_by(
+            title=u'python-nose-1.3.7-11.fc17').one()
+        python_paste_deploy = self.db.query(models.Update).filter_by(
+            title=u'python-paste-deploy-1.5.2-8.fc17').one()
+        for u in [python_nose, python_paste_deploy]:
+            self.assertFalse(u.locked)
+            self.assertIsNone(u.date_locked)
+
+    @mock.patch('bodhi.server.push.bodhi.server.notifications.publish')
+    def test_builds_flag(self, publish):
+        """
+        Assert correct operation when the --builds flag is given.
+        """
+        cli = CliRunner()
+        ejabberd = self.create_update([u'ejabberd-16.09-4.fc17'])
+        # Make it so we have three builds we could push out so that we can ask for and verify two
+        ejabberd.builds[0].signed = True
+        transaction.commit()
+
+        with mock.patch('bodhi.server.push.get_db_factory',
+                        return_value=base.TransactionalSessionMaker(self.Session)):
+            result = cli.invoke(
+                push.push,
+                ['--username', 'bowlofeggs', '--builds',
+                 'python-nose-1.3.7-11.fc17,ejabberd-16.09-4.fc17'],
+                input='y')
+
+        self.assertEqual(result.exit_code, 0)
+        self.assertEqual(result.output, TEST_BUILDS_FLAG_EXPECTED_OUTPUT)
+        publish.assert_called_once_with(
+            topic='masher.start',
+            msg={'updates': [u'ejabberd-16.09-4.fc17', u'python-nose-1.3.7-11.fc17'],
+                 'resume': False, 'agent': 'bowlofeggs'},
+            force=True)
+
+        ejabberd = self.db.query(models.Update).filter_by(title=u'ejabberd-16.09-4.fc17').one()
+        python_nose = self.db.query(models.Update).filter_by(
+            title=u'python-nose-1.3.7-11.fc17').one()
+        python_paste_deploy = self.db.query(models.Update).filter_by(
+            title=u'python-paste-deploy-1.5.2-8.fc17').one()
+        for u in [ejabberd, python_nose]:
+            self.assertTrue(u.locked)
+            self.assertTrue(u.date_locked <= datetime.utcnow())
+        self.assertFalse(python_paste_deploy.locked)
+        self.assertIsNone(python_paste_deploy.date_locked)
+
+    @mock.patch('bodhi.server.push.bodhi.server.notifications.init')
+    @mock.patch('bodhi.server.push.bodhi.server.notifications.publish')
+    def test_cert_prefix_flag(self, publish, init):
+        """
+        Test correct operation when the --cert-prefix flag is used.
+        """
+        cli = CliRunner()
+        transaction.commit()
+
+        with mock.patch('bodhi.server.push.get_db_factory',
+                        return_value=base.TransactionalSessionMaker(self.Session)):
+            result = cli.invoke(
+                push.push, ['--username', 'bowlofeggs', '--cert-prefix', 'some_prefix'], input='y')
+
+        self.assertEqual(result.exit_code, 0)
+        self.assertEqual(result.output, TEST_CERT_PREFIX_FLAG_EXPECTED_OUTPUT)
+        init.assert_called_once_with(active=True, cert_prefix='some_prefix')
+        publish.assert_called_once_with(
+            topic='masher.start',
+            msg={'updates': ['python-nose-1.3.7-11.fc17', u'python-paste-deploy-1.5.2-8.fc17'],
+                 'resume': False, 'agent': 'bowlofeggs'},
+            force=True)
+
+    @mock.patch('bodhi.server.push.file')
+    @mock.patch('bodhi.server.push.bodhi.server.notifications.publish')
+    @mock.patch('bodhi.server.push.glob.glob',
+                return_value=['/mnt/koji/mash/updates/MASHING-f17-updates'])
+    @mock.patch('bodhi.server.push.json.load', return_value={'updates': ['ejabberd-16.09-4.fc17']})
+    def test_locked_updates(self, load, glob, publish, mock_file):
+        """
+        Test correct operation when there are some locked updates.
+        """
+        cli = CliRunner()
+        # Let's mark ejabberd as locked and already in a push. It should get silently ignored.
+        ejabberd = self.create_update([u'ejabberd-16.09-4.fc17'])
+        ejabberd.builds[0].signed = True
+        ejabberd.locked = True
+        ejabberd.date_locked = datetime.utcnow()
+        transaction.commit()
+
+        with mock.patch('bodhi.server.push.get_db_factory',
+                        return_value=base.TransactionalSessionMaker(self.Session)):
+            result = cli.invoke(push.push, ['--username', 'bowlofeggs'], input='y')
+
+        self.assertEqual(result.exit_code, 0)
+        self.assertEqual(result.output, TEST_LOCKED_UPDATES_EXPECTED_OUTPUT)
+        glob.assert_called_once_with('/mnt/koji/mash/updates/MASHING-*')
+        publish.assert_called_once_with(
+            topic='masher.start',
+            msg={'updates': ['python-nose-1.3.7-11.fc17', 'python-paste-deploy-1.5.2-8.fc17'],
+                 'resume': False, 'agent': 'bowlofeggs'},
+            force=True)
+        mock_file.assert_called_once_with('/mnt/koji/mash/updates/MASHING-f17-updates')
+
+        ejabberd = self.db.query(models.Update).filter_by(title=u'ejabberd-16.09-4.fc17').one()
+        python_nose = self.db.query(models.Update).filter_by(
+            title=u'python-nose-1.3.7-11.fc17').one()
+        python_paste_deploy = self.db.query(models.Update).filter_by(
+            title=u'python-paste-deploy-1.5.2-8.fc17').one()
+        for u in [ejabberd, python_nose, python_paste_deploy]:
+            self.assertTrue(u.locked)
+            self.assertTrue(u.date_locked <= datetime.utcnow())
+
+    @mock.patch('bodhi.server.push.file')
+    @mock.patch('bodhi.server.push.bodhi.server.notifications.publish')
+    @mock.patch('bodhi.server.push.glob.glob',
+                return_value=['/mnt/koji/mash/updates/MASHING-f17-updates'])
+    @mock.patch('bodhi.server.push.json.load', return_value={'updates': ['bodhi-2.0-1.fc17']})
+    def test_locked_updates_not_in_a_push(self, load, glob, publish, mock_file):
+        """
+        Test correct operation when there are some locked updates that aren't in a push.
+        """
+        cli = CliRunner()
+        # Let's mark ejabberd as locked but not already in a push. It should print a warning but
+        # still get pushed.
+        ejabberd = self.create_update([u'ejabberd-16.09-4.fc17'])
+        ejabberd.builds[0].signed = True
+        ejabberd.locked = True
+        ejabberd.date_locked = datetime.utcnow()
+        transaction.commit()
+
+        with mock.patch('bodhi.server.push.get_db_factory',
+                        return_value=base.TransactionalSessionMaker(self.Session)):
+            result = cli.invoke(push.push, ['--username', 'bowlofeggs'], input='y')
+
+        self.assertEqual(result.exit_code, 0)
+        self.assertEqual(result.output, TEST_LOCKED_UPDATES_NOT_IN_A_PUSH_EXPECTED_OUTPUT)
+        glob.assert_called_once_with('/mnt/koji/mash/updates/MASHING-*')
+        publish.assert_called_once_with(
+            topic='masher.start',
+            msg={'updates': ['python-nose-1.3.7-11.fc17', 'python-paste-deploy-1.5.2-8.fc17',
+                             'ejabberd-16.09-4.fc17'],
+                 'resume': False, 'agent': 'bowlofeggs'},
+            force=True)
+        mock_file.assert_called_once_with('/mnt/koji/mash/updates/MASHING-f17-updates')
+
+        ejabberd = self.db.query(models.Update).filter_by(title=u'ejabberd-16.09-4.fc17').one()
+        python_nose = self.db.query(models.Update).filter_by(
+            title=u'python-nose-1.3.7-11.fc17').one()
+        python_paste_deploy = self.db.query(models.Update).filter_by(
+            title=u'python-paste-deploy-1.5.2-8.fc17').one()
+        for u in [ejabberd, python_nose, python_paste_deploy]:
+            self.assertTrue(u.locked)
+            self.assertTrue(u.date_locked <= datetime.utcnow())
+
+    @mock.patch('bodhi.server.push.bodhi.server.notifications.publish')
+    def test_no_updates_to_push(self, publish):
+        """
+        If there are no updates to push, no push message should get sent.
+        """
+        cli = CliRunner()
+        python_nose = self.db.query(models.Update).filter_by(
+            title=u'python-nose-1.3.7-11.fc17').one()
+        python_paste_deploy = self.db.query(models.Update).filter_by(
+            title=u'python-paste-deploy-1.5.2-8.fc17').one()
+        python_nose.builds[0].signed = False
+        python_paste_deploy.builds[0].signed = False
+        transaction.commit()
+
+        with mock.patch('bodhi.server.push.get_db_factory',
+                        return_value=base.TransactionalSessionMaker(self.Session)):
+            result = cli.invoke(push.push, ['--username', 'bowlofeggs'], input='y')
+
+        self.assertEqual(result.exit_code, 0)
+        self.assertEqual(result.output, TEST_NO_UPDATES_TO_PUSH_EXPECTED_OUTPUT)
+        self.assertEqual(publish.call_count, 0)
+
+        # The updates should not be locked
+        python_nose = self.db.query(models.Update).filter_by(
+            title=u'python-nose-1.3.7-11.fc17').one()
+        python_paste_deploy = self.db.query(models.Update).filter_by(
+            title=u'python-paste-deploy-1.5.2-8.fc17').one()
+        for u in [python_nose, python_paste_deploy]:
+            self.assertFalse(u.locked)
+            self.assertIsNone(u.date_locked)
+
+    @mock.patch('bodhi.server.push.bodhi.server.notifications.publish')
+    def test_releases_flag(self, publish):
+        """
+        Assert correct operation from the --releases flag.
+        """
+        f25 = models.Release(
+            name=u'F25', long_name=u'Fedora 25',
+            id_prefix=u'FEDORA', version=u'25',
+            dist_tag=u'f25', stable_tag=u'f25-updates',
+            testing_tag=u'f25-updates-testing',
+            candidate_tag=u'f25-updates-candidate',
+            pending_signing_tag=u'f25-updates-testing-signing',
+            pending_testing_tag=u'f25-updates-testing-pending',
+            pending_stable_tag=u'f25-updates-pending',
+            override_tag=u'f25-override',
+            branch=u'f25', state=models.ReleaseState.current)
+        f26 = models.Release(
+            name=u'F26', long_name=u'Fedora 26',
+            id_prefix=u'FEDORA', version=u'26',
+            dist_tag=u'f26', stable_tag=u'f26-updates',
+            testing_tag=u'f26-updates-testing',
+            candidate_tag=u'f26-updates-candidate',
+            pending_signing_tag=u'f26-updates-testing-signing',
+            pending_testing_tag=u'f26-updates-testing-pending',
+            pending_stable_tag=u'f26-updates-pending',
+            override_tag=u'f26-override',
+            branch=u'f26', state=models.ReleaseState.current)
+        self.db.add(f25)
+        self.db.add(f26)
+        # Let's make an update for each release
+        python_nose = self.create_update([u'python-nose-1.3.7-11.fc25'], u'F25')
+        python_paste_deploy = self.create_update([u'python-paste-deploy-1.5.2-8.fc26'], u'F26')
+        python_nose.builds[0].signed = True
+        python_paste_deploy.builds[0].signed = True
+        transaction.commit()
+        cli = CliRunner()
+
+        with mock.patch('bodhi.server.push.get_db_factory',
+                        return_value=base.TransactionalSessionMaker(self.Session)):
+            # We will specify that we want F25 and F26, which should exclude the F17 updates we've
+            # been pushing in all the other tests. We'll leave the F off of 26 and lowercase the f
+            # on 25 to make sure it's flexible.
+            result = cli.invoke(push.push, ['--username', 'bowlofeggs', '--releases', 'f25,26'],
+                                input='y')
+
+        self.assertEqual(result.exit_code, 0)
+        self.assertEqual(result.output, TEST_RELEASES_FLAG_EXPECTED_OUTPUT)
+        publish.assert_called_once_with(
+            topic='masher.start',
+            msg={'updates': ['python-nose-1.3.7-11.fc25', 'python-paste-deploy-1.5.2-8.fc26'],
+                 'resume': False, 'agent': 'bowlofeggs'},
+            force=True)
+
+        # The Fedora 17 updates should not have been locked.
+        f17_python_nose = self.db.query(models.Update).filter_by(
+            title=u'python-nose-1.3.7-11.fc17').one()
+        f17_python_paste_deploy = self.db.query(models.Update).filter_by(
+            title=u'python-paste-deploy-1.5.2-8.fc17').one()
+        self.assertFalse(f17_python_nose.locked)
+        self.assertIsNone(f17_python_nose.date_locked)
+        self.assertFalse(f17_python_paste_deploy.locked)
+        self.assertIsNone(f17_python_paste_deploy.date_locked)
+        # The new updates should both be locked.
+        f25_python_nose = self.db.query(models.Update).filter_by(
+            title=u'python-nose-1.3.7-11.fc25').one()
+        f26_python_paste_deploy = self.db.query(models.Update).filter_by(
+            title=u'python-paste-deploy-1.5.2-8.fc26').one()
+        self.assertTrue(f25_python_nose.locked)
+        self.assertTrue(f25_python_nose.date_locked <= datetime.utcnow())
+        self.assertTrue(f26_python_paste_deploy.locked)
+        self.assertTrue(f26_python_paste_deploy.date_locked <= datetime.utcnow())
+
+    @mock.patch('bodhi.server.push.bodhi.server.notifications.publish')
+    def test_request_flag(self, publish):
+        """
+        Assert that the --request flag works correctly.
+        """
+        cli = CliRunner()
+        # Let's mark nose as a stable request so it gets excluded when we request a testing update.
+        python_nose = self.db.query(models.Update).filter_by(
+            title=u'python-nose-1.3.7-11.fc17').one()
+        python_nose.request = models.UpdateRequest.stable
+        transaction.commit()
+
+        with mock.patch('bodhi.server.push.get_db_factory',
+                        return_value=base.TransactionalSessionMaker(self.Session)):
+            result = cli.invoke(push.push, ['--username', 'bowlofeggs', '--request', 'testing'],
+                                input='y')
+
+        self.assertEqual(result.exit_code, 0)
+        self.assertEqual(result.output, TEST_REQUEST_FLAG_EXPECTED_OUTPUT)
+        publish.assert_called_once_with(
+            topic='masher.start',
+            msg={'updates': ['python-paste-deploy-1.5.2-8.fc17'],
+                 'resume': False, 'agent': 'bowlofeggs'},
+            force=True)
+
+        python_nose = self.db.query(models.Update).filter_by(
+            title=u'python-nose-1.3.7-11.fc17').one()
+        python_paste_deploy = self.db.query(models.Update).filter_by(
+            title=u'python-paste-deploy-1.5.2-8.fc17').one()
+        self.assertFalse(python_nose.locked)
+        self.assertIsNone(python_nose.date_locked)
+        self.assertTrue(python_paste_deploy.locked)
+        self.assertTrue(python_paste_deploy.date_locked <= datetime.utcnow())
+
+    @mock.patch('bodhi.server.push.file')
+    @mock.patch('bodhi.server.push.bodhi.server.notifications.publish')
+    @mock.patch('bodhi.server.push.glob.glob',
+                return_value=['/mnt/koji/mash/updates/MASHING-f17-updates'])
+    @mock.patch('bodhi.server.push.json.load', return_value={'updates': [u'ejabberd-16.09-4.fc17']})
+    def test_resume_flag(self, load, glob, publish, mock_file):
+        """
+        Test correct operation when the --resume flag is given.
+        """
+        cli = CliRunner()
+        # Let's mark ejabberd as locked and already in a push. Since we are resuming, it should be
+        # the only package that gets included.
+        ejabberd = self.create_update([u'ejabberd-16.09-4.fc17'])
+        ejabberd.builds[0].signed = True
+        ejabberd.locked = True
+        ejabberd.date_locked = datetime.utcnow()
+        transaction.commit()
+
+        with mock.patch('bodhi.server.push.get_db_factory',
+                        return_value=base.TransactionalSessionMaker(self.Session)):
+            result = cli.invoke(push.push, ['--username', 'bowlofeggs', '--resume'], input='y\ny')
+
+        self.assertEqual(result.exit_code, 0)
+        self.assertEqual(result.output, TEST_RESUME_FLAG_EXPECTED_OUTPUT)
+        glob.assert_called_once_with('/mnt/koji/mash/updates/MASHING-*')
+        publish.assert_called_once_with(
+            topic='masher.start',
+            msg={'updates': ['ejabberd-16.09-4.fc17'],
+                 'resume': True, 'agent': 'bowlofeggs'},
+            force=True)
+        mock_file.assert_called_once_with('/mnt/koji/mash/updates/MASHING-f17-updates')
+
+        ejabberd = self.db.query(models.Update).filter_by(title=u'ejabberd-16.09-4.fc17').one()
+        python_nose = self.db.query(models.Update).filter_by(
+            title=u'python-nose-1.3.7-11.fc17').one()
+        python_paste_deploy = self.db.query(models.Update).filter_by(
+            title=u'python-paste-deploy-1.5.2-8.fc17').one()
+        # ejabberd should be locked still
+        self.assertTrue(ejabberd.locked)
+        self.assertTrue(ejabberd.date_locked <= datetime.utcnow())
+        # The other packages should have been left alone
+        for u in [python_nose, python_paste_deploy]:
+            self.assertFalse(u.locked)
+            self.assertIsNone(u.date_locked)
+
+    @mock.patch('bodhi.server.push.file')
+    @mock.patch('bodhi.server.push.bodhi.server.notifications.publish')
+    @mock.patch('bodhi.server.push.glob.glob',
+                return_value=['/mnt/koji/mash/updates/MASHING-f17-testing',
+                              '/mnt/koji/mash/updates/MASHING-f17-updates'])
+    @mock.patch('bodhi.server.push.json.load',
+                side_effect=[{'updates': [u'python-nose-1.3.7-11.fc17']},
+                             {'updates': [u'ejabberd-16.09-4.fc17']}])
+    def test_resume_human_says_no(self, load, glob, publish, mock_file):
+        """
+        Test correct operation when the --resume flag is given but the human says they don't want to
+        resume one of the lockfiles.
+        """
+        cli = CliRunner()
+        # Let's mark ejabberd as locked and already in a push. Since we are resuming and since we
+        # will decline pushing the first time we are asked, it should be the only package that gets
+        # included.
+        ejabberd = self.create_update([u'ejabberd-16.09-4.fc17'])
+        ejabberd.builds[0].signed = True
+        ejabberd.locked = True
+        ejabberd.date_locked = datetime.utcnow()
+        transaction.commit()
+
+        with mock.patch('bodhi.server.push.get_db_factory',
+                        return_value=base.TransactionalSessionMaker(self.Session)):
+            result = cli.invoke(push.push, ['--username', 'bowlofeggs', '--resume'],
+                                input='n\ny\ny')
+
+        self.assertEqual(result.exit_code, 0)
+        self.assertEqual(result.output, TEST_RESUME_HUMAN_SAYS_NO_EXPECTED_OUTPUT)
+        glob.assert_called_once_with('/mnt/koji/mash/updates/MASHING-*')
+        publish.assert_called_once_with(
+            topic='masher.start',
+            msg={'updates': ['ejabberd-16.09-4.fc17'],
+                 'resume': True, 'agent': 'bowlofeggs'},
+            force=True)
+        mock_file.assert_any_call('/mnt/koji/mash/updates/MASHING-f17-testing')
+        mock_file.assert_any_call('/mnt/koji/mash/updates/MASHING-f17-updates')
+
+        ejabberd = self.db.query(models.Update).filter_by(title=u'ejabberd-16.09-4.fc17').one()
+        python_nose = self.db.query(models.Update).filter_by(
+            title=u'python-nose-1.3.7-11.fc17').one()
+        python_paste_deploy = self.db.query(models.Update).filter_by(
+            title=u'python-paste-deploy-1.5.2-8.fc17').one()
+        # ejabberd should be locked still
+        self.assertTrue(ejabberd.locked)
+        self.assertTrue(ejabberd.date_locked <= datetime.utcnow())
+        # The other packages should have been left alone
+        for u in [python_nose, python_paste_deploy]:
+            self.assertFalse(u.locked)
+            self.assertIsNone(u.date_locked)
+
+    @mock.patch('bodhi.server.push.file')
+    @mock.patch('bodhi.server.push.bodhi.server.notifications.publish')
+    @mock.patch('bodhi.server.push.glob.glob',
+                return_value=['/mnt/koji/mash/updates/MASHING-f17-updates'])
+    @mock.patch('bodhi.server.push.json.load', return_value={'updates': [u'ejabberd-16.09-4.fc17']})
+    def test_staging_flag(self, load, glob, publish, mock_file):
+        """
+        Test correct operation when the --staging flag is given. The main thing that matters is that
+        the glob call happens on a different directory.
+        """
+        cli = CliRunner()
+        transaction.commit()
+
+        with mock.patch('bodhi.server.push.get_db_factory',
+                        return_value=base.TransactionalSessionMaker(self.Session)):
+            result = cli.invoke(push.push, ['--username', 'bowlofeggs', '--staging'], input='y')
+
+        self.assertEqual(result.exit_code, 0)
+        self.assertEqual(result.output, TEST_STAGING_FLAG_EXPECTED_OUTPUT)
+        glob.assert_called_once_with('/var/cache/bodhi/mashing/MASHING-*')
+        publish.assert_called_once_with(
+            topic='masher.start',
+            msg={'updates': ['python-nose-1.3.7-11.fc17', u'python-paste-deploy-1.5.2-8.fc17'],
+                 'resume': False, 'agent': 'bowlofeggs'},
+            force=True)
+        mock_file.assert_called_once_with('/mnt/koji/mash/updates/MASHING-f17-updates')
+
+        python_nose = self.db.query(models.Update).filter_by(
+            title=u'python-nose-1.3.7-11.fc17').one()
+        python_paste_deploy = self.db.query(models.Update).filter_by(
+            title=u'python-paste-deploy-1.5.2-8.fc17').one()
+        # The packages should be locked
+        for u in [python_nose, python_paste_deploy]:
+            self.assertTrue(u.locked)
+            self.assertTrue(u.date_locked <= datetime.utcnow())
+
+    @mock.patch('bodhi.server.push.bodhi.server.notifications.publish')
+    def test_unsigned_updates_skipped(self, publish):
+        """
+        Unsigned updates should get skipped.
+        """
+        cli = CliRunner()
+        # Let's mark nose unsigned so it gets skipped.
+        python_nose = self.db.query(models.Update).filter_by(
+            title=u'python-nose-1.3.7-11.fc17').one()
+        python_nose.builds[0].signed = False
+        transaction.commit()
+
+        with mock.patch('bodhi.server.push.get_db_factory',
+                        return_value=base.TransactionalSessionMaker(self.Session)):
+            result = cli.invoke(push.push, ['--username', 'bowlofeggs'], input='y')
+
+        self.assertEqual(result.exit_code, 0)
+        self.assertEqual(result.output, TEST_UNSIGNED_UPDATES_SKIPPED_EXPECTED_OUTPUT)
+        publish.assert_called_once_with(
+            topic='masher.start',
+            msg={'updates': ['python-paste-deploy-1.5.2-8.fc17'],
+                 'resume': False, 'agent': 'bowlofeggs'},
+            force=True)
+
+        python_nose = self.db.query(models.Update).filter_by(
+            title=u'python-nose-1.3.7-11.fc17').one()
+        python_paste_deploy = self.db.query(models.Update).filter_by(
+            title=u'python-paste-deploy-1.5.2-8.fc17').one()
+        self.assertFalse(python_nose.locked)
+        self.assertIsNone(python_nose.date_locked)
+        self.assertTrue(python_paste_deploy.locked)
+        self.assertTrue(python_paste_deploy.date_locked <= datetime.utcnow())

--- a/bodhi/tests/server/test_push.py
+++ b/bodhi/tests/server/test_push.py
@@ -235,21 +235,7 @@ Locking updates...
 Sending masher.start fedmsg
 """
 
-TEST_RESUME_FLAG_EXPECTED_OUTPUT = """Resume /mnt/koji/mash/updates/MASHING-f17-updates? (y/n) ================================================================================
-     ejabberd-16.09-4.fc17
-================================================================================
-    Release: Fedora 17
-     Status: pending
-       Type: bugfix
-      Karma: 0
-    Request: testing
-      Notes: Useful details!
-  Submitter: guest
-  Submitted: 1984-11-02 00:00:00
-
-  http://localhost:6543/updates/ejabberd-16.09-4.fc17
-
-ejabberd-16.09-4.fc17
+TEST_RESUME_FLAG_EXPECTED_OUTPUT = """Resume /mnt/koji/mash/updates/MASHING-f17-updates? (y/n) ejabberd-16.09-4.fc17
 Push these 1 updates? [y/N]: y
 
 Locking updates...
@@ -257,21 +243,7 @@ Locking updates...
 Sending masher.start fedmsg
 """
 
-TEST_RESUME_HUMAN_SAYS_NO_EXPECTED_OUTPUT = """Resume /mnt/koji/mash/updates/MASHING-f17-testing? (y/n) Resume /mnt/koji/mash/updates/MASHING-f17-updates? (y/n) ================================================================================
-     ejabberd-16.09-4.fc17
-================================================================================
-    Release: Fedora 17
-     Status: pending
-       Type: bugfix
-      Karma: 0
-    Request: testing
-      Notes: Useful details!
-  Submitter: guest
-  Submitted: 1984-11-02 00:00:00
-
-  http://localhost:6543/updates/ejabberd-16.09-4.fc17
-
-ejabberd-16.09-4.fc17
+TEST_RESUME_HUMAN_SAYS_NO_EXPECTED_OUTPUT = """Resume /mnt/koji/mash/updates/MASHING-f17-testing? (y/n) Resume /mnt/koji/mash/updates/MASHING-f17-updates? (y/n) ejabberd-16.09-4.fc17
 Push these 1 updates? [y/N]: y
 
 Locking updates...

--- a/bodhi/tests/server/test_push.py
+++ b/bodhi/tests/server/test_push.py
@@ -161,13 +161,14 @@ TEST_ABORT_PUSH_EXPECTED_OUTPUT = """Warning: bodhi-2.0-1.fc17 is locked but not
 Warning: bodhi-2.0-1.fc17 has unsigned builds and has been skipped
 python-nose-1.3.7-11.fc17
 python-paste-deploy-1.5.2-8.fc17
-Push these 2 updates? (y/n) 
-Aborting push
+Push these 2 updates? [y/N]: n
+Aborted!
 """
 
 TEST_BUILDS_FLAG_EXPECTED_OUTPUT = """ejabberd-16.09-4.fc17
 python-nose-1.3.7-11.fc17
-Push these 2 updates? (y/n) 
+Push these 2 updates? [y/N]: y
+
 Locking updates...
 
 Sending masher.start fedmsg
@@ -177,7 +178,8 @@ TEST_CERT_PREFIX_FLAG_EXPECTED_OUTPUT = """Warning: bodhi-2.0-1.fc17 is locked b
 Warning: bodhi-2.0-1.fc17 has unsigned builds and has been skipped
 python-nose-1.3.7-11.fc17
 python-paste-deploy-1.5.2-8.fc17
-Push these 2 updates? (y/n) 
+Push these 2 updates? [y/N]: y
+
 Locking updates...
 
 Sending masher.start fedmsg
@@ -187,7 +189,8 @@ TEST_LOCKED_UPDATES_EXPECTED_OUTPUT = """Warning: bodhi-2.0-1.fc17 is locked but
 Warning: bodhi-2.0-1.fc17 has unsigned builds and has been skipped
 python-nose-1.3.7-11.fc17
 python-paste-deploy-1.5.2-8.fc17
-Push these 2 updates? (y/n) 
+Push these 2 updates? [y/N]: y
+
 Locking updates...
 
 Sending masher.start fedmsg
@@ -197,7 +200,8 @@ TEST_LOCKED_UPDATES_NOT_IN_A_PUSH_EXPECTED_OUTPUT = """Warning: ejabberd-16.09-4
 python-nose-1.3.7-11.fc17
 python-paste-deploy-1.5.2-8.fc17
 ejabberd-16.09-4.fc17
-Push these 3 updates? (y/n) 
+Push these 3 updates? [y/N]: y
+
 Locking updates...
 
 Sending masher.start fedmsg
@@ -207,13 +211,15 @@ TEST_NO_UPDATES_TO_PUSH_EXPECTED_OUTPUT = """Warning: python-nose-1.3.7-11.fc17 
 Warning: python-paste-deploy-1.5.2-8.fc17 has unsigned builds and has been skipped
 Warning: bodhi-2.0-1.fc17 is locked but not in a push
 Warning: bodhi-2.0-1.fc17 has unsigned builds and has been skipped
-Push these 0 updates? (y/n) 
+Push these 0 updates? [y/N]: y
+
 Locking updates...
 """
 
 TEST_RELEASES_FLAG_EXPECTED_OUTPUT = """python-nose-1.3.7-11.fc25
 python-paste-deploy-1.5.2-8.fc26
-Push these 2 updates? (y/n) 
+Push these 2 updates? [y/N]: y
+
 Locking updates...
 
 Sending masher.start fedmsg
@@ -222,7 +228,8 @@ Sending masher.start fedmsg
 TEST_REQUEST_FLAG_EXPECTED_OUTPUT = """Warning: bodhi-2.0-1.fc17 is locked but not in a push
 Warning: bodhi-2.0-1.fc17 has unsigned builds and has been skipped
 python-paste-deploy-1.5.2-8.fc17
-Push these 1 updates? (y/n) 
+Push these 1 updates? [y/N]: y
+
 Locking updates...
 
 Sending masher.start fedmsg
@@ -243,7 +250,8 @@ TEST_RESUME_FLAG_EXPECTED_OUTPUT = """Resume /mnt/koji/mash/updates/MASHING-f17-
   http://localhost:6543/updates/ejabberd-16.09-4.fc17
 
 ejabberd-16.09-4.fc17
-Push these 1 updates? (y/n) 
+Push these 1 updates? [y/N]: y
+
 Locking updates...
 
 Sending masher.start fedmsg
@@ -264,7 +272,8 @@ TEST_RESUME_HUMAN_SAYS_NO_EXPECTED_OUTPUT = """Resume /mnt/koji/mash/updates/MAS
   http://localhost:6543/updates/ejabberd-16.09-4.fc17
 
 ejabberd-16.09-4.fc17
-Push these 1 updates? (y/n) 
+Push these 1 updates? [y/N]: y
+
 Locking updates...
 
 Sending masher.start fedmsg
@@ -274,7 +283,8 @@ TEST_STAGING_FLAG_EXPECTED_OUTPUT = """Warning: bodhi-2.0-1.fc17 is locked but n
 Warning: bodhi-2.0-1.fc17 has unsigned builds and has been skipped
 python-nose-1.3.7-11.fc17
 python-paste-deploy-1.5.2-8.fc17
-Push these 2 updates? (y/n) 
+Push these 2 updates? [y/N]: y
+
 Locking updates...
 
 Sending masher.start fedmsg
@@ -284,7 +294,8 @@ TEST_UNSIGNED_UPDATES_SKIPPED_EXPECTED_OUTPUT = """Warning: python-nose-1.3.7-11
 Warning: bodhi-2.0-1.fc17 is locked but not in a push
 Warning: bodhi-2.0-1.fc17 has unsigned builds and has been skipped
 python-paste-deploy-1.5.2-8.fc17
-Push these 1 updates? (y/n) 
+Push these 1 updates? [y/N]: y
+
 Locking updates...
 
 Sending masher.start fedmsg
@@ -319,8 +330,8 @@ class TestPush(base.BaseTestCase):
                         return_value=base.TransactionalSessionMaker(self.Session)):
             result = cli.invoke(push.push, ['--username', 'bowlofeggs'], input='n')
 
-        # The exit code is -1 when the push is aborted.
-        self.assertEqual(result.exit_code, -1)
+        # The exit code is 1 when the push is aborted.
+        self.assertEqual(result.exit_code, 1)
         self.assertEqual(result.output, TEST_ABORT_PUSH_EXPECTED_OUTPUT)
         self.assertEqual(publish.call_count, 0)
 

--- a/bodhi/tests/server/test_push.py
+++ b/bodhi/tests/server/test_push.py
@@ -211,9 +211,8 @@ TEST_NO_UPDATES_TO_PUSH_EXPECTED_OUTPUT = """Warning: python-nose-1.3.7-11.fc17 
 Warning: python-paste-deploy-1.5.2-8.fc17 has unsigned builds and has been skipped
 Warning: bodhi-2.0-1.fc17 is locked but not in a push
 Warning: bodhi-2.0-1.fc17 has unsigned builds and has been skipped
-Push these 0 updates? [y/N]: y
 
-Locking updates...
+There are no updates to push.
 """
 
 TEST_RELEASES_FLAG_EXPECTED_OUTPUT = """python-nose-1.3.7-11.fc25

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 [nosetests]
 cover-erase=TRUE
 cover-inclusive=TRUE
-cover-min-percentage=78
+cover-min-percentage=79
 cover-package=bodhi
 cover-xml=TRUE
 with-coverage=TRUE


### PR DESCRIPTION
This pull request has five commits that all depend on each other (hence why I'm putting them in one pull request instead of five as I might usually do). These commits all pertain to refactoring and testing ```bodhi.server.push```, and they get it to 100% test coverage!

This pull request also fixes #1113 and #1107.