### PR TITLE
Add a dependency to the Vagrant setup and update another.

### DIFF
--- a/devel/ansible/roles/dev/tasks/main.yml
+++ b/devel/ansible/roles/dev/tasks/main.yml
@@ -29,7 +29,10 @@
       - python-webtest
       - python-zmq
       - python2-createrepo_c
-      - python2-fedmsg-atomic-composer
+      # We can switch this back to python2-fedmsg-atomic-composer once
+      # https://bodhi.fedoraproject.org/updates/FEDORA-2016-bf2a514f37 is stable.
+      - https://kojipkgs.fedoraproject.org//packages/python-fedmsg-atomic-composer/2016.3/1.fc25/noarch/python2-fedmsg-atomic-composer-2016.3-1.fc25.noarch.rpm
+      - python2-fedmsg-consumers
       - python2-flake8
       - python2-nose-cov
       - redhat-rpm-config


### PR DESCRIPTION
This commit adds python2-fedmsg-consumers to the Vagrant
environment. It also updates the Vagrant environment to
python2-fedmsg-atomic-composer-2016.3 by getting it directly from
Koji.

Signed-off-by: Randy Barlow <randy@electronsweatshop.com>