### PR TITLE
Configure the Koji client to retry

### DIFF
--- a/bodhi/server/buildsys.py
+++ b/bodhi/server/buildsys.py
@@ -291,7 +291,17 @@ class DevBuildsys(Buildsystem):
 
 def koji_login(config):
     """ Login to Koji and return the session """
-    koji_client = koji.ClientSession(_koji_hub, {'krb_rdns': False})
+
+    koji_options = {
+        'krb_rdns': False,
+        'max_retries': 30,
+        'retry_interval': 10,
+        'offline_retry': True,
+        'offline_retry_interval': 10,
+        'anon_retry': True,
+    }
+
+    koji_client = koji.ClientSession(_koji_hub, koji_options)
     if not koji_client.krb_login(**get_krb_conf(config)):
         log.error('Koji krb_login failed')
     return koji_client

--- a/bodhi/tests/server/test_buildsys.py
+++ b/bodhi/tests/server/test_buildsys.py
@@ -124,8 +124,18 @@ class TestKojiLogin(unittest.TestCase):
         """Assert correct behavior for a successful login event."""
         config = {'some_meaningless_other_key': 'boring_value', 'krb_ccache': 'a_ccache',
                   'krb_keytab': 'a_keytab', 'krb_principal': 'a_principal'}
+        default_koji_opts = {
+            'krb_rdns': False,
+            'max_retries': 30,
+            'retry_interval': 10,
+            'offline_retry': True,
+            'offline_retry_interval': 10,
+            'anon_retry': True,
+        }
 
         client = buildsys.koji_login(config)
+        for key in default_koji_opts:
+            self.assertEqual(default_koji_opts[key], client.opts[key])
 
         self.assertEqual(type(client), koji.ClientSession)
         # No error should have been logged


### PR DESCRIPTION
Although the Koji client has a few defaults for the options set here, I
set them all explicitly. The difference here is that ``offline_retry``
is now ``True``. It's not entirely clear from the Koji code what cases
this covers, but it should help some with the reliability problems. This
commit does not handle problems with the Kerberos server.

Fixes #1201 in part

Signed-off-by: Jeremy Cline <jeremy@jcline.org>