### PR TITLE
Disable autopush if an update receives negative karma from logged-in user

### DIFF
--- a/bodhi/server/models/models.py
+++ b/bodhi/server/models/models.py
@@ -1720,9 +1720,9 @@ class Update(Base):
         # Return if the status of the update is not in testing
         if self.status != UpdateStatus.testing:
             return
-        # If critical update receives negative karma disable autopush
-        if self.critpath and self.autokarma and self._composite_karma[1] != 0:
-            log.info("Disabling Auto Push since the critical update has negative karma")
+        # If an update receives negative karma disable autopush
+        if self.autokarma and self._composite_karma[1] != 0:
+            log.info("Disabling Auto Push since the update has received negative karma")
             self.autokarma = False
         elif self.stable_karma and self.karma >= self.stable_karma:
             if self.autokarma:


### PR DESCRIPTION
Fixes #1191 
A point to be noted here: When autopush is disabled the update will be able to be pushed manually based of `karma threshold`.

Note that it will disable an update to go to obsolete state automatically when a testing update receives negative karma. It is going to wait for maintainer to decide. Hence we have this test failing for the same [test_obsolete_if_unstable_with_autopush_enabled_when_testing](https://github.com/fedora-infra/bodhi/blob/04cdcd5f4e7c3972761d8e6969e8cc9e79b50881/bodhi/tests/server/services/test_updates.py#L2165)