### PR TITLE
Add missing zope-sqlalchemy dependency to Ansible dev role

### DIFF
--- a/devel/ansible/roles/dev/tasks/main.yml
+++ b/devel/ansible/roles/dev/tasks/main.yml
@@ -28,6 +28,7 @@
       - python-webob
       - python-webtest
       - python-zmq
+      - python-zope-sqlalchemy
       - python2-createrepo_c
       # We can switch this back to python2-fedmsg-atomic-composer once
       # https://bodhi.fedoraproject.org/updates/FEDORA-2016-bf2a514f37 is stable.


### PR DESCRIPTION
Signed-off-by: Jeremy Cline <jeremy@jcline.org>