### PR TITLE
Fix dependencies

### DIFF
--- a/devel/ansible/roles/dev/tasks/main.yml
+++ b/devel/ansible/roles/dev/tasks/main.yml
@@ -15,31 +15,53 @@
       - libjpeg-devel
       - libjpeg-turbo-devel
       - openssl-devel
+      - packagedb-cli
       - pcaro-hermit-fonts
       - postgresql-devel
       - python
       - python-alembic
+      - python-arrow
+      - python-bugzilla
+      - python-bunch
+      - python-click
       - python-cornice
       - python-devel
+      - python-dogpile-cache
+      - python-fedora
+      - python-kitchen
       - python-librepo
       - python-mock
       - python-nose
+      - python-openid
       - python-pillow
+      - python-progressbar
       - python-psycopg2
+      - python-pydns
+      - python-pylibravatar
+      - python-pyramid
+      - python-pyramid-mako
+      - python-pyramid-fas-openid
+      - python-pyramid-tm
+      - python-simplemediawiki
+      - python-sqlalchemy
+      - python-webhelpers
       - python-webob
       - python-webtest
       - python-zmq
       - python-zope-sqlalchemy
+      - python2-colander
       - python2-createrepo_c
-      # We can switch this back to python2-fedmsg-atomic-composer once
-      # https://bodhi.fedoraproject.org/updates/FEDORA-2016-bf2a514f37 is stable.
-      - https://kojipkgs.fedoraproject.org//packages/python-fedmsg-atomic-composer/2016.3/1.fc25/noarch/python2-fedmsg-atomic-composer-2016.3-1.fc25.noarch.rpm
+      - python2-cryptography
+      - python2-fedmsg-atomic-composer
       - python2-fedmsg-consumers
       - python2-flake8
       - python2-nose-cov
+      - python2-markdown
+      - python2-sphinx
       # We can switch this to python2-sqlalchemy_schemadisplay once
       # https://bodhi.fedoraproject.org/updates/FEDORA-2017-e54acedb77 is stable
       - https://kojipkgs.fedoraproject.org//packages/python-sqlalchemy_schemadisplay/1.3/1.fc24/noarch/python2-sqlalchemy_schemadisplay-1.3-1.fc24.noarch.rpm
+      - python2-waitress
       - redhat-rpm-config
       - zlib-devel
 

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,6 @@ server_requires = [
     'click',
     'pyramid',
     'pyramid_mako',
-    'pyramid_debugtoolbar',
     'pyramid_tm',
     'waitress',
     'colander',
@@ -80,8 +79,6 @@ server_requires = [
     'fedmsg[consumers]',
     # The masher needs fedmsg-atomic-composer
     'fedmsg-atomic-composer >= 2016.3',
-
-    'Sphinx',
 
     'WebOb>=1.4.1',
     ]


### PR DESCRIPTION
This pull request has two commits (the second depends on the first):

1. Remove two development dependencies from the setup.py, since they aren't needed in production.
2. Make the Vagrant Ansible dev role install all dependencies by name from the Fedora 24 repository.