### PR TITLE
Add unit tests for bodhi/server/consumers/signed.py

### DIFF
--- a/bodhi/server/consumers/signed.py
+++ b/bodhi/server/consumers/signed.py
@@ -51,6 +51,39 @@ class SignedHandler(fedmsg.consumers.FedmsgConsumer):
                  '%s' % pprint.pformat(self.topic))
 
     def consume(self, message):
+        """
+        The method called when a fedmsg arrives with the configured topic.
+
+        This marks a build as signed if it is assigned to the pending testing release tag.
+
+        Example message format::
+            {
+                u'body': {
+                    u'i': 628,
+                    u'timestamp': 1484692585,
+                    u'msg_id': u'2017-821031da-be3a-4f4b-91df-0baa834ca8a4',
+                    u'crypto': u'x509',
+                    u'topic': u'org.fedoraproject.prod.buildsys.tag',
+                    u'signature': u'100% real please trust me',
+                    u'msg': {
+                        u'build_id': 442562,
+                        u'name': u'colord',
+                        u'tag_id': 214,
+                        u'instance': u's390',
+                        u'tag': 'f26-updates-testing-pending',
+                        u'user': u'sharkcz',
+                        u'version': u'1.3.4',
+                        u'owner': u'sharkcz',
+                        u'release': u'1.fc26'
+                    },
+                },
+            }
+
+        The message can contain additional keys.
+
+        Args:
+            message (dict): The incoming fedmsg in the format described above.
+        """
         msg = message['body']['msg']
 
         build_nvr = '%(name)s-%(version)s-%(release)s' % msg

--- a/bodhi/tests/server/consumers/test_signed.py
+++ b/bodhi/tests/server/consumers/test_signed.py
@@ -14,6 +14,7 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 """This test suite contains tests for the bodhi.server.consumers.signed module."""
+from __future__ import absolute_import, unicode_literals
 
 import unittest
 
@@ -43,3 +44,73 @@ class TestSignedHandler___init__(unittest.TestCase):
 
         self.assertEqual(handler.topic, ['topic_prefix.environment.buildsys.tag'])
         __init__.assert_called_once_with(hub)
+
+
+class TestSignedHandlerConsume(unittest.TestCase):
+    """Test class for the :func:`SignedHandler.consume` method."""
+
+    def setUp(self):
+        self.sample_message = {
+            'body': {
+                'i': 628,
+                'timestamp': 1484692585,
+                'msg_id': '2017-821031da-be3a-4f4b-91df-0baa834ca8a4',
+                'crypto': 'x509',
+                'topic': 'org.fedoraproject.prod.buildsys.tag',
+                'signature': '100% real please trust me',
+                'msg': {
+                    'build_id': 442562,
+                    'name': 'colord',
+                    'tag_id': 214,
+                    'instance': 's390',
+                    'tag': 'f26-updates-testing-pending',
+                    'user': 'sharkcz',
+                    'version': '1.3.4',
+                    'owner': 'sharkcz',
+                    'release': '1.fc26'
+                },
+            },
+        }
+        hub = mock.MagicMock()
+        hub.config = {'environment': 'environment', 'topic_prefix': 'topic_prefix'}
+        self.handler = signed.SignedHandler(hub)
+
+    @mock.patch('bodhi.server.consumers.signed.Build')
+    def test_consume(self, mock_build_model):
+        """Assert that messages marking the build as signed updates the database"""
+        build = mock_build_model.get.return_value
+        build.release.pending_testing_tag = self.sample_message['body']['msg']['tag']
+
+        self.handler.consume(self.sample_message)
+        self.assertTrue(build.signed is True)
+
+    @mock.patch('bodhi.server.consumers.signed.Build')
+    def test_consume_not_pending_testing_tag(self, mock_build_model):
+        """
+        Assert that messages whose tag don't match the pending testing tag don't update the DB
+        """
+        build = mock_build_model.get.return_value
+        build.release.pending_testing_tag = "some tag that isn't pending testing"
+
+        self.handler.consume(self.sample_message)
+        self.assertFalse(build.signed is True)
+
+    @mock.patch('bodhi.server.consumers.signed.Build')
+    def test_consume_no_release(self, mock_build_model):
+        """
+        Assert that messages about builds that haven't been assigned a release don't update the DB
+        """
+        build = mock_build_model.get.return_value
+        build.release = None
+
+        self.handler.consume(self.sample_message)
+        self.assertFalse(build.signed is True)
+
+    @mock.patch('bodhi.server.consumers.signed.log')
+    @mock.patch('bodhi.server.consumers.signed.Build')
+    def test_consume_no_build(self, mock_build_model, mock_log):
+        """Assert that messages referencing builds Bodhi doesn't know about don't update the DB"""
+        mock_build_model.get.return_value = None
+
+        self.handler.consume(self.sample_message)
+        mock_log.info.assert_called_with('Build was not submitted, skipping')


### PR DESCRIPTION
This adds unit tests for the change made in https://github.com/fedora-infra/bodhi/pull/1139

Signed-off-by: Jeremy Cline <jeremy@jcline.org>