### PR TITLE
Reload builds and releases after we commit the transaction

### DIFF
--- a/bodhi/server/services/updates.py
+++ b/bodhi/server/services/updates.py
@@ -375,6 +375,17 @@ def new_update(request):
         # the builds as signed.
         transaction.commit()
 
+        # After we commit the transaction, we need to get the builds and releases again, since they
+        # were tied to the previous session that has now been terminated.
+        builds = []
+        releases = set()
+        for build in data['builds']:
+            # At this moment, we are sure the builds are in the database (that is what the commit
+            # was for actually).
+            build = Build.get(nvr, request.db)
+            builds.append(build)
+            releases.add(build.release)
+
         if data.get('edited'):
 
             log.info('Editing update: %s' % data['edited'])

--- a/bodhi/server/services/updates.py
+++ b/bodhi/server/services/updates.py
@@ -379,7 +379,7 @@ def new_update(request):
         # were tied to the previous session that has now been terminated.
         builds = []
         releases = set()
-        for build in data['builds']:
+        for nvr in data['builds']:
             # At this moment, we are sure the builds are in the database (that is what the commit
             # was for actually).
             build = Build.get(nvr, request.db)


### PR DESCRIPTION
This builds upon  https://github.com/fedora-infra/bodhi/issues/1137 and fixes a regression introduced by it which is currently in production. Specifically, it broke the feature that allowed you to submit multiple updates at a time (https://github.com/fedora-infra/bodhi/issues/219).