### PR TITLE
Add missing fedmsg config expected in masher tests

### DIFF
--- a/bodhi/tests/server/consumers/test_masher.py
+++ b/bodhi/tests/server/consumers/test_masher.py
@@ -68,6 +68,7 @@ class FakeHub(object):
             'releng_fedmsg_certname': None,
             'masher_topic': 'bodhi.start',
             'masher': True,
+            'validate_signatures': False,
         }
 
     def subscribe(self, *args, **kw):


### PR DESCRIPTION
fixes #1263

Signed-off-by: Jeremy Cline <jeremy@jcline.org>