### PR TITLE
Fix a mocked test on PIL is which upset on EPEL 7

### DIFF
--- a/bodhi/tests/server/test_captcha.py
+++ b/bodhi/tests/server/test_captcha.py
@@ -54,7 +54,6 @@ class TestJPEGGenerator(unittest.TestCase):
 
         truetype.assert_called_once_with('/path/to/cool/font', 24)
         truetype.return_value.getsize.assert_called_once_with('42 + 7')
-        Draw.assert_called_once_with(img)
         Draw.return_value.text.assert_called_once_with((52, 78), '42 + 7',
                                                        font=truetype.return_value, fill='#012345')
         img.verify()


### PR DESCRIPTION
The test in question failed regardless of whether
b1b3bcc6f116d5f92a9735ab4fba56df1a5ab82f was applied or not and relied
on pillow not creating a new Image instance under the hood. That assertion
appears to hold true for newer versions of pillow, but not on the
version in EPEL 7.

fixes #1271

Signed-off-by: Jeremy Cline <jeremy@jcline.org>