### PR TITLE
Adjust how ``file`` is mocked in a few tests

### DIFF
--- a/bodhi/tests/server/test_push.py
+++ b/bodhi/tests/server/test_push.py
@@ -379,7 +379,7 @@ class TestPush(base.BaseTestCase):
                  'resume': False, 'agent': 'bowlofeggs'},
             force=True)
 
-    @mock.patch('bodhi.server.push.file')
+    @mock.patch('bodhi.server.push.file', create=True)
     @mock.patch('bodhi.server.push.bodhi.server.notifications.publish')
     @mock.patch('bodhi.server.push.glob.glob',
                 return_value=['/mnt/koji/mash/updates/MASHING-f17-updates'])
@@ -419,7 +419,7 @@ class TestPush(base.BaseTestCase):
             self.assertTrue(u.locked)
             self.assertTrue(u.date_locked <= datetime.utcnow())
 
-    @mock.patch('bodhi.server.push.file')
+    @mock.patch('bodhi.server.push.file', create=True)
     @mock.patch('bodhi.server.push.bodhi.server.notifications.publish')
     @mock.patch('bodhi.server.push.glob.glob',
                 return_value=['/mnt/koji/mash/updates/MASHING-f17-updates'])
@@ -608,7 +608,7 @@ class TestPush(base.BaseTestCase):
         self.assertTrue(python_paste_deploy.locked)
         self.assertTrue(python_paste_deploy.date_locked <= datetime.utcnow())
 
-    @mock.patch('bodhi.server.push.file')
+    @mock.patch('bodhi.server.push.file', create=True)
     @mock.patch('bodhi.server.push.bodhi.server.notifications.publish')
     @mock.patch('bodhi.server.push.glob.glob',
                 return_value=['/mnt/koji/mash/updates/MASHING-f17-updates'])
@@ -653,7 +653,7 @@ class TestPush(base.BaseTestCase):
             self.assertFalse(u.locked)
             self.assertIsNone(u.date_locked)
 
-    @mock.patch('bodhi.server.push.file')
+    @mock.patch('bodhi.server.push.file', create=True)
     @mock.patch('bodhi.server.push.bodhi.server.notifications.publish')
     @mock.patch('bodhi.server.push.glob.glob',
                 return_value=['/mnt/koji/mash/updates/MASHING-f17-testing',
@@ -705,7 +705,7 @@ class TestPush(base.BaseTestCase):
             self.assertFalse(u.locked)
             self.assertIsNone(u.date_locked)
 
-    @mock.patch('bodhi.server.push.file')
+    @mock.patch('bodhi.server.push.file', create=True)
     @mock.patch('bodhi.server.push.bodhi.server.notifications.publish')
     @mock.patch('bodhi.server.push.glob.glob',
                 return_value=['/mnt/koji/mash/updates/MASHING-f17-updates'])


### PR DESCRIPTION
This appears to be a problem with the way mock handles patching builtins
in older version versus newer versions. Although setting ``create=True``
isn't great, I felt like it was the best option without digging very
deeply into the guts of mock and figuring out a way that works in the
old version and the new version.

Signed-off-by: Jeremy Cline <jeremy@jcline.org>