### PR TITLE
Change systemd module to service module in Dev environment setup

### DIFF
--- a/devel/ansible/roles/dev/tasks/main.yml
+++ b/devel/ansible/roles/dev/tasks/main.yml
@@ -121,7 +121,7 @@
       mode: 0644
 
 - name: Start and enable the bodhi service
-  systemd:
+  service:
       name: bodhi
       state: started
       enabled: yes


### PR DESCRIPTION
`systemd` module is introduced in to Ansible 2.2. But `service` module works for every version. 
Changing to `service` module would be more general.