### PR TITLE
Adding the edit updates command

### DIFF
--- a/docs/man_pages/bodhi.rst
+++ b/docs/man_pages/bodhi.rst
@@ -172,6 +172,48 @@ The ``updates`` command allows users to interact with bodhi updates.
 
         A path to a file containing all the update details.
 
+``bodhi updates edit [options] <updateid>``
+
+    Edit an existing bodhi update, given an update id. The
+    ``edit`` subcommand supports the following options:
+
+    ``--type [security | bugfix | enhancement | newpackage]``
+
+        The type of the new update.
+
+    ``--notes <text>``
+
+        The description of the update.
+
+    ``--bugs <bugs>``
+
+        A comma separated list of bugs to associate with this update.
+
+    ``--close-bugs``
+
+        If given, this flag will cause bodhi to close the referenced bugs automatically when the
+        update reaches stable.
+
+    ``--request [testing | stable | upush]``
+
+        The repository requested for this update.
+
+    ``--autokarma``
+
+        Enable autokarma for this update.
+
+    ``--stable-karma <integer>``
+
+        Configure the stable karma threshold for the given value.
+
+    ``--unstable-karma <integer>``
+
+        Configure the unstable karma threshold for the given value.
+
+    ``--suggest [logout | reboot]``
+
+        Suggest that the user logout or reboot upon applying the update.
+
 ``bodhi updates query [options]``
 
     Query the bodhi server for updates. The ``query`` subcommand supports the following options:

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -16,6 +16,8 @@ Features
   (`#1366 <https://github.com/fedora-infra/bodhi/pulls/1366>`_).
 * The web UI footer has been added with the documentation link.
   (`#1321 <https://github.com/fedora-infra/bodhi/issues/1321>`_).
+* The bodhi CLI now supports editing an update using the update id.
+  (`#937 <https://github.com/fedora-infra/bodhi/issues/937>`_)
 
 
 Bugs
@@ -56,6 +58,7 @@ The following contributors submitted patches for REPLACE THIS WITH A VERSION BEF
 * Ryan Lerch
 * Bianca Nenciu
 * Randy Barlow
+* Clement Verna
 
 
 2.5.0


### PR DESCRIPTION
This commit add the edit command to the updates group it uses the same API as the
new command but set the "edited" option with the update name.

Fixes #1125

Signed-off-by: Clement Verna <cverna@tutanota.com>