### PR TITLE
Some Python bindings fixes, and raise test coverage to 82%

### DIFF
--- a/bodhi/client/bindings.py
+++ b/bodhi/client/bindings.py
@@ -33,7 +33,6 @@ import logging
 import os
 import re
 import textwrap
-import warnings
 
 import six
 
@@ -165,13 +164,6 @@ class BodhiClient(OpenIdBaseClient):
                 raise UpdateNotFound(update)
             else:
                 raise
-
-    @errorhandled
-    def delete(self, update):
-        warnings.warn('Deleting updates has been disabled in Bodhi. '
-                      'This API call will unpush the update instead. '
-                      'Please use `set_request(update, "unpush")` instead')
-        self.request(update, 'unpush')
 
     @errorhandled
     def query(self, **kwargs):

--- a/bodhi/client/bindings.py
+++ b/bodhi/client/bindings.py
@@ -228,7 +228,10 @@ class BodhiClient(OpenIdBaseClient):
                 kwargs['packages'] = kwargs['package']
             del(kwargs['package'])
         if 'release' in kwargs:
-            kwargs['releases'] = kwargs['release']
+            if isinstance(kwargs['release'], list):
+                kwargs['releases'] = kwargs['release']
+            else:
+                kwargs['releases'] = [kwargs['release']]
             del(kwargs['release'])
         if 'type_' in kwargs:
             kwargs['type'] = kwargs['type_']

--- a/bodhi/client/bindings.py
+++ b/bodhi/client/bindings.py
@@ -372,7 +372,8 @@ class BodhiClient(OpenIdBaseClient):
                 for update in update_list:
                     yield update
 
-    def override_str(self, override):
+    @staticmethod
+    def override_str(override):
         """ Return a string representation of a given override dictionary.
 
         :arg override: An override dictionary.

--- a/bodhi/client/bindings.py
+++ b/bodhi/client/bindings.py
@@ -280,10 +280,7 @@ class BodhiClient(OpenIdBaseClient):
 
     @errorhandled
     def list_overrides(self, user=None):
-        """ Save a buildroot overrides.
-
-        This entails either creating a new buildroot override, or editing an
-        existing one.
+        """ List buildroot overrides.
 
         :kwarg user: A username whose buildroot overrides you want returned.
 

--- a/bodhi/client/bindings.py
+++ b/bodhi/client/bindings.py
@@ -222,7 +222,7 @@ class BodhiClient(OpenIdBaseClient):
             # update ID, so try and figure it out
             if re.search(r'(\.el|\.fc)\d\d?', kwargs['package']):
                 kwargs['builds'] = kwargs['package']
-            elif re.search(r'FEDORA-(EPEL)?-\d{4,4}', kwargs['package']):
+            elif re.search(r'FEDORA-(EPEL-)?\d{4,4}', kwargs['package']):
                 kwargs['updateid'] = kwargs['package']
             else:
                 kwargs['packages'] = kwargs['package']

--- a/bodhi/tests/client/test_bindings.py
+++ b/bodhi/tests/client/test_bindings.py
@@ -14,6 +14,7 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 """This module contains tests for bodhi.client.bindings."""
+from datetime import datetime, timedelta
 import copy
 import unittest
 
@@ -22,6 +23,435 @@ import mock
 
 from bodhi.client import bindings
 from bodhi.tests import client as client_test_data
+
+
+class TestBodhiClient___init__(unittest.TestCase):
+    """
+    This class contains tests for the BodhiClient.__init__() method.
+    """
+    def test_staging_false(self):
+        """
+        Test with staging set to False.
+        """
+        client = bindings.BodhiClient(base_url='http://example.com/bodhi/', username='some_user',
+                                      password='s3kr3t', staging=False, timeout=60)
+
+        self.assertEqual(client.base_url, 'http://example.com/bodhi/')
+        self.assertEqual(client.login_url, 'http://example.com/bodhi/login')
+        self.assertEqual(client.username, 'some_user')
+        self.assertEqual(client.timeout, 60)
+        self.assertEqual(client._password, 's3kr3t')
+        self.assertEqual(client.csrf_token, None)
+
+    def test_staging_true(self):
+        """
+        Test with staging set to True.
+        """
+        client = bindings.BodhiClient(base_url='http://example.com/bodhi/', username='some_user',
+                                      password='s3kr3t', staging=True, retries=5)
+
+        self.assertEqual(client.base_url, bindings.STG_BASE_URL)
+        self.assertEqual(client.login_url, bindings.STG_BASE_URL + 'login')
+        self.assertEqual(client.username, 'some_user')
+        self.assertEqual(client.timeout, None)
+        self.assertEqual(client.retries, 5)
+        self.assertEqual(client._password, 's3kr3t')
+        self.assertEqual(client.csrf_token, None)
+
+
+class TestBodhiClient_comment(unittest.TestCase):
+    """
+    Test the BodhiClient.comment() method.
+    """
+    def test_comment(self):
+        """
+        Test the comment() method.
+        """
+        client = bindings.BodhiClient()
+        client.csrf_token = 'a token'
+        client.send_request = mock.MagicMock(return_value='response')
+
+        response = client.comment('bodhi-2.4.0-1.fc25', 'It ate my cat!', karma=-1, email=True)
+
+        self.assertEqual(response, 'response')
+        client.send_request.assert_called_once_with(
+            'comments/', verb='POST', auth=True,
+            data={'update': 'bodhi-2.4.0-1.fc25', 'text': 'It ate my cat!', 'karma': -1,
+                  'email': True, 'csrf_token': 'a token'})
+
+
+class TestBodhiClient_csrf(unittest.TestCase):
+    """
+    Test the BodhiClient.csrf() method.
+    """
+    def test_with_csrf_token(self):
+        """
+        Test the method when csrf_token is set.
+        """
+        client = bindings.BodhiClient()
+        client.csrf_token = 'a token'
+        client.send_request = mock.MagicMock(return_value='response')
+
+        csrf = client.csrf()
+
+        self.assertEqual(csrf, 'a token')
+        self.assertEqual(client.send_request.call_count, 0)
+
+    def test_without_csrf_token_with_cookies(self):
+        """
+        Test the method when csrf_token is not set and has_cookies() returns True.
+        """
+        client = bindings.BodhiClient()
+        client.has_cookies = mock.MagicMock(return_value=True)
+        client.login = mock.MagicMock(return_value='login successful')
+        client.send_request = mock.MagicMock(return_value={'csrf_token': 'a great token'})
+
+        csrf = client.csrf()
+
+        self.assertEqual(csrf, 'a great token')
+        self.assertEqual(client.csrf_token, 'a great token')
+        client.has_cookies.assert_called_once_with()
+        self.assertEqual(client.login.call_count, 0)
+        client.send_request.assert_called_once_with('csrf', verb='GET', auth=True)
+
+    def test_without_csrf_token_without_cookies(self):
+        """
+        Test the method when csrf_token is not set and has_cookies() returns False.
+        """
+        client = bindings.BodhiClient(username='bowlofeggs', password='illnevertell')
+        client.has_cookies = mock.MagicMock(return_value=False)
+        client.login = mock.MagicMock(return_value='login successful')
+        client.send_request = mock.MagicMock(return_value={'csrf_token': 'a great token'})
+
+        csrf = client.csrf()
+
+        self.assertEqual(csrf, 'a great token')
+        self.assertEqual(client.csrf_token, 'a great token')
+        client.has_cookies.assert_called_once_with()
+        client.login.assert_called_once_with('bowlofeggs', 'illnevertell')
+        client.send_request.assert_called_once_with('csrf', verb='GET', auth=True)
+
+
+class TestBodhiClient_latest_builds(unittest.TestCase):
+    """
+    Test the BodhiClient.latest_builds() method.
+    """
+    def test_latest_builds(self):
+        """
+        Test latest_builds().
+        """
+        client = bindings.BodhiClient()
+        client.send_request = mock.MagicMock(return_value='bodhi-2.4.0-1.fc25')
+
+        latest_builds = client.latest_builds('bodhi')
+
+        self.assertEqual(latest_builds, 'bodhi-2.4.0-1.fc25')
+        client.send_request.assert_called_once_with('latest_builds', params={'package': 'bodhi'})
+
+
+class TestBodhiClient_list_overrides(unittest.TestCase):
+    """
+    Test the BodhiClient.list_overrides() method.
+    """
+    def test_with_user(self):
+        """
+        Test with the user parameter.
+        """
+        client = bindings.BodhiClient()
+        client.send_request = mock.MagicMock(return_value='response')
+
+        response = client.list_overrides(user='bowlofeggs')
+
+        self.assertEqual(response, 'response')
+        client.send_request.assert_called_once_with('overrides/', verb='GET',
+                                                    params={'user': 'bowlofeggs'})
+
+    def test_without_user(self):
+        """
+        Test without the user parameter.
+        """
+        client = bindings.BodhiClient()
+        client.send_request = mock.MagicMock(return_value='response')
+
+        response = client.list_overrides()
+
+        self.assertEqual(response, 'response')
+        client.send_request.assert_called_once_with('overrides/', verb='GET', params={})
+
+
+class TestBodhiClient_override_str(unittest.TestCase):
+    """
+    Test the BodhiClient.override_str() method.
+    """
+    def test_with_dict(self):
+        """
+        Test override_str() with a dict argument.
+        """
+        override = {
+            'submitter': {'name': 'bowlofeggs'}, 'build': {'nvr': 'python-pyramid-1.5.6-3.el7'},
+            'expiration_date': '2017-02-24'}
+
+        override = bindings.BodhiClient.override_str(override)
+
+        self.assertEqual(override,
+                         "bowlofeggs's python-pyramid-1.5.6-3.el7 override (expires 2017-02-24)")
+
+    def test_with_str(self):
+        """
+        Test override_str() with a str argument.
+        """
+        override = bindings.BodhiClient.override_str('this is an override')
+
+        self.assertEqual(override, 'this is an override')
+
+
+class TestBodhiClient_password(unittest.TestCase):
+    """
+    This class contains tests for the BodhiClient.password property.
+    """
+    @mock.patch('bodhi.client.bindings.getpass.getpass', return_value='typed password')
+    def test_password_not_set(self, getpass):
+        """
+        Assert correct behavior when the _password attribute is not set.
+        """
+        client = bindings.BodhiClient()
+
+        self.assertEqual(client.password, 'typed password')
+
+        getpass.assert_called_once_with()
+
+    @mock.patch('bodhi.client.bindings.getpass.getpass', return_value='typed password')
+    def test_password_set(self, getpass):
+        """
+        Assert correct behavior when the _password attribute is set.
+        """
+        client = bindings.BodhiClient(password='arg password')
+
+        self.assertEqual(client.password, 'arg password')
+
+        self.assertEqual(getpass.call_count, 0)
+
+
+class TestBodhiClient_query(unittest.TestCase):
+    """
+    Test BodhiClient.query().
+    """
+    def test_with_bugs_empty_string(self):
+        """
+        Test with the bugs kwargs set to an empty string.
+        """
+        client = bindings.BodhiClient()
+        client.send_request = mock.MagicMock(return_value='return_value')
+
+        result = client.query(builds='bodhi-2.4.0-1.fc26', bugs='')
+
+        self.assertEqual(result, 'return_value')
+        client.send_request.assert_called_once_with(
+            'updates/', verb='GET', params={'builds': 'bodhi-2.4.0-1.fc26', 'bugs': None})
+
+    def test_with_limit(self):
+        """
+        Assert that the limit kwargs gets translated to rows_per_page correctly.
+        """
+        client = bindings.BodhiClient()
+        client.send_request = mock.MagicMock(return_value='return_value')
+
+        result = client.query(builds='bodhi-2.4.0-1.fc26', limit=50)
+
+        self.assertEqual(result, 'return_value')
+        client.send_request.assert_called_once_with(
+            'updates/', verb='GET', params={'builds': 'bodhi-2.4.0-1.fc26', 'rows_per_page': 50})
+
+    def test_with_mine_false(self):
+        """
+        Assert correct behavior when the mine kwargs is False.
+        """
+        client = bindings.BodhiClient()
+        client.send_request = mock.MagicMock(return_value='return_value')
+
+        result = client.query(builds='bodhi-2.4.0-1.fc26', mine=False)
+
+        self.assertEqual(result, 'return_value')
+        client.send_request.assert_called_once_with(
+            'updates/', verb='GET', params={'builds': 'bodhi-2.4.0-1.fc26', 'mine': False})
+
+    def test_with_mine_true(self):
+        """
+        Assert correct behavior when the mine kwargs is True.
+        """
+        client = bindings.BodhiClient()
+        client.send_request = mock.MagicMock(return_value='return_value')
+        client.username = 'bowlofeggs'
+
+        result = client.query(builds='bodhi-2.4.0-1.fc26', mine=True)
+
+        self.assertEqual(result, 'return_value')
+        client.send_request.assert_called_once_with(
+            'updates/', verb='GET',
+            params={'builds': 'bodhi-2.4.0-1.fc26', 'mine': True, 'user': 'bowlofeggs'})
+
+    def test_with_package_el_build(self):
+        """
+        Test with the package arg expressed as an el7 build.
+        """
+        client = bindings.BodhiClient()
+        client.send_request = mock.MagicMock(return_value='return_value')
+
+        result = client.query(package='bodhi-2.4.0-1.el7')
+
+        self.assertEqual(result, 'return_value')
+        client.send_request.assert_called_once_with(
+            'updates/', verb='GET', params={'builds': 'bodhi-2.4.0-1.el7'})
+
+    def test_with_package_epel_id(self):
+        """
+        Test with the package arg expressed as a EPEL update id.
+        """
+        client = bindings.BodhiClient()
+        client.send_request = mock.MagicMock(return_value='return_value')
+
+        result = client.query(package='FEDORA-EPEL-2017-c3b112eb9e')
+
+        self.assertEqual(result, 'return_value')
+        client.send_request.assert_called_once_with(
+            'updates/', verb='GET', params={'updateid': 'FEDORA-EPEL-2017-c3b112eb9e'})
+
+    def test_with_package_fc_build(self):
+        """
+        Test with the package arg expressed as a fc26 build.
+        """
+        client = bindings.BodhiClient()
+        client.send_request = mock.MagicMock(return_value='return_value')
+
+        result = client.query(package='bodhi-2.4.0-1.fc26')
+
+        self.assertEqual(result, 'return_value')
+        client.send_request.assert_called_once_with(
+            'updates/', verb='GET', params={'builds': 'bodhi-2.4.0-1.fc26'})
+
+    def test_with_package_fedora_id(self):
+        """
+        Test with the package arg expressed as a Fedora update id.
+        """
+        client = bindings.BodhiClient()
+        client.send_request = mock.MagicMock(return_value='return_value')
+
+        result = client.query(package='FEDORA-2017-52506b30d4')
+
+        self.assertEqual(result, 'return_value')
+        client.send_request.assert_called_once_with(
+            'updates/', verb='GET', params={'updateid': 'FEDORA-2017-52506b30d4'})
+
+    def test_with_package_name(self):
+        """
+        Test with the package arg expressed as a package name.
+        """
+        client = bindings.BodhiClient()
+        client.send_request = mock.MagicMock(return_value='return_value')
+
+        result = client.query(package='bodhi')
+
+        self.assertEqual(result, 'return_value')
+        client.send_request.assert_called_once_with(
+            'updates/', verb='GET', params={'packages': 'bodhi'})
+
+    def test_with_release(self):
+        """
+        Test with a 'release' kwarg.
+        """
+        client = bindings.BodhiClient()
+        client.send_request = mock.MagicMock(return_value='return_value')
+
+        result = client.query(packages='bodhi', release='f26')
+
+        self.assertEqual(result, 'return_value')
+        client.send_request.assert_called_once_with(
+            'updates/', verb='GET', params={'packages': 'bodhi', 'releases': 'f26'})
+
+    def test_with_type_(self):
+        """
+        Test with the type_ kwarg.
+        """
+        client = bindings.BodhiClient()
+        client.send_request = mock.MagicMock(return_value='return_value')
+
+        result = client.query(packages='bodhi', type_='security')
+
+        self.assertEqual(result, 'return_value')
+        client.send_request.assert_called_once_with(
+            'updates/', verb='GET', params={'packages': 'bodhi', 'type': 'security'})
+
+
+class TestBodhiClient_save(unittest.TestCase):
+    """
+    This class contains tests for BodhiClient.save().
+    """
+    def test_with_type_(self):
+        """
+        Assert that save() handles type_ as a kwargs for backwards compatibility.
+        """
+        client = bindings.BodhiClient()
+        client.send_request = mock.MagicMock(return_value='return_value')
+        client.csrf_token = 'a token'
+        kwargs = {
+            'builds': ['bodhi-2.4.0-1.fc26'], 'type_': 'enhancement', 'notes': 'This is a test',
+            'request': 'testing', 'autokarma': True, 'stable_karma': 3, 'unstable_karma': -3,
+            'severity': 'low'}
+
+        response = client.save(**kwargs)
+
+        self.assertEqual(response, 'return_value')
+        kwargs['type'] = kwargs['type_']
+        kwargs['csrf_token'] = 'a token'
+        client.send_request.assert_called_once_with('updates/', verb='POST', auth=True, data=kwargs)
+
+    def test_without_type_(self):
+        """
+        Assert correct operation when type_ isn't given.
+        """
+        client = bindings.BodhiClient()
+        client.send_request = mock.MagicMock(return_value='return_value')
+        client.csrf_token = 'a token'
+        kwargs = {
+            'builds': ['bodhi-2.4.0-1.fc26'], 'type': 'enhancement', 'notes': 'This is a test',
+            'request': 'testing', 'autokarma': True, 'stable_karma': 3, 'unstable_karma': -3,
+            'severity': 'low'}
+
+        response = client.save(**kwargs)
+
+        self.assertEqual(response, 'return_value')
+        kwargs['csrf_token'] = 'a token'
+        client.send_request.assert_called_once_with('updates/', verb='POST', auth=True, data=kwargs)
+
+
+class TestBodhiClient_save_override(unittest.TestCase):
+    """
+    This class contains tests for BodhiClient.save_override().
+    """
+    def test_save_override(self):
+        """
+        Test the save_override() method.
+        """
+        client = bindings.BodhiClient()
+        client.send_request = mock.MagicMock(return_value='return_value')
+        client.csrf_token = 'a token'
+        now = datetime.utcnow()
+
+        response = client.save_override('python-pyramid-1.5.6-3.el7', 2,
+                                        'This is needed to build bodhi-2.4.0.')
+
+        self.assertEqual(response, 'return_value')
+        actual_expiration = client.send_request.mock_calls[0][2]['data']['expiration_date']
+        client.send_request.assert_called_once_with(
+            'overrides/', verb='POST', auth=True,
+            data={'nvr': 'python-pyramid-1.5.6-3.el7',
+                  'expiration_date': actual_expiration,
+                  'notes': 'This is needed to build bodhi-2.4.0.', 'csrf_token': 'a token'})
+        # Since we can't mock utcnow() since it's a C extension, let's just make sure the expiration
+        # date sent is within 5 minutes of the now variable. It would be surprising if it took more
+        # than 5 minutes to start the function and execute its first instruction!
+        expected_expiration = now + timedelta(days=2)
+        self.assertTrue((actual_expiration - expected_expiration) < timedelta(minutes=5))
 
 
 class TestBodhiClient_Resource(unittest.TestCase):
@@ -137,6 +567,59 @@ class TestBodhiClient_update_str(unittest.TestCase):
         self.assertEqual(text, expected_output)
 
 
+class TestErrorhandled(unittest.TestCase):
+    """
+    This class tests the errorhandled decorator.
+    """
+    def test_failure_with_given_errors(self):
+        """
+        Test the failure case for when errors were given in the response.
+        """
+        @bindings.errorhandled
+        def im_gonna_fail_but_ill_be_cool_about_it(x, y, z=None):
+            self.assertEqual(x, 1)
+            self.assertEqual(y, 2)
+            self.assertEqual(z, 3)
+
+            return {'errors': [{'description': 'insert'}, {'description': 'coin(s)'}]}
+
+        with self.assertRaises(bindings.BodhiClientException) as exc:
+            im_gonna_fail_but_ill_be_cool_about_it(1, y=2, z=3)
+
+        self.assertEqual(exc.exception.message, 'insert\ncoin(s)')
+
+    def test_success(self):
+        """
+        Test the decorator for the success case.
+        """
+        @bindings.errorhandled
+        def im_gonna_be_cool(x, y, z=None):
+            self.assertEqual(x, 1)
+            self.assertEqual(y, 2)
+            self.assertEqual(z, 3)
+
+            return 'here you go'
+
+        self.assertEqual(im_gonna_be_cool(1, 2, 3), 'here you go')
+
+    def test_unexpected_error(self):
+        """
+        Test the failure case when errors are not given in the response.
+        """
+        @bindings.errorhandled
+        def im_gonna_fail_and_i_wont_be_cool_about_it(x, y, z=None):
+            self.assertEqual(x, 1)
+            self.assertEqual(y, 2)
+            self.assertEqual(z, 3)
+
+            return {'errors': ['MEAN ERROR']}
+
+        with self.assertRaises(bindings.BodhiClientException) as exc:
+            im_gonna_fail_and_i_wont_be_cool_about_it(1, 2, z=3)
+
+        self.assertEqual(exc.exception.message, 'An unhandled error occurred in the BodhiClient')
+
+
 class TestUpdateNotFound(unittest.TestCase):
     """
     This class tests the UpdateNotFound class.
@@ -158,3 +641,4 @@ class TestUpdateNotFound(unittest.TestCase):
 
         self.assertEqual(unicode(exc.update), u'bodhi-2.2.4-1.el7')
         self.assertEqual(type(unicode(exc.update)), unicode)
+        self.assertEqual(unicode(exc), 'Update not found: bodhi-2.2.4-1.el7')

--- a/bodhi/tests/client/test_bindings.py
+++ b/bodhi/tests/client/test_bindings.py
@@ -355,9 +355,22 @@ class TestBodhiClient_query(unittest.TestCase):
         client.send_request.assert_called_once_with(
             'updates/', verb='GET', params={'packages': 'bodhi'})
 
-    def test_with_release(self):
+    def test_with_release_list(self):
         """
-        Test with a 'release' kwarg.
+        Test with a 'release' kwarg set to a list.
+        """
+        client = bindings.BodhiClient()
+        client.send_request = mock.MagicMock(return_value='return_value')
+
+        result = client.query(packages='bodhi', release=['f27'])
+
+        self.assertEqual(result, 'return_value')
+        client.send_request.assert_called_once_with(
+            'updates/', verb='GET', params={'packages': 'bodhi', 'releases': ['f27']})
+
+    def test_with_release_str(self):
+        """
+        Test with a 'release' kwarg set to a str.
         """
         client = bindings.BodhiClient()
         client.send_request = mock.MagicMock(return_value='return_value')
@@ -366,7 +379,7 @@ class TestBodhiClient_query(unittest.TestCase):
 
         self.assertEqual(result, 'return_value')
         client.send_request.assert_called_once_with(
-            'updates/', verb='GET', params={'packages': 'bodhi', 'releases': 'f26'})
+            'updates/', verb='GET', params={'packages': 'bodhi', 'releases': ['f26']})
 
     def test_with_type_(self):
         """

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,7 +2,7 @@
 cover-erase=TRUE
 cover-html=TRUE
 cover-inclusive=TRUE
-cover-min-percentage=81
+cover-min-percentage=82
 cover-package=bodhi
 cover-xml=TRUE
 with-coverage=TRUE


### PR DESCRIPTION
This pull request contains 6 commits. The first 4 commits fix various problems discovered while testing ```bodhi.client.bindings```, the 5th commit adds many tests for the bindings, and the last commit requires test coverage to remain at 82%.