### PR TITLE
Correctly calculate how many days to stable an Update has.

### DIFF
--- a/bodhi/server/models.py
+++ b/bodhi/server/models.py
@@ -1970,13 +1970,17 @@ class Update(Base):
 
     @property
     def days_to_stable(self):
-        """ Return the number of days until an update can be pushed to stable """
-        if self.meets_testing_requirements:
+        """Return the number of days until an update can be pushed to stable.
+
+        This method will return the number of days until an update can be pushed to stable, or 0.
+        0 is returned if the update meets testing requirements already, if it doesn't have a
+        "truthy" date_testing attribute, or if it's been in testing for the release's
+        mandatory_days_in_testing or longer."""
+        if not self.meets_testing_requirements and self.date_testing:
             return (
                 self.release.mandatory_days_in_testing -
                 (datetime.utcnow() - self.date_testing).days)
-        else:
-            return 0
+        return 0
 
     @property
     def days_in_testing(self):

--- a/bodhi/server/templates/update.html
+++ b/bodhi/server/templates/update.html
@@ -499,7 +499,7 @@ $(document).ready(function(){
       % if update.days_to_stable and update.status.description == 'testing':
       <tr>
         <td>Days to Stable</td>
-        <td>${str(update.days_to_stable).strip('-')}</td>
+        <td>${str(update.days_to_stable)}</td>
       </tr>
       % endif
 


### PR DESCRIPTION
The Update.days_to_stable() property only calculated the number of
days to stable for updates that were already eligible to go to
stable, in which case it returned negative values only. This commit
reworks the function so that it correctly returns the number of
days until an update can be pushed to stable, or 0 if the update
can already be pushed to stable.

fixes #1305

Signed-off-by: Randy Barlow <randy@electronsweatshop.com>