### PR TITLE
masher should clean up old mashes at the end of every run

### DIFF
--- a/bodhi/server/consumers/masher.py
+++ b/bodhi/server/consumers/masher.py
@@ -43,6 +43,7 @@ from bodhi.server.metadata import ExtendedMetadata
 from bodhi.server.models import (Update, UpdateRequest, UpdateType, Release,
                                  UpdateStatus, ReleaseState, Base)
 from bodhi.server.util import sorted_updates, sanity_check_repodata, transactional_session_maker
+from bodhi.server.scripts.clean_old_mashes import clean_up
 
 
 def checkpoint(method):
@@ -365,6 +366,7 @@ class MasherThread(threading.Thread):
 
             self.check_all_karma_thresholds()
             self.obsolete_older_updates()
+            self.clean_up()
 
         except:
             self.log.exception('Exception in MasherThread(%s)' % self.id)
@@ -973,6 +975,9 @@ class MasherThread(threading.Thread):
             raise ValueError("Could not find %s in the config file" % key)
 
         return master_repomd % (self.release.version, arch)
+
+    def clean_up(self):
+        pass
 
 
 class MashThread(threading.Thread):

--- a/bodhi/tests/server/consumers/test_masher.py
+++ b/bodhi/tests/server/consumers/test_masher.py
@@ -155,6 +155,10 @@ class TestMasher(unittest.TestCase):
 
         set_bugtracker.assert_called_once_with()
 
+    @mock.patch('bodhi.server.scripts.clean_old_mashes.NUM_TO_KEEP', 2)
+    def test_clean_up(self, clean_up):
+        self.assertEquals(len(clean_up.call_args_list), 1)
+
     @mock.patch('bodhi.server.notifications.publish')
     def test_invalid_signature(self, publish):
         """Make sure the masher ignores messages that aren't signed with the

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -33,6 +33,8 @@ Bugs
   (`#1351 <https://github.com/fedora-infra/bodhi/issues/1351>`_).
 * Initialize the bugtracker in ``main()`` instead of on import so that docs can be built without
   installing Bodhi (`#1359 <https://github.com/fedora-infra/bodhi/pulls/1359>`_).
+* Masher cleans up the old mashes at the end of every run
+  (`#1304 <https://github.com/fedora-infra/bodhi/issues/1304>`_).
 
 
 
@@ -56,6 +58,7 @@ The following contributors submitted patches for REPLACE THIS WITH A VERSION BEF
 * Ryan Lerch
 * Bianca Nenciu
 * Randy Barlow
+* Ankit Raj Ojha
 
 
 2.5.0


### PR DESCRIPTION
fixes #https://github.com/fedora-infra/bodhi/issues/1304