### PR TITLE
Make the new Bodhi comment be a constant and fix a typo in it.

### DIFF
--- a/bodhi/server/models.py
+++ b/bodhi/server/models.py
@@ -58,6 +58,11 @@ from bodhi.server.bugs import bugtracker
 from bodhi.server.util import transactional_session_maker
 
 
+DEFAULT_DISABLE_AUTOPUSH_MESSAGE = (
+    u'Bodhi is disabling automatic push to stable due to negative karma. '
+    u'The maintainer may push manually if they determine that the issue is not severe.')
+
+
 try:
     import rpm
 except ImportError:
@@ -1834,10 +1839,8 @@ class Update(Base):
         if self.autokarma and self._composite_karma[1] != 0:
             log.info("Disabling Auto Push since the update has received negative karma")
             self.autokarma = False
-            default_comment = (
-                u'Bodhi is disabling automatic push to stable due to negative karma. '
-                u'The maintainer may manually if they determine that the issue is not severe.')
-            text = unicode(config.get('disable_automatic_push_to_stable', default_comment))
+            text = unicode(config.get(
+                'disable_automatic_push_to_stable', DEFAULT_DISABLE_AUTOPUSH_MESSAGE))
             self.comment(db, text, author=u'bodhi')
         elif self.stable_karma and self.karma >= self.stable_karma:
             if self.autokarma:

--- a/bodhi/tests/server/services/test_updates.py
+++ b/bodhi/tests/server/services/test_updates.py
@@ -27,8 +27,9 @@ import mock
 
 from bodhi.server import main
 from bodhi.server.config import config
-from bodhi.server.models import (Build, BuildrootOverride, Group, Package, Release, ReleaseState,
-                                 Update, UpdateRequest, UpdateStatus, UpdateType, User)
+from bodhi.server.models import (
+    Build, BuildrootOverride, DEFAULT_DISABLE_AUTOPUSH_MESSAGE, Group, Package, Release,
+    ReleaseState, Update, UpdateRequest, UpdateStatus, UpdateType, User)
 import bodhi.tests.server.functional.base
 
 
@@ -3094,10 +3095,8 @@ class TestUpdatesService(bodhi.tests.server.functional.base.BaseWSGICase):
         up.comment(self.db, u'Failed to work', author=u'ralph', karma=-1)
         up = self.db.query(Update).filter_by(title=resp.json['title']).one()
 
-        default_comment = (
-            u'Bodhi is disabling automatic push to stable due to negative karma. '
-            u'The maintainer may manually if they determine that the issue is not severe.')
-        expected_comment = unicode(config.get('disable_automatic_push_to_stable', default_comment))
+        expected_comment = unicode(config.get(
+            'disable_automatic_push_to_stable', DEFAULT_DISABLE_AUTOPUSH_MESSAGE))
         self.assertEquals(up.comments[2].text, expected_comment)
 
         up.comment(self.db, u'LGTM Now', author=u'ralph', karma=1)

--- a/development.ini.example
+++ b/development.ini.example
@@ -26,7 +26,7 @@ stablekarma_comment = This update has reached the stable karma threshold and wil
 testing_approval_msg_based_on_karma = This update has reached the stable karma threshold and can be pushed to stable now if the maintainer wishes.
 not_yet_tested_msg_based_on_karma = This update has not reached stable karma threshold.
 
-disable_automatic_push_to_stable = Bodhi is disabling automatic push to stable due to negative karma. The maintainer may manually if they determine that the issue is not severe.
+disable_automatic_push_to_stable = Bodhi is disabling automatic push to stable due to negative karma. The maintainer may push manually if they determine that the issue is not severe.
 
 # Libravatar - If this is true libravatar will work as normal. Otherwise, all
 # libravatar links will be replaced with the string "libravatar.org" so that

--- a/production.ini
+++ b/production.ini
@@ -19,7 +19,7 @@ stablekarma_comment = This update has reached the stable karma threshold and wil
 testing_approval_msg_based_on_karma = This update has reached the stable karma threshold and can be pushed to stable now if the maintainer wishes.
 not_yet_tested_msg_based_on_karma = This update has not reached the stable karma threshold.
 
-disable_automatic_push_to_stable = Bodhi is disabling automatic push to stable due to negative karma. The maintainer may manually if they determine that the issue is not severe.
+disable_automatic_push_to_stable = Bodhi is disabling automatic push to stable due to negative karma. The maintainer may push manually if they determine that the issue is not severe.
 
 # Libravatar - If this is true libravatar will work as normal. Otherwise, all
 # libravatar links will be replaced with the string "libravatar.org" so that


### PR DESCRIPTION
This commit allows the test to import the default comment that
Bodhi uses when it disables autokarma, rather than duplicate the
default. It also corrects a typo in the comment.

Signed-off-by: Randy Barlow <randy@electronsweatshop.com>