### PR TITLE
Docs - Create role bodhi

### DIFF
--- a/docs/developer_docs.rst
+++ b/docs/developer_docs.rst
@@ -183,6 +183,7 @@ Import the bodhi2 database
 
     curl -O https://infrastructure.fedoraproject.org/infra/db-dumps/bodhi2.dump.xz
     sudo -u postgres createdb bodhi2
+    sudo -u postgres psql -c "create role bodhi2;"
     xzcat bodhi2.dump.xz | sudo -u postgres psql bodhi2
 
 .. note:: If you do not have a PostgreSQL server running, please see the


### PR DESCRIPTION
Avoid error when importing the database.
ERROR:  role "bodhi2" does not exist