### PR TITLE
Inject the repository root into the Python path for the docs build

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -92,7 +92,7 @@ pygments_style = 'sphinx'
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-html_theme = 'default'
+html_theme = 'alabaster'
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -11,12 +11,14 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 import datetime
+import os
+import sys
 
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
-# sys.path.insert(0, os.path.abspath('.'))
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../')))
 
 # -- General configuration -----------------------------------------------------
 


### PR DESCRIPTION
This lets Sphinx find and autodoc the Bodhi code.

While I was in the area, I switched Bodhi's theme to Alabaster since it's pretty (and the default for Sphinx now).