### PR TITLE
Add a requirements.txt and make setup.py use it

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,30 @@
+arrow
+bunch
+click
+colander
+cornice<2
+cryptography
+dogpile.cache
+fedmsg[consumers]
+fedmsg-atomic-composer >= 2016.3
+kitchen
+markdown
+packagedb-cli
+# for captchas
+Pillow
+progressbar
+pyDNS
+pylibravatar
+pyramid
+pyramid_fas_openid
+pyramid_mako
+pyramid_tm
+python-bugzilla
+python-fedora
+python-openid
+simplemediawiki
+sqlalchemy
+waitress
+webhelpers
+WebOb>=1.4.1
+zope.sqlalchemy


### PR DESCRIPTION
This makes it easy to install all the Bodhi server dependencies with
pip. This is particularly useful for RTD.

fixes #1320

Signed-off-by: Jeremy Cline <jeremy@jcline.org>