### PR TITLE
Introduce a new PEP-257 test and fix one module to comply.

### DIFF
--- a/bodhi/server/scripts/approve_testing.py
+++ b/bodhi/server/scripts/approve_testing.py
@@ -12,8 +12,10 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 """
-This script is responsible for commenting on updates after they reach the
-mandatory amount of time spent in the testing repository.
+This module generates the bodhi-approve-testing console script.
+
+Iis responsible for commenting on updates after they reach the mandatory amount of time spent in the
+testing repository.
 """
 
 import os
@@ -31,6 +33,12 @@ from ..config import config
 
 
 def usage(argv):
+    """
+    Print usage information and exit with code 1.
+
+    Args:
+        argv (list): The arguments that were passed to the CLI from sys.argv.
+    """
     cmd = os.path.basename(argv[0])
     print('usage: %s <config_uri>\n'
           '(example: "%s development.ini")' % (cmd, cmd))
@@ -38,6 +46,19 @@ def usage(argv):
 
 
 def main(argv=sys.argv):
+    """
+    Comment on updates that are eligible to be pushed to stable.
+
+    Queries for updates in the testing state that have a NULL request, looping over them looking for
+    updates that are eligible to be pushed to stable but haven't had comments from Bodhi to this
+    effect. For each such update it finds it will add a comment stating that the update may now be
+    pushed to stable.
+
+    This function is the entry point for the bodhi-approve-testing console script.
+
+    Args:
+        argv (list): A list of command line arguments. Defaults to sys.argv.
+    """
     if len(argv) != 2:
         usage(argv)
 

--- a/bodhi/tests/test_style.py
+++ b/bodhi/tests/test_style.py
@@ -35,3 +35,21 @@ class TestStyle(unittest.TestCase):
         flake8_command = ['flake8', '--max-line-length', '100', '--ignore=E712', REPO_PATH]
 
         self.assertEqual(subprocess.call(flake8_command), 0)
+
+    @unittest.skipUnless(os.path.exists('/usr/bin/pydocstyle'),
+                         'This test only runs if /usr/bin/pydocstyle exists.')
+    def test_code_with_pydocstyle(self):
+        """Enforce PEP-257 compliance on the codebase.
+
+        This test runs pydocstyle on a subset of the code. The bodhi code is currently undergoing a
+        change to bring all of the codebase into PEP-257 compliance, but the changes will be made
+        slowly. This test enforces only modules that have been corrected to comply with pydocstyle.
+        The goal is that this test would one day check the entire codebase.
+        """
+        enforced_paths = ['bodhi/server/scripts/approve_testing.py']
+
+        enforced_paths = [os.path.join(REPO_PATH, p) for p in enforced_paths]
+        pydocstyle_command = ['pydocstyle']
+        pydocstyle_command.extend(enforced_paths)
+
+        self.assertEqual(subprocess.call(pydocstyle_command), 0)

--- a/devel/ansible/roles/dev/tasks/main.yml
+++ b/devel/ansible/roles/dev/tasks/main.yml
@@ -71,6 +71,11 @@
   pip:
       name: pyramid_debugtoolbar
 
+# This isn't packaged in Fedora yet, but there is a package review open https://bugzilla.redhat.com/show_bug.cgi?id=1409654
+- name: pip install pydocstyle
+  pip:
+      name: pydocstyle
+
 - name: Install bodhi in developer mode
   command: python /home/vagrant/bodhi/setup.py develop
   args:


### PR DESCRIPTION
This commit introduces a new style test to check for PEP-257
compliance and converts bodhi.server.scripts.approve_testing to
comply.

Signed-off-by: Randy Barlow <randy@electronsweatshop.com>