### PR TITLE
Require test coverage to be at least 83%.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -2,7 +2,7 @@
 cover-erase=TRUE
 cover-html=TRUE
 cover-inclusive=TRUE
-cover-min-percentage=82
+cover-min-percentage=83
 cover-package=bodhi
 cover-xml=TRUE
 with-coverage=TRUE


### PR DESCRIPTION
The PR I wrote to have the masher support alternative architectures bumped the test coverage up by one more percent!

Signed-off-by: Randy Barlow <randy@electronsweatshop.com>