### PR TITLE
Add titles to the header icons in the Update page

### DIFF
--- a/bodhi/server/templates/update.html
+++ b/bodhi/server/templates/update.html
@@ -410,7 +410,7 @@ $(document).ready(function(){
         ${self.util.type2icon(update.type) | n}
       % endif
       % if update.critpath:
-      <span class="label label-danger"> <i class="fa fa-fire"></i></span>
+      <span data-toggle="tooltip" title="This update is in the critical path" class="label label-danger"> <i class="fa fa-fire"></i></span>
       % endif
 
       % if can_edit:

--- a/bodhi/server/util.py
+++ b/bodhi/server/util.py
@@ -437,7 +437,9 @@ def type2icon(context, kind):
         'enhancement': 'fa-bolt',
     }.get(kind)
 
-    return "<span class='label label-%s'><i class='fa %s'></i></span>" % (cls, fontawesome)
+    return "<span class='label label-%s' data-toggle='tooltip'\
+            title='This is a %s update'><i class='fa %s'></i></span> \
+            " % (cls, kind, fontawesome)
 
 
 def severity2html(context, severity):

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -1,5 +1,21 @@
 Release notes
 =============
+develop
+-------
+
+Features
+^^^^^^^^
+
+
+Bugs
+^^^^
+
+* The icons that we introduced in the new theme previously didn't have titles.
+  Consequently, a user might not have know what these icons meant. Now if a user
+  hovers over these icons, they get a description of what they mean, for
+  example: "This is a bugfix update" or "This update is in the critial path"
+  (`#1362 <https://github.com/fedora-infra/bodhi/issues/1362>`_).
+
 
 develop
 -------


### PR DESCRIPTION
Previously, the icons at the top of the Update page that provide glancable context for the update type and critial path status did not have titles. Consequently, if the user did not know what they meant, they were a little cryptic.

This change adds a title to each that explains the icon when the user hovers over them.

![bodhitopicons2](https://cloud.githubusercontent.com/assets/592259/24170987/730426f6-0ece-11e7-970f-007c13089cb6.png)
![bodhitopicons1](https://cloud.githubusercontent.com/assets/592259/24170988/73058b22-0ece-11e7-9e59-065f6b6e93a8.png)


Fixes: #1362