### PR TITLE
Restyle the footer

### DIFF
--- a/bodhi/server/templates/master.html
+++ b/bodhi/server/templates/master.html
@@ -187,16 +187,22 @@
 
     <div class="footer p-y-3">
       <div class="container">
-        <p class="text-muted text-center"> Running
-          <code>bodhi-${util.version()}</code> on
-          <code>${util.hostname()}</code>.
-        <a href="https://github.com/fedora-infra/bodhi">
-        bodhi<span class="glyphicon glyphicon-link"></span></a> is Free Software.
-        Please <a href="https://github.com/fedora-infra/bodhi/issues">
-        file issues<span class="glyphicon glyphicon-link"></span></a>
-        if you have any problems.  Copyright &copy; 2007-2017 Red Hat, Inc. and
-        <a href="https://github.com/fedora-infra/bodhi/graphs/contributors">
-        others<span class="glyphicon glyphicon-link"></span></a>.
+        <p class="text-muted text-xs-center">
+          Copyright &copy; 2007-2017 Red Hat, Inc. and
+          <a href="https://github.com/fedora-infra/bodhi/graphs/contributors">
+          others</a>.
+        </p>
+        <p class="text-muted text-xs-center">
+          Running
+          <strong>bodhi-${util.version()}</strong> on
+          <strong>${util.hostname()}</strong>.
+        </p>
+        <p class="text-muted text-xs-center">
+          <a href="https://github.com/fedora-infra/bodhi">
+          bodhi</a> is Free Software.
+          Please <a href="https://github.com/fedora-infra/bodhi/issues">
+          file issues</a>
+          if you have any problems.
         </p>
       </div>
     </div>


### PR DESCRIPTION
Previously, the footer use code tags to show the bodhi version name and hostname. This did not look so good with the new dark footer, so this change makes them bold.

Also, removed the old glyphicons that were not showing any more and re-organized the content a little.

### Before:
![footer-before](https://cloud.githubusercontent.com/assets/592259/24171607/e77d6ffe-0ed0-11e7-8a02-9d9f0b346c84.png)

### After:
![footer-after](https://cloud.githubusercontent.com/assets/592259/24171612/ec086fec-0ed0-11e7-8c09-8ac2ecca9d5c.png)
