### PR TITLE
make the html title and update description shorter for large updates

### DIFF
--- a/bodhi/server/templates/master.html
+++ b/bodhi/server/templates/master.html
@@ -19,11 +19,11 @@
     <link rel="shortcut icon" href="${request.static_url('bodhi:server/static/ico/favicon.ico')}">
 
     <base href="${request.registry.settings['base_address']}"/>
-    % if not update:
-        <title>Fedora Updates System</title>
-    % else:
-        <title>${update.title} - Fedora Updates System</title>
-    % endif
+    <title>
+      <%block name="pagetitle">
+      Fedora Updates System
+      </%block>
+    </title>
     <link href="${request.static_url('bodhi:server/static/fedora-bootstrap-1.0.1/fedora-bootstrap.css') }" rel="stylesheet" />
     <link href="${request.static_url('bodhi:server/static/fonts/open-sans.css') }" rel="stylesheet" />
     <link href="${request.static_url('bodhi:server/static/fonts/hack.css') }" rel="stylesheet" />

--- a/bodhi/server/templates/update.html
+++ b/bodhi/server/templates/update.html
@@ -2,6 +2,40 @@
 <%namespace name="captcha" module="bodhi.server.captcha"/>
 <%namespace name="json" module="json"/>
 
+<%def name="generateupdatetitlestring()">
+
+  % if len(update.builds) == 1:
+    % for build in update.builds:
+      ${self.util.packagename_from_nvr(build.nvr)}
+    % endfor
+  % elif len(update.builds) == 2:
+    % for build in update.builds:
+      % if loop.last:
+      and
+      % endif
+      ${self.util.packagename_from_nvr(build.nvr)}
+    % endfor
+  % elif len(update.builds) > 2:
+    % for build in update.builds:
+      % if loop.index == 0:
+      ${self.util.packagename_from_nvr(build.nvr)},
+      % elif loop.index == 1:
+      ${self.util.packagename_from_nvr(build.nvr)}
+      &amp; ${len(update.builds)-2} more
+      % endif
+    % endfor
+  % endif
+</%def>
+
+<%block name="pagetitle">
+% if update.alias:
+  ${update.alias}
+% endif
+&mdash;
+${update.type} update for ${generateupdatetitlestring()}
+&mdash; Fedora Updates System
+</%block>
+
 <link rel="alternate" type="application/atom+xml" title="New Comments on ${update.alias}" href="${request.route_url('comments_rss')}?updates=${update.alias}"/>
 
 <script type="text/javascript">
@@ -412,13 +446,11 @@ $(document).ready(function(){
       % endif
 
     </h1>
-    <h3>
-      ${update.type} update for
-      % for build in update.builds:
-        ${self.util.packagename_from_nvr(build.nvr)}
-      % endfor
+    <h4>
+      ${update.type} update
       in ${update.release.long_name}
-    </h3>
+      for ${generateupdatetitlestring()}
+    </h4>
     <div>
       Status: ${self.util.status2html(update.status) | n}
       % if 'pending' in update.status:


### PR DESCRIPTION
This adds the logic described in #1351 to format and truncate the html title and the subheader line if of updates with more than one build.

Some screenshots:

### 1 Build
![1-build](https://cloud.githubusercontent.com/assets/592259/24183025/31933ade-0f11-11e7-8a3e-60f3f313ff01.png)

### 2 Builds
![2-builds](https://cloud.githubusercontent.com/assets/592259/24183026/31939966-0f11-11e7-9bca-396ce7331cc0.png)

### 3 Builds
![3-builds](https://cloud.githubusercontent.com/assets/592259/24183028/3197e3fe-0f11-11e7-8b3b-ab31bafdd916.png)

### 5 Builds
![5-builds](https://cloud.githubusercontent.com/assets/592259/24183024/318fc106-0f11-11e7-9061-79c20403a4fe.png)

### 53 Builds
![53-builds](https://cloud.githubusercontent.com/assets/592259/24183027/3193ec72-0f11-11e7-9e9a-d5df0a489d2b.png)


Fixes: #957 #1351