### PR TITLE
Fix #1172. Show about 25 points on the X-axis.

### DIFF
--- a/bodhi/server/templates/release.html
+++ b/bodhi/server/templates/release.html
@@ -26,7 +26,15 @@
             % endfor
           ]
         }
-        var ctx = document.getElementById("releasechart").getContext("2d");
+        // About 25 labels should be printed at most.
+        let every_nth = Math.max(1, Math.round(data.labels.length / 25));
+        let every_filter = function(element, index) {
+            return index % every_nth == 0;
+        }
+        data.labels = data.labels.filter(every_filter);
+        for (let dataset of data.datasets) {
+            dataset.data = dataset.data.filter(every_filter);
+        }
         var myNewChart = new Chart(ctx).Line(data);
       </script>
       <table class="table">


### PR DESCRIPTION
Fixes #1172.

The ideal way would be using a newer version of Chart.js that has this functionality built-in. I did not want to break anything.

Basically, this fix filters data depending to show about 25 points. I chose the number of 25 empirically.

Signed-off-by: Bianca Nenciu <nenciu.bianca@gmail.com>