### PR TITLE
Document the USERNAME environment variable and clarify --user.

### DIFF
--- a/docs/man_pages/bodhi.rst
+++ b/docs/man_pages/bodhi.rst
@@ -39,7 +39,11 @@ Most of the commands will accept these options:
 
 ``--user <username>``
 
-    Many commands accept this flag to specify which user's updates should be operated upon.
+    Many commands accept this flag to specify a Fedora username to authenticate with. The
+    username can also be provided via the ``USERNAME`` environment variable. Note that some read
+    operations such as querying updates and overrides use this same flag, but as a search parameter
+    instead of authentication (as authentication is not required for these operations). Those
+    operations do not use the ``USERNAME`` environment variable.
 
 ``--version``
 


### PR DESCRIPTION
This commit documents the USERNAME environment variable in the
bodhi man page and clarifies that the --user flag is overloaded and
is sometimes used for authentication and other times is used as a
query parameter.

Signed-off-by: Randy Barlow <randy@electronsweatshop.com>