### PR TITLE
Turn the Package model into a single-table inheritance model

### DIFF
--- a/alembic/versions/fc6b0169c596_add_a_column_for_single_table_.py
+++ b/alembic/versions/fc6b0169c596_add_a_column_for_single_table_.py
@@ -17,8 +17,8 @@ down_revision = '4f2f825bcf4a'
 def upgrade():
     """Add the column used for polymorphic identity in Packages."""
     # The default of ``1`` is the RPM package type.
-    op.add_column('packages', sa.Column('type', sa.Integer(), nullable=False, default=1))
-    op.alter_column('packages', 'type', default=None)
+    op.add_column('packages', sa.Column('type', sa.Integer(), nullable=False, server_default=u'1'))
+    op.alter_column('packages', 'type', server_default=None)
 
 
 def downgrade():

--- a/alembic/versions/fc6b0169c596_add_a_column_for_single_table_.py
+++ b/alembic/versions/fc6b0169c596_add_a_column_for_single_table_.py
@@ -1,0 +1,26 @@
+"""
+Add a column for single-table inheritance to the packages table.
+
+Revision ID: fc6b0169c596
+Revises: 4f2f825bcf4a
+Create Date: 2017-03-31 16:40:07.136469
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = 'fc6b0169c596'
+down_revision = '4f2f825bcf4a'
+
+
+def upgrade():
+    """Add the column used for polymorphic identity in Packages."""
+    # The default of ``1`` is the RPM package type.
+    op.add_column('packages', sa.Column('type', sa.Integer(), nullable=False, default=1))
+    op.alter_column('packages', 'type', default=None)
+
+
+def downgrade():
+    """Remove the column used for polymorphic identity in Packages."""
+    op.drop_column('packages', 'type')

--- a/bodhi/server/models.py
+++ b/bodhi/server/models.py
@@ -483,12 +483,15 @@ class Package(Base):
 
     Attributes:
         name (unicode): A unicode string that uniquely identifies the package.
-        requirements (unicode): A unicode string that describes the requirements of a package.
+        requirements (unicode): A unicode string that lists space-separated taskotron test
+            results that must pass for this package
         type (int): The polymorphic identity column. This is used to identify what Python
             class to create when loading rows from the database.
-        builds (list): A list of :class:`Build` objects.
-        test_cases (list): A list of :class:`TestCase` objects.
-        committers (list): A list of :class:`User` objects who are committers.
+        builds (sqlalchemy.orm.collections.InstrumentedList): A list of :class:`Build` objects.
+        test_cases (sqlalchemy.orm.collections.InstrumentedList): A list of :class:`TestCase`
+            objects.
+        committers (sqlalchemy.orm.collections.InstrumentedList): A list of :class:`User` objects
+            who are committers.
         stack_id (int): A foreign key to the :class:`Stack`
     """
     __tablename__ = 'packages'

--- a/bodhi/server/services/builds.py
+++ b/bodhi/server/services/builds.py
@@ -18,7 +18,7 @@ from pyramid.exceptions import HTTPNotFound
 from sqlalchemy import func, distinct
 from sqlalchemy.sql import or_
 
-from bodhi.server.models import Update, Build, Package, Release
+from bodhi.server.models import Update, Build, RpmPackage, Release
 from bodhi.server.validators import validate_updates, validate_packages, validate_releases
 import bodhi.server.schemas
 import bodhi.server.security
@@ -68,7 +68,7 @@ def query_builds(request):
     packages = data.get('packages')
     if packages is not None:
         query = query.join(Build.package)
-        query = query.filter(or_(*[Package.id == p.id for p in packages]))
+        query = query.filter(or_(*[RpmPackage.id == p.id for p in packages]))
 
     releases = data.get('releases')
     if releases is not None:

--- a/bodhi/server/services/overrides.py
+++ b/bodhi/server/services/overrides.py
@@ -21,7 +21,7 @@ from sqlalchemy import func, distinct
 from sqlalchemy.sql import or_
 
 from bodhi.server import log
-from bodhi.server.models import Build, BuildrootOverride, Package, Release, User
+from bodhi.server.models import Build, BuildrootOverride, RpmPackage, Release, User
 import bodhi.server.schemas
 import bodhi.server.services.errors
 from bodhi.server.validators import (
@@ -111,7 +111,7 @@ def query_overrides(request):
     packages = data.get('packages')
     if packages is not None:
         query = query.join(BuildrootOverride.build).join(Build.package)
-        query = query.filter(or_(*[Package.name == pkg.name for pkg in packages]))
+        query = query.filter(or_(*[RpmPackage.name == pkg.name for pkg in packages]))
 
     releases = data.get('releases')
     if releases is not None:

--- a/bodhi/server/services/packages.py
+++ b/bodhi/server/services/packages.py
@@ -16,7 +16,7 @@ import math
 from cornice import Service
 from sqlalchemy import func, distinct
 
-from bodhi.server.models import Package
+from bodhi.server.models import RpmPackage
 import bodhi.server.schemas
 import bodhi.server.security
 import bodhi.server.services.errors
@@ -35,20 +35,20 @@ packages = Service(name='packages', path='/packages/',
 def query_packages(request):
     db = request.db
     data = request.validated
-    query = db.query(Package)
+    query = db.query(RpmPackage)
 
     name = data.get('name')
     if name is not None:
-        query = query.filter(Package.name == name)
+        query = query.filter(RpmPackage.name == name)
 
     like = data.get('like')
     if like is not None:
-        query = query.filter(Package.name.like('%%%s%%' % like))
+        query = query.filter(RpmPackage.name.like('%%%s%%' % like))
 
     # We can't use ``query.count()`` here because it is naive with respect to
     # all the joins that we're doing above.
     count_query = query.with_labels().statement\
-        .with_only_columns([func.count(distinct(Package.name))])\
+        .with_only_columns([func.count(distinct(RpmPackage.name))])\
         .order_by(None)
     total = db.execute(count_query).scalar()
 

--- a/bodhi/server/services/releases.py
+++ b/bodhi/server/services/releases.py
@@ -26,7 +26,7 @@ from bodhi.server.models import (
     UpdateType,
     Build,
     BuildrootOverride,
-    Package,
+    RpmPackage,
     Release,
 )
 from bodhi.server.validators import (
@@ -206,7 +206,7 @@ def query_releases_json(request):
     packages = data.get('packages')
     if packages is not None:
         query = query.join(Release.builds).join(Build.package)
-        query = query.filter(or_(*[Package.id == p.id for p in packages]))
+        query = query.filter(or_(*[RpmPackage.id == p.id for p in packages]))
 
     # We can't use ``query.count()`` here because it is naive with respect to
     # all the joins that we're doing above.

--- a/bodhi/server/services/stacks.py
+++ b/bodhi/server/services/stacks.py
@@ -22,7 +22,7 @@ from sqlalchemy import func, distinct
 from sqlalchemy.sql import or_
 
 from bodhi.server import log, notifications
-from bodhi.server.models import Package, Stack, Group, User
+from bodhi.server.models import RpmPackage, Stack, Group, User
 from bodhi.server.util import tokenize
 from bodhi.server.validators import validate_packages, validate_stack, validate_requirements
 import bodhi.server.schemas
@@ -75,8 +75,8 @@ def query_stacks(request):
 
     packages = data.get('packages')
     if packages:
-        query = query.join(Package.stack)
-        query = query.filter(or_(*[Package.name == pkg.name for pkg in packages]))
+        query = query.join(RpmPackage.stack)
+        query = query.filter(or_(*[RpmPackage.name == pkg.name for pkg in packages]))
 
     # We can't use ``query.count()`` here because it is naive with respect to
     # all the joins that we're doing above.
@@ -154,12 +154,12 @@ def save_stack(request):
     # We make a special case out of packages here, since when a package is
     # added to a stack, we want to give it the same requirements as the stack
     # has. See https://github.com/fedora-infra/bodhi/issues/101
-    new, same, rem = stack.update_relationship('packages', Package, data, db)
+    new, same, rem = stack.update_relationship('packages', RpmPackage, data, db)
     if stack.requirements:
         additional = list(tokenize(stack.requirements))
 
         for name in new:
-            package = Package.get(name, db)
+            package = RpmPackage.get(name, db)
             original = package.requirements
             original = [] if not original else list(tokenize(original))
             package.requirements = " ".join(list(set(original + additional)))

--- a/bodhi/server/services/updates.py
+++ b/bodhi/server/services/updates.py
@@ -22,7 +22,7 @@ import transaction
 
 from bodhi.server import log
 from bodhi.server.exceptions import BodhiException, LockedUpdateException
-from bodhi.server.models import Update, Build, Bug, CVE, Package, UpdateRequest, ReleaseState
+from bodhi.server.models import Update, Build, Bug, CVE, RpmPackage, UpdateRequest, ReleaseState
 import bodhi.server.schemas
 import bodhi.server.security
 import bodhi.server.services.errors
@@ -217,7 +217,7 @@ def query_updates(request):
     packages = data.get('packages')
     if packages is not None:
         query = query.join(Update.builds).join(Build.package)
-        query = query.filter(or_(*[Package.name == pkg for pkg in packages]))
+        query = query.filter(or_(*[RpmPackage.name == pkg for pkg in packages]))
 
     package = None
     if packages and len(packages):
@@ -349,11 +349,11 @@ def new_update(request):
         releases = set()
         builds = []
 
-        # Create the Package and Build entities
+        # Create the RpmPackage and Build entities
         for nvr in data['builds']:
             name, version, release = request.buildinfo[nvr]['nvr']
             # The package will have been created by validate_acls
-            package = request.db.query(Package).filter_by(name=name).one()
+            package = request.db.query(RpmPackage).filter_by(name=name).one()
 
             build = Build.get(nvr, request.db)
 

--- a/bodhi/server/services/user.py
+++ b/bodhi/server/services/user.py
@@ -18,7 +18,7 @@ from pyramid.exceptions import HTTPNotFound
 from sqlalchemy import func, distinct
 from sqlalchemy.sql import or_
 
-from bodhi.server.models import Group, Package, Update, User
+from bodhi.server.models import Group, RpmPackage, Update, User
 from bodhi.server.validators import validate_updates, validate_packages, validate_groups
 import bodhi.server.schemas
 import bodhi.server.security
@@ -122,7 +122,7 @@ def query_users(request):
     packages = data.get('packages')
     if packages is not None:
         query = query.join(User.packages)
-        query = query.filter(or_(*[Package.id == p.id for p in packages]))
+        query = query.filter(or_(*[RpmPackage.id == p.id for p in packages]))
 
     # We can't use ``query.count()`` here because it is naive with respect to
     # all the joins that we're doing above.

--- a/bodhi/server/validators.py
+++ b/bodhi/server/validators.py
@@ -24,7 +24,7 @@ import rpm
 
 from . import captcha
 from . import log
-from .models import (Release, Package, Build, Update, UpdateStatus,
+from .models import (Release, RpmPackage, Build, Update, UpdateStatus,
                      UpdateRequest, UpdateSeverity, UpdateType,
                      UpdateSuggestion, User, Group, Comment,
                      Bug, TestCase, ReleaseState, Stack)
@@ -261,11 +261,11 @@ def validate_acls(request):
 
             buildinfo = request.buildinfo[build]
 
-            # Get the Package object
+            # Get the RpmPackage object
             package_name = buildinfo['nvr'][0]
-            package = db.query(Package).filter_by(name=package_name).first()
+            package = db.query(RpmPackage).filter_by(name=package_name).first()
             if not package:
-                package = Package(name=package_name)
+                package = RpmPackage(name=package_name)
                 db.add(package)
                 db.flush()
 
@@ -420,7 +420,7 @@ def validate_packages(request):
     validated_packages = []
 
     for p in packages:
-        package = Package.get(p, db)
+        package = RpmPackage.get(p, db)
 
         if not package:
             bad_packages.append(p)
@@ -614,7 +614,7 @@ def validate_update_id(request):
     if update:
         request.validated['update'] = update
     else:
-        package = Package.get(request.matchdict['id'], request.db)
+        package = RpmPackage.get(request.matchdict['id'], request.db)
         if package:
             query = dict(packages=package.name)
             location = request.route_url('updates', _query=query)
@@ -821,9 +821,9 @@ def _validate_override_build(request, nvr, db):
             return
 
         pkgname, version, rel = get_nvr(nvr)
-        package = Package.get(pkgname, db)
+        package = RpmPackage.get(pkgname, db)
         if not package:
-            package = Package(name=pkgname)
+            package = RpmPackage(name=pkgname)
             db.add(package)
             db.flush()
 

--- a/bodhi/tests/server/__init__.py
+++ b/bodhi/tests/server/__init__.py
@@ -4,7 +4,7 @@ import mock
 import sqlalchemy
 
 from bodhi.server.models import (
-    Bug, Build, BuildrootOverride, Comment, CVE, Group, Package, Release, ReleaseState, Update,
+    Bug, Build, BuildrootOverride, Comment, CVE, Group, RpmPackage, Release, ReleaseState, Update,
     UpdateRequest, UpdateType, User, TestCase)
 
 
@@ -26,9 +26,9 @@ def create_update(session, build_nvrs, release_name=u'F17'):
     for nvr in build_nvrs:
         name, version, rel = nvr.rsplit('-', 2)
         try:
-            package = session.query(Package).filter_by(name=name).one()
+            package = session.query(RpmPackage).filter_by(name=name).one()
         except sqlalchemy.orm.exc.NoResultFound:
-            package = Package(name=name)
+            package = RpmPackage(name=name)
             session.add(package)
             user.packages.append(package)
             testcase = TestCase(name=u'Wat')

--- a/bodhi/tests/server/functional/test_overrides.py
+++ b/bodhi/tests/server/functional/test_overrides.py
@@ -16,7 +16,7 @@ from datetime import datetime, timedelta
 
 import mock
 
-from bodhi.server.models import Build, Package, Release, User
+from bodhi.server.models import Build, RpmPackage, Release, User
 import bodhi.tests.server.functional.base
 
 
@@ -89,7 +89,7 @@ class TestOverridesService(bodhi.tests.server.functional.base.BaseWSGICase):
         self.assertEquals(override['notes'], 'blah blah blah')
 
     def test_list_overrides_by_packages_without_override(self):
-        self.db.add(Package(name=u'python'))
+        self.db.add(RpmPackage(name=u'python'))
         self.db.flush()
 
         res = self.app.get('/overrides/', {'packages': 'python'})
@@ -181,7 +181,7 @@ class TestOverridesService(bodhi.tests.server.functional.base.BaseWSGICase):
     def test_create_override(self, publish):
         release = Release.get(u'F17', self.db)
 
-        package = Package(name=u'not-bodhi')
+        package = RpmPackage(name=u'not-bodhi')
         self.db.add(package)
         build = Build(nvr=u'not-bodhi-2.0-2.fc17', package=package,
                       release=release)
@@ -209,7 +209,7 @@ class TestOverridesService(bodhi.tests.server.functional.base.BaseWSGICase):
     @mock.patch('bodhi.server.notifications.publish')
     def test_create_duplicate_override(self, publish):
         release = Release.get(u'F17', self.db)
-        package = Package(name=u'not-bodhi')
+        package = RpmPackage(name=u'not-bodhi')
         self.db.add(package)
         build = Build(nvr=u'not-bodhi-2.0-2.fc17', package=package,
                       release=release)
@@ -242,14 +242,14 @@ class TestOverridesService(bodhi.tests.server.functional.base.BaseWSGICase):
     @mock.patch('bodhi.server.notifications.publish')
     def test_create_override_multiple_nvr(self, publish):
         release = Release.get(u'F17', self.db)
-        package = Package(name=u'not-bodhi')
+        package = RpmPackage(name=u'not-bodhi')
         self.db.add(package)
         build1 = Build(nvr=u'not-bodhi-2.0-2.fc17', package=package,
                        release=release)
         self.db.add(build1)
         self.db.flush()
 
-        package = Package(name=u'another-not-bodhi')
+        package = RpmPackage(name=u'another-not-bodhi')
         self.db.add(package)
         build2 = Build(nvr=u'another-not-bodhi-2.0-2.fc17', package=package,
                        release=release)
@@ -288,7 +288,7 @@ class TestOverridesService(bodhi.tests.server.functional.base.BaseWSGICase):
     def test_create_override_too_long(self, publish):
         release = Release.get(u'F17', self.db)
 
-        package = Package(name=u'not-bodhi')
+        package = RpmPackage(name=u'not-bodhi')
         self.db.add(package)
         build = Build(nvr=u'not-bodhi-2.0-2.fc17', package=package,
                       release=release)

--- a/bodhi/tests/server/functional/test_packages.py
+++ b/bodhi/tests/server/functional/test_packages.py
@@ -18,14 +18,14 @@
 import bodhi.tests.server.functional.base
 
 from bodhi.server.models import (
-    Package,
+    RpmPackage,
 )
 
 
-class TestPackagesService(bodhi.tests.server.functional.base.BaseWSGICase):
+class TestRpmPackagesService(bodhi.tests.server.functional.base.BaseWSGICase):
     def test_basic_json(self):
         """ Test querying with no arguments... """
-        self.db.add(Package(name=u'a_second_package'))
+        self.db.add(RpmPackage(name=u'a_second_package'))
         resp = self.app.get('/packages/')
         body = resp.json_body
         self.assertEquals(len(body['packages']), 2)
@@ -33,7 +33,7 @@ class TestPackagesService(bodhi.tests.server.functional.base.BaseWSGICase):
     def test_filter_by_name(self):
         """ Test that filtering by name returns one package and not the other.
         """
-        self.db.add(Package(name=u'a_second_package'))
+        self.db.add(RpmPackage(name=u'a_second_package'))
         resp = self.app.get('/packages/', dict(name='bodhi'))
         body = resp.json_body
         self.assertEquals(len(body['packages']), 1)
@@ -41,7 +41,7 @@ class TestPackagesService(bodhi.tests.server.functional.base.BaseWSGICase):
     def test_filter_by_like(self):
         """ Test that filtering by like returns one package and not the other.
         """
-        self.db.add(Package(name=u'a_second_package'))
+        self.db.add(RpmPackage(name=u'a_second_package'))
         resp = self.app.get('/packages/', dict(like='odh'))
         body = resp.json_body
         self.assertEquals(len(body['packages']), 1)

--- a/bodhi/tests/server/functional/test_stacks.py
+++ b/bodhi/tests/server/functional/test_stacks.py
@@ -14,7 +14,7 @@
 
 import mock
 
-from bodhi.server.models import Group, Package, Stack, User
+from bodhi.server.models import Group, RpmPackage, Stack, User
 import bodhi.tests.server.functional.base
 
 
@@ -28,7 +28,7 @@ class TestStacksService(bodhi.tests.server.functional.base.BaseWSGICase):
 
     def setUp(self):
         super(TestStacksService, self).setUp()
-        package = Package(name=u'gnome-shell')
+        package = RpmPackage(name=u'gnome-shell')
         self.db.add(package)
         self.db.flush()
         self.stack = stack = Stack(name=u'GNOME', packages=[package])
@@ -52,8 +52,8 @@ class TestStacksService(bodhi.tests.server.functional.base.BaseWSGICase):
 
     def test_list_stacks_with_pagination(self):
         # Create a second stack
-        pkg1 = Package(name=u'firefox')
-        pkg2 = Package(name=u'xulrunner')
+        pkg1 = RpmPackage(name=u'firefox')
+        pkg2 = RpmPackage(name=u'xulrunner')
         self.db.add(pkg1)
         self.db.add(pkg2)
         self.db.flush()
@@ -160,11 +160,11 @@ class TestStacksService(bodhi.tests.server.functional.base.BaseWSGICase):
         self.assertEquals(body['requirements'], 'upgradepath')
 
         # Adding gnome-music to the stack should change its requirements, too.
-        package = self.db.query(Package).filter(Package.name == u'gnome-music').one()
+        package = self.db.query(RpmPackage).filter(RpmPackage.name == u'gnome-music').one()
         self.assertEquals(package.requirements, attrs['requirements'])
 
         # But not gnome-shell, since it was already in the stack.
-        package = self.db.query(Package).filter(Package.name == u'gnome-shell').one()
+        package = self.db.query(RpmPackage).filter(RpmPackage.name == u'gnome-shell').one()
         self.assertEquals(package.requirements, None)
 
     def test_delete_stack(self):

--- a/bodhi/tests/server/services/test_updates.py
+++ b/bodhi/tests/server/services/test_updates.py
@@ -28,7 +28,7 @@ import mock
 from bodhi.server import main
 from bodhi.server.config import config
 from bodhi.server.models import (
-    Build, BuildrootOverride, DEFAULT_DISABLE_AUTOPUSH_MESSAGE, Group, Package, Release,
+    Build, BuildrootOverride, DEFAULT_DISABLE_AUTOPUSH_MESSAGE, Group, RpmPackage, Release,
     ReleaseState, Update, UpdateRequest, UpdateStatus, UpdateType, User)
 import bodhi.tests.server.functional.base
 
@@ -281,7 +281,7 @@ class TestNewUpdate(bodhi.tests.server.functional.base.BaseWSGICase):
     @mock.patch(**mock_valid_requirements)
     def test_new_update_with_existing_build(self, *args):
         """Test submitting a new update with a build already in the database"""
-        package = Package.get(u'bodhi', self.db)
+        package = RpmPackage.get(u'bodhi', self.db)
         self.db.add(Build(nvr=u'bodhi-2.0.0-3.fc17', package=package))
         self.db.flush()
 
@@ -293,7 +293,7 @@ class TestNewUpdate(bodhi.tests.server.functional.base.BaseWSGICase):
     @mock.patch(**mock_valid_requirements)
     def test_new_update_with_existing_package(self, *args):
         """Test submitting a new update with a package that is already in the database."""
-        package = Package(name=u'existing-package')
+        package = RpmPackage(name=u'existing-package')
         self.db.add(package)
         self.db.flush()
         args = self.get_update(u'existing-package-2.4.1-5.fc17')
@@ -301,7 +301,7 @@ class TestNewUpdate(bodhi.tests.server.functional.base.BaseWSGICase):
         resp = self.app.post_json('/updates/', args)
 
         eq_(resp.json['title'], 'existing-package-2.4.1-5.fc17')
-        package = self.db.query(Package).filter_by(name=u'existing-package').one()
+        package = self.db.query(RpmPackage).filter_by(name=u'existing-package').one()
         self.assertEqual(package.name, 'existing-package')
 
     @mock.patch(**mock_valid_requirements)
@@ -312,14 +312,14 @@ class TestNewUpdate(bodhi.tests.server.functional.base.BaseWSGICase):
         resp = self.app.post_json('/updates/', args)
 
         eq_(resp.json['title'], 'missing-package-2.4.1-5.fc17')
-        package = self.db.query(Package).filter_by(name=u'missing-package').one()
+        package = self.db.query(RpmPackage).filter_by(name=u'missing-package').one()
         self.assertEqual(package.name, 'missing-package')
 
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
     def test_cascade_package_requirements_to_update(self, publish, *args):
 
-        package = self.db.query(Package).filter_by(name=u'bodhi').one()
+        package = self.db.query(RpmPackage).filter_by(name=u'bodhi').one()
         package.requirements = u'upgradepath rpmlint'
         self.db.flush()
 
@@ -1763,7 +1763,7 @@ class TestUpdatesService(bodhi.tests.server.functional.base.BaseWSGICase):
             override_tag=u'f18-override',
             branch=u'f18')
         self.db.add(release)
-        pkg = Package(name=u'nethack')
+        pkg = RpmPackage(name=u'nethack')
         self.db.add(pkg)
 
         args = self.get_update('bodhi-2.0.0-2.fc17,nethack-4.0.0-1.fc18')
@@ -2495,7 +2495,7 @@ class TestUpdatesService(bodhi.tests.server.functional.base.BaseWSGICase):
             override_tag=u'f18-override',
             branch=u'f18')
         self.db.add(release)
-        pkg = Package(name=u'nethack')
+        pkg = RpmPackage(name=u'nethack')
         self.db.add(pkg)
 
         # A multi-release submission!!!  This should create *two* updates

--- a/bodhi/tests/server/test_metadata.py
+++ b/bodhi/tests/server/test_metadata.py
@@ -30,7 +30,7 @@ from bodhi.server import log
 from bodhi.server.buildsys import (setup_buildsystem, teardown_buildsystem,
                                    get_session, DevBuildsys)
 from bodhi.server.config import config
-from bodhi.server.models import (Package, Update, Build, Base, UpdateRequest, UpdateStatus,
+from bodhi.server.models import (RpmPackage, Update, Build, Base, UpdateRequest, UpdateStatus,
                                  UpdateType)
 from bodhi.server.metadata import ExtendedMetadata
 from bodhi.server.util import mkmetadatadir
@@ -434,7 +434,7 @@ class TestExtendedMetadata(unittest.TestCase):
 
         # Create a new non-security update for the same package
         newbuild = u'bodhi-2.0-2.fc17'
-        pkg = self.db.query(Package).filter_by(name=u'bodhi').one()
+        pkg = self.db.query(RpmPackage).filter_by(name=u'bodhi').one()
         build = Build(nvr=newbuild, package=pkg)
         self.db.add(build)
         self.db.flush()
@@ -501,7 +501,7 @@ class TestExtendedMetadata(unittest.TestCase):
 
         # Create a new non-security update for the same package
         newbuild = u'bodhi-2.0-2.fc17'
-        pkg = self.db.query(Package).filter_by(name=u'bodhi').one()
+        pkg = self.db.query(RpmPackage).filter_by(name=u'bodhi').one()
         build = Build(nvr=newbuild, package=pkg)
         self.db.add(build)
         self.db.flush()

--- a/bodhi/tests/server/test_push.py
+++ b/bodhi/tests/server/test_push.py
@@ -52,7 +52,7 @@ class TestFilterReleases(base.BaseTestCase):
         self.db.add(archived_release)
 
         # Let's add an obscure package called bodhi to the release.
-        pkg = self.db.query(models.Package).filter_by(name=u'bodhi').one()
+        pkg = self.db.query(models.RpmPackage).filter_by(name=u'bodhi').one()
         build = models.Build(nvr=u'bodhi-2.3.2-1.fc22', release=archived_release, package=pkg)
         self.db.add(build)
 
@@ -96,7 +96,7 @@ class TestFilterReleases(base.BaseTestCase):
         self.db.add(disabled_release)
         self.db.add(pending_release)
         # Let's add the bodhi package to both releases.
-        pkg = self.db.query(models.Package).filter_by(name=u'bodhi').one()
+        pkg = self.db.query(models.RpmPackage).filter_by(name=u'bodhi').one()
         disabled_build = models.Build(nvr=u'bodhi-2.3.2-1.fc21', release=disabled_release,
                                       package=pkg)
         pending_build = models.Build(nvr=u'bodhi-2.3.2-1.fc25', release=pending_release,


### PR DESCRIPTION
This turns the Package model into the parent class using single-table
inheritance that sub-classes can inherit from to create different
Package types. It includes a migration that sets the type of all
existing Packages to RpmPackage.

fixes #1392