### PR TITLE
Add update type icons to update list tables

### DIFF
--- a/bodhi/server/templates/fragments.html
+++ b/bodhi/server/templates/fragments.html
@@ -77,7 +77,7 @@
 </%def>
 
 <%def name="update(update, display_user=True, display_request=False, display_release=True, display_karma=True)">
-  <td class="stretch-table-column">${util.update2html(update) | n}</td>
+  <td class="stretch-table-column">${util.update2html(update) | n} ${util.type2icon(update['type'])|n} </td>
   <td class="nowrap">
     <span title="${update['date_submitted']} UTC">
       ${util.age(update['date_submitted'], True)}


### PR DESCRIPTION
In the new bodhi webinterface, we now use icons to signify
if the update is one of the 4 types -- security, newpackage,
bugfix or enhancement. This adds these icons to the lists of
updates that we render

![icons-in-update-page](https://cloud.githubusercontent.com/assets/592259/24645666/727d0d90-195c-11e7-8c98-c32a022c6c2d.png)
