### PR TITLE
Fix issue #1408  --notes-file

### DIFF
--- a/docs/man_pages/bodhi.rst
+++ b/docs/man_pages/bodhi.rst
@@ -185,6 +185,10 @@ The ``updates`` command allows users to interact with bodhi updates.
 
         The description of the update.
 
+    ``--notes-file <path>``
+
+        A path to a file containing a description of the update.
+
     ``--bugs <bugs>``
 
         A comma separated list of bugs to associate with this update.


### PR DESCRIPTION
The --notes-file parameter is now shared between the new and edit CLI commands. 