### PR TITLE
update the label colour for testing on table lists

### DIFF
--- a/bodhi/server/util.py
+++ b/bodhi/server/util.py
@@ -468,8 +468,8 @@ def request2html(context, request):
     request = unicode(request)
     cls = {
         'unpush': 'danger',
-        'obsolete': 'warning',
-        'testing': 'primary',
+        'obsolete': 'default',
+        'testing': 'warning',
         'stable': 'success',
     }.get(request)
 


### PR DESCRIPTION
previously, when displaying a list of updates in a table,
the if the request field was "testing", we used the bootstrap
class for success (blue) as the colour for the label. However,
elsewhere in bodhi when showing the testing label, we used the
yellow. This changes the colour of the label to the yellow on
table list views of updates.