### PR TITLE
Checks exit code of process to determine where stderr is logged.

### DIFF
--- a/bodhi/server/util.py
+++ b/bodhi/server/util.py
@@ -601,7 +601,10 @@ def cmd(cmd, cwd=None):
     if out:
         log.debug(out)
     if err:
-        log.error(err)
+        if p.returncode == 0:
+            log.debug(err)
+        else:
+            log.error(err)
     if p.returncode != 0:
         log.error('return code %s', p.returncode)
     return out, err, p.returncode

--- a/bodhi/tests/server/test_utils.py
+++ b/bodhi/tests/server/test_utils.py
@@ -12,6 +12,9 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
+import mock
+import unittest
+import subprocess
 from bodhi.server.buildsys import setup_buildsystem, teardown_buildsystem
 from bodhi.server.config import config
 from bodhi.server.util import (get_critpath_pkgs, get_nvr, markup,
@@ -70,3 +73,59 @@ class TestUtils(object):
         b1, b2 = sorted_builds([new, old])
         assert b1 == new, b1
         assert b2 == old, b2
+
+
+class TestCMDFunctions(unittest.TestCase):
+    @mock.patch('bodhi.server.log.debug')
+    @mock.patch('bodhi.server.log.error')
+    @mock.patch('subprocess.Popen')
+    def test_err_nonzero_return_code(self, mock_popen, mock_error, mock_debug):
+        """
+        Ensures proper behavior when there is err output and the exit code isn't 0.
+        See https://github.com/fedora-infra/bodhi/issues/1412
+        """
+        mock_popen.return_value = mock.Mock()
+        mock_popen_obj = mock_popen.return_value
+        mock_popen_obj.communicate.return_value = ('output', 'error')
+        mock_popen_obj.returncode = 1
+        cmd('/bin/echo', '"home/imgs/catpix"')
+        mock_popen.assert_called_once_with(['/bin/echo'], cwd='"home/imgs/catpix"',
+                                           stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        mock_error.assert_any_call('error')
+        mock_debug.assert_called_once_with('output')
+
+    @mock.patch('bodhi.server.log.debug')
+    @mock.patch('bodhi.server.log.error')
+    @mock.patch('subprocess.Popen')
+    def test_no_err_zero_return_code(self, mock_popen, mock_error, mock_debug):
+        """
+        Ensures proper behavior when there is no err output and the exit code is 0.
+        See https://github.com/fedora-infra/bodhi/issues/1412
+        """
+        mock_popen.return_value = mock.Mock()
+        mock_popen_obj = mock_popen.return_value
+        mock_popen_obj.communicate.return_value = ('output', None)
+        mock_popen_obj.returncode = 0
+        cmd('/bin/echo', '"home/imgs/catpix"')
+        mock_popen.assert_called_once_with(['/bin/echo'], cwd='"home/imgs/catpix"',
+                                           stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        mock_error.assert_not_called()
+        mock_debug.assert_called_once_with('output')
+
+    @mock.patch('bodhi.server.log.debug')
+    @mock.patch('bodhi.server.log.error')
+    @mock.patch('subprocess.Popen')
+    def test_err_zero_return_code(self, mock_popen, mock_error, mock_debug):
+        """
+        Ensures proper behavior when there is err output, but the exit code is 0.
+        See https://github.com/fedora-infra/bodhi/issues/1412
+        """
+        mock_popen.return_value = mock.Mock()
+        mock_popen_obj = mock_popen.return_value
+        mock_popen_obj.communicate.return_value = ('output', 'error')
+        mock_popen_obj.returncode = 0
+        cmd('/bin/echo', '"home/imgs/catpix"')
+        mock_popen.assert_called_once_with(['/bin/echo'], cwd='"home/imgs/catpix"',
+                                           stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        mock_error.assert_not_called()
+        mock_debug.assert_called_with('error')


### PR DESCRIPTION
If exit code is 0, the stderr is logged at info. If it is non-zero, stderr logs messages at error.

fixes #1412