### PR TITLE
Show openQA results in the web UI

### DIFF
--- a/bodhi/server/templates/update.html
+++ b/bodhi/server/templates/update.html
@@ -245,6 +245,7 @@ ${update.type} update for ${generateupdatetitlestring()}
     for (index = 0, len = builds.length; index < len; ++index) {
       request_results(base_url+"results/latest?item="+builds[index]+"&type=koji_build&testcases:like=dist.*");
     }
+    request_results(base_url+"results/latest?item=${update.alias}&type=bodhi_update&testcases:like=update.*");
   });
 </script>
 


### PR DESCRIPTION
This includes openQA results (as well as Taskotron) in the
web UI "Automated Tests" view. Yay one-liners! It does not
allow you to gate an update on openQA tests, as that code is
separate.

We may need to make this more complex if we ever start running
openQA update tests with more complex 'scenarios' (when two
jobs have the same test name but different arch, or 'flavor',
or BIOS vs. UEFI, stuff like that). But with the set of tests
we currently run, this works fine.

Signed-off-by: Adam Williamson <awilliam@redhat.com>