### PR TITLE
Split the Build model to be polymorphic.

### DIFF
--- a/alembic/versions/9241378c92ab_convert_the_builds_table_to_be_.py
+++ b/alembic/versions/9241378c92ab_convert_the_builds_table_to_be_.py
@@ -1,0 +1,25 @@
+"""Convert the builds table to be polymorphic.
+
+Revision ID: 9241378c92ab
+Revises: fc6b0169c596
+Create Date: 2017-04-06 20:37:24.766366
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '9241378c92ab'
+down_revision = 'fc6b0169c596'
+
+
+def upgrade():
+    """Add the type column to the builds table."""
+    # The default of ``1`` is the RPM Build type.
+    op.add_column('builds', sa.Column('type', sa.Integer(), nullable=False, server_default=u'1'))
+    op.alter_column('builds', 'type', server_default=None)
+
+
+def downgrade():
+    """Remove the type column from the builds table."""
+    op.drop_column('builds', 'type')

--- a/bodhi/server/consumers/signed.py
+++ b/bodhi/server/consumers/signed.py
@@ -25,7 +25,7 @@ import fedmsg.consumers
 
 from bodhi.server import initialize_db
 from bodhi.server.config import config
-from bodhi.server.models import Build
+from bodhi.server.models import RpmBuild
 from bodhi.server.util import transactional_session_maker
 
 
@@ -95,13 +95,13 @@ class SignedHandler(fedmsg.consumers.FedmsgConsumer):
         log.info("%s tagged into %s" % (build_nvr, tag))
 
         with self.db_factory() as session:
-            build = Build.get(build_nvr, session)
+            build = RpmBuild.get(build_nvr, session)
             if not build:
-                log.info("Build was not submitted, skipping")
+                log.info("RpmBuild was not submitted, skipping")
                 return
 
             if not build.release:
-                log.info('Build is not assigned to release, skipping')
+                log.info('RpmBuild is not assigned to release, skipping')
                 return
 
             if build.release.pending_testing_tag != tag:
@@ -111,6 +111,6 @@ class SignedHandler(fedmsg.consumers.FedmsgConsumer):
             # This build was moved into the pending_testing tag for the applicable release, which
             # is done by RoboSignatory to indicate that the build has been correctly signed and
             # written out. Mark it as such.
-            log.info("Build has been signed, marking")
+            log.info("RpmBuild has been signed, marking")
             build.signed = True
-            log.info("Build %s has been marked as signed" % build_nvr)
+            log.info("RpmBuild %s has been marked as signed" % build_nvr)

--- a/bodhi/server/metadata.py
+++ b/bodhi/server/metadata.py
@@ -22,7 +22,7 @@ import createrepo_c as cr
 
 from bodhi.server.buildsys import get_session
 from bodhi.server.config import config
-from bodhi.server.models import Build, UpdateStatus, UpdateRequest, UpdateSuggestion
+from bodhi.server.models import RpmBuild, UpdateStatus, UpdateRequest, UpdateSuggestion
 
 
 __version__ = '2.0'
@@ -179,7 +179,7 @@ class ExtendedMetadata(object):
         log.debug("%d builds found" % len(kojiBuilds))
         for build in kojiBuilds:
             self.builds[build['nvr']] = build
-            build_obj = self.db.query(Build).filter_by(nvr=unicode(build['nvr'])).first()
+            build_obj = self.db.query(RpmBuild).filter_by(nvr=unicode(build['nvr'])).first()
             if build_obj:
                 if build_obj.update:
                     self.updates.add(build_obj.update)

--- a/bodhi/server/push.py
+++ b/bodhi/server/push.py
@@ -24,7 +24,7 @@ import click
 
 from bodhi.server import initialize_db
 from bodhi.server.config import config
-from bodhi.server.models import Build, Release, ReleaseState, Update, UpdateRequest
+from bodhi.server.models import Release, ReleaseState, RpmBuild, Update, UpdateRequest
 from bodhi.server.util import transactional_session_maker
 import bodhi.server.notifications
 
@@ -84,7 +84,7 @@ def push(username, cert_prefix, **kwargs):
             if kwargs.get('builds'):
                 query = query.join(Update.builds)
                 query = query.filter(
-                    or_(*[Build.nvr == build for build in kwargs['builds'].split(',')]))
+                    or_(*[RpmBuild.nvr == build for build in kwargs['builds'].split(',')]))
 
             query = _filter_releases(session, query, kwargs.get('releases'))
 

--- a/bodhi/server/services/overrides.py
+++ b/bodhi/server/services/overrides.py
@@ -21,7 +21,7 @@ from sqlalchemy import func, distinct
 from sqlalchemy.sql import or_
 
 from bodhi.server import log
-from bodhi.server.models import Build, BuildrootOverride, RpmPackage, Release, User
+from bodhi.server.models import Build, BuildrootOverride, RpmPackage, Release, RpmBuild, User
 import bodhi.server.schemas
 import bodhi.server.services.errors
 from bodhi.server.validators import (
@@ -58,7 +58,7 @@ def get_override(request):
     db = request.db
     nvr = request.matchdict.get('nvr')
 
-    build = Build.get(nvr, db)
+    build = RpmBuild.get(nvr, db)
 
     if not build:
         request.errors.add('url', 'nvr', 'No such build')
@@ -122,7 +122,7 @@ def query_overrides(request):
     if like is not None:
         query = query.join(BuildrootOverride.build)
         query = query.filter(or_(*[
-            Build.nvr.like('%%%s%%' % like)
+            RpmBuild.nvr.like('%%%s%%' % like)
         ]))
 
     submitter = data.get('user')
@@ -215,7 +215,7 @@ def save_override(request):
         else:
             log.info("Editing buildroot override: %s" % edited)
 
-            edited = Build.get(edited, request.db)
+            edited = RpmBuild.get(edited, request.db)
 
             if edited is None:
                 request.errors.add('body', 'edited', 'No such build')

--- a/bodhi/tests/server/__init__.py
+++ b/bodhi/tests/server/__init__.py
@@ -4,8 +4,8 @@ import mock
 import sqlalchemy
 
 from bodhi.server.models import (
-    Bug, Build, BuildrootOverride, Comment, CVE, Group, RpmPackage, Release, ReleaseState, Update,
-    UpdateRequest, UpdateType, User, TestCase)
+    Bug, BuildrootOverride, Comment, CVE, Group, RpmPackage, Release, ReleaseState, RpmBuild,
+    Update, UpdateRequest, UpdateType, User, TestCase)
 
 
 def create_update(session, build_nvrs, release_name=u'F17'):
@@ -35,7 +35,7 @@ def create_update(session, build_nvrs, release_name=u'F17'):
             session.add(testcase)
             package.test_cases.append(testcase)
 
-        builds.append(Build(nvr=nvr, release=release, package=package))
+        builds.append(RpmBuild(nvr=nvr, release=release, package=package))
         session.add(builds[-1])
 
         # Add a buildroot override for this build

--- a/bodhi/tests/server/consumers/test_masher.py
+++ b/bodhi/tests/server/consumers/test_masher.py
@@ -27,8 +27,8 @@ import mock
 from bodhi.server import buildsys, log, initialize_db
 from bodhi.server.config import config
 from bodhi.server.consumers.masher import Masher, MasherThread
-from bodhi.server.models import (Base, Build, BuildrootOverride, Release, ReleaseState, Update,
-                                 UpdateRequest, UpdateStatus, UpdateType, User)
+from bodhi.server.models import (Base, Build, BuildrootOverride, Release, ReleaseState, RpmBuild,
+                                 Update, UpdateRequest, UpdateStatus, UpdateType, User)
 from bodhi.server.util import mkmetadatadir, transactional_session_maker
 from bodhi.tests.server import base, populate
 
@@ -312,7 +312,7 @@ class TestMasher(unittest.TestCase):
         with self.db_factory() as session:
             firstupdate = session.query(Update).filter_by(
                 title=self.msg['body']['msg']['updates'][1]).one()
-            build = Build(nvr=otherbuild, package=firstupdate.builds[0].package)
+            build = RpmBuild(nvr=otherbuild, package=firstupdate.builds[0].package)
             session.add(build)
             update = Update(
                 title=otherbuild, builds=[build], type=UpdateType.bugfix,
@@ -481,8 +481,7 @@ References:
                 override_tag=u'f18-override',
                 branch=u'f18')
             db.add(release)
-            build = Build(nvr=u'bodhi-2.0-1.fc18', release=release,
-                          package=up.builds[0].package)
+            build = RpmBuild(nvr=u'bodhi-2.0-1.fc18', release=release, package=up.builds[0].package)
             db.add(build)
             update = Update(
                 title=u'bodhi-2.0-1.fc18',
@@ -563,8 +562,7 @@ References:
                 override_tag=u'f18-override',
                 branch=u'f18')
             db.add(release)
-            build = Build(nvr=u'bodhi-2.0-1.fc18', release=release,
-                          package=up.builds[0].package)
+            build = RpmBuild(nvr=u'bodhi-2.0-1.fc18', release=release, package=up.builds[0].package)
             db.add(build)
             update = Update(
                 title=u'bodhi-2.0-1.fc18',
@@ -637,8 +635,7 @@ References:
                 override_tag=u'f18-override',
                 branch=u'f18')
             db.add(release)
-            build = Build(nvr=u'bodhi-2.0-1.fc18', release=release,
-                          package=up.builds[0].package)
+            build = RpmBuild(nvr=u'bodhi-2.0-1.fc18', release=release, package=up.builds[0].package)
             db.add(build)
             update = Update(
                 title=u'bodhi-2.0-1.fc18',
@@ -1098,7 +1095,7 @@ References:
             oldupdate.locked = False
 
             # Create a newer build
-            build = Build(nvr=otherbuild, package=oldupdate.builds[0].package)
+            build = RpmBuild(nvr=otherbuild, package=oldupdate.builds[0].package)
             session.add(build)
             update = Update(
                 title=otherbuild, builds=[build], type=UpdateType.bugfix,

--- a/bodhi/tests/server/consumers/test_signed.py
+++ b/bodhi/tests/server/consumers/test_signed.py
@@ -75,7 +75,7 @@ class TestSignedHandlerConsume(unittest.TestCase):
         hub.config = {'environment': 'environment', 'topic_prefix': 'topic_prefix'}
         self.handler = signed.SignedHandler(hub)
 
-    @mock.patch('bodhi.server.consumers.signed.Build')
+    @mock.patch('bodhi.server.consumers.signed.RpmBuild')
     def test_consume(self, mock_build_model):
         """Assert that messages marking the build as signed updates the database"""
         build = mock_build_model.get.return_value
@@ -84,7 +84,7 @@ class TestSignedHandlerConsume(unittest.TestCase):
         self.handler.consume(self.sample_message)
         self.assertTrue(build.signed is True)
 
-    @mock.patch('bodhi.server.consumers.signed.Build')
+    @mock.patch('bodhi.server.consumers.signed.RpmBuild')
     def test_consume_not_pending_testing_tag(self, mock_build_model):
         """
         Assert that messages whose tag don't match the pending testing tag don't update the DB
@@ -95,7 +95,7 @@ class TestSignedHandlerConsume(unittest.TestCase):
         self.handler.consume(self.sample_message)
         self.assertFalse(build.signed is True)
 
-    @mock.patch('bodhi.server.consumers.signed.Build')
+    @mock.patch('bodhi.server.consumers.signed.RpmBuild')
     def test_consume_no_release(self, mock_build_model):
         """
         Assert that messages about builds that haven't been assigned a release don't update the DB
@@ -107,10 +107,10 @@ class TestSignedHandlerConsume(unittest.TestCase):
         self.assertFalse(build.signed is True)
 
     @mock.patch('bodhi.server.consumers.signed.log')
-    @mock.patch('bodhi.server.consumers.signed.Build')
+    @mock.patch('bodhi.server.consumers.signed.RpmBuild')
     def test_consume_no_build(self, mock_build_model, mock_log):
         """Assert that messages referencing builds Bodhi doesn't know about don't update the DB"""
         mock_build_model.get.return_value = None
 
         self.handler.consume(self.sample_message)
-        mock_log.info.assert_called_with('Build was not submitted, skipping')
+        mock_log.info.assert_called_with('RpmBuild was not submitted, skipping')

--- a/bodhi/tests/server/functional/test_builds.py
+++ b/bodhi/tests/server/functional/test_builds.py
@@ -12,7 +12,7 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
-from bodhi.server.models import Build
+from bodhi.server.models import RpmBuild
 import bodhi.tests.server.functional.base
 
 
@@ -37,7 +37,7 @@ class TestBuildsService(bodhi.tests.server.functional.base.BaseWSGICase):
 
         # First, stuff a second build in there
         session = self.db
-        build = Build(nvr=u'bodhi-3.0-1.fc21')
+        build = RpmBuild(nvr=u'bodhi-3.0-1.fc21')
         session.add(build)
         session.flush()
 

--- a/bodhi/tests/server/functional/test_overrides.py
+++ b/bodhi/tests/server/functional/test_overrides.py
@@ -16,7 +16,7 @@ from datetime import datetime, timedelta
 
 import mock
 
-from bodhi.server.models import Build, RpmPackage, Release, User
+from bodhi.server.models import RpmBuild, RpmPackage, Release, User
 import bodhi.tests.server.functional.base
 
 
@@ -183,8 +183,7 @@ class TestOverridesService(bodhi.tests.server.functional.base.BaseWSGICase):
 
         package = RpmPackage(name=u'not-bodhi')
         self.db.add(package)
-        build = Build(nvr=u'not-bodhi-2.0-2.fc17', package=package,
-                      release=release)
+        build = RpmBuild(nvr=u'not-bodhi-2.0-2.fc17', package=package, release=release)
         self.db.add(build)
         self.db.flush()
 
@@ -211,8 +210,7 @@ class TestOverridesService(bodhi.tests.server.functional.base.BaseWSGICase):
         release = Release.get(u'F17', self.db)
         package = RpmPackage(name=u'not-bodhi')
         self.db.add(package)
-        build = Build(nvr=u'not-bodhi-2.0-2.fc17', package=package,
-                      release=release)
+        build = RpmBuild(nvr=u'not-bodhi-2.0-2.fc17', package=package, release=release)
         self.db.add(build)
         self.db.flush()
 
@@ -244,15 +242,13 @@ class TestOverridesService(bodhi.tests.server.functional.base.BaseWSGICase):
         release = Release.get(u'F17', self.db)
         package = RpmPackage(name=u'not-bodhi')
         self.db.add(package)
-        build1 = Build(nvr=u'not-bodhi-2.0-2.fc17', package=package,
-                       release=release)
+        build1 = RpmBuild(nvr=u'not-bodhi-2.0-2.fc17', package=package, release=release)
         self.db.add(build1)
         self.db.flush()
 
         package = RpmPackage(name=u'another-not-bodhi')
         self.db.add(package)
-        build2 = Build(nvr=u'another-not-bodhi-2.0-2.fc17', package=package,
-                       release=release)
+        build2 = RpmBuild(nvr=u'another-not-bodhi-2.0-2.fc17', package=package, release=release)
         self.db.add(build2)
         self.db.flush()
 
@@ -290,8 +286,7 @@ class TestOverridesService(bodhi.tests.server.functional.base.BaseWSGICase):
 
         package = RpmPackage(name=u'not-bodhi')
         self.db.add(package)
-        build = Build(nvr=u'not-bodhi-2.0-2.fc17', package=package,
-                      release=release)
+        build = RpmBuild(nvr=u'not-bodhi-2.0-2.fc17', package=package, release=release)
         self.db.add(build)
         self.db.flush()
 
@@ -304,10 +299,10 @@ class TestOverridesService(bodhi.tests.server.functional.base.BaseWSGICase):
 
     @mock.patch('bodhi.server.notifications.publish')
     def test_create_override_for_newer_build(self, publish):
-        old_build = Build.get(u'bodhi-2.0-1.fc17', self.db)
+        old_build = RpmBuild.get(u'bodhi-2.0-1.fc17', self.db)
 
-        build = Build(nvr=u'bodhi-2.0-2.fc17', package=old_build.package,
-                      release=old_build.release)
+        build = RpmBuild(nvr=u'bodhi-2.0-2.fc17', package=old_build.package,
+                         release=old_build.release)
         self.db.add(build)
         self.db.flush()
 
@@ -329,7 +324,7 @@ class TestOverridesService(bodhi.tests.server.functional.base.BaseWSGICase):
                           expiration_date.strftime("%Y-%m-%d %H:%M:%S"))
         self.assertEquals(o['expired_date'], None)
 
-        old_build = Build.get(u'bodhi-2.0-1.fc17', self.db)
+        old_build = RpmBuild.get(u'bodhi-2.0-1.fc17', self.db)
 
         self.assertNotEquals(old_build.override['expired_date'], None)
 
@@ -344,7 +339,7 @@ class TestOverridesService(bodhi.tests.server.functional.base.BaseWSGICase):
         expiration_date = o['expiration_date']
         old_build_id = o['build_id']
 
-        build = Build(nvr=u'bodhi-2.0-2.fc17', release=release)
+        build = RpmBuild(nvr=u'bodhi-2.0-2.fc17', release=release)
         self.db.add(build)
         self.db.flush()
 
@@ -365,7 +360,7 @@ class TestOverridesService(bodhi.tests.server.functional.base.BaseWSGICase):
     def test_edit_unexisting_override(self):
         release = Release.get(u'F17', self.db)
 
-        build = Build(nvr=u'bodhi-2.0-2.fc17', release=release)
+        build = RpmBuild(nvr=u'bodhi-2.0-2.fc17', release=release)
         self.db.add(build)
         self.db.flush()
 
@@ -460,7 +455,7 @@ class TestOverridesService(bodhi.tests.server.functional.base.BaseWSGICase):
     def test_unexpire_override(self, publish):
         # First expire a buildroot override
         old_nvr = u'bodhi-2.0-1.fc17'
-        override = Build.get(old_nvr, self.db).override
+        override = RpmBuild.get(old_nvr, self.db).override
         override.expire()
         self.db.add(override)
         self.db.flush()

--- a/bodhi/tests/server/test_metadata.py
+++ b/bodhi/tests/server/test_metadata.py
@@ -27,7 +27,7 @@ from bodhi.server import log, Session, initialize_db
 from bodhi.server.buildsys import (setup_buildsystem, teardown_buildsystem,
                                    get_session, DevBuildsys)
 from bodhi.server.config import config
-from bodhi.server.models import (RpmPackage, Update, Build, Base, UpdateRequest, UpdateStatus,
+from bodhi.server.models import (RpmPackage, Update, Base, RpmBuild, UpdateRequest, UpdateStatus,
                                  UpdateType)
 from bodhi.server.metadata import ExtendedMetadata
 from bodhi.server.util import mkmetadatadir
@@ -430,7 +430,7 @@ class TestExtendedMetadata(unittest.TestCase):
         # Create a new non-security update for the same package
         newbuild = u'bodhi-2.0-2.fc17'
         pkg = self.db.query(RpmPackage).filter_by(name=u'bodhi').one()
-        build = Build(nvr=newbuild, package=pkg)
+        build = RpmBuild(nvr=newbuild, package=pkg)
         self.db.add(build)
         self.db.flush()
         newupdate = Update(title=newbuild,
@@ -497,7 +497,7 @@ class TestExtendedMetadata(unittest.TestCase):
         # Create a new non-security update for the same package
         newbuild = u'bodhi-2.0-2.fc17'
         pkg = self.db.query(RpmPackage).filter_by(name=u'bodhi').one()
-        build = Build(nvr=newbuild, package=pkg)
+        build = RpmBuild(nvr=newbuild, package=pkg)
         self.db.add(build)
         self.db.flush()
         newupdate = Update(title=newbuild,

--- a/bodhi/tests/server/test_models.py
+++ b/bodhi/tests/server/test_models.py
@@ -189,9 +189,9 @@ class TestPackage(ModelTest):
         assert self.obj.committers[0].name == u'lmacken'
 
 
-class TestBuild(ModelTest):
-    """Unit test case for the ``Build`` model."""
-    klass = model.Build
+class TestRpmBuild(ModelTest):
+    """Unit test case for the ``RpmBuild`` model."""
+    klass = model.RpmBuild
     attrs = dict(nvr=u"TurboGears-1.0.8-3.fc11")
 
     def do_get_dependencies(self):
@@ -234,8 +234,9 @@ class TestUpdate(ModelTest):
     def do_get_dependencies(self):
         release = model.Release(**TestRelease.attrs)
         return dict(
-            builds=[model.Build(nvr=u'TurboGears-1.0.8-3.fc11',
-                                package=model.Package(**TestPackage.attrs), release=release)],
+            builds=[model.RpmBuild(
+                nvr=u'TurboGears-1.0.8-3.fc11', package=model.Package(**TestPackage.attrs),
+                release=release)],
             bugs=[model.Bug(bug_id=1), model.Bug(bug_id=2)],
             cves=[model.CVE(cve_id=u'CVE-2009-0001')],
             release=release,
@@ -248,7 +249,7 @@ class TestUpdate(ModelTest):
         pkg = self.db.query(model.Package).filter_by(name=u'TurboGears').one()
         rel = self.db.query(model.Release).filter_by(name=u'F11').one()
         attrs.update(dict(
-            builds=[model.Build(nvr=name, package=pkg, release=rel)],
+            builds=[model.RpmBuild(nvr=name, package=pkg, release=rel)],
             release=rel))
         return self.klass(**attrs)
 
@@ -995,7 +996,7 @@ class TestBuildrootOverride(ModelTest):
 
     def do_get_dependencies(self):
         return dict(
-            build=model.Build(nvr=u'TurboGears-1.0.8-3.fc11',
-                              package=model.Package(**TestPackage.attrs),
-                              release=model.Release(**TestRelease.attrs)),
+            build=model.RpmBuild(
+                nvr=u'TurboGears-1.0.8-3.fc11', package=model.Package(**TestPackage.attrs),
+                release=model.Release(**TestRelease.attrs)),
             submitter=model.User(name=u'lmacken'))

--- a/bodhi/tests/server/test_push.py
+++ b/bodhi/tests/server/test_push.py
@@ -52,10 +52,10 @@ class TestFilterReleases(base.BaseTestCase):
 
         # Let's add an obscure package called bodhi to the release.
         pkg = self.db.query(models.RpmPackage).filter_by(name=u'bodhi').one()
-        build = models.Build(nvr=u'bodhi-2.3.2-1.fc22', release=archived_release, package=pkg)
+        build = models.RpmBuild(nvr=u'bodhi-2.3.2-1.fc22', release=archived_release, package=pkg)
         self.db.add(build)
 
-        # And an Update with the Build.
+        # And an Update with the RpmBuild.
         self.archived_release_update = models.Update(
             title=u'bodhi-2.3.2-1.fc22', builds=[build], user=self.user,
             request=models.UpdateRequest.stable, notes=u'Useful details!', release=archived_release,
@@ -96,10 +96,10 @@ class TestFilterReleases(base.BaseTestCase):
         self.db.add(pending_release)
         # Let's add the bodhi package to both releases.
         pkg = self.db.query(models.RpmPackage).filter_by(name=u'bodhi').one()
-        disabled_build = models.Build(nvr=u'bodhi-2.3.2-1.fc21', release=disabled_release,
-                                      package=pkg)
-        pending_build = models.Build(nvr=u'bodhi-2.3.2-1.fc25', release=pending_release,
-                                     package=pkg)
+        disabled_build = models.RpmBuild(nvr=u'bodhi-2.3.2-1.fc21', release=disabled_release,
+                                         package=pkg)
+        pending_build = models.RpmBuild(nvr=u'bodhi-2.3.2-1.fc25', release=pending_release,
+                                        package=pkg)
         self.db.add(disabled_build)
         self.db.add(pending_build)
         # Now let's create updates for both packages.


### PR DESCRIPTION
This commit reworks the Build model to be polymorphic to allow it
to support more types than just RPMs, and it adds a new RpmBuild
model.

fixes #1393

Signed-off-by: Randy Barlow <randy@electronsweatshop.com>