### PR TITLE
Support editing an override via the CLI

### DIFF
--- a/bodhi/client/__init__.py
+++ b/bodhi/client/__init__.py
@@ -432,14 +432,14 @@ def print_resp(resp, client):
         click.echo(client.update_str(resp))
     elif 'overrides' in resp:
         if len(resp.overrides) == 1:
-            click.echo(client.override_str(resp.overrides[0]))
+            click.echo(client.override_str(resp.overrides[0], minimal=False))
         else:
             for override in resp.overrides:
                 click.echo(client.override_str(override).strip())
         click.echo(
             '%s overrides found (%d shown)' % (resp.total, len(resp.overrides)))
     elif 'build' in resp:
-        click.echo(client.override_str(resp))
+        click.echo(client.override_str(resp, minimal=False))
     elif 'comment' in resp:
         click.echo('The following comment was added to %s' % resp.comment['update'].title)
         click.echo(resp.comment.text)

--- a/bodhi/client/bindings.py
+++ b/bodhi/client/bindings.py
@@ -273,7 +273,7 @@ class BodhiClient(OpenIdBaseClient):
                   'csrf_token': self.csrf()})
 
     @errorhandled
-    def save_override(self, nvr, duration, notes):
+    def save_override(self, nvr, duration, notes, edit=False, expired=False):
         """ Save a buildroot override.
 
         This entails either creating a new buildroot override, or editing an
@@ -283,18 +283,22 @@ class BodhiClient(OpenIdBaseClient):
         :kwarg duration: Number of days from now that this override should
             expire.
         :kwarg notes: Notes about why this override is in place.
+        :kwargs edit: A boolean to edit an existing override.
+        :kwargs expired: A boolean to expire an override.
 
         """
         expiration_date = datetime.datetime.utcnow() + \
             datetime.timedelta(days=duration)
-
-        return self.send_request(
-            'overrides/', verb='POST', auth=True, data={
-                'nvr': nvr,
+        data = {'nvr': nvr,
                 'expiration_date': expiration_date,
                 'notes': notes,
-                'csrf_token': self.csrf(),
-            })
+                'csrf_token': self.csrf()}
+        if edit:
+            data['edited'] = nvr
+        if expired:
+            data['expired'] = expired
+        return self.send_request(
+            'overrides/', verb='POST', auth=True, data=data)
 
     @errorhandled
     def list_overrides(self, user=None):

--- a/bodhi/client/bindings.py
+++ b/bodhi/client/bindings.py
@@ -391,21 +391,32 @@ class BodhiClient(OpenIdBaseClient):
                     yield update
 
     @staticmethod
-    def override_str(override):
+    def override_str(override, minimal=True):
         """ Return a string representation of a given override dictionary.
 
         :arg override: An override dictionary.
+        :kwarg minimal: Return a minimal one-line representation of the update.
 
         """
         if isinstance(override, six.string_types):
             return override
 
-        # TODO -- make this fancy.
-        return "{submitter}'s {build} override (expires {expiry})".format(
-            submitter=override['submitter']['name'],
-            build=override['build']['nvr'],
-            expiry=override['expiration_date'],
-        )
+        if minimal:
+            return "{submitter}'s {build} override (expires {expiry})".format(
+                submitter=override['submitter']['name'],
+                build=override['build']['nvr'],
+                expiry=override['expiration_date'],
+            )
+
+        val = "%s\n%s\n%s\n" % ('=' * 60, '\n'.join(
+            textwrap.wrap(override['build']['nvr'].replace(',', ', '), width=60,
+                          initial_indent=' ' * 5, subsequent_indent=' ' * 5)), '=' * 60)
+        val += "  Submitter: {}\n".format(override['submitter']['name'])
+        val += "  Expiration Date: {}\n".format(override['expiration_date'])
+        val += "  Notes: {}\n".format(override['notes'])
+        val += "  Expired: {}".format(override['expired_date'] is not None)
+
+        return val
 
     def update_str(self, update, minimal=False):
         """ Return a string representation of a given update dictionary.

--- a/bodhi/tests/client/__init__.py
+++ b/bodhi/tests/client/__init__.py
@@ -78,6 +78,14 @@ EXAMPLE_OVERRIDE_MUNCH = Munch({
         u'openid': None, u'name': u'bowlofeggs', u'show_popups': True, u'id': 2897, u'avatar': None,
         u'groups': [Munch({u'name': u'packager'})], u'email': u'email@example.com'})})
 
+EXAMPLE_EXPIRED_OVERRIDE_MUNCH = Munch({
+    u'build_id': 108570, u'submission_date': u'2017-02-28 23:05:32', u'caveats': [],
+    u'nvr': u'js-tag-it-2.0-1.fc25', u'expiration_date': u'2017-03-07 23:05:31',
+    u'notes': u'This is an expired override', u'submitter_id': 2897,
+    u'build': Munch({u'epoch': 0, u'nvr': u'js-tag-it-2.0-1.fc25', u'signed': True}),
+    u'expired_date': '2017-03-07 23:05:31', u'submitter': Munch({
+        u'openid': None, u'name': u'bowlofeggs', u'show_popups': True, u'id': 2897, u'avatar': None,
+        u'groups': [Munch({u'name': u'packager'})], u'email': u'email@example.com'})})
 
 EXAMPLE_QUERY_MUNCH = Munch({
     u'chrome': True,
@@ -498,4 +506,22 @@ EXPECTED_UPDATE_OUTPUT = u"""===================================================
              notes.
 
   http://example.com/tests/updates/FEDORA-EPEL-2016-3081a94111
+"""
+
+EXPECTED_OVERRIDES_OUTPUT = u"""============================================================
+     js-tag-it-2.0-1.fc25
+============================================================
+  Submitter: bowlofeggs
+  Expiration Date: 2017-03-07 23:05:31
+  Notes: No explanation given...
+  Expired: False
+"""
+
+EXPECTED_EXPIRED_OVERRIDES_OUTPUT = u"""============================================================
+     js-tag-it-2.0-1.fc25
+============================================================
+  Submitter: bowlofeggs
+  Expiration Date: 2017-03-07 23:05:31
+  Notes: This is an expired override
+  Expired: True
 """

--- a/bodhi/tests/client/test_bindings.py
+++ b/bodhi/tests/client/test_bindings.py
@@ -191,9 +191,9 @@ class TestBodhiClient_override_str(unittest.TestCase):
     """
     Test the BodhiClient.override_str() method.
     """
-    def test_with_dict(self):
+    def test_with_min_dict(self):
         """
-        Test override_str() with a dict argument.
+        Test override_str() with a dict argument and minimal set to true.
         """
         override = {
             'submitter': {'name': 'bowlofeggs'}, 'build': {'nvr': 'python-pyramid-1.5.6-3.el7'},
@@ -203,6 +203,19 @@ class TestBodhiClient_override_str(unittest.TestCase):
 
         self.assertEqual(override,
                          "bowlofeggs's python-pyramid-1.5.6-3.el7 override (expires 2017-02-24)")
+
+    def test_with_dict(self):
+        """
+        Test override_str() with a dict argument.
+        """
+        override = {
+            'submitter': {'name': 'bowlofeggs'}, 'build': {'nvr': 'js-tag-it-2.0-1.fc25'},
+            'expiration_date': '2017-03-07 23:05:31', 'notes': 'No explanation given...',
+            'expired_date': None}
+
+        override = bindings.BodhiClient.override_str(override, minimal=False)
+
+        self.assertEqual(override, client_test_data.EXPECTED_OVERRIDES_OUTPUT.rstrip())
 
     def test_with_str(self):
         """
@@ -457,9 +470,9 @@ class TestBodhiClient_save_override(unittest.TestCase):
         client.send_request = mock.MagicMock(return_value='return_value')
         client.csrf_token = 'a token'
         now = datetime.utcnow()
-
-        response = client.save_override('python-pyramid-1.5.6-3.el7', 2,
-                                        'This is needed to build bodhi-2.4.0.')
+        response = client.save_override(nvr='python-pyramid-1.5.6-3.el7',
+                                        duration=2,
+                                        notes='This is needed to build bodhi-2.4.0.')
 
         self.assertEqual(response, 'return_value')
         actual_expiration = client.send_request.mock_calls[0][2]['data']['expiration_date']
@@ -467,7 +480,7 @@ class TestBodhiClient_save_override(unittest.TestCase):
             'overrides/', verb='POST', auth=True,
             data={'nvr': 'python-pyramid-1.5.6-3.el7',
                   'expiration_date': actual_expiration,
-                  'notes': 'This is needed to build bodhi-2.4.0.', 'csrf_token': 'a token'})
+                  'csrf_token': 'a token', 'notes': 'This is needed to build bodhi-2.4.0.'})
         # Since we can't mock utcnow() since it's a C extension, let's just make sure the expiration
         # date sent is within 5 minutes of the now variable. It would be surprising if it took more
         # than 5 minutes to start the function and execute its first instruction!

--- a/docs/man_pages/bodhi.rst
+++ b/docs/man_pages/bodhi.rst
@@ -90,6 +90,13 @@ The ``overrides`` command allows users to manage build overrides.
 
         Notes on why this override is in place.
 
+``bodhi overrides edit [options] <nvr>``
+
+    Edit the build root given by ``<nvr>`` as a buildroot override. The ``edit`` subcommand supports
+    the same options than the ``save`` command and also the following option:
+
+    ``--expire``
+        Force an override to the expired state.
 
 Updates
 =======

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -1,6 +1,24 @@
 Release notes
 =============
 
+2.7.0
+-----
+
+Features
+^^^^^^^^
+
+* The bodhi CLI now supports editing an override.
+  (`#1049 <https://github.com/fedora-infra/bodhi/issues/1049>`_)
+
+
+Release contributors
+^^^^^^^^^^^^^^^^^^^^
+
+The following contributors submitted patches for Bodhi 2.7.0:
+
+* Clement Verna
+
+
 2.6.0
 -----
 


### PR DESCRIPTION
This commit add support for editing overrides to the CLI.
By using the overrides edit command you can now expire an override using the
--expired flag.
Fixed #1049

Signed-off-by: Clement Verna <cverna@tutanota.com>