### PR TITLE
Add a query property to the base model class

### DIFF
--- a/bodhi/server/models.py
+++ b/bodhi/server/models.py
@@ -39,7 +39,7 @@ from sqlalchemy.orm.properties import RelationshipProperty
 from sqlalchemy.sql import text
 from sqlalchemy.types import SchemaType, TypeDecorator, Enum
 
-from bodhi.server import bugs, buildsys, log, mail, notifications
+from bodhi.server import bugs, buildsys, log, mail, notifications, Session
 from bodhi.server.config import config
 from bodhi.server.exceptions import BodhiException, LockedUpdateException
 from bodhi.server.util import (
@@ -162,12 +162,24 @@ class DeclEnumType(SchemaType, TypeDecorator):
 
 
 class BodhiBase(object):
-    """ Our custom model base class """
-    __exclude_columns__ = ('id',)  # List of columns to exclude from JSON
-    __include_extras__ = tuple()  # List of methods or attrs to include in JSON
-    __get_by__ = ()  # Columns that get() will query
+    """
+    Base class for the SQLAlchemy model base class.
+
+    Attributes:
+        __exclude_columns__ (tuple): A list of columns to exclude from JSON
+        __include_extras__ (tuple): A list of methods or attrs to include in JSON
+        __get_by__ (tuple): A list of columns that :meth:`.get` will query.
+        id (int): An integer id that serves as the default primary key.
+        query (sqlalchemy.orm.query.Query): a class property which produces a
+            Query object against the class and the current Session when called.
+    """
+    __exclude_columns__ = ('id',)
+    __include_extras__ = tuple()
+    __get_by__ = ()
 
     id = Column(Integer, primary_key=True)
+
+    query = Session.query_property()
 
     @classmethod
     def get(cls, id, db):

--- a/bodhi/tests/server/test_models.py
+++ b/bodhi/tests/server/test_models.py
@@ -31,6 +31,7 @@ from bodhi.server.exceptions import BodhiException
 from bodhi.server.models import (
     Base, BugKarma, get_db_factory, ReleaseState, UpdateRequest, UpdateSeverity, UpdateStatus,
     UpdateSuggestion, UpdateType)
+from bodhi.tests.server.base import BaseTestCase
 
 
 class DummyUser(object):
@@ -85,6 +86,14 @@ class ModelTest(object):
     def test_get(self):
         for col in self.obj.__get_by__:
             eq_(self.klass.get(getattr(self.obj, col), self.db), self.obj)
+
+
+class TestQueryProperty(BaseTestCase):
+
+    def test_session(self):
+        """Assert the session the query property uses is from the scoped session."""
+        query = model.Package.query
+        self.assertTrue(Session() is query.session)
 
 
 class TestComment(unittest.TestCase):


### PR DESCRIPTION
This lets you perform queries using the model directly without
explicitly creating a session:

```
Package.query.first()
```

Signed-off-by: Jeremy Cline <jeremy@jcline.org>