### PR TITLE
Drop the ``get_db_factory`` function in the models module

### DIFF
--- a/bodhi/server/consumers/signed.py
+++ b/bodhi/server/consumers/signed.py
@@ -23,7 +23,10 @@ import pprint
 
 import fedmsg.consumers
 
-from bodhi.server.models import Build, get_db_factory
+from bodhi.server import initialize_db
+from bodhi.server.config import config
+from bodhi.server.models import Build
+from bodhi.server.util import transactional_session_maker
 
 
 log = logging.getLogger('bodhi')
@@ -38,7 +41,7 @@ class SignedHandler(fedmsg.consumers.FedmsgConsumer):
     config_key = 'signed_handler'
 
     def __init__(self, hub, *args, **kwargs):
-        self.db_factory = get_db_factory()
+        self.db_factory = transactional_session_maker(initialize_db(config))
 
         prefix = hub.config.get('topic_prefix')
         env = hub.config.get('environment')

--- a/bodhi/server/models.py
+++ b/bodhi/server/models.py
@@ -30,8 +30,8 @@ from pkgdb2client import PkgDB
 from pyramid.settings import asbool
 from simplemediawiki import MediaWiki
 from six.moves.urllib.parse import quote
-from sqlalchemy import (and_, Boolean, Column, DateTime, engine_from_config, ForeignKey, Integer,
-                        or_, Table, Unicode, UnicodeText)
+from sqlalchemy import (and_, Boolean, Column, DateTime, ForeignKey, Integer, or_, Table, Unicode,
+                        UnicodeText)
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import class_mapper, relationship, backref
 from sqlalchemy.orm.exc import NoResultFound
@@ -44,7 +44,7 @@ from bodhi.server.config import config
 from bodhi.server.exceptions import BodhiException, LockedUpdateException
 from bodhi.server.util import (
     avatar as get_avatar, build_evr, flash_log, get_age, get_age_in_days, get_critpath_pkgs,
-    get_nvr, get_rpm_header, header, tokenize, transactional_session_maker)
+    get_nvr, get_rpm_header, header, tokenize)
 import bodhi.server.util
 
 
@@ -2453,15 +2453,3 @@ class Stack(Base):
     # Many-to-many relationships
     groups = relationship("Group", secondary=stack_group_table, backref='stacks')
     users = relationship("User", secondary=stack_user_table, backref='stacks')
-
-
-def get_db_factory():
-    """
-    This function generates and returns a database factory that can be used for non-request
-    transactions. You can instantiate the class returned by this function to get a database
-    session that you can use with a context manager. If you wish to get a database session for a
-    request, see bodhi.server.get_db_session_for_request().
-    """
-    engine = engine_from_config(config, 'sqlalchemy.')
-    Base.metadata.create_all(engine)
-    return transactional_session_maker(engine)

--- a/bodhi/server/push.py
+++ b/bodhi/server/push.py
@@ -22,7 +22,10 @@ import json
 from sqlalchemy.sql import or_
 import click
 
-from bodhi.server.models import Build, get_db_factory, Release, ReleaseState, Update, UpdateRequest
+from bodhi.server import initialize_db
+from bodhi.server.config import config
+from bodhi.server.models import Build, Release, ReleaseState, Update, UpdateRequest
+from bodhi.server.util import transactional_session_maker
 import bodhi.server.notifications
 
 
@@ -59,7 +62,8 @@ def push(username, cert_prefix, **kwargs):
 
     update_titles = None
 
-    with get_db_factory()() as session:
+    db_factory = transactional_session_maker(initialize_db(config))
+    with db_factory() as session:
         updates = []
         # If we're resuming a push
         if resume:

--- a/bodhi/tests/server/test_models.py
+++ b/bodhi/tests/server/test_models.py
@@ -25,11 +25,11 @@ from sqlalchemy.exc import IntegrityError
 import cornice
 import mock
 
-from bodhi.server import models as model, bugs, buildsys, mail, util, initialize_db, Session
+from bodhi.server import models as model, bugs, buildsys, mail, initialize_db, Session
 from bodhi.server.config import config
 from bodhi.server.exceptions import BodhiException
 from bodhi.server.models import (
-    Base, BugKarma, get_db_factory, ReleaseState, UpdateRequest, UpdateSeverity, UpdateStatus,
+    Base, BugKarma, ReleaseState, UpdateRequest, UpdateSeverity, UpdateStatus,
     UpdateSuggestion, UpdateType)
 
 
@@ -95,18 +95,6 @@ class TestComment(unittest.TestCase):
         https://github.com/fedora-infra/bodhi/issues/949.
         """
         self.assertEqual(model.Comment.__table__.columns['text'].nullable, False)
-
-
-class TestGetDBFactory(unittest.TestCase):
-    """
-    This class contains tests for the get_db_factory() function.
-    """
-    def test_return_type(self):
-        """
-        """
-        Session = get_db_factory()
-
-        self.assertEqual(type(Session), util.TransactionalSessionMaker)
 
 
 class TestRelease(ModelTest):

--- a/bodhi/tests/server/test_push.py
+++ b/bodhi/tests/server/test_push.py
@@ -299,7 +299,7 @@ class TestPush(base.BaseTestCase):
         cli = CliRunner()
         self.db.commit()
 
-        with mock.patch('bodhi.server.push.get_db_factory',
+        with mock.patch('bodhi.server.push.transactional_session_maker',
                         return_value=base.TransactionalSessionMaker(self.Session)):
             result = cli.invoke(push.push, ['--username', 'bowlofeggs'], input='n')
 
@@ -328,7 +328,7 @@ class TestPush(base.BaseTestCase):
         ejabberd.builds[0].signed = True
         self.db.commit()
 
-        with mock.patch('bodhi.server.push.get_db_factory',
+        with mock.patch('bodhi.server.push.transactional_session_maker',
                         return_value=base.TransactionalSessionMaker(self.Session)):
             result = cli.invoke(
                 push.push,
@@ -364,7 +364,7 @@ class TestPush(base.BaseTestCase):
         cli = CliRunner()
         self.db.commit()
 
-        with mock.patch('bodhi.server.push.get_db_factory',
+        with mock.patch('bodhi.server.push.transactional_session_maker',
                         return_value=base.TransactionalSessionMaker(self.Session)):
             result = cli.invoke(
                 push.push, ['--username', 'bowlofeggs', '--cert-prefix', 'some_prefix'], input='y')
@@ -395,7 +395,7 @@ class TestPush(base.BaseTestCase):
         ejabberd.date_locked = datetime.utcnow()
         self.db.commit()
 
-        with mock.patch('bodhi.server.push.get_db_factory',
+        with mock.patch('bodhi.server.push.transactional_session_maker',
                         return_value=base.TransactionalSessionMaker(self.Session)):
             result = cli.invoke(push.push, ['--username', 'bowlofeggs'], input='y')
 
@@ -436,7 +436,7 @@ class TestPush(base.BaseTestCase):
         ejabberd.date_locked = datetime.utcnow()
         self.db.commit()
 
-        with mock.patch('bodhi.server.push.get_db_factory',
+        with mock.patch('bodhi.server.push.transactional_session_maker',
                         return_value=base.TransactionalSessionMaker(self.Session)):
             result = cli.invoke(push.push, ['--username', 'bowlofeggs'], input='y')
 
@@ -484,7 +484,7 @@ class TestPush(base.BaseTestCase):
         python_paste_deploy.builds[0].signed = False
         self.db.commit()
 
-        with mock.patch('bodhi.server.push.get_db_factory',
+        with mock.patch('bodhi.server.push.transactional_session_maker',
                         return_value=base.TransactionalSessionMaker(self.Session)):
             result = cli.invoke(push.push, ['--username', 'bowlofeggs'], input='y')
 
@@ -538,7 +538,7 @@ class TestPush(base.BaseTestCase):
         self.db.commit()
         cli = CliRunner()
 
-        with mock.patch('bodhi.server.push.get_db_factory',
+        with mock.patch('bodhi.server.push.transactional_session_maker',
                         return_value=base.TransactionalSessionMaker(self.Session)):
             # We will specify that we want F25 and F26, which should exclude the F17 updates we've
             # been pushing in all the other tests. We'll leave the F off of 26 and lowercase the f
@@ -585,7 +585,7 @@ class TestPush(base.BaseTestCase):
         python_nose.request = models.UpdateRequest.stable
         self.db.commit()
 
-        with mock.patch('bodhi.server.push.get_db_factory',
+        with mock.patch('bodhi.server.push.transactional_session_maker',
                         return_value=base.TransactionalSessionMaker(self.Session)):
             result = cli.invoke(push.push, ['--username', 'bowlofeggs', '--request', 'testing'],
                                 input='y')
@@ -625,7 +625,7 @@ class TestPush(base.BaseTestCase):
         ejabberd.date_locked = datetime.utcnow()
         self.db.commit()
 
-        with mock.patch('bodhi.server.push.get_db_factory',
+        with mock.patch('bodhi.server.push.transactional_session_maker',
                         return_value=base.TransactionalSessionMaker(self.Session)):
             result = cli.invoke(push.push, ['--username', 'bowlofeggs', '--resume'], input='y\ny')
 
@@ -675,7 +675,7 @@ class TestPush(base.BaseTestCase):
         ejabberd.date_locked = datetime.utcnow()
         self.db.commit()
 
-        with mock.patch('bodhi.server.push.get_db_factory',
+        with mock.patch('bodhi.server.push.transactional_session_maker',
                         return_value=base.TransactionalSessionMaker(self.Session)):
             result = cli.invoke(push.push, ['--username', 'bowlofeggs', '--resume'],
                                 input='n\ny\ny')
@@ -717,7 +717,7 @@ class TestPush(base.BaseTestCase):
         cli = CliRunner()
         self.db.commit()
 
-        with mock.patch('bodhi.server.push.get_db_factory',
+        with mock.patch('bodhi.server.push.transactional_session_maker',
                         return_value=base.TransactionalSessionMaker(self.Session)):
             result = cli.invoke(push.push, ['--username', 'bowlofeggs', '--staging'], input='y')
 
@@ -752,7 +752,7 @@ class TestPush(base.BaseTestCase):
         python_nose.builds[0].signed = False
         self.db.commit()
 
-        with mock.patch('bodhi.server.push.get_db_factory',
+        with mock.patch('bodhi.server.push.transactional_session_maker',
                         return_value=base.TransactionalSessionMaker(self.Session)):
             result = cli.invoke(push.push, ['--username', 'bowlofeggs'], input='y')
 


### PR DESCRIPTION
During my purge of various methods of creating database engines, I
neglected to remove this function. This removes the function and moves
all the users of the function to the default ``initialize_db`` and
global scoped session workflow.

Signed-off-by: Jeremy Cline <jeremy@jcline.org>