### PR TITLE
Make sure ``pop`` calls load the configuration

### DIFF
--- a/bodhi/server/__init__.py
+++ b/bodhi/server/__init__.py
@@ -144,9 +144,10 @@ def initialize_db(config):
     Returns:
         sqlalchemy.engine: The database engine created from the configuration.
     """
-    #: The SQLAlchemy database engine. This is constructed using the value of
-    #: ``DB_URL`` in :data:`config``.
-    engine = engine_from_config(config, 'sqlalchemy.')
+    # The SQLAlchemy database engine. This is constructed using the value of
+    # ``DB_URL`` in :data:`config``. Note: A copy is provided since ``engine_from_config``
+    # uses ``pop``.
+    engine = engine_from_config(config.copy(), 'sqlalchemy.')
     # When using SQLite we need to make sure foreign keys are enabled:
     # http://docs.sqlalchemy.org/en/latest/dialects/sqlite.html#foreign-key-support
     if config['sqlalchemy.url'].startswith('sqlite:'):

--- a/bodhi/server/config.py
+++ b/bodhi/server/config.py
@@ -51,6 +51,16 @@ class BodhiConfig(dict):
             self.load_config()
         return super(BodhiConfig, self).get(*args, **kw)
 
+    def pop(self, *args, **kw):
+        if not self.loaded:
+            self.load_config()
+        return super(BodhiConfig, self).pop(*args, **kw)
+
+    def copy(self, *args, **kw):
+        if not self.loaded:
+            self.load_config()
+        return super(BodhiConfig, self).copy(*args, **kw)
+
     def load_config(self):
         configfile = get_configfile()
         self.update(get_appsettings(configfile))

--- a/bodhi/tests/server/test_config.py
+++ b/bodhi/tests/server/test_config.py
@@ -1,0 +1,143 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2017 Red Hat, Inc.
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+import unittest
+
+import mock
+
+from bodhi.server.config import BodhiConfig
+
+
+class BodhiConfigGetItemTests(unittest.TestCase):
+    """Tests for the ``__getitem__`` method on the :class:`BodhiConfig` class."""
+
+    def setUp(self):
+        self.config = BodhiConfig()
+        self.config.load_config = mock.Mock()
+        self.config['password'] = 'hunter2'
+
+    def test_not_loaded(self):
+        """Assert calling ``__getitem__`` causes the config to load."""
+        self.assertFalse(self.config.loaded)
+        self.assertEqual('hunter2', self.config['password'])
+        self.config.load_config.assert_called_once()
+
+    def test_loaded(self):
+        """Assert calling ``__getitem__`` when the config is loaded doesn't reload the config."""
+        self.config.loaded = True
+
+        self.assertEqual('hunter2', self.config['password'])
+        self.assertEqual(0, self.config.load_config.call_count)
+
+    def test_missing(self):
+        """Assert you still get normal dictionary errors from the config."""
+        self.assertRaises(KeyError, self.config.__getitem__, 'somemissingkey')
+
+
+class BodhiConfigGetTests(unittest.TestCase):
+    """Tests for the ``get`` method on the :class:`BodhiConfig` class."""
+
+    def setUp(self):
+        self.config = BodhiConfig()
+        self.config.load_config = mock.Mock()
+        self.config['password'] = 'hunter2'
+
+    def test_not_loaded(self):
+        """Assert calling ``get`` causes the config to load."""
+        self.assertFalse(self.config.loaded)
+        self.assertEqual('hunter2', self.config.get('password'))
+        self.config.load_config.assert_called_once()
+
+    def test_loaded(self):
+        """Assert calling ``get`` when the config is loaded doesn't reload the config."""
+        self.config.loaded = True
+
+        self.assertEqual('hunter2', self.config.get('password'))
+        self.assertEqual(0, self.config.load_config.call_count)
+
+    def test_missing(self):
+        """Assert you get ``None`` when the key is missing."""
+        self.assertEqual(None, self.config.get('somemissingkey'))
+
+
+class BodhiConfigPopItemTests(unittest.TestCase):
+    """Tests for the ``pop`` method on the :class:`BodhiConfig` class."""
+
+    def setUp(self):
+        self.config = BodhiConfig()
+        self.config.load_config = mock.Mock()
+        self.config['password'] = 'hunter2'
+
+    def test_not_loaded(self):
+        """Assert calling ``pop`` causes the config to load."""
+        self.assertFalse(self.config.loaded)
+        self.assertEqual('hunter2', self.config.pop('password'))
+        self.config.load_config.assert_called_once()
+
+    def test_loaded(self):
+        """Assert calling ``pop`` when the config is loaded doesn't reload the config."""
+        self.config.loaded = True
+
+        self.assertEqual('hunter2', self.config.pop('password'))
+        self.assertEqual(0, self.config.load_config.call_count)
+
+    def test_removes(self):
+        """Assert the configuration is removed with ``pop``."""
+        self.assertEqual('hunter2', self.config.pop('password'))
+        self.assertRaises(KeyError, self.config.pop, 'password')
+
+    def test_get_missing(self):
+        """Assert you still get normal dictionary errors from the config."""
+        self.assertRaises(KeyError, self.config.pop, 'somemissingkey')
+
+
+class BodhiConfigCopyTests(unittest.TestCase):
+    """Tests for the ``copy`` method on the :class:`BodhiConfig` class."""
+
+    def setUp(self):
+        self.config = BodhiConfig()
+        self.config.load_config = mock.Mock()
+        self.config['password'] = 'hunter2'
+
+    def test_not_loaded(self):
+        """Assert calling ``copy`` causes the config to load."""
+        self.assertFalse(self.config.loaded)
+        self.assertEqual({'password': 'hunter2'}, self.config.copy())
+        self.config.load_config.assert_called_once()
+
+    def test_loaded(self):
+        """Assert calling ``copy`` when the config is loaded doesn't reload the config."""
+        self.config.loaded = True
+
+        self.assertEqual({'password': 'hunter2'}, self.config.copy())
+        self.assertEqual(0, self.config.load_config.call_count)
+
+
+class BodhiConfigLoadConfig(unittest.TestCase):
+
+    @mock.patch('bodhi.server.config.get_configfile', mock.Mock(return_value='/some/config.ini'))
+    @mock.patch('bodhi.server.config.get_appsettings')
+    def test_marks_loaded(self, mock_appsettings):
+        config = BodhiConfig()
+        mock_appsettings.return_value = {'password': 'hunter2'}
+
+        config.load_config()
+
+        mock_appsettings.assert_called_once_with('/some/config.ini')
+        self.assertEqual([('password', 'hunter2')], config.items())
+        self.assertTrue(config.loaded)

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,7 +2,7 @@
 cover-erase=TRUE
 cover-html=TRUE
 cover-inclusive=TRUE
-cover-min-percentage=83
+cover-min-percentage=84
 cover-package=bodhi
 cover-xml=TRUE
 with-coverage=TRUE


### PR DESCRIPTION
SQLAlchemy calls ``pop`` on the configuration its given which didn't
load the configuration. This commit makes sure ``pop`` behaves like
``get`` and ``__getitem__`` (in that it loads the configuration). It
also makes sure copying the dictionary triggers a configuration load,
and uses copy to provide SQLAlchemy with a configuration to mutate.

fixes #1423

Signed-off-by: Jeremy Cline <jeremy@jcline.org>