### PR TITLE
Drop an unused inherited column from the builds table.

### DIFF
--- a/alembic/versions/12d3e8695f90_drop_the_unused_inherited_column_from_.py
+++ b/alembic/versions/12d3e8695f90_drop_the_unused_inherited_column_from_.py
@@ -1,0 +1,29 @@
+"""Drop the unused inherited column from the builds table.
+
+Revision ID: 12d3e8695f90
+Revises: fc6b0169c596
+Create Date: 2017-04-12 23:26:25.293009
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '12d3e8695f90'
+down_revision = 'fc6b0169c596'
+
+
+def upgrade():
+    """Remove the unused inherited column from the builds table."""
+    op.drop_column('builds', 'inherited')
+
+
+def downgrade():
+    """Add the inherited column back and set all records to False."""
+    op.add_column('builds',
+                  sa.Column('inherited', sa.BOOLEAN(), autoincrement=False, nullable=True))
+    # Build a fake mini version of the builds table so we can form an UPDATE statement.
+    builds = sa.sql.table('builds', sa.sql.column('inherited', sa.Boolean))
+    # Set all records to False, since that was the default before and since there was no way to set
+    # it to anything else through the API.
+    op.execute(builds.update().values({'inherited': False}))

--- a/bodhi/server/models.py
+++ b/bodhi/server/models.py
@@ -618,13 +618,11 @@ class RpmPackage(Package):
 class Build(Base):
     __tablename__ = 'builds'
     __exclude_columns__ = ('id', 'package', 'package_id', 'release',
-                           'release_id', 'update_id', 'update', 'inherited',
-                           'override')
+                           'release_id', 'update_id', 'update', 'override')
     __get_by__ = ('nvr',)
 
     nvr = Column(Unicode(100), unique=True, nullable=False)
     epoch = Column(Integer, default=0)
-    inherited = Column(Boolean, default=False)
     package_id = Column(Integer, ForeignKey('packages.id'))
     release_id = Column(Integer, ForeignKey('releases.id'))
     update_id = Column(Integer, ForeignKey('updates.id'))

--- a/bodhi/tests/server/test_models.py
+++ b/bodhi/tests/server/test_models.py
@@ -192,7 +192,7 @@ class TestPackage(ModelTest):
 class TestBuild(ModelTest):
     """Unit test case for the ``Build`` model."""
     klass = model.Build
-    attrs = dict(nvr=u"TurboGears-1.0.8-3.fc11", inherited=False)
+    attrs = dict(nvr=u"TurboGears-1.0.8-3.fc11")
 
     def do_get_dependencies(self):
         return dict(release=model.Release(**TestRelease.attrs),


### PR DESCRIPTION
While converting the Build model to support multiple types, I
noticed that there's a boolean column on the builds table called
inherited that is always False. In fact, the API did not present
this field and it seems that no code used it at all. Thus, this
commit removes the field from the models and provides a migration
to remove it in the database as well.

Signed-off-by: Randy Barlow <randy@electronsweatshop.com>