### PR TITLE
Only show openQA results since last update modification (#1435)

### DIFF
--- a/bodhi/server/templates/update.html
+++ b/bodhi/server/templates/update.html
@@ -242,7 +242,14 @@ ${update.type} update for ${generateupdatetitlestring()}
     for (index = 0, len = builds.length; index < len; ++index) {
       request_results(base_url+"results/latest?item="+builds[index]+"&type=koji_build&testcases:like=dist.*");
     }
-    request_results(base_url+"results/latest?item=${update.alias}&type=bodhi_update&testcases:like=update.*");
+
+    var oqaquery = "?item=${update.alias}&type=bodhi_update&testcases:like=update.*&since=";
+    % if update.date_modified:
+    oqaquery += "${update.date_modified.isoformat()}";
+    % else:
+    oqaquery += "${update.date_submitted.isoformat()}";
+    % endif
+    request_results(base_url+"results/latest"+oqaquery);
   });
 </script>
 


### PR DESCRIPTION
As suggested by @kparal, when getting automated test results
to display in the web UI, only request openQA results submitted
since the update was last modified, to avoid displaying outdated
results.

Signed-off-by: Adam Williamson <awilliam@redhat.com>