### PR TITLE
Correct a migration's down_revision to give alembic back one head.

### DIFF
--- a/alembic/versions/9241378c92ab_convert_the_builds_table_to_be_.py
+++ b/alembic/versions/9241378c92ab_convert_the_builds_table_to_be_.py
@@ -1,7 +1,7 @@
 """Convert the builds table to be polymorphic.
 
 Revision ID: 9241378c92ab
-Revises: fc6b0169c596
+Revises: 12d3e8695f90
 Create Date: 2017-04-06 20:37:24.766366
 """
 from alembic import op
@@ -10,7 +10,7 @@ import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision = '9241378c92ab'
-down_revision = 'fc6b0169c596'
+down_revision = '12d3e8695f90'
 
 
 def upgrade():


### PR DESCRIPTION
fixes #1449

Signed-off-by: Randy Barlow <randy@electronsweatshop.com>