### PR TITLE
Add a uniqueness constraint on (name, type) for Packages

### DIFF
--- a/alembic/versions/c6a5e2849ca4_add_a_uniqueness_constraint_on_name_.py
+++ b/alembic/versions/c6a5e2849ca4_add_a_uniqueness_constraint_on_name_.py
@@ -1,0 +1,26 @@
+"""
+Add a uniqueness constraint on (name, type) for the packages table.
+
+This is necessary since sub-types of packages may have the same name.
+
+Revision ID: c6a5e2849ca4
+Revises: 9241378c92ab
+Create Date: 2017-04-20 19:30:54.278981
+"""
+from alembic import op
+
+
+revision = 'c6a5e2849ca4'
+down_revision = '9241378c92ab'
+
+
+def upgrade():
+    """Add the new constraint on the name and type combined, then drop the name constraint."""
+    op.create_unique_constraint('packages_name_and_type_key', 'packages', ['name', 'type'])
+    op.drop_constraint(u'packages_name_key', 'packages', type_='unique')
+
+
+def downgrade():
+    """Add the new constraint on the name alone, then drop the (name, type) constraint."""
+    op.create_unique_constraint(u'packages_name_key', 'packages', ['name'])
+    op.drop_constraint('packages_name_and_type_key', 'packages', type_='unique')

--- a/bodhi/server/models.py
+++ b/bodhi/server/models.py
@@ -31,7 +31,7 @@ from pyramid.settings import asbool
 from simplemediawiki import MediaWiki
 from six.moves.urllib.parse import quote
 from sqlalchemy import (and_, Boolean, Column, DateTime, ForeignKey, Integer, or_, Table, Unicode,
-                        UnicodeText)
+                        UnicodeText, UniqueConstraint)
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import class_mapper, relationship, backref, validates
 from sqlalchemy.orm.exc import NoResultFound
@@ -495,7 +495,7 @@ class Package(Base):
     __get_by__ = ('name',)
     __exclude_columns__ = ('id', 'committers', 'test_cases', 'builds',)
 
-    name = Column(UnicodeText, unique=True, nullable=False)
+    name = Column(UnicodeText, nullable=False)
     requirements = Column(UnicodeText)
     type = Column(Integer, nullable=False)
 
@@ -510,6 +510,10 @@ class Package(Base):
         'polymorphic_on': type,
         'polymorphic_identity': 0,
     }
+
+    __table_args__ = (
+        UniqueConstraint('name', 'type', name='packages_name_and_type_key'),
+    )
 
     def get_pkg_pushers(self, branch, settings):
         """ Pull users who can commit and are watching a package.

--- a/bodhi/tests/server/test_models.py
+++ b/bodhi/tests/server/test_models.py
@@ -148,6 +148,28 @@ class MockWiki(object):
         return self.response
 
 
+class TestPackageUniqueConstraints(BaseTestCase):
+    """Tests for the Package model's uniqueness constraints."""
+
+    def test_two_package_different_types(self):
+        """Assert two different package types with the same name is fine."""
+        package1 = model.Package(name=u'python-requests')
+        package2 = model.RpmPackage(name=u'python-requests')
+
+        self.db.add(package1)
+        self.db.add(package2)
+        self.db.flush()
+
+    def test_two_package_same_type(self):
+        """Assert two packages of the same type with the same name is *not* fine."""
+        package1 = model.RpmPackage(name=u'python-requests')
+        package2 = model.RpmPackage(name=u'python-requests')
+
+        self.db.add(package1)
+        self.db.add(package2)
+        self.assertRaises(IntegrityError, self.db.flush)
+
+
 class TestPackage(ModelTest):
     """Unit test case for the ``Package`` model."""
     klass = model.Package


### PR DESCRIPTION
Packages of different types may have overlapping names. For example,
there is a python-requests RPM and a python-requests module. This adds a
uniqueness constraint on the combination of name and type and removes
the uniqueness constraint on name alone.

Signed-off-by: Jeremy Cline <jeremy@jcline.org>