### PR TITLE
add a new command to the vagrant setup to run the style tests

### DIFF
--- a/devel/ansible/roles/dev/files/.bashrc
+++ b/devel/ansible/roles/dev/files/.bashrc
@@ -14,6 +14,7 @@ alias blog="sudo journalctl -u bodhi"
 alias brestart="sudo systemctl restart bodhi && echo 'The Application is running on http://localhost:6543'"
 alias bstart="sudo systemctl start bodhi && echo 'The Application is running on http://localhost:6543'"
 alias bstop="sudo systemctl stop bodhi"
+alias bteststyle="pushd /home/vagrant/bodhi && nosetests -sx ~/bodhi/bodhi/tests/test_style.py; popd"
 
 function btest {
     find /home/vagrant/bodhi -name "*.pyc" -delete;

--- a/devel/ansible/roles/dev/files/motd
+++ b/devel/ansible/roles/dev/files/motd
@@ -1,15 +1,16 @@
 
 Welcome to the Bodhi development environment! Here are some helpful commands:
 
-bdocs:    Build Bodhi's documentation.
-blog:     View Bodhi's log.
-brestart: Restart the Bodhi service.
-bstart:   Start the Bodhi service.
-bstop:    Stop the Bodhi service.
-btest:    Run Bodhi's test suite.
+bdocs:      Build Bodhi's documentation.
+blog:       View Bodhi's log.
+brestart:   Restart the Bodhi service.
+bstart:     Start the Bodhi service.
+bstop:      Stop the Bodhi service.
+btest:      Run Bodhi's test suite.
+bteststyle: Run just the flake8 code style tests.
+
 
 The BODHI_URL environment variable is set to http://localhost:6543 so the
 bodhi client will use the local development server.
 
 Happy hacking!
-


### PR DESCRIPTION
This adds a new alias in the .bashrc that we use in the default
vagrant setup that allows just the flake8 style tests to be run