### PR TITLE
Remove the __init__() method from TransactionalSessionMaker.

### DIFF
--- a/bodhi/server/consumers/masher.py
+++ b/bodhi/server/consumers/masher.py
@@ -121,7 +121,7 @@ Once mash is done:
             settings = get_appsettings(config_uri)
             engine = engine_from_config(settings, 'sqlalchemy.')
             Base.metadata.create_all(engine)
-            self.db_factory = transactional_session_maker(engine)
+            self.db_factory = transactional_session_maker()
         else:
             self.db_factory = db_factory
 

--- a/bodhi/server/consumers/signed.py
+++ b/bodhi/server/consumers/signed.py
@@ -41,7 +41,8 @@ class SignedHandler(fedmsg.consumers.FedmsgConsumer):
     config_key = 'signed_handler'
 
     def __init__(self, hub, *args, **kwargs):
-        self.db_factory = transactional_session_maker(initialize_db(config))
+        initialize_db(config)
+        self.db_factory = transactional_session_maker()
 
         prefix = hub.config.get('topic_prefix')
         env = hub.config.get('environment')

--- a/bodhi/server/consumers/updates.py
+++ b/bodhi/server/consumers/updates.py
@@ -54,8 +54,8 @@ class UpdatesHandler(fedmsg.consumers.FedmsgConsumer):
     config_key = 'updates_handler'
 
     def __init__(self, hub, *args, **kwargs):
-        engine = initialize_db(config)
-        self.db_factory = util.transactional_session_maker(engine)
+        initialize_db(config)
+        self.db_factory = util.transactional_session_maker()
 
         prefix = hub.config.get('topic_prefix')
         env = hub.config.get('environment')

--- a/bodhi/server/push.py
+++ b/bodhi/server/push.py
@@ -62,7 +62,8 @@ def push(username, cert_prefix, **kwargs):
 
     update_titles = None
 
-    db_factory = transactional_session_maker(initialize_db(config))
+    initialize_db(config)
+    db_factory = transactional_session_maker()
     with db_factory() as session:
         updates = []
         # If we're resuming a push

--- a/bodhi/server/util.py
+++ b/bodhi/server/util.py
@@ -649,9 +649,6 @@ def taskotron_results(settings, entity='results', **kwargs):
 
 class TransactionalSessionMaker(object):
     """Provide a transactional scope around a series of operations."""
-    def __init__(self, engine):
-        self.engine = engine
-
     @contextmanager
     def __call__(self):
         session = Session()

--- a/bodhi/tests/server/consumers/test_masher.py
+++ b/bodhi/tests/server/consumers/test_masher.py
@@ -117,7 +117,7 @@ class TestMasher(unittest.TestCase):
                 pass
         engine = initialize_db({'sqlalchemy.url': db_path})
         Base.metadata.create_all(engine)
-        self.db_factory = transactional_session_maker(engine)
+        self.db_factory = transactional_session_maker()
 
         with self.db_factory() as session:
             populate(session)


### PR DESCRIPTION
The TransactionalSessionMaker used to have an __init__() method so
that the database engine could be passed in. However, it was
recently modified to use the threadlocal Session object and no
longer used self.engine. This commit drops the no longer necessary
code and fixes all calling code.

Signed-off-by: Randy Barlow <randy@electronsweatshop.com>