### PR TITLE
Setup fedmsg so published messages are viewable

### DIFF
--- a/devel/ansible/roles/dev/files/fedmsg-tail.service
+++ b/devel/ansible/roles/dev/files/fedmsg-tail.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=fedmsg tail
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+User=vagrant
+ExecStart=/usr/bin/fedmsg-tail
+
+[Install]
+WantedBy=multi-user.target

--- a/devel/ansible/roles/dev/tasks/main.yml
+++ b/devel/ansible/roles/dev/tasks/main.yml
@@ -5,6 +5,8 @@
       state: present
   with_items:
       - createrepo_c
+      - fedmsg-hub
+      - fedmsg-relay
       - freetype-devel
       - gcc
       - git
@@ -55,6 +57,7 @@
       - python2-createrepo_c
       - python2-cryptography
       - python2-fedmsg-atomic-composer
+      - python2-fedmsg-commands
       - python2-fedmsg-consumers
       - python2-flake8
       - python2-nose-cov
@@ -106,11 +109,14 @@
   args:
       chdir: /home/vagrant/bodhi
 
-- name: Install the systemd unit
+- name: Install the systemd unit files
   copy:
-      src: bodhi.service
-      dest: /etc/systemd/system/bodhi.service
+      src: "{{ item }}"
+      dest: /etc/systemd/system/{{ item }}
       mode: 0644
+  with_items:
+      - bodhi.service
+      - fedmsg-tail.service
 
 - name: Install the .bashrc
   copy:
@@ -134,8 +140,38 @@
       dest: /etc/motd
       mode: 0644
 
+- name: Remove default fedmsg endpoints
+  file: path=/etc/fedmsg.d/endpoints.py state=absent
+
+- name: Remove default fedmsg ssl config
+  file: path=/etc/fedmsg.d/ssl.py state=absent
+
+- name: Link the bodhi fedmsg config
+  file:
+    src: /home/vagrant/bodhi/fedmsg.d/bodhi.py
+    dest: /etc/fedmsg.d/bodhi.py
+    state: link
+
 - name: Start and enable the bodhi service
   service:
       name: bodhi
+      state: started
+      enabled: yes
+
+- name: Start and enable the fedmsg-hub service
+  service:
+      name: fedmsg-hub
+      state: started
+      enabled: yes
+
+- name: Start and enable the fedmsg-relay service
+  service:
+      name: fedmsg-relay
+      state: started
+      enabled: yes
+
+- name: Start and enable the fedmsg-tail service
+  service:
+      name: fedmsg-tail
       state: started
       enabled: yes

--- a/development.ini.example
+++ b/development.ini.example
@@ -36,7 +36,7 @@ libravatar_enabled = True
 libravatar_dns = False
 
 # Set this to True in order to send fedmsg messages.
-#fedmsg_enabled = True
+fedmsg_enabled = True
 
 
 # Captcha - if 'captcha.secret' is not None, then it will be used for comments

--- a/fedmsg.d/bodhi.py
+++ b/fedmsg.d/bodhi.py
@@ -3,8 +3,8 @@
 import socket
 hostname = socket.gethostname().split('.')[0]
 
-config = dict(
-    endpoints={
+config = {
+    'endpoints': {
         "bodhi.%s" % hostname: [
             'tcp://127.0.0.1:8084',
             'tcp://127.0.0.1:8085',
@@ -15,5 +15,7 @@ config = dict(
             'tcp://127.0.0.1:8090',
             'tcp://127.0.0.1:8091',
         ]
-    }
-)
+    },
+    'sign_messages': False,
+    'validate_signatures': False,
+}


### PR DESCRIPTION
This sets up a fedmsg relay which can be tailed to see what messages
Bodhi is publishing. A service, fedmsg-tail, is enabled and started in
Vagrant. This causes all fedmsgs sent by Bodhi to be logged to the
systemd journal.

Signed-off-by: Jeremy Cline <jeremy@jcline.org>