### PR TITLE
Web requests now use the correct Session object when committing.

### DIFF
--- a/bodhi/server/__init__.py
+++ b/bodhi/server/__init__.py
@@ -188,13 +188,14 @@ def main(global_config, testing=None, session=None, **settings):
 
     # Initialize the database scoped session
     initialize_db(settings)
-    config.registry.sessionmaker = Session.session_factory
 
     # Lazy-loaded memoized request properties
     if session:
-        config.add_request_method(lambda _: session, 'db', reify=True)
+        config.registry.sessionmaker = lambda: session
     else:
-        config.add_request_method(get_db_session_for_request, 'db', reify=True)
+        config.registry.sessionmaker = Session
+
+    config.add_request_method(get_db_session_for_request, 'db', reify=True)
 
     config.add_request_method(get_user, 'user', reify=True)
     config.add_request_method(get_koji, 'koji', reify=True)

--- a/bodhi/tests/server/base.py
+++ b/bodhi/tests/server/base.py
@@ -46,16 +46,20 @@ if os.environ.get('BUILD_ID'):
 
 
 class BaseTestCase(unittest.TestCase):
+    _populate_db = True
+
     def setUp(self):
         bugs.set_bugtracker()
         self.config = {'sqlalchemy.url': DB_PATH}
         self.engine = initialize_db(self.config)
+        Session.configure(bind=self.engine, expire_on_commit=False)
         self.Session = Session
         log.debug('Creating all models for %s' % self.engine)
         models.Base.metadata.bind = self.engine
         models.Base.metadata.create_all(self.engine)
         self.db = self.Session()
-        populate(self.db)
+        if self._populate_db:
+            populate(self.db)
 
         # Track sql statements in every test
         self.sql_statements = []

--- a/bodhi/tests/server/test_notifications.py
+++ b/bodhi/tests/server/test_notifications.py
@@ -89,6 +89,7 @@ class TestInit(unittest.TestCase):
 class TestPublish(base.BaseTestCase):
     """Tests for :func:`bodhi.server.notifications.publish`."""
 
+    @mock.patch.dict('bodhi.server.config.config', {'fedmsg_enabled': False})
     def test_publish_off(self, mock_init):
         """Assert publish doesn't populate the info dict when publishing is off."""
         notifications.publish('demo.topic', {'such': 'important'})
@@ -103,9 +104,9 @@ class TestPublish(base.BaseTestCase):
         session = Session()
         self.assertIn('fedmsg', session.info)
         self.assertEqual(session.info['fedmsg']['demo.topic'], [{'such': 'important'}])
-        mock_init.assert_called_once_with()
 
     @mock.patch.dict('bodhi.server.config.config', {'fedmsg_enabled': True})
+    @mock.patch('bodhi.server.notifications.fedmsg_is_initialized', mock.Mock(return_value=False))
     @mock.patch('bodhi.server.notifications.fedmsg.publish')
     def test_publish_force(self, mock_fedmsg_publish, mock_init):
         """Assert publish with the force flag sends the message immediately."""


### PR DESCRIPTION
Prior to this commit, the web request lifecycle would commit a
different database session than the rest of the code would use to
do its work.

fixes #1470
fixes #1473

Signed-off-by: Randy Barlow <randy@electronsweatshop.com>

This commit was also partially written by Jeremy Cline, and this is
his original commit message:

Many tests need to inspect objects tied to sessions that are
automatically removed after the session is committed and removed from
the session registry. This configures the scoped session used in the
tests to not expire objects when their session is no longer active.

Signed-off-by: Jeremy Cline <jeremy@jcline.org>