### PR TITLE
Edit updates with the update title

### DIFF
--- a/bodhi/client/bindings.py
+++ b/bodhi/client/bindings.py
@@ -46,6 +46,9 @@ BASE_URL = 'https://bodhi.fedoraproject.org/'
 STG_BASE_URL = 'https://bodhi.stg.fedoraproject.org/'
 STG_OPENID_API = 'https://id.stg.fedoraproject.org/api/v1/'
 
+UPDATE_ID_RE = r'FEDORA-(EPEL-)?\d{4,4}'
+UPDATE_TITLE_RE = r'(\.el|\.fc)\d\d?'
+
 
 class BodhiClientException(FedoraClientError):
     pass
@@ -235,9 +238,9 @@ class BodhiClient(OpenIdBaseClient):
         if 'package' in kwargs:
             # for Bodhi 1, 'package' could be a package name, build, or
             # update ID, so try and figure it out
-            if re.search(r'(\.el|\.fc)\d\d?', kwargs['package']):
+            if re.search(UPDATE_TITLE_RE, kwargs['package']):
                 kwargs['builds'] = kwargs['package']
-            elif re.search(r'FEDORA-(EPEL-)?\d{4,4}', kwargs['package']):
+            elif re.search(UPDATE_ID_RE, kwargs['package']):
                 kwargs['updateid'] = kwargs['package']
             else:
                 kwargs['packages'] = kwargs['package']

--- a/docs/man_pages/bodhi.rst
+++ b/docs/man_pages/bodhi.rst
@@ -179,9 +179,9 @@ The ``updates`` command allows users to interact with bodhi updates.
 
         A path to a file containing all the update details.
 
-``bodhi updates edit [options] <updateid>``
+``bodhi updates edit [options] <update>``
 
-    Edit an existing bodhi update, given an update id. The
+    Edit an existing bodhi update, given an update id or an update title. The
     ``edit`` subcommand supports the following options:
 
     ``--type [security | bugfix | enhancement | newpackage]``

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -9,6 +9,8 @@ Features
 
 * The bodhi CLI now supports editing an override.
   (`#1049 <https://github.com/fedora-infra/bodhi/issues/1049>`_)
+* The bodhi CLI now supports editing an update using the update title.
+  (`#1409 <https://github.com/fedora-infra/bodhi/issues/1409>`_)
 
 
 Release contributors


### PR DESCRIPTION
This commit makes possible to edit an update using the update title
Fixes #1409

Signed-off-by: Clement Verna <cverna@tutanota.com>