### PR TITLE
Add an alias for fedmsg and pretty-print messages

### DIFF
--- a/devel/ansible/roles/dev/files/.bashrc
+++ b/devel/ansible/roles/dev/files/.bashrc
@@ -16,6 +16,7 @@ alias bshell="pshell /home/vagrant/bodhi/development.ini"
 alias bstart="sudo systemctl start bodhi && echo 'The Application is running on http://localhost:6543'"
 alias bstop="sudo systemctl stop bodhi"
 alias bteststyle="pushd /home/vagrant/bodhi && nosetests -sx ~/bodhi/bodhi/tests/test_style.py; popd"
+alias bfedmsg="sudo journalctl -u fedmsg-tail"
 
 function btest {
     find /home/vagrant/bodhi -name "*.pyc" -delete;

--- a/devel/ansible/roles/dev/files/fedmsg-tail.service
+++ b/devel/ansible/roles/dev/files/fedmsg-tail.service
@@ -5,7 +5,7 @@ Wants=network-online.target
 
 [Service]
 User=vagrant
-ExecStart=/usr/bin/fedmsg-tail
+ExecStart=/usr/bin/fedmsg-tail --really-pretty
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
This makes inspecting fedmsgs easier in bodhi by adding an alias and
pretty-printing the messages so they're easy to read (although not
terribly compact).

Signed-off-by: Jeremy Cline <jeremy@jcline.org>