### PR TITLE
Acquire the global DDL lock if BDR is enabled

### DIFF
--- a/alembic.ini
+++ b/alembic.ini
@@ -14,9 +14,13 @@ script_location = alembic
 # Don't bother, this is obtained from the Bodhi config file
 sqlalchemy.url = sqlite://bodhi.db
 
-# Set to true to aquire the global DDL lock for BDR
-# See http://bdr-project.org/docs/stable/ddl-replication-advice.html
-bdr = false
+# Set to true to acquire the global DDL lock for BDR for offline SQL scripts.
+# BDR is automatically detected during online migrations and this setting is
+# ignored.
+#
+# See http://bdr-project.org/docs/stable/ddl-replication-advice.html for more
+# information about Postgres-BDR.
+offline_postgres_bdr = false
 
 
 # Logging configuration

--- a/alembic.ini
+++ b/alembic.ini
@@ -14,6 +14,10 @@ script_location = alembic
 # Don't bother, this is obtained from the Bodhi config file
 sqlalchemy.url = sqlite://bodhi.db
 
+# Set to true to aquire the global DDL lock for BDR
+# See http://bdr-project.org/docs/stable/ddl-replication-advice.html
+bdr = false
+
 
 # Logging configuration
 [loggers]


### PR DESCRIPTION
This should allow users to run Alembic in "online" mode with a Postgres
BDR system. It will also emit the correct SQL for offline migrations.

It introduces a new boolean setting in alembic.ini, "bdr", which
defaults to false.

Signed-off-by: Jeremy Cline <jeremy@jcline.org>