### PR TITLE
Handle openQA 'same test case, multiple flavors'

### DIFF
--- a/bodhi/server/templates/update.html
+++ b/bodhi/server/templates/update.html
@@ -74,7 +74,7 @@ ${update.type} update for ${generateupdatetitlestring()}
     // These are the required taskotron tests
     var requirements = ${update.requirements_json | n};
 
-    var make_row = function(outcome, testcase, note, arch, time, url) {
+    var make_row = function(outcome, testcase, note, arch, time, url, flavor) {
       var icon = '<span data-toggle="tooltip" data-placement="top" ' +
         'title="' + outcome + '" ' +
         'class="fa fa-' + icons[outcome] + ' text-' + classes[outcome] + '">' +
@@ -91,6 +91,11 @@ ${update.type} update for ${generateupdatetitlestring()}
       if (arch != undefined) {
         testcase = testcase + "&nbsp;<span class='label label-default'>"
           + arch + "</label>";
+      }
+
+      if (flavor) {
+        testcase = testcase + "&nbsp;<span class='label label-default'>"
+          + flavor + "</label>";
       }
 
       var age = '';
@@ -128,6 +133,14 @@ ${update.type} update for ${generateupdatetitlestring()}
         if (result.outcome == 'ABORTED') return;
 
         var name = result.testcase.name;
+        // we want to stash results by scenario when there is one, use name
+        // when there isn't
+        var scenario = result.testcase.name;
+        if (result.data.scenario) {
+            scenario = result.data.scenario[0];
+        }
+        // note: these are actually single-item arrays, though this doesn't
+        // seem to break anything
         var arch = result.data.arch;
         var item = result.data.item;
         var submit_time = new Date(result.submit_time);
@@ -137,12 +150,13 @@ ${update.type} update for ${generateupdatetitlestring()}
           latest[item] = {};
         if (latest[item][arch] === undefined)
           latest[item][arch] = {};
-        if (latest[item][arch][name] === undefined) {
-          latest[item][arch][name] = result;
+        if (latest[item][arch][scenario] === undefined) {
+          latest[item][arch][scenario] = result;
 
-          // the latest/ api endpoint doesnt take into account multiple arches
-          // for dist.depcheck. So if we hit one of these for the first time
-          // we do a call to get the other one.
+          // the latest/ api endpoint doesn't take into account 'scenarios'
+          // like "same testcase different arch" (depcheck) or "same testcase
+          // different flavor" (openQA). So we have to know about these and
+          // on the first hit, query the other 'scenario'.
           if (name == 'dist.depcheck'){
             var theurl = base_url+"results?testcases=dist.depcheck&item="+item+"&type=koji_build&limit=1";
             if (arch == 'x86_64'){
@@ -152,9 +166,25 @@ ${update.type} update for ${generateupdatetitlestring()}
             }
             request_results(theurl);
           }
+          else if (name.startsWith('update.base')) {
+            // unfortunately we don't report the flavor to rdb, so we have to
+            // do this in a silly way involving knowledge about 'scenario'
+            // and the flavors that exist for update tests. this all sucks and
+            // we need a better 'scenario' implementation.
+            var otherscen;
+            var theurl = base_url+"results?testcases="+name+"&item="+item+"&type=bodhi_update&limit=1";
+            if (scenario.includes("updates-server")) {
+              otherscen = scenario.replace("updates-server", "updates-workstation");
+            }
+            else {
+              otherscen = scenario.replace("updates-workstation", "updates-server");
+            }
+            theurl = theurl+"&scenario="+otherscen;
+            request_results(theurl);
+          }
         }
-        if (new Date(latest[item][arch][name].submit_time) < submit_time) {
-          latest[item][arch][name] = result;
+        if (new Date(latest[item][arch][scenario].submit_time) < submit_time) {
+          latest[item][arch][scenario] = result;
         }
       });
 
@@ -168,14 +198,23 @@ ${update.type} update for ${generateupdatetitlestring()}
         "</h4><table class='table table-hover' id='buildresults"+count+
         "'></table>")
         $.each(obj1, function(arch, obj2) {
-          $.each(obj2, function(testcasename, result) {
+          $.each(obj2, function(scenario, result) {
+            var flavor;
+            if (scenario.includes("updates-server")) {
+              flavor = "server";
+            }
+            else if (scenario.includes("updates-workstation")) {
+              flavor = "workstation";
+            }
             $('#buildresults'+count).append(make_row(
                 result.outcome,
                 result.testcase.name,
                 result.note,
+                // note: this is a single-item array
                 result.data.arch,
                 result.submit_time,
-                result.ref_url
+                result.ref_url,
+                flavor
             ));
           });
         });


### PR DESCRIPTION
So, this is the infamous 'scenario' problem. In openQA, we run
four of the update tests - the base_ tests - twice, once from
a Server base image, once from a Workstation base image (as the
results of the tests could potentially differ). In openQA's
terms, the 'test' is the same, the 'flavor' differs.

The term 'scenario' is one openQA came up with while working
with this problem. Basically, if two tests have the same
'scenario', it means they're "the same test". openQA defines
a constant consisting of all the metadata keys that, taken
together, define a test's 'scenario', and call them the
'scenario keys'.

When we report an openQA result to ResultsDB, we basically use
the openQA test name (transmogrified a bit) as the testcase
name, so there can be multiple openQA results with the same
testcase name that are not considered to be re-runs of each
other. We take the values of all the 'scenario keys', glue
them together (with periods), and report this string as the
'scenario' in the result extradata. This was my initial attempt
to set things up so consumers (like Bodhi) could handle the
scenario problem.

Unfortunately now we come to actually use it on the consumer
end, some problems become apparent. Firstly, you can't ask
ResultsDB something like "give me the latest results for item
X by scenario"; the `/latest` endpoint code is hardcoded to
only give you "latest by testcase name". I looked at adding a
'latest by scenario' feature somehow or other, but it's rather
hard to implement given how ResultsDB actually stores its data
(the 'extradata' values are in a different table from the core
values like 'testcase name', and the way they're stored isn't
very amenable to a trivial JOIN operation here, so you rapidly
wind up in advanced-SQL-land).

Secondly, just providing an ugly 'scenario' string misses out
on answering an important part of the problem: it doesn't help
a consumer like Bodhi know how to *display* scenario-bound
results. Just having a scenario string means we either have to
teach the consumer to parse it (as this commit, reluctantly,
does) or the consumer has to just show two apparently-identical
results and let the reader try and figure it out somehow.

This commit is a fairly ugly short-term band-aid which works
for how we *currently* run openQA update tests; in practice
the only 'scenario' element that matters currently is the
'flavor', so we handle that very similarly to how we handle
'arch' for the Taskotron `dist.depcheck` results (note that this
increases the number of queries we have to run). We may start
running the tests on multiple arches at some point, but if we
do that, we can easily extend the existing 'arch' special-casing
a bit to handle it. If we start running the tests on x86_64 and
UEFI or any other openQA 'scenario' case beyond 'flavor' and
'arch', though, we'll have the problem again.

It's worth noting that the `dist.depcheck` 'arch' case already
*is* the "scenario problem"; it's just that no-one bothered
to conceptualize it before, it just got worked around. To put it
formally, the 'scenario' for a Taskotron depcheck test consists
of the testcase name ('dist.depcheck') plus the arch; for all the
other current Taskotron tests, the 'scenario' is just the test
case name. But I think it's pretty clear that we should try and
come up with a better, more generic way to do this than just
teaching Bodhi how to deal with different 'scenario' cases as
they crop up. We need to go back to the drawing board on the
'scenario' thing and come up with a better implementation that
Bodhi and other consumers can use to handle this kind of case
without special knowledge. Perhaps we can start from @kparal 's
idea of having results define their 'scenario keys', not just
provide a glommed-together scenario string...

fixes #1471

Signed-off-by: Adam Williamson <awilliam@redhat.com>