### PR TITLE
Add a ci_status to updates

### DIFF
--- a/alembic/versions/4b357c65441e_add_ci_status_to_builds.py
+++ b/alembic/versions/4b357c65441e_add_ci_status_to_builds.py
@@ -1,0 +1,38 @@
+"""Add ci_status to builds
+
+Revision ID: 4b357c65441e
+Revises: b01a62d98aa4
+Create Date: 2017-05-11 20:13:41.879435
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '4b357c65441e'
+down_revision = 'b01a62d98aa4'
+
+
+def upgrade():
+    """ Add the ci_status to builds with the corresponding enum. """
+
+    op.execute(
+        "CREATE TYPE ck_ci_status AS ENUM "
+        "('ignored', 'queued', 'running', 'passed', 'failed', 'waiting')")
+
+    op.add_column(
+        'builds',
+        sa.Column(
+            'ci_status',
+            sa.Enum(
+                'ignored', 'queued', 'running', 'passed', 'failed', 'waiting',
+                name='ck_ci_status'),
+            nullable=True
+        )
+    )
+
+
+def downgrade():
+    """ Remove the ci_status from builds with the corresponding enum. """
+    op.drop_column('builds', 'ci_status')
+    op.execute("DROP TYPE ck_ci_status")

--- a/alembic/versions/8eaacb38b036_add_the_ci_url_field_to_builds.py
+++ b/alembic/versions/8eaacb38b036_add_the_ci_url_field_to_builds.py
@@ -1,0 +1,27 @@
+"""Add the ci_url field to builds
+
+Revision ID: 8eaacb38b036
+Revises: 4b357c65441e
+Create Date: 2017-05-18 12:01:20.698762
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '8eaacb38b036'
+down_revision = '4b357c65441e'
+
+
+def upgrade():
+    """ Add the ci_url to builds. """
+
+    op.add_column(
+        'builds',
+        sa.Column('ci_url', sa.UnicodeText, nullable=True)
+    )
+
+
+def downgrade():
+    """ Remove the ci_url from builds. """
+    op.drop_column('builds', 'ci_url')

--- a/bodhi/server/config.py
+++ b/bodhi/server/config.py
@@ -323,6 +323,12 @@ class BodhiConfig(dict):
         'captcha.ttl': {
             'value': 300,
             'validator': int},
+        'ci.required': {
+            'value': False,
+            'validator': _validate_bool},
+        'ci.url': {
+            'value': '',
+            'validator': unicode},
         'compose_atomic_trees': {
             'value': False,
             'validator': _validate_bool},

--- a/bodhi/server/templates/update.html
+++ b/bodhi/server/templates/update.html
@@ -686,6 +686,23 @@ $(document).ready(function(){
                 </div>
               </div>
 
+              % if request.registry.settings.get('ci.required'):
+              <div class="p-b-1">
+                <div>
+                  % if request.registry.settings.get('ci.url'):
+                    <a href="${request.registry.settings.get('ci.url')}" title="More information about CI">
+                      <strong>CI Status</strong>
+                    </a>
+                  % else:
+                    <strong>CI Status</strong>
+                  % endif
+                </div>
+                <div>
+                  ${self.util.ci_status2html(update.ci_status.description) | n}
+                </div>
+              </div>
+              % endif
+
               % if update.request:
               <div class="p-b-1">
                 <div>
@@ -862,6 +879,17 @@ $(document).ready(function(){
           <td>
             <a href="https://koji.fedoraproject.org/koji/search?terms=${build.nvr}&type=build&match=glob" target="_blank">
                 ${build.nvr}</a>
+          </td>
+          % if request.registry.settings.get('ci.required'):
+            <td>
+              % if build.ci_url:
+                <a href="${build.ci_url}">${self.util.ci_status2html(build.ci_status.description) | n}</a>
+              % else:
+                ${self.util.ci_status2html(build.ci_status.description) | n}
+              % endif
+            </td>
+          % endif
+          <td class="pull-right">
             % if build.signed:
               <span class="fa fa-key text-muted" aria-hidden="true" data-toggle="tooltip" data-placement="top" title="Build signed"></span>
             % endif

--- a/bodhi/server/util.py
+++ b/bodhi/server/util.py
@@ -320,6 +320,32 @@ def status2html(context, status):
     return "<span class='label label-%s'>%s</span>" % (cls, status)
 
 
+def ci_status2html(context, status):
+    """ Convert the specified status into a html string used to present the
+    CI status in a human friendly way.
+
+    Args:
+        context (mako.runtime.Context): Unused.
+        status (unicode): The description of the CI status
+
+    Returns:
+        unicode: A human friendly HTML label of the CI status
+
+    """
+    cls = {
+        'Ignored': 'success',
+        'Running': 'warning',
+        'Passed': 'success',
+        'Failed': 'danger',
+        'Queued': 'info',
+        'Waiting': 'info',
+        'None': 'primary',
+    }[str(status)]
+    if status is None:
+        status = 'not running'
+    return u"<span class='label label-%s'>Tests %s</span>" % (cls, status)
+
+
 def state2class(context, state):
     state = unicode(state)
     cls = {

--- a/bodhi/tests/server/__init__.py
+++ b/bodhi/tests/server/__init__.py
@@ -5,7 +5,7 @@ import sqlalchemy
 
 from bodhi.server.models import (
     Bug, BuildrootOverride, Comment, CVE, Group, RpmPackage, Release, ReleaseState, RpmBuild,
-    Update, UpdateRequest, UpdateType, User, TestCase)
+    Update, CiStatus, UpdateRequest, UpdateType, User, TestCase)
 
 
 def create_update(session, build_nvrs, release_name=u'F17'):
@@ -35,7 +35,9 @@ def create_update(session, build_nvrs, release_name=u'F17'):
             session.add(testcase)
             package.test_cases.append(testcase)
 
-        builds.append(RpmBuild(nvr=nvr, release=release, package=package))
+        builds.append(RpmBuild(
+            nvr=nvr, release=release, package=package,
+            ci_status=CiStatus.passed))
         session.add(builds[-1])
 
         # Add a buildroot override for this build

--- a/bodhi/tests/server/consumers/test_masher.py
+++ b/bodhi/tests/server/consumers/test_masher.py
@@ -28,7 +28,8 @@ from bodhi.server import buildsys, log, initialize_db
 from bodhi.server.config import config
 from bodhi.server.consumers.masher import Masher, MasherThread
 from bodhi.server.models import (Base, Build, BuildrootOverride, Release, ReleaseState, RpmBuild,
-                                 Update, UpdateRequest, UpdateStatus, UpdateType, User)
+                                 Update, CiStatus, UpdateRequest, UpdateStatus, UpdateType,
+                                 User)
 from bodhi.server.util import mkmetadatadir, transactional_session_maker
 from bodhi.tests.server import base, populate
 
@@ -481,7 +482,9 @@ References:
                 override_tag=u'f18-override',
                 branch=u'f18')
             db.add(release)
-            build = RpmBuild(nvr=u'bodhi-2.0-1.fc18', release=release, package=up.builds[0].package)
+            build = RpmBuild(
+                nvr=u'bodhi-2.0-1.fc18', release=release, package=up.builds[0].package,
+                ci_status=CiStatus.passed)
             db.add(build)
             update = Update(
                 title=u'bodhi-2.0-1.fc18',
@@ -562,7 +565,9 @@ References:
                 override_tag=u'f18-override',
                 branch=u'f18')
             db.add(release)
-            build = RpmBuild(nvr=u'bodhi-2.0-1.fc18', release=release, package=up.builds[0].package)
+            build = RpmBuild(
+                nvr=u'bodhi-2.0-1.fc18', release=release, package=up.builds[0].package,
+                ci_status=CiStatus.passed)
             db.add(build)
             update = Update(
                 title=u'bodhi-2.0-1.fc18',
@@ -635,7 +640,9 @@ References:
                 override_tag=u'f18-override',
                 branch=u'f18')
             db.add(release)
-            build = RpmBuild(nvr=u'bodhi-2.0-1.fc18', release=release, package=up.builds[0].package)
+            build = RpmBuild(
+                nvr=u'bodhi-2.0-1.fc18', release=release, package=up.builds[0].package,
+                ci_status=CiStatus.passed)
             db.add(build)
             update = Update(
                 title=u'bodhi-2.0-1.fc18',

--- a/bodhi/tests/server/test_utils.py
+++ b/bodhi/tests/server/test_utils.py
@@ -409,6 +409,41 @@ class TestUtils(unittest.TestCase):
         splitspacestring = util.splitter("build-0.1 build-0.2")
         self.assertEqual(splitspacestring, ['build-0.1', 'build-0.2'])
 
+    def test_ci_status2html_ignored(self):
+        """ Test the ci_status2html method with a status: Ignored. """
+        output = util.ci_status2html(None, 'Ignored')
+        assert output == "<span class='label label-success'>Tests Ignored</span>"
+
+    def test_ci_status2html_running(self):
+        """ Test the ci_status2html method with a status: Running. """
+        output = util.ci_status2html(None, 'Running')
+        assert output == "<span class='label label-warning'>Tests Running</span>"
+
+    def test_ci_status2html_passed(self):
+        """ Test the ci_status2html method with a status: Passed. """
+        output = util.ci_status2html(None, 'Passed')
+        assert output == "<span class='label label-success'>Tests Passed</span>"
+
+    def test_ci_status2html_failed(self):
+        """ Test the ci_status2html method with a status: Failed. """
+        output = util.ci_status2html(None, 'Failed')
+        assert output == "<span class='label label-danger'>Tests Failed</span>"
+
+    def test_ci_status2html_queued(self):
+        """ Test the ci_status2html method with a status: Queued. """
+        output = util.ci_status2html(None, 'Queued')
+        assert output == "<span class='label label-info'>Tests Queued</span>"
+
+    def test_ci_status2html_waiting(self):
+        """ Test the ci_status2html method with a status: Waiting. """
+        output = util.ci_status2html(None, 'Waiting')
+        assert output == "<span class='label label-info'>Tests Waiting</span>"
+
+    def test_ci_status2html_missing(self):
+        """ Test the ci_status2html method with a status: None. """
+        output = util.ci_status2html(None, None)
+        assert output == "<span class='label label-primary'>Tests not running</span>"
+
 
 class TestCMDFunctions(unittest.TestCase):
     @mock.patch('bodhi.server.log.debug')

--- a/development.ini.example
+++ b/development.ini.example
@@ -56,13 +56,23 @@ badge_ids = binary-star|both-bull-and-self-transcended-tester-viii|catching-the-
 
 
 ##
-## Wiki Test Cases
+## Testing
 ##
 
 ## Query the wiki for test cases
 # query_wiki_test_cases = False
 # wiki_url = https://fedoraproject.org/w/api.php
 # test_case_base_url = https://fedoraproject.org/wiki/
+
+# URL of the resultsdb for integrating checks and stuff
+# resultsdb_api_url = https://taskotron.fedoraproject.org/resultsdb_api/
+
+# Set this to True to enable gating based on Continuous Integration test results.
+# ci.required = False
+
+# If this is set to a URL, a "More information about CI" link will appear on update pages for users
+# to click and learn more.
+# ci.url =
 
 # Email domain to prepend usernames to
 # default_email_domain = fedoraproject.org
@@ -207,9 +217,6 @@ dogpile.cache.arguments.filename = %(here)s/dogpile-cache.dbm
 
 # URL of where users should go to set up their notifications
 # fmn_url = https://apps.fedoraproject.org/notifications/
-
-# URL of the resultsdb for integrating checks and stuff
-# resultsdb_api_url = https://taskotron.fedoraproject.org/resultsdb_api/
 
 # fedmenu.url = https://apps.fedoraproject.org/fedmenu
 # fedmenu.data_url = https://apps.fedoraproject.org/js/data.js

--- a/production.ini
+++ b/production.ini
@@ -58,13 +58,23 @@ use = egg:bodhi-server
 
 
 ##
-## Wiki Test Cases
+## Testing
 ##
 
 ## Query the wiki for test cases
 # query_wiki_test_cases = False
 # wiki_url = https://fedoraproject.org/w/api.php
 # test_case_base_url = https://fedoraproject.org/wiki/
+
+# URL of the resultsdb for integrating checks and stuff
+# resultsdb_api_url = https://taskotron.fedoraproject.org/resultsdb_api/
+
+# Set this to True to enable gating based on Continuous Integration test results.
+# ci.required = False
+
+# If this is set to a URL, a "More information about CI" link will appear on update pages for users
+# to click and learn more.
+# ci.url =
 
 # Email domain to prepend usernames to
 # default_email_domain = fedoraproject.org
@@ -207,9 +217,6 @@ use = egg:bodhi-server
 
 # URL of where users should go to set up their notifications
 # fmn_url = https://apps.fedoraproject.org/notifications/
-
-# URL of the resultsdb for integrating checks and stuff
-# resultsdb_api_url = https://taskotron.fedoraproject.org/resultsdb_api/
 
 # fedmenu.url = https://apps.fedoraproject.org/fedmenu
 # fedmenu.data_url = https://apps.fedoraproject.org/js/data.js


### PR DESCRIPTION
This status is used to reflect the status of the update in the CI
pipeline.
It can be:
- ignored: all the builds in the update are and will not be tested by the
  CI pipeline
- queued: at least one build in the update has been queued to be tested
  in the CI pipeline
- running: at least one build in the update is being tested in the CI
  pipeline
- passed: all the builds in the update have passed testing in the CI
  pipeline
- failed: at least one build in the update has failed testedin in the CI
  pipeline

Note: the status is currently implemented using an update wide flag while
it is the builds composing the update that are being tested.
We may want to rework this approach to make the ci_status be a property
that inspects the ci_status of the builds composing the update and
implements the logic described above.

Signed-off-by: Pierre-Yves Chibon <pingou@pingoured.fr>