### PR TITLE
Do not prompt CLI users for the password.

### DIFF
--- a/bodhi/client/__init__.py
+++ b/bodhi/client/__init__.py
@@ -51,7 +51,7 @@ url_option = click.option('--url', envvar='BODHI_URL', default=bindings.BASE_URL
 
 new_edit_options = [
     click.option('--user', envvar='USERNAME'),
-    click.option('--password', prompt=True, hide_input=True),
+    click.option('--password', hide_input=True),
     click.option('--type', default='bugfix', help='Update type', required=True,
                  type=click.Choice(['security', 'bugfix', 'enhancement', 'newpackage'])),
     click.option('--notes', help='Update description'),
@@ -77,7 +77,7 @@ save_edit_options = [
     click.option('--notes', default="No explanation given...",
                  help='Notes on why this override is in place.'),
     click.option('--user', envvar='USERNAME'),
-    click.option('--password', prompt=True, hide_input=True),
+    click.option('--password', hide_input=True),
     click.option('--staging', help='Use the staging bodhi instance',
                  is_flag=True, default=False),
     url_option]
@@ -275,7 +275,7 @@ def query(url, **kwargs):
 @click.argument('update')
 @click.argument('state')
 @click.option('--user', envvar='USERNAME')
-@click.option('--password', prompt=True, hide_input=True)
+@click.option('--password', hide_input=True)
 @click.option('--staging', help='Use the staging bodhi instance',
               is_flag=True, default=False)
 @url_option
@@ -310,7 +310,7 @@ def request(update, state, user, password, url, **kwargs):
 @click.argument('text')
 @click.option('--karma', default=0, type=click.INT, help='The karma for this comment (+1/0/-1)')
 @click.option('--user', envvar='USERNAME')
-@click.option('--password', prompt=True, hide_input=True)
+@click.option('--password', hide_input=True)
 @click.option('--staging', help='Use the staging bodhi instance',
               is_flag=True, default=False)
 @url_option


### PR DESCRIPTION
We do not need to prompt CLI users for the password because the
bindings superclass will handle that for us if it is needed. This
commit drops the prompt=True flag on the CLI commands that had it.

Signed-off-by: Randy Barlow <randy@electronsweatshop.com>