### PR TITLE
Move the type icons to the left of the update titles so they align.

### DIFF
--- a/bodhi/server/templates/fragments.html
+++ b/bodhi/server/templates/fragments.html
@@ -77,7 +77,7 @@
 </%def>
 
 <%def name="update(update, display_user=True, display_request=False, display_release=True, display_karma=True)">
-  <td class="stretch-table-column">${util.update2html(update) | n} ${util.type2icon(update['type'])|n} </td>
+  <td class="stretch-table-column">${util.type2icon(update['type'])|n} ${util.update2html(update)|n}</td>
   <td class="nowrap">
     <span title="${update['date_submitted']} UTC">
       ${util.age(update['date_submitted'], True)}

--- a/bodhi/server/util.py
+++ b/bodhi/server/util.py
@@ -435,7 +435,7 @@ def type2icon(context, kind):
     }.get(kind)
 
     return "<span class='label label-%s' data-toggle='tooltip'\
-            title='This is a %s update'><i class='fa %s'></i></span> \
+            title='This is a %s update'><i class='fa fa-fw %s'></i></span> \
             " % (cls, kind, fontawesome)
 
 


### PR DESCRIPTION
Signed-off-by: Randy Barlow <randy@electronsweatshop.com>