### PR TITLE
fix half-hidden button on smaller (mobile) screen sizes

### DIFF
--- a/bodhi/server/templates/update.html
+++ b/bodhi/server/templates/update.html
@@ -626,8 +626,8 @@ $(document).ready(function(){
               % endif
 
               <div class="form-group m-t-1">
-                <div class="col-sm-12">
-                  <button type="submit" class="pull-right btn btn-default">
+                <div class="col-sm-12 text-xs-right">
+                  <button type="submit" class="btn btn-default">
                     <span class="indicator fa fa-comment" data-spinclass="indicator fa fa-spinner fa-spin"></span>
                     Add Comment &amp; Feedback
                   </button>


### PR DESCRIPTION
Previously, on the update page, when viewing bodhi
from a mobile device with a narrow screen width,
the "Add Comment & Feedback" button may have been
partally or wholly obscured. This was caused by
an inapproprite use of a float class.

This patch makes the button sit towards the right
without a float, and fixes the issue.