### PR TITLE
Don't show the edit update form if a user can't edit

### DIFF
--- a/bodhi/server/services/updates.py
+++ b/bodhi/server/services/updates.py
@@ -89,7 +89,11 @@ def get_update(request):
 
 
 @update_edit.get(accept="text/html", renderer="new_update.html",
-                 error_handler=bodhi.server.services.errors.html_handler)
+                 error_handler=bodhi.server.services.errors.html_handler,
+                 permission='edit',
+                 validators=(
+                     validate_acls,
+                 ))
 def get_update_for_editing(request):
     """Return a single update from an id, title, or alias for the edit form"""
     return dict(

--- a/bodhi/tests/server/services/test_updates.py
+++ b/bodhi/tests/server/services/test_updates.py
@@ -446,6 +446,38 @@ class TestNewUpdate(bodhi.tests.server.functional.base.BaseWSGICase):
         self.assertEquals(up.comments[-1].text, expected_comment)
 
 
+class TestEditUpdateForm(bodhi.tests.server.functional.base.BaseWSGICase):
+
+    def test_edit_with_permission(self):
+        """
+        Test a logged in User with permissions on the update can see the form
+        """
+        resp = self.app.get('/updates/FEDORA-2017-a3bbe1a8f2/edit')
+        self.assertIn('Editing an update requires JavaScript', resp)
+
+    def test_edit_without_permission(self):
+        """
+        Test a logged in User without permissions on the update can't see the form
+        """
+        app = TestApp(main({}, testing=u'anonymous', session=self.db, **self.app_settings))
+        resp = app.get('/updates/FEDORA-2017-a3bbe1a8f2/edit', status=400)
+        self.assertIn('anonymous does not have commit access to bodhi', resp)
+
+    def test_edit_not_loggedin(self):
+        """
+        Test a non logged in User can't see the form
+        """
+        anonymous_settings = copy.copy(self.app_settings)
+        anonymous_settings.update({
+            'authtkt.secret': 'whatever',
+            'authtkt.secure': True,
+        })
+        app = TestApp(main({}, session=self.db, **anonymous_settings))
+        resp = app.get('/updates/FEDORA-2017-a3bbe1a8f2/edit', status=403)
+        self.assertIn('<h1>403 <small>Forbidden</small></h1>', resp)
+        self.assertIn('<p class="lead">Access was denied to this resource.</p>', resp)
+
+
 class TestUpdatesService(bodhi.tests.server.functional.base.BaseWSGICase):
 
     def test_home_html(self):


### PR DESCRIPTION
Previously, both users that were not logged in, and
users logged in, but not having permissions to edit
an update could view the edit update form. These
users were correctly unable to submit the form, and
buttons that linked them to the form were not shown,
but if the URL was typed in, the user could still
access the form page.

This commit changes it so users that don't have
edit privs on an update get a 403 rather than the
edit form.

Fixes #1521