### PR TITLE
enable fenced_code python-markdown extension

### DIFF
--- a/bodhi/server/util.py
+++ b/bodhi/server/util.py
@@ -327,7 +327,8 @@ def hostname(context=None):
 
 def markup(context, text):
     return markdown.markdown(text, safe_mode="replace",
-                             html_replacement_text="--RAW HTML NOT ALLOWED--")
+                             html_replacement_text="--RAW HTML NOT ALLOWED--",
+                             extensions=['markdown.extensions.fenced_code'])
 
 
 def status2html(context, status):

--- a/bodhi/tests/server/functional/test_generic.py
+++ b/bodhi/tests/server/functional/test_generic.py
@@ -202,6 +202,17 @@ class TestGenericViews(bodhi.tests.server.functional.base.BaseWSGICase):
             "</div>"
         )
 
+    def test_markdown_with_fenced_code_block(self):
+        res = self.app.get('/markdown', {
+            'text': '```\nsudo dnf install bodhi\n```',
+        }, status=200)
+        self.assertEquals(
+            res.json_body['html'],
+            "<div class='markdown'>"
+            '<pre><code>sudo dnf install bodhi\n</code></pre>\n'
+            "</div>"
+        )
+
     def test_metrics(self):
         res = self.app.get('/metrics')
         self.assertIn('$.plot', res)


### PR DESCRIPTION
Enables the markdown.extensions.fenced_code extension on
markdown output so codeblocks with triple-backticks work

fixes #1509