### PR TITLE
Add the signing status of an update to the update page

### DIFF
--- a/bodhi/server/templates/update.html
+++ b/bodhi/server/templates/update.html
@@ -647,6 +647,9 @@ $(document).ready(function(){
                 </div>
                 <div>
                   ${self.util.status2html(update.status) | n}
+                  % if update.signed:
+                    <span class="fa fa-key text-muted" aria-hidden="true" data-toggle="tooltip" data-placement="top" title="Update signed"></span>
+                  % endif
                 </div>
               </div>
 
@@ -657,9 +660,6 @@ $(document).ready(function(){
                 </div>
                 <div>
                   ${self.util.request2html(update.request) | n}
-                  % if not update.signed:
-                    <span class="fa fa-cog" data-toggle="tooltip" data-placement="top" title="Update is being signed"></span>
-                  % endif
                 </div>
               </div>
               % endif
@@ -826,13 +826,14 @@ $(document).ready(function(){
       <table class="table">
         % for build in update.builds:
         <tr class="media">
-          <td><a href="https://koji.fedoraproject.org/koji/search?terms=${build.nvr}&type=build&match=glob" target="_blank">${build.nvr}</a></td>
-          <td class="pull-right">
+          <td>
+            <a href="https://koji.fedoraproject.org/koji/search?terms=${build.nvr}&type=build&match=glob" target="_blank">
+                ${build.nvr}</a>
             % if build.signed:
-              <span class="fa fa-lock" aria-hidden="true" data-toggle="tooltip" data-placement="top" title="Build signed"></span>
-            % else:
-              <span class="fa fa-cog" aria-hidden="true" data-toggle="tooltip" data-placement="top" title="Build is being signed"></span>
+              <span class="fa fa-key text-muted" aria-hidden="true" data-toggle="tooltip" data-placement="top" title="Build signed"></span>
             % endif
+          </td>
+          <td class="pull-right">
             <a href='${request.route_url("updates_rss") + "?packages=" + build.package.name}'>
               <span class="fa fa-rss" data-toggle="tooltip" data-placement="top" title="RSS feed for new Bodhi updates containing ${build.package.name}"></span>
             </a>


### PR DESCRIPTION
This changes the icon on the builds tab to signify that
a build is signed to be a key rather than a lock.

Also adds the key icon to the status area in the right
bar on the Details tab of an update if the Update is
signed.

Removed the cog icon that stated that the "Build is being Signed"
as this was just shown if the build was not signed, not that
the build was in the process of being signed.

Fixes #1469