### PR TITLE
Don't double document the dev aliases.

### DIFF
--- a/docs/developer_docs.rst
+++ b/docs/developer_docs.rst
@@ -67,14 +67,8 @@ You can ssh into your running Vagrant box like this::
     $ vagrant ssh
 
 Once you are inside the development environment, there are a helpful set of commands in your
-``.bashrc``:
-
-* ``bdocs``: Build Bodhi's documentation.
-* ``blog``: View Bodhi's log.
-* ``brestart``: Restart the Bodhi service.
-* ``bstart``: Start the Bodhi service.
-* ``bstop``: Stop the Bodhi service.
-* ``btest``: Run Bodhi's test suite.
+``.bashrc`` that will be printed to the screen via the ``/etc/motd`` file. Be sure to familiarize
+yourself with these.
 
 Keep in mind that all ``vagrant`` commands should be run with your current working directory set to
 your Bodhi checkout. The code from your development host will be mounted in ``/home/vagrant/bodhi``


### PR DESCRIPTION
The bashrc aliases are already documented in the /etc/motd file, so
this commit removes a second place they were documented in the
developer docs so we don't have to maintain both copies. In its
place it instructs the developer to familiarize themselves with the
aliases printed upon login.

Signed-off-by: Randy Barlow <randy@electronsweatshop.com>