### PR TITLE
Add disabled Edit button on Locked updates

### DIFF
--- a/bodhi/server/static/js/site.js
+++ b/bodhi/server/static/js/site.js
@@ -39,7 +39,7 @@ $(document).ready(function() {
     });
 
     // Attach bootstrap tooltips to everything.
-    $('span').tooltip();
+    $('[data-toggle="tooltip"]').tooltip();
 
     // Make the rows on the comment form change color on click.
     $('.table td > input').click(function() {

--- a/bodhi/server/templates/update.html
+++ b/bodhi/server/templates/update.html
@@ -456,6 +456,14 @@ $(document).ready(function(){
             <a id='unpush' class="btn btn-sm btn-danger"><span class="fa fa-arrow-circle-left"></span> Unpush</a>
           % endif
           </div>
+        % else:
+          <div id='updatebuttons' class="btn-group pull-right" role="group" aria-label="...">
+            <button class="btn btn-sm btn-primary" disabled data-placement="bottom"
+                    data-toggle="tooltip" data-placement="bottom"
+                    title="Update is locked and cannot be edited. Locking of an update usually occurs when a push is in progress.">
+              <span class="fa fa-pencil"></span> Edit
+            </button>
+          </div>
         % endif
       % endif
 


### PR DESCRIPTION
Previously, if an updated was Locked, the edit button for
an update was not shown to the user, even if they have
edit privs on that Update.

Now, we show a disabled Edit button for an update if the
user has edit privs, but the update is locked.

Fixes: #1492 

![screenshot from 2017-05-17 14-05-57](https://cloud.githubusercontent.com/assets/592259/26138709/68d9f694-3b0e-11e7-9cca-91341cebf5e0.png)
