### PR TITLE
Fix Pyramid deprecation warnings

### DIFF
--- a/bodhi/server/__init__.py
+++ b/bodhi/server/__init__.py
@@ -23,7 +23,6 @@ from pyramid.authorization import ACLAuthorizationPolicy
 from pyramid.config import Configurator
 from pyramid.exceptions import HTTPForbidden
 from pyramid.renderers import JSONP
-from pyramid.security import unauthenticated_userid
 from pyramid.settings import asbool
 from sqlalchemy import engine_from_config, event
 from sqlalchemy.orm import scoped_session, sessionmaker
@@ -79,7 +78,7 @@ def get_cacheregion(request):
 
 def get_user(request):
     from bodhi.server.models import User
-    userid = unauthenticated_userid(request)
+    userid = request.unauthenticated_userid
     if userid is not None:
         user = request.db.query(User).filter_by(name=unicode(userid)).first()
         # Why munch?  https://github.com/fedora-infra/bodhi/issues/473

--- a/bodhi/server/services/stacks.py
+++ b/bodhi/server/services/stacks.py
@@ -16,7 +16,6 @@ import math
 
 from cornice import Service
 from pyramid.exceptions import HTTPForbidden
-from pyramid.security import authenticated_userid
 from pyramid.view import view_config
 from sqlalchemy import func, distinct
 from sqlalchemy.sql import or_
@@ -186,7 +185,7 @@ def delete_stack(request):
 @view_config(route_name='new_stack', renderer='new_stack.html')
 def new_stack(request):
     """ Returns the new stack form """
-    user = authenticated_userid(request)
+    user = request.authenticated_userid
     if not user:
         raise HTTPForbidden("You must be logged in.")
     return dict()

--- a/bodhi/server/views/admin.py
+++ b/bodhi/server/views/admin.py
@@ -12,7 +12,6 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
-from pyramid.security import effective_principals
 from cornice import Service
 
 from bodhi.server import log
@@ -27,5 +26,5 @@ admin_service = Service(name='admin', path='/admin/',
 def admin(request):
     user = request.user
     log.info('%s logged into admin panel' % user.name)
-    principals = effective_principals(request)
+    principals = request.effective_principals
     return {'user': user.name, 'principals': principals}

--- a/bodhi/server/views/generic.py
+++ b/bodhi/server/views/generic.py
@@ -17,7 +17,6 @@ import sqlalchemy as sa
 
 import cornice.errors
 
-from pyramid.security import authenticated_userid
 from pyramid.settings import asbool
 from pyramid.view import view_config, notfound_view_config
 from pyramid.exceptions import HTTPForbidden, HTTPBadRequest
@@ -91,7 +90,7 @@ def home(request):
 @view_config(route_name='new_update', renderer='new_update.html')
 def new_update(request):
     """ Returns the new update form """
-    user = authenticated_userid(request)
+    user = request.authenticated_userid
     if not user:
         raise HTTPForbidden("You must be logged in.")
     return dict(
@@ -187,7 +186,7 @@ def masher_status(request):
 def new_override(request):
     """ Returns the new buildroot override form """
     nvr = request.params.get('nvr')
-    user = authenticated_userid(request)
+    user = request.authenticated_userid
     if not user:
         raise HTTPForbidden("You must be logged in.")
     return dict(nvr=nvr)
@@ -196,7 +195,7 @@ def new_override(request):
 @view_config(route_name='popup_toggle', request_method='POST')
 def popup_toggle(request):
     # Get the user
-    userid = authenticated_userid(request)
+    userid = request.authenticated_userid
     if userid is None:
         raise HTTPForbidden("You must be logged in.")
     user = request.db.query(models.User).filter_by(name=unicode(userid)).first()

--- a/bodhi/tests/client/test_bindings.py
+++ b/bodhi/tests/client/test_bindings.py
@@ -859,7 +859,7 @@ class TestErrorhandled(unittest.TestCase):
             # raised.
             wrong_password_lol(a_fake_self)
 
-        self.assertEqual(exc.exception.message, 'wrong password lol')
+        self.assertEqual(str(exc.exception), 'wrong password lol')
         a_fake_self._session.cookies.clear.assert_called_once_with()
         self.assertTrue(a_fake_self.csrf_token is None)
         self.assertEqual(a_fake_self.call_count, 2)


### PR DESCRIPTION
Pyramid has deprecated a number of API items in the pyramid.security
module that Bodhi was using. These are now attributes in the Pyramid
request. This patch changes authenticated_userid,unauthenticated_userid,
and effective_principals to use the corresponding attributes in the
Pyramid request object.

This also fixes a Python decprication warning the same as the ones
fixed in PR  #1498 

This PR fixes the following warnings that were being shown when running the 
unit tests in the Vagrant dev environment:

```
/home/vagrant/bodhi/bodhi/server/__init__.py:26: DeprecationWarning: unauthenticated_userid: As of Pyramid 1.5 the "pyramid.security.unauthenticated_userid" API is now deprecated.  It will be removed in Pyramd 1.8.  Use the "unauthenticated_userid" attribute of the Pyramid request instead.

/home/vagrant/bodhi/bodhi/server/services/stacks.py:19: DeprecationWarning: authenticated_userid: As of Pyramid 1.5 the "pyramid.security.authenticated_userid" API is now deprecated.  It will be removed in Pyramd 1.8.  Use the "authenticated_userid" attribute of the Pyramid request instead.

/home/vagrant/bodhi/bodhi/server/views/admin.py:15: DeprecationWarning: effective_principals: As of Pyramid 1.5 the "pyramid.security.effective_principals" API is now deprecated.  It will be removed in Pyramd 1.8.  Use the "effective_principals" attribute of the Pyramid request instead.

/home/vagrant/bodhi/bodhi/server/views/generic.py:20: DeprecationWarning: authenticated_userid: As of Pyramid 1.5 the "pyramid.security.authenticated_userid" API is now deprecated.  It will be removed in Pyramd 1.8.  Use the "authenticated_userid" attribute of the Pyramid request instead.

/home/vagrant/bodhi/bodhi/tests/client/test_bindings.py:862: DeprecationWarning: BaseException.message has been deprecated as of Python 2.6 self.assertEqual(exc.exception.message, 'wrong password lol')
```