### PR TITLE
[Factory 2.0] Add the ability to restrict Bodhi updates by using ACLs in Pagure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ html-docs
 masher/
 Vagrantfile
 .dnf-cache/
+.idea

--- a/bodhi/server/models.py
+++ b/bodhi/server/models.py
@@ -44,7 +44,7 @@ from bodhi.server.config import config
 from bodhi.server.exceptions import BodhiException, LockedUpdateException
 from bodhi.server.util import (
     avatar as get_avatar, build_evr, flash_log, get_critpath_pkgs,
-    get_nvr, get_rpm_header, header, tokenize)
+    get_nvr, get_rpm_header, header, tokenize, pagure_api_get)
 import bodhi.server.util
 
 
@@ -611,6 +611,45 @@ class Package(Base):
                             committers.append(name)
 
         return (committers, watchers), (committergroups, watchergroups)
+
+    def get_pkg_committers_from_pagure(self):
+        """
+        Pull users who can commit and are watching a package in Pagure.
+
+        Return two two-tuples of lists:
+        * The first tuple is for usernames.  The second tuple is for groups.
+        * The first list of the tuple is for committers. The second is for
+          watchers.
+        """
+        pagure_url = config.get(
+            'pagure_url', 'https://src.fedoraproject.org/pagure/')
+        # Pagure uses plural names for its namespaces such as "rpms"
+        namespace = self.type.name + 's'
+        package_pagure_url = '{0}/api/0/{1}/{2}'.format(
+            pagure_url.rstrip('/'), namespace, self.name)
+        package_json = pagure_api_get(package_pagure_url)
+
+        committers = set()
+        for access_type in ['owner', 'admin', 'commit']:
+            committers = committers | set(
+                package_json['access_users'][access_type])
+        for access_type in ['admin', 'commit']:
+            # We resolve the group membership here since these are Pagure
+            # groups, and not FAS groups. Bodhi understands the latter but not
+            # the former.
+            for group_name in package_json['access_groups'][access_type]:
+                group_pagure_url = '{0}/api/0/group/{1}'.format(
+                    config['pagure_url'].rstrip('/'), group_name)
+                group_json = pagure_api_get(group_pagure_url)
+                committers = committers | set(group_json['members'])
+
+        # The first list contains users with commit access. The second list is
+        # supposed to contain groups with commit access. Since Pagure uses
+        # Pagure groups, which Bodhi doesn't understand, the code above
+        # resolves the group membership. That is why the second list is empty.
+        # These return values maintain compatibility with other functions such
+        # as get_pkg_pushers.
+        return list(committers), []
 
     def fetch_test_cases(self, db):
         """ Get a list of test cases from the wiki """

--- a/bodhi/tests/server/test_models.py
+++ b/bodhi/tests/server/test_models.py
@@ -386,6 +386,62 @@ class TestRpmPackage(ModelTest, unittest.TestCase):
         # This should not raise any Exception.
         self.db.flush()
 
+    @mock.patch('bodhi.server.util.requests.get')
+    def test_get_pkg_committers_from_pagure(self, mock_get):
+        """ Ensure that the package commiters can be found using the Pagure
+        API.
+        """
+        mock_get.return_value.status_code = 200
+        json_one = {
+            "access_groups": {
+                "admin": [],
+                "commit": ['factory2'],
+                "ticket": []
+            },
+            "access_users": {
+                "admin": [],
+                "commit": [],
+                "owner": [
+                    "mprahl"
+                ],
+                "ticket": ["jsmith"]
+            },
+            "close_status": [],
+            "custom_keys": [],
+            "date_created": "1494947106",
+            "description": "Python",
+            "fullname": "rpms/python",
+            "id": 2,
+            "milestones": {},
+            "name": "python",
+            "namespace": "rpms",
+            "parent": None,
+            "priorities": {},
+            "tags": [],
+            "user": {
+                "fullname": "Matt Prahl",
+                "name": "mprahl"
+            }
+        }
+        json_two = {
+            "creator": {
+                "fullname": "Ralph Bean",
+                "name": "ralph"
+            },
+            "date_created": "1495035052",
+            "description": "Factory 2.0 Developers",
+            "display_name": "factory2",
+            "group_type": "user",
+            "members": [
+                "ralph",
+                "mikeb"
+            ],
+            "name": "factory2"
+        }
+        mock_get.return_value.json.side_effect = [json_one, json_two]
+        rv = self.package.get_pkg_committers_from_pagure()
+        assert rv == (['ralph', 'mikeb', 'mprahl'], []), rv
+
 
 class TestRpmBuild(ModelTest):
     """Unit test case for the ``RpmBuild`` model."""

--- a/bodhi/tests/server/test_utils.py
+++ b/bodhi/tests/server/test_utils.py
@@ -34,8 +34,10 @@ class TestUtils(object):
         assert config.get('sqlalchemy.url'), config
         assert config['sqlalchemy.url'], config
 
-    def test_get_critpath_components(self):
-        """Ensure the pkgdb's critpath API works"""
+    def test_get_critpath_components_dummy(self):
+        """ Ensure that critpath packages can be found using the hardcoded
+        list.
+        """
         pkgs = util.get_critpath_components()
         assert 'kernel' in pkgs, pkgs
 

--- a/bodhi/tests/server/test_validators.py
+++ b/bodhi/tests/server/test_validators.py
@@ -1,0 +1,175 @@
+# Copyright 2017 Red Hat, Inc.
+# This file is part of bodhi.
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+"""This module contains tests for bodhi.server.validators."""
+import mock
+from cornice.errors import Errors
+
+from bodhi.server import validators
+from bodhi.tests.server.base import BaseTestCase
+from bodhi.server import models
+
+
+class TestValidateAcls(BaseTestCase):
+    """ Test the validate_acls() function.
+    """
+    def get_mock_request(self, acl_system):
+        """
+        A helper function that creates a mock request.
+        :param acl_system: a string representing the acl_system to set in the
+        configuration.
+        :return: a Mock object representing a request
+        """
+        update = self.db.query(models.Update).filter_by(
+            title='bodhi-2.0-1.fc17').one()
+        user = self.db.query(models.User).filter_by(id=1).one()
+        mock_request = mock.Mock()
+        mock_request.user = user
+        mock_request.db = self.db
+        mock_request.registry.settings = {
+            'acl_system': acl_system,
+            'pagure_url': 'http://domain.local',
+            'admin_packager_groups': 'provenpackager',
+            'mandatory_packager_groups': 'packager'
+        }
+        mock_request.errors = Errors()
+        mock_request.validated = {'update': update}
+        mock_request.buildinfo = {'bodhi-2.0-1.fc17': {}}
+        return mock_request
+
+    # Mocking the get_pkg_committers_from_pagure function because it will
+    # simplify the overall number of mocks. This function is tested on its own
+    # elsewhere.
+    @mock.patch('bodhi.server.models.Package.get_pkg_committers_from_pagure',
+                return_value=(['guest'], []))
+    def test_validate_acls_pagure(self, mock_gpcfp):
+        """ Test validate_acls when the acl system is Pagure.
+        """
+        mock_request = self.get_mock_request('pagure')
+        validators.validate_acls(mock_request)
+        assert len(mock_request.errors) == 0, mock_request.errors
+        mock_gpcfp.assert_called_once()
+
+    @mock.patch('bodhi.server.models.Package.get_pkg_committers_from_pagure',
+                return_value=(['tbrady'], []))
+    def test_validate_acls_pagure_proven_packager(self, mock_gpcfp):
+        """ Test validate_acls when the acl system is Pagure when the user is
+        a proven packager but doesn't have access through Pagure.
+        """
+        user = self.db.query(models.User).filter_by(id=1).one()
+        group = self.db.query(models.Group).filter_by(
+            name='provenpackager').one()
+        user.groups.pop(0)
+        user.groups.append(group)
+        self.db.flush()
+        mock_request = self.get_mock_request('pagure')
+        validators.validate_acls(mock_request)
+        assert len(mock_request.errors) == 0, mock_request.errors
+        mock_gpcfp.assert_not_called()
+
+    @mock.patch('bodhi.server.models.Package.get_pkg_committers_from_pagure',
+                return_value=(['guest'], []))
+    def test_validate_acls_pagure_not_a_packager(self, mock_gpcfp):
+        """ Test validate_acls when the acl system is Pagure when the user is
+        not a packager but has access through Pagure. This should not be
+        allowed.
+        """
+        user = self.db.query(models.User).filter_by(id=1).one()
+        user.groups.pop(0)
+        self.db.flush()
+        mock_request = self.get_mock_request('pagure')
+        validators.validate_acls(mock_request)
+        error = [{
+            'location': 'body',
+            'name': 'builds',
+            'description': ('guest is not a member of "packager", which is a '
+                            'mandatory packager group')
+        }]
+        assert mock_request.errors == error, mock_request.errors
+        mock_gpcfp.assert_not_called()
+
+    @mock.patch('bodhi.server.models.Package.get_pkg_committers_from_pagure',
+                return_value=(['tbrady'], []))
+    def test_validate_acls_pagure_no_commit_access(self, mock_gpcfp):
+        """ Test validate_acls when the acl system is Pagure when the user is
+        a packager but doesn't have access through Pagure.
+        """
+        mock_request = self.get_mock_request('pagure')
+        validators.validate_acls(mock_request)
+        error = [{
+            'location': 'body',
+            'name': 'builds',
+            'description': 'guest does not have commit access to bodhi'
+        }]
+        assert mock_request.errors == error, mock_request.errors
+        mock_gpcfp.assert_called_once()
+
+    @mock.patch('bodhi.server.models.Package.get_pkg_committers_from_pagure',
+                return_value=(['guest'], []))
+    def test_validate_acls_pagure_runtime_error(self, mock_gpcfp):
+        """ Test validate_acls when the acl system is Pagure and a RuntimeError
+        is raised.
+        """
+        mock_request = self.get_mock_request('pagure')
+        mock_gpcfp.side_effect = RuntimeError('some error')
+        validators.validate_acls(mock_request)
+        assert len(mock_request.errors) == 1, mock_request.errors
+        expected_error = [{
+            'location': 'body',
+            'name': 'builds',
+            'description': 'some error'
+        }]
+        assert mock_request.errors == expected_error, mock_request.errors
+        mock_gpcfp.assert_called_once()
+
+    @mock.patch('bodhi.server.models.Package.get_pkg_committers_from_pagure',
+                return_value=(['guest'], []))
+    def test_validate_acls_pagure_exception(self, mock_gpcfp):
+        """ Test validate_acls when the acl system is Pagure and an exception
+        that isn't a RuntimeError is raised.
+        """
+        mock_request = self.get_mock_request('pagure')
+        mock_gpcfp.side_effect = ValueError('some error')
+        validators.validate_acls(mock_request)
+        assert len(mock_request.errors) == 1, mock_request.errors
+        expected_error = [{
+            'location': 'body',
+            'name': 'builds',
+            'description': ('Unable to access Pagure to check ACLs. Please '
+                            'try again later.')
+        }]
+        assert mock_request.errors == expected_error, mock_request.errors
+        mock_gpcfp.assert_called_once()
+
+    def test_validate_acls_dummy(self):
+        """ Test validate_acls when the acl system is dummy.
+        """
+        mock_request = self.get_mock_request('dummy')
+        validators.validate_acls(mock_request)
+        assert len(mock_request.errors) == 0, mock_request.errors
+
+    def test_validate_acls_invalid_acl_system(self):
+        """ Test validate_acls when the acl system is invalid.
+        This will ensure that the user does not have rights.
+        """
+        mock_request = self.get_mock_request('nonexistent')
+        validators.validate_acls(mock_request)
+        error = [{
+            'location': 'body',
+            'name': 'builds',
+            'description': 'guest does not have commit access to bodhi'
+        }]
+        assert mock_request.errors == error, mock_request.errors

--- a/development.ini.example
+++ b/development.ini.example
@@ -272,8 +272,8 @@ fedmenu.data_url = https://apps.fedoraproject.org/js/data.js
 ##
 ## ACL system
 ## Choices are 'pkgdb', which will send a JSON query to the pkgdb_url below,
-## or 'dummy', which will always return guest credentials (used for local
-## development).
+## 'pagure', which will query the pagure_url below, or 'dummy', which will
+## always return guest credentials (used for local development).
 ##
 acl_system = dummy
 
@@ -281,6 +281,16 @@ acl_system = dummy
 ## Package DB
 ##
 pkgdb_url = https://admin.fedoraproject.org/pkgdb
+
+##
+## Pagure
+##
+# pagure_url = https://src.fedoraproject.org/pagure/
+
+##
+## Product Definition Center (PDC)
+##
+# pdc_url = https://pdc.fedoraproject.org/
 
 # We used to get our package tags from pkgdb, but they come from tagger now.
 # https://github.com/fedora-infra/fedora-tagger/pull/74
@@ -327,11 +337,14 @@ reboot_pkgs = kernel kernel-smp kernel-xen-hypervisor kernel-PAE kernel-xen0 ker
 ## https://fedoraproject.org/wiki/Critical_path_package
 ##
 
-# Enable this to query the Fedora Package Database for the list of Critical
-# Path Packages.  If disabled, it'll just use the hardcoded list below.
+# You can allow Bodhi to query for critpath packages from the Fedora Package
+# Database by setting this value to `pkgdb` or the Product Definition
+# Center by setting this value to `pdc`. If it isn't set, it'll just use the
+# hardcoded list below.
 #critpath.type = pkgdb
 
-# You can hardcode a list of critical path packages instead of using the PackageDB
+# You can hardcode a list of critical path packages instead of using the PkgDB
+# or PDC
 critpath_pkgs = kernel
 
 # The number of admin approvals it takes to be able to push a critical path

--- a/production.ini
+++ b/production.ini
@@ -253,8 +253,8 @@ resultsdb_api_url = https://taskotron.fedoraproject.org/resultsdb_api/
 ##
 ## ACL system
 ## Choices are 'pkgdb', which will send a JSON query to the pkgdb_url below,
-## or 'dummy', which will always return guest credentials (used for local
-## development).
+## 'pagure', which will query the pagure_url below, or 'dummy', which will
+## always return guest credentials (used for local development).
 ##
 acl_system = dummy
 
@@ -262,6 +262,16 @@ acl_system = dummy
 ## Package DB
 ##
 pkgdb_url = https://admin.fedoraproject.org/pkgdb
+
+##
+## Pagure
+##
+# pagure_url = https://src.fedoraproject.org/pagure/
+
+##
+## Product Definition Center (PDC)
+##
+# pdc_url = https://pdc.fedoraproject.org/
 
 # We used to get our package tags from pkgdb, but they come from tagger now.
 # https://github.com/fedora-infra/fedora-tagger/pull/74
@@ -308,11 +318,14 @@ reboot_pkgs = kernel kernel-smp kernel-xen-hypervisor kernel-PAE kernel-xen0 ker
 ## https://fedoraproject.org/wiki/Critical_path_package
 ##
 
-# Enable this to query the Fedora Package Database for the list of Critical
-# Path Packages.  If disabled, it'll just use the hardcoded list below.
+# You can allow Bodhi to query for critpath packages from the Fedora Package
+# Database by setting this value to `pkgdb` or the Product Definition
+# Center by setting this value to `pdc`. If it isn't set, it'll just use the
+# hardcoded list below.
 #critpath.type = pkgdb
 
-# You can hardcode a list of critical path packages instead of using the PackageDB
+# You can hardcode a list of critical path packages instead of using the PkgDB
+# or PDC
 critpath_pkgs = kernel
 
 # The number of admin approvals it takes to be able to push a critical path

--- a/tools/metrics.py
+++ b/tools/metrics.py
@@ -27,7 +27,7 @@ from sqlalchemy.sql import and_
 
 from bodhi.server import Session, initialize_db
 from bodhi.server.models import Update, Release, UpdateStatus, UpdateType
-from bodhi.server.util import header, get_critpath_pkgs
+from bodhi.server.util import header, get_critpath_components
 import bodhi
 
 
@@ -56,7 +56,7 @@ def main(releases=None):
         if releases and release.name not in releases:
             continue
         updates = db.query(Update).filter_by(release=release)
-        critpath_pkgs = get_critpath_pkgs(release.name.lower())
+        critpath_pkgs = get_critpath_components(release.name.lower())
         total = updates.count()
         if not total:
             continue


### PR DESCRIPTION
This PR does the following things:
* Adds the ability to restrict Bodhi updates by using ACLs in Pagure
* Adds the ability to get the critpath packages from PDC

This functionality is to enable the Arbitrary Branching project as described at https://fedoraproject.org/wiki/Infrastructure/Factory2/Focus/ArbitraryBranching

This change will not currently work in production because Pagure over dist-git is not yet deployed, but it worked in my local environment. This should not affect the production Bodhi instance because to enable this change, you'd need to set `acl_system` to `pagure` in the config file.

If you are interested, here is a short video demo showing the functionality of the first bullet point from above:
https://fedorapeople.org/groups/factory2/sprint-031/mprahl-bodhi-acls-using-pagure.mp4

Thank you for time and help reviewing this PR. If you have any questions or concerns, please let me know.
