### PR TITLE
PEP-8 docs/conf.py by reducing a line length.

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -217,7 +217,8 @@ latex_documents = [
 # (source start file, name, description, authors, manual section).
 man_pages = [
     ('man_pages/bodhi', 'bodhi', u'manage Fedora updates', ['Randy Barlow', 'Luke Macken'], 1),
-    ('man_pages/bodhi-approve-testing', 'bodhi-approve-testing', u'approve updates', ['Randy Barlow'], 1),
+    ('man_pages/bodhi-approve-testing', 'bodhi-approve-testing', u'approve updates',
+     ['Randy Barlow'], 1),
     ('man_pages/bodhi-push', 'bodhi-push', u'push Fedora updates', ['Randy Barlow'], 1),
     ('man_pages/initialize_bodhi_db', 'initialize_bodhi_db', u'intialize bodhi\'s database',
      ['Randy Barlow'], 1)


### PR DESCRIPTION
I have no idea how I missed that this was causing the flake8 test to fail, but it is ☹

Signed-off-by: Randy Barlow <randy@electronsweatshop.com>