### PR TITLE
make placeholder text for updates more descriptive

### DIFF
--- a/bodhi/server/templates/new_update.html
+++ b/bodhi/server/templates/new_update.html
@@ -138,7 +138,7 @@
           </div>
           <div class="card-block p-a-0">
             <textarea class="form-control" id="notes" name="notes" rows="6"
-              placeholder="Update notes go here.  They're really *really* useful, so feel free to write as you please." required="true">
+              placeholder="Update notes go here.  Please be as descriptive as possible.  Help testers know what to test, and users know why this update is available and what major changes it brings (if any)." required="true">
 % if update:
 ${update.notes}
 % endif


### PR DESCRIPTION
The tooltip is already descriptive, but let's make the placeholder text also explain the purpose.