### PR TITLE
Support non-rpm content (modules) in the API.

### DIFF
--- a/bodhi/server/buildsys.py
+++ b/bodhi/server/buildsys.py
@@ -130,6 +130,7 @@ class DevBuildsys(Buildsystem):
                 'completion_time': '2007-08-24 23:26:10.890319',
                 'creation_event_id': 151517,
                 'creation_time': '2007-08-24 19:38:29.422344',
+                'extra': None,
                 'epoch': None,
                 'id': theid,
                 'owner_id': 388,
@@ -143,6 +144,24 @@ class DevBuildsys(Buildsystem):
         release_tokens = release.split(".")
 
         for token in release_tokens:
+            # Starting to hardcode some dev buildsys bits for docker.
+            # See https://github.com/fedora-infra/bodhi/pull/1543
+            if token.endswith("container"):
+                tag = "f%s-updates-testing" % token.replace("fc", "").replace("container", "")
+                data['extra'] = {
+                    'container_koji_task_id': 19708268,
+                    'image': {},
+                }
+                break
+
+            # Hardcoding for modules in the dev buildsys
+            if token.startswith("2017"):
+                tag = "f17-updates-testing"
+                data['extra'] = {
+                    'typeinfo': {'module': {'more': 'mbs stuff goes here'}}
+                }
+                break
+
             if token.startswith("fc"):
                 if testing:
                     tag = "f%s-updates-testing" % token.replace("fc", "")
@@ -154,7 +173,6 @@ class DevBuildsys(Buildsystem):
             if token.startswith("el"):
                 tag = "dist-%sE-epel-testing-candidate" % token.replace("el", "")
                 break
-
         else:
             raise ValueError("Couldn't determine dist for build '%s'" % build)
 
@@ -216,6 +234,16 @@ class DevBuildsys(Buildsystem):
                  'name': 'dist-5E-epel-testing-candidate', 'perm': None, 'perm_id': None},
                 {'arches': 'i386 x86_64 ppc ppc64', 'id': 5, 'locked': True, 'name': 'dist-5E-epel',
                  'perm': None, 'perm_id': None}]
+        elif '-master-' in build:
+            # Hardcoding for modules in the dev buildsys
+            result = [
+                {'arches': 'x86_64', 'id': 15, 'locked': True,
+                 'name': 'f17-updates-candidate'},
+                {'arches': 'x86_64', 'id': 16, 'locked': True,
+                 'name': 'f17-updates-testing'},
+                {'arches': 'x86_64', 'id': 17, 'locked': True,
+                 'name': 'f17'},
+            ]
         else:
             release = build.split('.')[-1].replace('fc', 'f')
             result = [

--- a/bodhi/server/schemas.py
+++ b/bodhi/server/schemas.py
@@ -17,8 +17,15 @@ import re
 import colander
 
 from bodhi.server import util
-from bodhi.server.models import (ReleaseState, UpdateRequest, UpdateSeverity, UpdateStatus,
-                                 UpdateSuggestion, UpdateType)
+from bodhi.server.models import (
+    ContentType,
+    ReleaseState,
+    UpdateRequest,
+    UpdateSeverity,
+    UpdateStatus,
+    UpdateSuggestion,
+    UpdateType,
+)
 from bodhi.server.validators import validate_csrf_token
 
 
@@ -522,6 +529,13 @@ class ListUpdateSchema(PaginatedSchema, SearchableSchema, Cosmetics):
         location="querystring",
         missing=None,
         validator=colander.OneOf(UpdateType.values()),
+    )
+
+    content_type = colander.SchemaNode(
+        colander.String(),
+        location="querystring",
+        missing=None,
+        validator=colander.OneOf(ContentType.values()),
     )
 
     user = colander.SchemaNode(

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -1,6 +1,17 @@
 Release notes
 =============
 
+NEXT
+----
+
+Features
+^^^^^^^^
+
+* The API and fedmsg messages now support non-RPM content
+  (`#1325 <https://github.com/fedora-infra/bodhi/issues/1325>`_ and
+  `#1326 <https://github.com/fedora-infra/bodhi/issues/1326>`_).
+
+
 2.7.0
 -----
 


### PR DESCRIPTION
This should fix #1325 and #1326.

As mentioned in #1325, this:

- Expands the GET api to return the `content_type` of a given update.
- Expands the search api to allow filtering on the `content_type` of updates.
- Enhances the submission api to *infer* the content_type from the given NVR,
  which should have minimal impact on users.

To this last point, we have to add an additional call to koji during module
submission to get the `extra` info back from the `koji.getBuild()` API.
Certain markers live in that block that can help us figure out what kind of
build this is.  Containers built in OSBS and Modules from the MBS will have
identifying keys there.

The code should have full coverage.  I introduced some unit tests of new
functions and methods I added and I also tested full request/reply paths
through the affected cornice services.