### PR TITLE
Give Bodhi central configuration validation.

### DIFF
--- a/bodhi/server/bugs.py
+++ b/bodhi/server/bugs.py
@@ -59,7 +59,7 @@ class Bugzilla(BugTracker):
 
     def _connect(self):
         user = config.get('bodhi_email')
-        password = config.get('bodhi_password', None)
+        password = config.get('bodhi_password')
         url = config.get("bz_server")
         log.info("Using BZ URL %s" % url)
         if user and password:
@@ -167,7 +167,7 @@ class Bugzilla(BugTracker):
     def modified(self, bug_id):
         try:
             bug = self.bz.getbug(bug_id)
-            if bug.product not in config.get('bz_products', '').split(','):
+            if bug.product not in config.get('bz_products'):
                 log.info("Skipping %r bug" % bug.product)
                 return
             if bug.bug_status not in ('MODIFIED', 'VERIFIED', 'CLOSED'):

--- a/bodhi/server/captcha.py
+++ b/bodhi/server/captcha.py
@@ -50,15 +50,14 @@ def math_generator(plainkey, settings):
 
 def jpeg_generator(plainkey, settings):
     image_size = image_width, image_height = (
-        int(settings.get('captcha.image_width', 300)),
-        int(settings.get('captcha.image_height', 80)),
+        settings.get('captcha.image_width'),
+        settings.get('captcha.image_height'),
     )
-    default_font = '/usr/share/fonts/liberation/LiberationMono-Regular.ttf'
-    font_path = settings.get('captcha.font_path', default_font)
-    font_size = int(settings.get('captcha.font_size', 36))
-    font_color = settings.get('captcha.font_color', '#000000')
-    background_color = settings.get('captcha.background_color', '#ffffff')
-    padding = int(settings.get('captcha.padding', 5))
+    font_path = settings.get('captcha.font_path')
+    font_size = settings.get('captcha.font_size')
+    font_color = settings.get('captcha.font_color')
+    background_color = settings.get('captcha.background_color')
+    padding = settings.get('captcha.padding')
 
     img = Image.new('RGB', image_size, color=background_color)
 
@@ -171,7 +170,7 @@ def encrypt(plaintext, settings):
 
 
 def decrypt(ciphertext, settings):
-    ttl = int(settings['captcha.ttl'])
+    ttl = settings['captcha.ttl']
     secret = settings['captcha.secret']
     engine = cryptography.fernet.Fernet(secret)
 

--- a/bodhi/server/config.py
+++ b/bodhi/server/config.py
@@ -11,11 +11,14 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
-
+from datetime import datetime
 import os
 import logging
 
+from pyramid import settings
 from pyramid.paster import get_appsettings
+import cryptography.fernet
+
 
 log = logging.getLogger('bodhi')
 
@@ -38,8 +41,510 @@ def get_configfile():
     return configfile
 
 
+def _generate_list_validator(splitter=' ', validator=unicode):
+    """Return a function that takes a value and interprets it to be a list with the given splitter.
+
+    This function generates a function that can take a string and interpret it as a list by
+    splitting with the given splitter string. Each element of the resulting list is then validated
+    with the given validator.
+
+    Args:
+        splitter (basestring): A string to use to split the input into a list.
+        validator (function):  A function to apply to each element of the list to validate it.
+    Returns:
+        function: A validator function that accepts an argument to be validated.
+    """
+    def _validate_list(value):
+        """Validate that the value is a list or can be split into a list, and validate its elements.
+
+        This function will validate that the given value is a list, or it will use the splitter to
+        turn it into a list. Once it is a list, it will use the validator on each element of the
+        list.
+
+        Args:
+            value (basestring or list): The list to be validated.
+        Returns:
+            unicode: The interpreted list.
+        Raises:
+            ValueError: If validator fails on any of the list's elements.
+        """
+        if isinstance(value, basestring):
+            value = [idx.strip() for idx in value.split(splitter) if idx.strip()]
+
+        if not isinstance(value, list):
+            raise ValueError('"{}" cannot be intepreted as a list.'.format(value))
+
+        # Run the validator on each element of the list.
+        value = [validator(v) for v in value]
+
+        return value
+
+    return _validate_list
+
+
+def _validate_bool(value):
+    """Return a bool version of value.
+
+    This function will ensure that value is a bool, or that it is a string that can be interpreted
+    as a bool. It will return a bool. If it cannot do that, it will raise ValueError.
+
+    Args:
+        value (basestring or bool): The value to be validated as a bool.
+    Returns:
+        bool: The boolean interpretation of value.
+    Raises:
+        ValueError: If value cannot be interpreted as a boolean.
+    """
+    if isinstance(value, basestring):
+        # Recent versions of Pyramid define a settings.falsey, but version 1.5.6 does not so its
+        # values have been backported here for the False case. Pyramid defines an asbool(), but it
+        # will not raise any error for strings that aren't in the truthy or falsey lists, and we
+        # want strict validation.
+        if value.lower().strip() in settings.truthy:
+            return True
+        elif value.lower().strip() in ('f', 'false', 'n', 'no', 'off', '0'):
+            return False
+        else:
+            raise ValueError('"{}" cannot be interpreted as a boolean value.'.format(value))
+
+    if not isinstance(value, bool):
+        raise ValueError('"{}" is not a bool or a string.'.format(value))
+
+    return value
+
+
+def _validate_color(value):
+    """Ensure that value is a valid expression of a color, in the form #dddddd.
+
+    Return the value if it is a valid color expression, or raise ValueError.
+
+    Args:
+        value (basestring): The color to be validated.
+    Returns:
+        unicode: The color.
+    Raises:
+        ValueError: If value is not in the form #dddddd.
+    """
+    e = ValueError('"{}" is not a valid color expression.'.format(value))
+
+    if not isinstance(value, basestring):
+        raise e
+    if not len(value) == 7:
+        raise e
+    if value[0] != '#':
+        raise e
+    try:
+        int(value[-6:], 16)
+    except ValueError:
+        raise e
+
+    return unicode(value)
+
+
+def _validate_fernet_key(value):
+    """Ensure the value is not CHANGEME, that it is a Fernet key, and convert it to a str.
+
+    This function is used to ensure that secret values in the config have been set by the user to
+    something other than the default of CHANGEME and that the value can be used as a Fernet key. It
+    is converted to unicode before returning.
+
+    Args:
+        value (basestring): The value to be validated.
+    Returns:
+        unicode: The value.
+    Raises:
+        ValueError: If value is "CHANGEME" or if it cannot be used as a Fernet key.
+    """
+    _validate_secret(value)
+
+    if isinstance(value, unicode):
+        value = value.encode('utf-8')
+
+    try:
+        engine = cryptography.fernet.Fernet(value)
+        # This will raise a ValueError if value is not suitable as a Fernet key.
+        engine.encrypt('a secret test string')
+    except TypeError:
+        raise ValueError('Fernet key must be 32 url-safe base64-encoded bytes.')
+
+    return value
+
+
+def _validate_none_or(validator):
+    """Return a function that will ensure a value is None or passes validator.
+
+    This function returns a function that will take a single argument, value, and will ensure
+    that value is None or that it passes the given validator.
+
+    Args:
+        validator (function): A function to apply when value is not None.
+    Returns:
+        function: A validator function that accepts an argument to be validated.
+    """
+    def _validate(value):
+        if value is None:
+            return value
+
+        return validator(value)
+
+    return _validate
+
+
+def _validate_path(value):
+    """Ensure that value is an existing path on the local filesystem and return it.
+
+    Use os.path.exists to ensure that value is an existing path. Return the value if it is, else
+    raise ValueError.
+
+    Args:
+        value (basestring): The path to be validated.
+    Returns:
+        unicode: The path.
+    Raises:
+        ValueError: If os.path.exists returns False.
+    """
+    if not os.path.exists(value):
+        raise ValueError('"{}" does not exist.'.format(value))
+
+    return unicode(value)
+
+
+def _validate_secret(value):
+    """Ensure that the value is not CHANGEME and convert it to unicode.
+
+    This function is used to ensure that secret values in the config have been set by the user to
+    something other than the default of CHANGEME.
+
+    Args:
+        value (basestring): The value to be validated.
+    Returns:
+        unicode: The value.
+    Raises:
+        ValueError: If value is "CHANGEME".
+    """
+    if value == 'CHANGEME':
+        raise ValueError('This setting must be changed from its default value.')
+
+    return unicode(value)
+
+
+def _validate_tls_url(value):
+    """Ensure that the value is a string that starts with https://.
+
+    Args:
+        value (basestring): The value to be validated.
+    Returns:
+        unicode: The value.
+    Raises:
+        ValueError: If value is not a string starting with https://.
+    """
+    if not isinstance(value, basestring) or not value.startswith('https://'):
+        raise ValueError('This setting must be a URL starting with https://.')
+
+    return unicode(value)
+
+
 class BodhiConfig(dict):
     loaded = False
+
+    _defaults = {
+        'acl_system': {
+            'value': 'dummy',
+            'validator': unicode},
+        'admin_groups': {
+            'value': ['proventesters', 'security_respons', 'bodhiadmin', 'sysadmin-main'],
+            'validator': _generate_list_validator()},
+        'admin_packager_groups': {
+            'value': ['provenpackager', 'releng', 'security_respons'],
+            'validator': _generate_list_validator()},
+        'authtkt.secret': {
+            'value': 'CHANGEME',
+            'validator': _validate_secret},
+        'authtkt.secure': {
+            'value': True,
+            'validator': _validate_bool},
+        'authtkt.timeout': {
+            'value': 86400,
+            'validator': int},
+        'badge_ids': {
+            'value': [],
+            'validator': _generate_list_validator('|')},
+        'base_address': {
+            'value': 'https://admin.fedoraproject.org/updates/',
+            'validator': unicode},
+        'bodhi_email': {
+            'value': 'updates@fedoraproject.org',
+            'validator': unicode},
+        'bodhi_password': {
+            'value': None,
+            'validator': _validate_none_or(unicode)},
+        'buglink': {
+            'value': 'https://bugzilla.redhat.com/show_bug.cgi?id=%s',
+            'validator': unicode},
+        'bugtracker': {
+            'value': None,
+            'validator': _validate_none_or(unicode)},
+        'buildroot_limit': {
+            'value': 31,
+            'validator': int},
+        'buildsystem': {
+            'value': 'dev',
+            'validator': unicode},
+        'bz_products': {
+            'value': ['Fedora', 'Fedora EPEL'],
+            'validator': _generate_list_validator(',')},
+        'bz_server': {
+            'value': 'https://bugzilla.redhat.com/xmlrpc.cgi',
+            'validator': unicode},
+        'captcha.background_color': {
+            'value': '#ffffff',
+            'validator': _validate_color},
+        'captcha.font_color': {
+            'value': '#000000',
+            'validator': _validate_color},
+        'captcha.font_path': {
+            'value': '/usr/share/fonts/liberation/LiberationMono-Regular.ttf',
+            'validator': _validate_path},
+        'captcha.font_size': {
+            'value': 36,
+            'validator': int},
+        'captcha.image_height': {
+            'value': 80,
+            'validator': int},
+        'captcha.image_width': {
+            'value': 300,
+            'validator': int},
+        'captcha.padding': {
+            'value': 5,
+            'validator': int},
+        'captcha.secret': {
+            'value': None,
+            'validator': _validate_none_or(_validate_fernet_key)},
+        'captcha.ttl': {
+            'value': 300,
+            'validator': int},
+        'compose_atomic_trees': {
+            'value': False,
+            'validator': _validate_bool},
+        'comps_dir': {
+            'value': os.path.join(os.path.dirname(__file__), '..', '..', 'masher', 'comps'),
+            'validator': unicode},
+        'comps_url': {
+            'value': 'https://git.fedorahosted.org/comps.git',
+            'validator': _validate_tls_url},
+        'cors_connect_src': {
+            'value': 'https://*.fedoraproject.org/ wss://hub.fedoraproject.org:9939/',
+            'validator': unicode},
+        'cors_origins_ro': {
+            'value': '*',
+            'validator': unicode},
+        'cors_origins_rw': {
+            'value': 'https://bodhi.fedoraproject.org',
+            'validator': unicode},
+        'critpath_pkgs': {
+            'value': ['kernel'],
+            'validator': _generate_list_validator()},
+        'critpath.min_karma': {
+            'value': 2,
+            'validator': int},
+        'critpath.num_admin_approvals': {
+            'value': 2,
+            'validator': int},
+        'critpath.stable_after_days_without_negative_karma': {
+            'value': 14,
+            'validator': int},
+        'critpath.type': {
+            'value': None,
+            'validator': _validate_none_or(unicode)},
+        'datagrepper_url': {
+            'value': 'https://apps.fedoraproject.org/datagrepper',
+            'validator': unicode},
+        'default_email_domain': {
+            'value': 'fedoraproject.org',
+            'validator': unicode},
+        'disable_automatic_push_to_stable': {
+            'value': (
+                'Bodhi is disabling automatic push to stable due to negative karma. The '
+                'maintainer may push manually if they determine that the issue is not severe.'),
+            'validator': unicode},
+        'dogpile.cache.arguments.filename': {
+            'value': '/var/cache/bodhi-dogpile-cache.dbm',
+            'validator': unicode},
+        'dogpile.cache.backend': {
+            'value': 'dogpile.cache.dbm',
+            'validator': unicode},
+        'dogpile.cache.expiration_time': {
+            'value': '100',
+            'validator': unicode},
+        'exclude_mail': {
+            'value': ['autoqa', 'taskotron'],
+            'validator': _generate_list_validator()},
+        'fedmenu.data_url': {
+            'value': 'https://apps.fedoraproject.org/js/data.js',
+            'validator': unicode},
+        'fedmenu.url': {
+            'value': 'https://apps.fedoraproject.org/fedmenu',
+            'validator': unicode},
+        'fedmsg_enabled': {
+            'value': False,
+            'validator': _validate_bool},
+        'file_url': {
+            'value': 'https://download.fedoraproject.org/pub/fedora/linux/updates',
+            'validator': unicode},
+        'fmn_url': {
+            'value': 'https://apps.fedoraproject.org/notifications/',
+            'validator': unicode},
+        'important_groups': {
+            'value': ['proventesters', 'provenpackager,' 'releng', 'security_respons', 'packager',
+                      'bodhiadmin'],
+            'validator': _generate_list_validator()},
+        'initial_bug_msg': {
+            'value': '%s has been submitted as an update to %s. %s',
+            'validator': unicode},
+        'koji_hub': {
+            'value': 'https://koji.stg.fedoraproject.org/kojihub',
+            'validator': unicode},
+        'krb_ccache': {
+            'value': None,
+            'validator': _validate_none_or(unicode)},
+        'krb_keytab': {
+            'value': None,
+            'validator': _validate_none_or(unicode)},
+        'krb_principal': {
+            'value': None,
+            'validator': _validate_none_or(unicode)},
+        'libravatar_dns': {
+            'value': False,
+            'validator': _validate_bool},
+        'libravatar_enabled': {
+            'value': True,
+            'validator': _validate_bool},
+        'mako.directories': {
+            'value': 'bodhi:server/templates',
+            'validator': unicode},
+        'mandatory_packager_groups': {
+            'value': ['packager'],
+            'validator': _generate_list_validator()},
+        'mash_conf': {
+            'value': '/etc/mash/mash.conf',
+            'validator': unicode},
+        'mash_dir': {
+            'value': os.path.join(os.path.dirname(__file__), '..', '..', 'masher', 'mash'),
+            'validator': _validate_path},
+        'mash_stage_dir': {
+            'value': os.path.join(os.path.dirname(__file__), '..', '..', 'masher'),
+            'validator': _validate_path},
+        'max_update_length_for_ui': {
+            'value': 30,
+            'validator': int},
+        'message_id_email_domain': {
+            'value': 'admin.fedoraproject.org',
+            'validator': unicode},
+        'not_yet_tested_epel_msg': {
+            'value': (
+                'This update has not yet met the minimum testing requirements defined in the '
+                '<a href="https://fedoraproject.org/wiki/EPEL_Updates_Policy">EPEL Update Policy'
+                '</a>'),
+            'validator': unicode},
+        'not_yet_tested_msg': {
+            'value': (
+                'This update has not yet met the minimum testing requirements defined in the '
+                '<a href="https://fedoraproject.org/wiki/Package_update_acceptance_criteria">'
+                'Package Update Acceptance Criteria</a>'),
+            'validator': unicode},
+        'openid.provider': {
+            'value': 'https://id.fedoraproject.org/openid/',
+            'validator': unicode},
+        'openid.sreg_required': {
+            'value': 'email',
+            'validator': unicode},
+        'openid.success_callback': {
+            'value': 'bodhi.server.security:remember_me',
+            'validator': unicode},
+        'openid.url': {
+            'value': 'https://id.fedoraproject.org/',
+            'validator': unicode},
+        'openid_template': {
+            'value': '{username}.id.fedoraproject.org',
+            'validator': unicode},
+        'pagure_url': {
+            'value': 'https://src.fedoraproject.org/pagure/',
+            'validator': _validate_tls_url},
+        'pdc_url': {
+            'value': 'https://pdc.fedoraproject.org/',
+            'validator': _validate_tls_url},
+        'pkgdb_url': {
+            'value': 'https://admin.fedoraproject.org/pkgdb',
+            'validator': unicode},
+        'pkgtags_url': {
+            'value': 'https://apps.fedoraproject.org/tagger/api/v1/tag/sqlitebuildtags/',
+            'validator': unicode},
+        'query_wiki_test_cases': {
+            'value': False,
+            'validator': _validate_bool},
+        'release_team_address': {
+            'value': 'bodhiadmin-members@fedoraproject.org',
+            'validator': unicode},
+        'resultsdb_api_url': {
+            'value': 'https://taskotron.fedoraproject.org/resultsdb_api/',
+            'validator': unicode},
+        'session.secret': {
+            'value': 'CHANGEME',
+            'validator': _validate_secret},
+        'site_requirements': {
+            'value': 'depcheck upgradepath',
+            'validator': unicode},
+        'smtp_server': {
+            'value': None,
+            'validator': _validate_none_or(unicode)},
+        'sqlalchemy.url': {
+            'value': 'sqlite:////var/cache/bodhi.db',
+            'validator': unicode},
+        'stable_bug_msg': {
+            'value': ('%s has been pushed to the %s repository. If problems still persist, please '
+                      'make note of it in this bug report.'),
+            'validator': unicode},
+        'stacks_enabled': {
+            'value': False,
+            'validator': _validate_bool},
+        'stats_blacklist': {
+            'value': ['bodhi', 'anonymous', 'autoqa', 'taskotron'],
+            'validator': _generate_list_validator()},
+        'system_users': {
+            'value': ['bodhi', 'autoqa', 'taskotron'],
+            'validator': _generate_list_validator()},
+        'test_case_base_url': {
+            'value': 'https://fedoraproject.org/wiki/',
+            'validator': unicode},
+        'testing_approval_msg_based_on_karma': {
+            'value': ('This update has reached the stable karma threshold and can be pushed to '
+                      'stable now if the maintainer wishes.'),
+            'validator': unicode
+        },
+        'testing_approval_msg': {
+            'value': ('This update has reached %d days in testing and can be pushed to stable now '
+                      'if the maintainer wishes'),
+            'validator': unicode},
+        'testing_bug_epel_msg': {
+            'value': (
+                '\nSee https://fedoraproject.org/wiki/QA:Updates_Testing for\ninstructions on how '
+                'to install test updates.\nYou can provide feedback for this update here: %s'),
+            'validator': unicode},
+        'testing_bug_msg': {
+            'value': (
+                '\nSee https://fedoraproject.org/wiki/QA:Updates_Testing for\ninstructions on how '
+                'to install test updates.\nYou can provide feedback for this update here: %s'),
+            'validator': unicode},
+        'top_testers_timeframe': {
+            'value': 7,
+            'validator': int},
+        'updateinfo_rights': {
+            'value': 'Copyright (C) {} Red Hat, Inc. and others.'.format(datetime.now().year),
+            'validator': unicode},
+        'wiki_url': {
+            'value': 'https://fedoraproject.org/w/api.php',
+            'validator': unicode},
+    }
 
     def __getitem__(self, *args, **kw):
         if not self.loaded:
@@ -61,10 +566,40 @@ class BodhiConfig(dict):
             self.load_config()
         return super(BodhiConfig, self).copy(*args, **kw)
 
-    def load_config(self):
+    def load_config(self, settings=None):
+        """
+        Load the configuration either from the config file, or from the given settings.
+
+        args:
+            settings (dict): If given, the settings are pulled from this dictionary. Otherwise, the
+                config file is used.
+        """
+        self._load_defaults()
         configfile = get_configfile()
-        self.update(get_appsettings(configfile))
+        if settings:
+            self.update(settings)
+        else:
+            self.update(get_appsettings(configfile))
         self.loaded = True
+        self._validate()
+
+    def _load_defaults(self):
+        """Iterate over self._defaults and set all default values on self."""
+        for k, v in self._defaults.items():
+            self[k] = v['value']
+
+    def _validate(self):
+        """Run the validators found in self._defaults on all the corresponding values."""
+        errors = []
+        for k in self._defaults.keys():
+            try:
+                self[k] = self._defaults[k]['validator'](self[k])
+            except ValueError as e:
+                errors.append('\t{}: {}'.format(k, unicode(e)))
+
+        if errors:
+            raise ValueError(
+                'Invalid config values were set: \n{}'.format('\n'.join(errors)))
 
 
 config = BodhiConfig()

--- a/bodhi/server/consumers/masher.py
+++ b/bodhi/server/consumers/masher.py
@@ -632,9 +632,6 @@ class MasherThread(threading.Thread):
         self.log.info("Updating comps")
         comps_dir = config.get('comps_dir')
         comps_url = config.get('comps_url')
-        if not comps_url.startswith('https://'):
-            self.log.error('comps_url must start with https://')
-            return
 
         if not os.path.exists(comps_dir):
             util.cmd(['git', 'clone', comps_url, comps_dir], os.path.dirname(comps_dir))
@@ -1031,7 +1028,7 @@ class MashThread(threading.Thread):
         self.log = log
         self.success = False
         mash_cmd = 'mash -o {outputdir} -c {config} -f {compsfile} {tag}'
-        mash_conf = config.get('mash_conf', '/etc/mash/mash.conf')
+        mash_conf = config.get('mash_conf')
         if os.path.exists(previous):
             mash_cmd += ' -p {}'.format(previous)
         self.mash_cmd = mash_cmd.format(outputdir=outputdir, config=mash_conf,

--- a/bodhi/server/mail.py
+++ b/bodhi/server/mail.py
@@ -182,7 +182,7 @@ To reply to this comment, please visit the URL at the bottom of this mail
 """,
         'fields': lambda agent, x: {
             'package': x.title,
-            'comment': x.comments[-1].text,
+            'comment': x.comments[-1],
             'updatestr': unicode(x)
         }
     },

--- a/bodhi/server/mail.py
+++ b/bodhi/server/mail.py
@@ -182,7 +182,7 @@ To reply to this comment, please visit the URL at the bottom of this mail
 """,
         'fields': lambda agent, x: {
             'package': x.title,
-            'comment': x.comments[-1],
+            'comment': x.comments[-1].text,
             'updatestr': unicode(x)
         }
     },
@@ -463,7 +463,7 @@ def send_mail(from_addr, to_addr, subject, body_text, headers=None):
     if headers:
         for key, value in headers.items():
             msg.append('%s: %s' % (key, to_bytes(value)))
-    msg.append('X-Bodhi: %s' % config.get('default_email_domain'))
+    msg.append('X-Bodhi: %s' % to_bytes(config.get('default_email_domain')))
     msg += ['Subject: %s' % subject, '', body_text]
     body = to_bytes('\r\n'.join(msg))
 
@@ -500,7 +500,7 @@ def send(to, msg_type, update, sender=None, agent=None):
             headers["References"] = initial_message_id
             headers["In-Reply-To"] = initial_message_id
 
-    subject_template = '[Fedora Update] %s[%s] %s'
+    subject_template = u'[Fedora Update] %s[%s] %s'
     for person in iterate(to):
         subject = subject_template % (critpath, msg_type, update.title)
         fields = MESSAGES[msg_type]['fields'](agent, update)

--- a/bodhi/server/models.py
+++ b/bodhi/server/models.py
@@ -47,11 +47,6 @@ from bodhi.server.util import (
 import bodhi.server.util
 
 
-DEFAULT_DISABLE_AUTOPUSH_MESSAGE = (
-    u'Bodhi is disabling automatic push to stable due to negative karma. '
-    u'The maintainer may push manually if they determine that the issue is not severe.')
-
-
 # http://techspot.zzzeek.org/2011/01/14/the-enum-recipe
 
 class EnumSymbol(object):
@@ -2206,7 +2201,7 @@ class Update(Base):
         if self.autokarma and self._composite_karma[1] != 0:
             log.info("Disabling Auto Push since the update has received negative karma")
             self.autokarma = False
-            text = config.get('disable_automatic_push_to_stable', DEFAULT_DISABLE_AUTOPUSH_MESSAGE)
+            text = config.get('disable_automatic_push_to_stable')
             self.comment(db, text, author=u'bodhi')
         elif self.stable_karma and self.karma >= self.stable_karma:
             if self.autokarma:

--- a/bodhi/server/scripts/approve_testing.py
+++ b/bodhi/server/scripts/approve_testing.py
@@ -79,7 +79,7 @@ def main(argv=sys.argv):
             if update.stable_karma not in (0, None) and update.karma >= update.stable_karma \
                     and not update.autokarma and update.meets_testing_requirements:
                 print('%s now reaches stable karma threshold' % update.title)
-                text = unicode(config.get('testing_approval_msg_based_on_karma'))
+                text = config.get('testing_approval_msg_based_on_karma')
                 update.comment(db, text, author=u'bodhi')
                 continue
 

--- a/bodhi/server/security.py
+++ b/bodhi/server/security.py
@@ -30,13 +30,13 @@ from .models import User, Group
 def admin_only_acl(request):
     """Generate our admin-only ACL"""
     return [(Allow, 'group:' + group, ALL_PERMISSIONS) for group in
-            request.registry.settings['admin_groups'].split()] + \
+            request.registry.settings['admin_groups']] + \
            [DENY_ALL]
 
 
 def packagers_allowed_acl(request):
     """Generate an ACL for update submission"""
-    groups = request.registry.settings['mandatory_packager_groups'].split()
+    groups = request.registry.settings['mandatory_packager_groups']
     return [
         (Allow, 'group:' + group, ALL_PERMISSIONS) for group in groups
     ] + [DENY_ALL]

--- a/bodhi/server/services/stacks.py
+++ b/bodhi/server/services/stacks.py
@@ -21,6 +21,7 @@ from sqlalchemy import func, distinct
 from sqlalchemy.sql import or_
 
 from bodhi.server import log, notifications
+from bodhi.server.config import config
 from bodhi.server.models import RpmPackage, Stack, Group, User
 from bodhi.server.util import tokenize
 from bodhi.server.validators import validate_packages, validate_stack, validate_requirements
@@ -145,7 +146,7 @@ def save_stack(request):
     # assume they mean *really*, no requirements so we leave the value null.
     reqs = data['requirements']
     if reqs is None:
-        stack.requirements = unicode(request.registry.settings.get('site_requirements'))
+        stack.requirements = config.get('site_requirements')
     elif reqs:
         stack.requirements = reqs
 

--- a/bodhi/server/templates/home.html
+++ b/bodhi/server/templates/home.html
@@ -12,8 +12,8 @@
     <script>
         $(document).ready(function() {
           generate_newsfeed(
-            "${request.registry.settings.get('datagrepper_url', 'https://apps.fedoraproject.org/datagrepper')}",
-            ${str([idx.strip() for idx in request.registry.settings.get('badge_ids', '').split('|') if idx.strip()]) | n});
+            "${request.registry.settings.get('datagrepper_url')}",
+            ${str(request.registry.settings.get('badge_ids')) | n});
         });
     </script>
   </div>-->

--- a/bodhi/server/templates/master.html
+++ b/bodhi/server/templates/master.html
@@ -82,7 +82,7 @@
                             <a class="dropdown-item" href="${request.route_url('new_override')}">
                                 New Override
                             </a>
-                            % if request.registry.settings.get('stacks_enabled') == 'True':
+                            % if request.registry.settings.get('stacks_enabled') == True:
                             <a class="dropdown-item" href="${request.route_url('new_stack')}">
                                 New Stack
                             </a>

--- a/bodhi/server/templates/new_stack.html
+++ b/bodhi/server/templates/new_stack.html
@@ -106,7 +106,7 @@
             % if stack is not UNDEFINED:
                          value="${stack.requirements}"
             % else:
-                         value="${request.registry.settings.get('site_requirements', '')}"
+                         value="${request.registry.settings.get('site_requirements')}"
             % endif
                          placeholder="An optional list of Taskotron checks required for updates of this stack.">
               </div>

--- a/bodhi/server/templates/override.html
+++ b/bodhi/server/templates/override.html
@@ -169,7 +169,7 @@ $(document).ready(function() {
     var today = new Date(now.getFullYear(), now.getMonth(), now.getDate(),
                          0, 0, 0, 0);
     var tomorrow = new Date(today.getTime() + 24*60*60*1000);
-    var limit = ${ int(request.registry.settings.get('buildroot_limit', 31)) };
+    var limit = ${ request.registry.settings.get('buildroot_limit') };
     var horizon = new Date(today.getTime() + (24*60*60*1000) * limit);
 
     var expiration = $('#expiration_date').datepicker({

--- a/bodhi/server/templates/update.html
+++ b/bodhi/server/templates/update.html
@@ -653,7 +653,7 @@ $(document).ready(function(){
                 </div>
               </div>
 
-              % if not request.user and request.registry.settings.get('captcha.secret', None):
+              % if not request.user and request.registry.settings.get('captcha.secret'):
               <%
                 captcha_key, captcha_url = captcha.generate_captcha(request)
               %>

--- a/bodhi/server/util.py
+++ b/bodhi/server/util.py
@@ -30,7 +30,6 @@ import urllib
 
 from kitchen.iterutils import iterate
 from pyramid.i18n import TranslationStringFactory
-from pyramid.settings import asbool
 import arrow
 import bleach
 import colander
@@ -177,7 +176,7 @@ def get_critpath_components(collection='master', component_type='rpm'):
         critpath_components = get_critpath_components_from_pdc(
             collection, component_type)
     else:
-        critpath_components = config.get('critpath_pkgs', '').split()
+        critpath_components = config.get('critpath_pkgs')
     return critpath_components
 
 
@@ -244,8 +243,8 @@ def avatar(context, username, size):
     @request.cache.cache_on_arguments()
     def work(username, size):
         openid = "http://%s.id.fedoraproject.org/" % username
-        if asbool(config.get('libravatar_enabled', True)):
-            if asbool(config.get('libravatar_dns', False)):
+        if config.get('libravatar_enabled'):
+            if config.get('libravatar_dns'):
                 return libravatar.libravatar_url(
                     openid=openid,
                     https=https,
@@ -466,7 +465,7 @@ def update2html(context, update):
 
     url = request.route_url('update', id=alias or title)
     settings = request.registry.settings
-    max_length = int(settings.get('max_update_length_for_ui', 30))
+    max_length = settings.get('max_update_length_for_ui')
     if len(title) > max_length:
         title = title[:max_length] + "..."
     return link(url, title)
@@ -516,9 +515,7 @@ def bug_link(context, bug, short=False):
 
 
 def testcase_link(context, test, short=False):
-    settings = context['request'].registry
-    default = 'https://fedoraproject.org/wiki/'
-    url = settings.get('test_case_base_url', default) + test.name
+    url = config.get('test_case_base_url') + test.name
     display = test.name.replace('QA:Testcase ', '')
     link = "<a target='_blank' href='%s'>%s</a>" % (url, display)
     if not short:
@@ -672,7 +669,7 @@ def get_critpath_components_from_pdc(branch, component_type='rpm'):
     :return: a list of critical path packages
     """
     pdc_api_url = '{}/rest_api/v1/component-branches/'.format(
-        config.get('pdc_url', 'https://pdc.fedoraproject.org/').rstrip('/'))
+        config.get('pdc_url').rstrip('/'))
     query_args = urllib.urlencode({
         'active': 'true',
         'critical_path': 'true',

--- a/bodhi/server/views/generic.py
+++ b/bodhi/server/views/generic.py
@@ -23,13 +23,14 @@ from pyramid.exceptions import HTTPForbidden, HTTPBadRequest
 from pyramid.httpexceptions import HTTPFound
 
 from bodhi.server import log, models
+from bodhi.server.config import config
 import bodhi.server.util
 
 
 def get_top_testers(request):
     db = request.db
-    blacklist = request.registry.settings.get('stats_blacklist').split()
-    days = int(request.registry.settings.get('top_testers_timeframe', 7))
+    blacklist = config.get('stats_blacklist')
+    days = config.get('top_testers_timeframe')
     start_time = datetime.datetime.utcnow() - datetime.timedelta(days=days)
 
     query = db.query(

--- a/bodhi/tests/server/consumers/test_masher.py
+++ b/bodhi/tests/server/consumers/test_masher.py
@@ -1322,14 +1322,6 @@ class TestMasherThread_update_comps(unittest.TestCase):
         self.assertEqual(calls, mock_cmd.call_args_list)
         mock_exists.assert_called_once_with('/some/path')
 
-    @mock.patch('bodhi.server.consumers.masher.config', {'comps_dir': '/some/path',
-                                                         'comps_url': 'http://example.com/'})
-    @mock.patch('bodhi.server.consumers.masher.util.cmd')
-    def test_comps_unsafe_http_url(self, mock_cmd):
-        self.masher_thread.update_comps()
-        self.assertEqual(0, mock_cmd.call_count)
-        self.masher_thread.log.error.assert_called_once_with('comps_url must start with https://')
-
 
 class TestMasherThread_wait_for_sync(MasherThreadBaseTestCase):
     """This test class contains tests for the MasherThread.wait_for_sync() method."""

--- a/bodhi/tests/server/functional/base.py
+++ b/bodhi/tests/server/functional/base.py
@@ -20,6 +20,7 @@ from bodhi.tests.server.base import BaseTestCase, DB_NAME, DB_PATH, FAITOUT
 
 class BaseWSGICase(BaseTestCase):
     app_settings = {
+        'authtkt.secret': 'sssshhhhhh',
         'sqlalchemy.url': DB_PATH,
         'mako.directories': 'bodhi:server/templates',
         'session.type': 'memory',
@@ -40,6 +41,7 @@ class BaseWSGICase(BaseTestCase):
         'admin_packager_groups': 'provenpackager',
         'mandatory_packager_groups': 'packager',
         'critpath_pkgs': 'kernel',
+        'critpath.num_admin_approvals': 0,
         'bugtracker': 'dummy',
         'stats_blacklist': 'bodhi autoqa',
         'system_users': 'bodhi autoqa',

--- a/bodhi/tests/server/functional/test_users.py
+++ b/bodhi/tests/server/functional/test_users.py
@@ -12,7 +12,7 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
-from pyramid.settings import asbool
+import mock
 
 from bodhi.server.config import config
 from bodhi.server.models import Update, User
@@ -41,12 +41,10 @@ class TestUsersService(bodhi.tests.server.functional.base.BaseWSGICase):
         url = 'https://apps.fedoraproject.org/img/icons/bodhi-24.png'
         self.assertEquals(res.json_body['user']['avatar'], url)
 
+    @mock.patch.dict(config, {'libravatar_enabled': True})
     def test_get_single_avatar(self):
         res = self.app.get('/users/guest')
         self.assertEquals(res.json_body['user']['name'], 'guest')
-
-        if not asbool(config.get('libravatar_enabled', True)):
-            return
 
         base = 'https://seccdn.libravatar.org/avatar/'
         h = 'eb48e08cc23bcd5961de9541ba5156c385cd39799e1dbf511477aa4d4d3a37e7'

--- a/bodhi/tests/server/services/test_updates.py
+++ b/bodhi/tests/server/services/test_updates.py
@@ -28,7 +28,7 @@ import mock
 from bodhi.server import main
 from bodhi.server.config import config
 from bodhi.server.models import (
-    BuildrootOverride, DEFAULT_DISABLE_AUTOPUSH_MESSAGE, Group, RpmPackage, Release,
+    BuildrootOverride, Group, RpmPackage, Release,
     ReleaseState, RpmBuild, Update, UpdateRequest, UpdateStatus, UpdateType, User)
 import bodhi.tests.server.functional.base
 
@@ -3246,8 +3246,7 @@ class TestUpdatesService(bodhi.tests.server.functional.base.BaseWSGICase):
         up.comment(self.db, u'Failed to work', author=u'ralph', karma=-1)
         up = self.db.query(Update).filter_by(title=resp.json['title']).one()
 
-        expected_comment = unicode(config.get(
-            'disable_automatic_push_to_stable', DEFAULT_DISABLE_AUTOPUSH_MESSAGE))
+        expected_comment = config.get('disable_automatic_push_to_stable')
         self.assertEquals(up.comments[2].text, expected_comment)
 
         up.comment(self.db, u'LGTM Now', author=u'ralph', karma=1)

--- a/bodhi/tests/server/test___init__.py
+++ b/bodhi/tests/server/test___init__.py
@@ -20,6 +20,7 @@ from pyramid import authentication, authorization
 import mock
 
 from bodhi import server
+from bodhi.server.config import config
 from bodhi.tests.server.functional import base
 
 
@@ -80,6 +81,15 @@ class TestMain(base.BaseWSGICase):
         server.main({}, testing='guest', session=self.db, **self.app_settings)
 
         set_bugtracker.assert_called_once_with()
+
+    @mock.patch.dict('bodhi.server.config.config', {'test': 'changeme'})
+    def test_settings(self):
+        """Ensure that passed settings make their way into the Bodhi config."""
+        self.app_settings.update({'test': 'setting'})
+
+        server.main({}, testing='guest', session=self.db, **self.app_settings)
+
+        self.assertEqual(config['test'], 'setting')
 
 
 class TestGetDbSessionForRequest(unittest.TestCase):

--- a/bodhi/tests/server/test_bugs.py
+++ b/bodhi/tests/server/test_bugs.py
@@ -168,6 +168,19 @@ class TestBugzilla(unittest.TestCase):
         self.assertTrue(return_value is bz._bz.getbug.return_value)
         bz._bz.getbug.assert_called_once_with(1411188)
 
+    @mock.patch('bodhi.server.bugs.log.info')
+    def test_modified_product_skipped(self, info):
+        """Test the modified() method when the bug's product is not in the bz_products config."""
+        bz = bugs.Bugzilla()
+        bz._bz = mock.MagicMock()
+        bz._bz.getbug.return_value.product = 'not fedora!'
+
+        bz.modified(1411188)
+
+        bz._bz.getbug.assert_called_once_with(1411188)
+        info.assert_called_once_with("Skipping 'not fedora!' bug")
+        self.assertEqual(bz._bz.getbug.return_value.setstatus.call_count, 0)
+
     @mock.patch('bodhi.server.bugs.log.exception')
     def test_on_qa_failure(self, exception):
         """

--- a/bodhi/tests/server/test_captcha.py
+++ b/bodhi/tests/server/test_captcha.py
@@ -21,20 +21,24 @@ import mock
 import PIL.Image
 
 from bodhi.server import captcha
+from bodhi.server.config import config
+
+
+class TestDecrypt(unittest.TestCase):
+    """Test the decrypt function."""
+    @mock.patch.dict(config, {'captcha.secret': 'gFqE6rcBXVLssjLjffsQsAa-nlm5Bg06MTKrVT9hsMA='})
+    def test_decrypt_from_encrypt(self):
+        """Ensure that decrypt can decrypt what encrypt generated."""
+        plaintext = "don't let eve see this!"
+        bobs_message = captcha.encrypt(plaintext, config)
+
+        result = captcha.decrypt(bobs_message, config)
+
+        self.assertEqual(result, plaintext)
 
 
 class TestJPEGGenerator(unittest.TestCase):
     """This test class contains tests for the jpeg_generator() function."""
-    def test_with_defaults(self):
-        """Test the jpeg_generator with default settings."""
-        img = captcha.jpeg_generator('42 + 7', {})
-
-        img.verify()
-        self.assertTrue(isinstance(img, PIL.Image.Image))
-        # Ensure the image is the default size
-        self.assertEqual(img.size, (300, 80))
-        self.assertEqual(img.mode, 'RGB')
-
     @mock.patch('bodhi.server.captcha.ImageDraw.Draw')
     @mock.patch('bodhi.server.captcha.ImageFont.truetype')
     @mock.patch('bodhi.server.captcha.random.randint')

--- a/bodhi/tests/server/test_config.py
+++ b/bodhi/tests/server/test_config.py
@@ -20,14 +20,14 @@ import unittest
 
 import mock
 
-from bodhi.server.config import BodhiConfig
+from bodhi.server import config
 
 
 class BodhiConfigGetItemTests(unittest.TestCase):
     """Tests for the ``__getitem__`` method on the :class:`BodhiConfig` class."""
 
     def setUp(self):
-        self.config = BodhiConfig()
+        self.config = config.BodhiConfig()
         self.config.load_config = mock.Mock()
         self.config['password'] = 'hunter2'
 
@@ -53,7 +53,7 @@ class BodhiConfigGetTests(unittest.TestCase):
     """Tests for the ``get`` method on the :class:`BodhiConfig` class."""
 
     def setUp(self):
-        self.config = BodhiConfig()
+        self.config = config.BodhiConfig()
         self.config.load_config = mock.Mock()
         self.config['password'] = 'hunter2'
 
@@ -79,7 +79,7 @@ class BodhiConfigPopItemTests(unittest.TestCase):
     """Tests for the ``pop`` method on the :class:`BodhiConfig` class."""
 
     def setUp(self):
-        self.config = BodhiConfig()
+        self.config = config.BodhiConfig()
         self.config.load_config = mock.Mock()
         self.config['password'] = 'hunter2'
 
@@ -110,7 +110,7 @@ class BodhiConfigCopyTests(unittest.TestCase):
     """Tests for the ``copy`` method on the :class:`BodhiConfig` class."""
 
     def setUp(self):
-        self.config = BodhiConfig()
+        self.config = config.BodhiConfig()
         self.config.load_config = mock.Mock()
         self.config['password'] = 'hunter2'
 
@@ -130,14 +130,291 @@ class BodhiConfigCopyTests(unittest.TestCase):
 
 class BodhiConfigLoadConfig(unittest.TestCase):
 
+    @mock.patch('bodhi.server.config.get_appsettings')
+    def test_loads_defaults(self, get_appsettings):
+        """Test that defaults are loaded."""
+        c = config.BodhiConfig()
+
+        c.load_config({'session.secret': 'secret', 'authtkt.secret': 'secret'})
+
+        self.assertEqual(c['top_testers_timeframe'], 7)
+
     @mock.patch('bodhi.server.config.get_configfile', mock.Mock(return_value='/some/config.ini'))
     @mock.patch('bodhi.server.config.get_appsettings')
     def test_marks_loaded(self, mock_appsettings):
-        config = BodhiConfig()
-        mock_appsettings.return_value = {'password': 'hunter2'}
+        c = config.BodhiConfig()
+        mock_appsettings.return_value = {'password': 'hunter2', 'session.secret': 'ssshhhhh',
+                                         'authtkt.secret': 'keepitsafe'}
 
-        config.load_config()
+        c.load_config()
 
         mock_appsettings.assert_called_once_with('/some/config.ini')
-        self.assertEqual([('password', 'hunter2')], config.items())
-        self.assertTrue(config.loaded)
+        self.assertTrue(('password', 'hunter2') in c.items())
+        self.assertTrue(c.loaded)
+
+    @mock.patch('bodhi.server.config.get_appsettings')
+    def test_validates(self, get_appsettings):
+        """Test that the config is validated."""
+        c = config.BodhiConfig()
+
+        with self.assertRaises(ValueError) as exc:
+            c.load_config({'fedmsg_enabled': 'not a bool', 'session.secret': 'secret',
+                           'authtkt.secret': 'secret'})
+
+        self.assertEqual(
+            str(exc.exception),
+            ('Invalid config values were set: \n\tfedmsg_enabled: "not a bool" cannot be '
+             'interpreted as a boolean value.'))
+
+    @mock.patch('bodhi.server.config.get_appsettings')
+    def test_with_settings(self, get_appsettings):
+        """Test with the optional settings parameter."""
+        c = config.BodhiConfig()
+
+        c.load_config({'wiki_url': 'test', 'session.secret': 'secret', 'authtkt.secret': 'secret'})
+
+        self.assertEqual(c['wiki_url'], 'test')
+        self.assertEqual(get_appsettings.call_count, 0)
+
+
+class BodhiConfigLoadDefaultsTests(unittest.TestCase):
+    """Test the BodhiConfig._load_defaults() method."""
+    @mock.patch.dict('bodhi.server.config.BodhiConfig._defaults', {'one': {'value': 'default'}},
+                     clear=True)
+    def test_load_defaults(self):
+        c = config.BodhiConfig()
+
+        c._load_defaults()
+
+        self.assertEqual(c, {'one': 'default'})
+
+
+class BodhiConfigValidate(unittest.TestCase):
+    def test_comps_unsafe_http_url(self):
+        """Ensure that setting comps_url to http://example.com fails validation."""
+        c = config.BodhiConfig()
+        c.load_config()
+        c['comps_url'] = 'http://example.com'
+
+        with self.assertRaises(ValueError) as exc:
+            c._validate()
+
+        self.assertEqual(str(exc.exception), ('Invalid config values were set: \n\tcomps_url: This '
+                                              'setting must be a URL starting with https://.'))
+
+    def test_valid_config(self):
+        """A valid config should not raise Exceptions."""
+        c = config.BodhiConfig()
+        c.load_config({'session.secret': 'secret', 'authtkt.secret': 'secret'})
+
+        # This should not raise an Excepton
+        c._validate()
+
+
+class GenerateListValidatorTests(unittest.TestCase):
+    """Tests the _generate_list_validator() function."""
+    def test_custom_splitter(self):
+        """Test with a non-default splitter."""
+        result = config._generate_list_validator('|')('thing 1| thing 2')
+
+        self.assertEqual(result, [u'thing 1', u'thing 2'])
+        self.assertTrue(all([isinstance(v, unicode) for v in result]))
+
+    def test_custom_validator(self):
+        """Test with a non-default validator."""
+        result = config._generate_list_validator(validator=int)('1 23 456')
+
+        self.assertEqual(result, [1, 23, 456])
+        self.assertTrue(all([isinstance(v, int) for v in result]))
+
+    def test_with_defaults(self):
+        """Test with the default parameters."""
+        result = config._generate_list_validator()('play it again sam')
+
+        self.assertEqual(result, [u'play', u'it', u'again', u'sam'])
+        self.assertTrue(all([isinstance(v, unicode) for v in result]))
+
+    def test_with_list(self):
+        """Test with a list."""
+        result = config._generate_list_validator(validator=int)(['1', '23', 456])
+
+        self.assertEqual(result, [1, 23, 456])
+        self.assertTrue(all([isinstance(v, int) for v in result]))
+
+    def test_wrong_type(self):
+        """Test with a non string, non list data type."""
+        with self.assertRaises(ValueError) as exc:
+            config._generate_list_validator()({'lol': 'wut'})
+
+        self.assertEqual(str(exc.exception), '"{\'lol\': \'wut\'}" cannot be intepreted as a list.')
+
+
+class ValidateBoolTests(unittest.TestCase):
+    """This class contains tests for the _validate_bool() function."""
+    def test_bool(self):
+        """Test with boolean values."""
+        self.assertTrue(config._validate_bool(False) is False)
+        self.assertTrue(config._validate_bool(True) is True)
+
+    def test_other(self):
+        """Test with a non-string and non-bool type."""
+        with self.assertRaises(ValueError) as exc:
+            config._validate_bool({'not a': 'bool'})
+
+        self.assertEqual(str(exc.exception), "\"{'not a': 'bool'}\" is not a bool or a string.")
+
+    def test_string_falsey(self):
+        """Test with "falsey" strings."""
+        for s in ('f', 'false', 'n', 'no', 'off', '0'):
+            self.assertTrue(config._validate_bool(s) is False)
+
+    def test_string_other(self):
+        """Test with an ambiguous string."""
+        with self.assertRaises(ValueError) as exc:
+            config._validate_bool('oops typo')
+
+        self.assertEqual(str(exc.exception),
+                         '"oops typo" cannot be interpreted as a boolean value.')
+
+    def test_string_truthy(self):
+        """Test with "truthy" strings."""
+        for s in ('t', 'true', 'y', 'yes', 'on', '1'):
+            self.assertTrue(config._validate_bool(s) is True)
+
+
+class ValidateColorTests(unittest.TestCase):
+    """Test the _validate_color() function."""
+    def test_non_string(self):
+        """A non-string parameter should raise a ValueError."""
+        with self.assertRaises(ValueError) as exc:
+            config._validate_color(['this', 'should', 'not', 'work'])
+
+        self.assertEqual(str(exc.exception),
+                         "\"['this', 'should', 'not', 'work']\" is not a valid color expression.")
+
+    def test_valid_color(self):
+        """A valid color string should not raise a ValueError and should be converted to unicode."""
+        color = config._validate_color('#65FE00')
+
+        self.assertEqual(color, u'#65FE00')
+        self.assertTrue(isinstance(color, unicode))
+
+    def test_wrong_base(self):
+        """A string that isn't a base-16 number should raise a ValueError."""
+        with self.assertRaises(ValueError) as exc:
+            config._validate_color('#65FE0G')
+
+        self.assertEqual(str(exc.exception), '"#65FE0G" is not a valid color expression.')
+
+    def test_wrong_first_char(self):
+        """A string that doesn't start with # should raise a ValueError."""
+        with self.assertRaises(ValueError) as exc:
+            config._validate_color('065FE00')
+
+        self.assertEqual(str(exc.exception), '"065FE00" is not a valid color expression.')
+
+    def test_wrong_length(self):
+        """A string with the wrong length should raise a ValueError."""
+        with self.assertRaises(ValueError) as exc:
+            config._validate_color('#65FE0')
+
+        self.assertEqual(str(exc.exception), '"#65FE0" is not a valid color expression.')
+
+
+class ValidateFernetKey(unittest.TestCase):
+    """This class contains tests for the _validate_fernet_key() function."""
+    def test_changeme(self):
+        """A value of CHANGE should raise a ValueError."""
+        with self.assertRaises(ValueError) as exc:
+            config._validate_fernet_key('CHANGEME')
+
+        self.assertEqual(str(exc.exception), 'This setting must be changed from its default value.')
+
+    def test_non_base64_key(self):
+        """A non-base64 key should also raise a ValueError."""
+        with self.assertRaises(ValueError) as exc:
+            config._validate_fernet_key('not base 64')
+
+        self.assertEqual(str(exc.exception), 'Fernet key must be 32 url-safe base64-encoded bytes.')
+
+    def test_valid_key(self):
+        """A valid key should be converted to a unicode object."""
+        key = 'gFqE6rcBXVLssjLjffsQsAa-nlm5Bg06MTKrVT9hsMA='
+        result = config._validate_fernet_key(key)
+
+        self.assertEqual(result, key)
+        self.assertTrue(type(result), str)
+
+    def test_wrong_length_key(self):
+        """An key with wrong length should raise a ValueError."""
+        with self.assertRaises(ValueError) as exc:
+            config._validate_fernet_key('VGhpcyBpcyBhIHRlc3Qgb2YgdGhlIHN5c3RlbS4K')
+
+        self.assertEqual(str(exc.exception), 'Fernet key must be 32 url-safe base64-encoded bytes.')
+
+
+class ValidateNoneOrTests(unittest.TestCase):
+    """Test the _validate_none_or() function."""
+    def test_with_none(self):
+        """Assert that None is allowed."""
+        result = config._validate_none_or(unicode)(None)
+
+        self.assertTrue(result is None)
+
+    def test_with_string(self):
+        """Assert that a string is validated and converted to unicode."""
+        result = config._validate_none_or(unicode)('unicode?')
+
+        self.assertEqual(result, u'unicode?')
+        self.assertTrue(isinstance(result, unicode))
+
+
+class ValidatePathTests(unittest.TestCase):
+    """Test the _validate_path() function."""
+    def test_path_does_not_exist(self):
+        """Test with a path that does not exist."""
+        with self.assertRaises(ValueError) as exc:
+            config._validate_path('/does/not/exist')
+
+        self.assertEqual(str(exc.exception), '"/does/not/exist" does not exist.')
+
+    def test_path_exists(self):
+        """Test with a path that exists."""
+        result = config._validate_path(__file__)
+
+        self.assertEqual(result, __file__)
+        self.assertTrue(isinstance(result, unicode))
+
+
+class ValidateSecretTests(unittest.TestCase):
+    """Test the _validate_secret() function."""
+    def test_with_changeme(self):
+        """Ensure that CHANGEME raises a ValueError."""
+        with self.assertRaises(ValueError) as exc:
+            config._validate_secret('CHANGEME')
+
+        self.assertEqual(str(exc.exception), 'This setting must be changed from its default value.')
+
+    def test_with_secret(self):
+        """Ensure that a secret gets changed to a unicode."""
+        result = config._validate_secret('secret')
+
+        self.assertEqual(result, u'secret')
+        self.assertTrue(isinstance(result, unicode))
+
+
+class ValidateTLSURL(unittest.TestCase):
+    """Test the _validate_tls_url() function."""
+    def test_with_http(self):
+        """Ensure that http:// URLs raise a ValueError."""
+        with self.assertRaises(ValueError) as exc:
+            config._validate_tls_url('http://example.com')
+
+        self.assertEqual(str(exc.exception), 'This setting must be a URL starting with https://.')
+
+    def test_with_https(self):
+        """Ensure that https:// urls get converted to unicode."""
+        result = config._validate_tls_url('https://example.com')
+
+        self.assertEqual(result, u'https://example.com')
+        self.assertTrue(isinstance(result, unicode))

--- a/development.ini.example
+++ b/development.ini.example
@@ -6,7 +6,7 @@ use = egg:bodhi-server
 ## This will compose Atomic OSTrees during the push process using the fedmsg-atomic-composer
 ## https://github.com/fedora-infra/fedmsg-atomic-composer
 ##
-compose_atomic_trees =
+# compose_atomic_trees = False
 
 ##
 ## Messages
@@ -18,22 +18,22 @@ frontpage_notice =
 # A notice to flash on the New Update page
 newupdate_notice =
 
-testing_approval_msg = This update has reached %d days in testing and can be pushed to stable now if the maintainer wishes.
-not_yet_tested_msg = This update has not yet met the minimum testing requirements defined in the <a href="https://fedoraproject.org/wiki/Package_update_acceptance_criteria">Package Update Acceptance Criteria</a>.
-not_yet_tested_epel_msg = This update has not yet met the minimum testing requirements defined in the <a href="https://fedoraproject.org/wiki/EPEL_Updates_Policy">EPEL Update Policy</a>.
+# testing_approval_msg = This update has reached %d days in testing and can be pushed to stable now if the maintainer wishes.
+# not_yet_tested_msg = This update has not yet met the minimum testing requirements defined in the <a href="https://fedoraproject.org/wiki/Package_update_acceptance_criteria">Package Update Acceptance Criteria</a>.
+# not_yet_tested_epel_msg = This update has not yet met the minimum testing requirements defined in the <a href="https://fedoraproject.org/wiki/EPEL_Updates_Policy">EPEL Update Policy</a>.
 stablekarma_comment = This update has reached the stable karma threshold and will be pushed to the stable updates repository.
 
-testing_approval_msg_based_on_karma = This update has reached the stable karma threshold and can be pushed to stable now if the maintainer wishes.
+# testing_approval_msg_based_on_karma = This update has reached the stable karma threshold and can be pushed to stable now if the maintainer wishes.
 not_yet_tested_msg_based_on_karma = This update has not reached stable karma threshold.
 
-disable_automatic_push_to_stable = Bodhi is disabling automatic push to stable due to negative karma. The maintainer may push manually if they determine that the issue is not severe.
+# disable_automatic_push_to_stable = Bodhi is disabling automatic push to stable due to negative karma. The maintainer may push manually if they determine that the issue is not severe.
 
 # Libravatar - If this is true libravatar will work as normal. Otherwise, all
 # libravatar links will be replaced with the string "libravatar.org" so that
 # the tests can still pass.
-libravatar_enabled = True
+# libravatar_enabled = True
 # Set this to true if you want to do federated dns libravatar lookup
-libravatar_dns = False
+# libravatar_dns = False
 
 # Set this to True in order to send fedmsg messages.
 fedmsg_enabled = True
@@ -42,25 +42,24 @@ fedmsg_enabled = True
 # Captcha - if 'captcha.secret' is not None, then it will be used for comments
 # captcha.secret must be 32 url-safe base64-encoded bytes
 # you can generate afresh with >>> cryptography.fernet.Fernet.generate_key()
-captcha.secret = ccmTv3CZUALZ7_ua6GSCl_9163FH2f0XfhY5G13tWJs=
+# captcha.secret = ccmTv3CZUALZ7_ua6GSCl_9163FH2f0XfhY5G13tWJs=
 # Dimensions
-captcha.image_width = 300
-captcha.image_height = 80
+# captcha.image_width = 300
+# captcha.image_height = 80
 # Any truetype font will do.
-# This font lives in pcaro-hermit-fonts package
-#captcha.font_path = /usr/share/fonts/pcaro-hermit/Hermit-medium.otf
-captcha.font_path = /usr/share/fonts/liberation/LiberationMono-Regular.ttf
-captcha.font_size = 36
+# /usr/share/fonts/liberation/LiberationMono-Regular.ttf lives in liberation-mono-fonts.
+# /usr/share/fonts/pcaro-hermit/Hermit-medium.otf lives in pcaro-hermit-fonts package.
+# captcha.font_path = /usr/share/fonts/liberation/LiberationMono-Regular.ttf
+# captcha.font_size = 36
 # Colors
-captcha.font_color = #000000
-captcha.background_color = #ffffff
+# captcha.font_color = #000000
+# captcha.background_color = #ffffff
 # In pixels
-captcha.padding = 5
+# captcha.padding = 5
 # If a captcha sits around for this many seconds, it will stop working.
-captcha.ttl = 300
+# captcha.ttl = 300
 
-#datagrepper_url = http://localhost:5000
-datagrepper_url = https://apps.fedoraproject.org/datagrepper
+# datagrepper_url = https://apps.fedoraproject.org/datagrepper
 badge_ids = binary-star|both-bull-and-self-transcended-tester-viii|catching-the-bull-tester-iv|corporate-drone|corporate-overlord|corporate-shill|discovery-of-the-footprints-tester-ii|in-search-of-the-bull-tester-i|is-this-thing-on-updates-testing-i|is-this-thing-on-updates-testing-ii|is-this-thing-on-updates-testing-iii|is-this-thing-on-updates-testing-iv|it-still-works!|like-a-rock-updates-stable-i|like-a-rock-updates-stable-ii|like-a-rock-updates-stable-iii|like-a-rock-updates-stable-iv|mic-check!-updates-testing-v|missed-the-train|override,-you-say|perceiving-the-bull-tester-iii|reaching-the-source-tester-ix|return-to-society-tester-x|riding-the-bull-home-tester-vi|stop-that-update!|take-this-and-call-me-in-the-morning|taming-the-bull-tester-v|tectonic!-updates-stable-v|the-bull-transcended-tester-vii|what-goes-around-comes-around-karma-i|what-goes-around-comes-around-karma-ii|what-goes-around-comes-around-karma-iii|what-goes-around-comes-around-karma-iv|white-hat|you-can-pry-it-from-my-cold,-dead-hands
 
 
@@ -69,22 +68,22 @@ badge_ids = binary-star|both-bull-and-self-transcended-tester-viii|catching-the-
 ##
 
 ## Query the wiki for test cases
-query_wiki_test_cases = False
-wiki_url = https://fedoraproject.org/w/api.php
-test_case_base_url = https://fedoraproject.org/wiki/
+# query_wiki_test_cases = False
+# wiki_url = https://fedoraproject.org/w/api.php
+# test_case_base_url = https://fedoraproject.org/wiki/
 
 # Email domain to prepend usernames to
-default_email_domain = fedoraproject.org
+# default_email_domain = fedoraproject.org
 
 # domain for generated message IDs
-message_id_email_domain = admin.fedoraproject.org
+# message_id_email_domain = admin.fedoraproject.org
 
 ##
 ## Mash settings
 ##
 
 # If defined, the bodhi masher will ensure that messages are signed with the given cert
-#releng_fedmsg_certname = releng-releng04.phx2.fedoraproject.org
+# releng_fedmsg_certname = releng-releng04.phx2.fedoraproject.org
 
 # The masher is a bodhi instance that is responsible for composing the update
 # repositories, regenerating metrics, sending update notices, closing bugs,
@@ -94,12 +93,12 @@ message_id_email_domain = admin.fedoraproject.org
 #masher = None
 
 # Where to initially mash repositories
-mash_dir = %(here)s/masher/mash/
+# mash_dir = %(here)s/masher/mash/
 
 # Where to symlink the latest repos by their tag name
-mash_stage_dir = %(here)s/masher/
+# mash_stage_dir = %(here)s/masher/
 
-mash_conf = /etc/mash/mash.conf
+# mash_conf = /etc/mash/mash.conf
 
 createrepo_cache_dir = /var/tmp/createrepo
 
@@ -108,15 +107,14 @@ createrepo_cache_dir = /var/tmp/createrepo
 jobs = cache_release_data refresh_metrics approve_testing_updates
 
 ## Comps configuration
-#comps_dir = /usr/share/bodhi/
-comps_dir = %(here)s/masher/comps
-comps_url = https://git.fedorahosted.org/comps.git
+# comps_dir = %(here)s/masher/comps
+# comps_url = https://git.fedorahosted.org/comps.git
 
 ##
 ## Mirror settings
 ##
 # file_url: Used in the repo metadata to set RPM URLs.
-file_url = https://download.fedoraproject.org/pub/fedora/linux/updates
+# file_url = https://download.fedoraproject.org/pub/fedora/linux/updates
 
 # {release}_{request}_master_repomd: This is used by the masher to determine when a
 #     primary architecture push has been synchronized to the master mirror for a given release and
@@ -126,10 +124,10 @@ file_url = https://download.fedoraproject.org/pub/fedora/linux/updates
 #     arches listed in {release}_{version}_primary_arches when it is defined, else used for all
 #     arches. You must put two %s's in this setting - the first will be replaced with the release
 #     version and the second will be replaced with the architecture.
-fedora_stable_master_repomd = http://download01.phx2.fedoraproject.org/pub/fedora/linux/updates/%s/%s/repodata/repomd.xml
-fedora_testing_master_repomd = http://download01.phx2.fedoraproject.org/pub/fedora/linux/updates/testing/%s/%s/repodata/repomd.xml
-fedora_epel_stable_master_repomd = http://download01.phx2.fedoraproject.org/pub/epel/%s/%s/repodata/repomd.xml
-fedora_epel_testing_master_repomd = http://download01.phx2.fedoraproject.org/pub/epel/testing/%s/%s/repodata/repomd.xml
+# fedora_stable_master_repomd = http://download01.phx2.fedoraproject.org/pub/fedora/linux/updates/%s/%s/repodata/repomd.xml
+# fedora_testing_master_repomd = http://download01.phx2.fedoraproject.org/pub/fedora/linux/updates/testing/%s/%s/repodata/repomd.xml
+# fedora_epel_stable_master_repomd = http://download01.phx2.fedoraproject.org/pub/epel/%s/%s/repodata/repomd.xml
+# fedora_epel_testing_master_repomd = http://download01.phx2.fedoraproject.org/pub/epel/testing/%s/%s/repodata/repomd.xml
 
 # {release}_{request}_alt_master_repomd: This is used by the masher to determine when a
 #     secondary architecture push has been synchronized to the master mirror for a given release and
@@ -139,14 +137,13 @@ fedora_epel_testing_master_repomd = http://download01.phx2.fedoraproject.org/pub
 #     arches listed in {release}_{version}_secondary_arches if it is defined. You must put two %s's
 #     in this setting - the first will be replaced with the release version and the second will be
 #     replaced with the architecture.
-fedora_stable_alt_master_repomd = http://download01.phx2.fedoraproject.org/pub/fedora-secondary/updates/%s/%s/repodata/repomd.xml
-fedora_testing_alt_master_repomd = http://download01.phx2.fedoraproject.org/pub/fedora-secondary/updates/testing/%s/%s/repodata/repomd.xml
+# fedora_stable_alt_master_repomd = http://download01.phx2.fedoraproject.org/pub/fedora-secondary/updates/%s/%s/repodata/repomd.xml
+# fedora_testing_alt_master_repomd = http://download01.phx2.fedoraproject.org/pub/fedora-secondary/updates/testing/%s/%s/repodata/repomd.xml
 
 
 ## The base url of this application
 ## Used as the <base/> tag in the master template.
 base_address = http://localhost:6543/
-#base_address = https://admin.stg.fedoraproject.org/updates/
 
 ## Supported update types
 update_types = bugfix enhancement security newpackage
@@ -161,45 +158,46 @@ update_types = bugfix enhancement security newpackage
 ##      Bodhi looks for primary arches with the {release}_{request}_master_repomd setting above, and
 ##      for alternative arches at the {release}_{request}_alt_master_repomd setting above. If this
 ##      is not set, Bodhi will assume the release only has primary arches.
-fedora_26_primary_arches = armhfp x86_64
+# fedora_26_primary_arches = armhfp x86_64
 
 ##
 ## Email setting
 ##
 
-smtp_server =
+# smtp_server =
 
 # The updates system itself.  This email address is used in fetching Bugzilla
 # information, as well as email notifications
-bodhi_email = updates@fedoraproject.org
-#bodhi_password =
+# bodhi_email = updates@fedoraproject.org
+# bodhi_password =
 
 # The address that gets the requests
-release_team_address = bodhiadmin-members@fedoraproject.org
+# release_team_address = bodhiadmin-members@fedoraproject.org
 
 # The address to notify when security updates are initially added to bodhi
 security_team = security_respons-members@fedoraproject.org
 
-# Public announcement lists
+# Public lists where we send update announcements.
+# These variables should be named per: Release.prefix_id.lower()_announce_list.
 fedora_announce_list = package-announce@lists.fedoraproject.org
 fedora_test_announce_list = test@lists.fedoraproject.org
 fedora_epel_announce_list = epel-package-announce@lists.fedoraproject.org
 fedora_epel_test_announce_list = epel-devel@lists.fedoraproject.org
 
 # Superuser groups
-admin_groups = proventesters security_respons bodhiadmin sysadmin-main
+# admin_groups = proventesters security_respons bodhiadmin sysadmin-main
 
 # Users that we don't want to show up in the "leaderboard(s)"
-stats_blacklist = bodhi anonymous autoqa taskotron
+# stats_blacklist = bodhi anonymous autoqa taskotron
 
 # A list of non-person users
-system_users = bodhi autoqa taskotron
+# system_users = bodhi autoqa taskotron
 
 # The max length for an update title before we truncate it in the web ui
-max_update_length_for_ui = 70
+# max_update_length_for_ui = 30
 
 # The number of days used for calculating the 'top testers' metric
-top_testers_timeframe = 900
+# top_testers_timeframe = 7
 
 # The email address of the proventesters
 proventesters_email = proventesters-members@fedoraproject.org
@@ -209,31 +207,23 @@ proventesters_email = proventesters-members@fedoraproject.org
 # because, while you can create stacks, you can't automatically create updates
 # *from* a stack (which was the whole point).  We'll work on that for a later
 # release.
-stacks_enabled = False
+# stacks_enabled = False
 
 
 # These are the default requirements that we apply to stacks, packages, and
 # updates.  Users have free-reign to override them for each kind of entity.  At
 # the end of the day, we only consider the requirements defined by single
 # updates themselves when gating in the backend masher process.
-site_requirements = depcheck upgradepath
-## Some day we'll have rpmgrill, and that will be cool.  Ask tflink.
-#site_requirements = depcheck upgradepath rpmgrill
-
-# Where do we send update announcements to ?
-# These variables should be named per: Release.prefix_id.lower()_announce_list
-#fedora_announce_list =
-#fedora_test_announce_list =
-#fedora_epel_announce_list =
-#fedora_epel_test_announce_list =
+# Some day we'll have rpmgrill, and that will be cool.  Ask tflink.
+# site_requirements = depcheck upgradepath
 
 # Cache settings
-dogpile.cache.backend = dogpile.cache.dbm
-dogpile.cache.expiration_time = 100
+# dogpile.cache.backend = dogpile.cache.dbm
+# dogpile.cache.expiration_time = 100
 dogpile.cache.arguments.filename = %(here)s/dogpile-cache.dbm
 
 # Exclude sending emails to these users
-exclude_mail = autoqa taskotron
+# exclude_mail = autoqa taskotron
 
 ##
 ## Buildsystem settings
@@ -242,10 +232,10 @@ exclude_mail = autoqa taskotron
 # What buildsystem do we want to use?  For development, we'll use a fake
 # buildsystem that always does what we tell it to do.  For production, we'll
 # want to use 'koji'.
-buildsystem = dev
+# buildsystem = dev
 
 # Koji's XML-RPC hub
-koji_hub = https://koji.stg.fedoraproject.org/kojihub
+# koji_hub = https://koji.stg.fedoraproject.org/kojihub
 
 # Root url of the Koji instance to point to. No trailing slash
 koji_url = http://koji.stg.fedoraproject.org
@@ -255,16 +245,19 @@ koji_url = http://koji.stg.fedoraproject.org
 override_limit = 31
 
 # URL of where users should go to set up their notifications
-fmn_url = https://apps.fedoraproject.org/notifications/
+# fmn_url = https://apps.fedoraproject.org/notifications/
 
 # URL of the resultsdb for integrating checks and stuff
 resultsdb_url = https://taskotron.fedoraproject.org/resultsdb/
-resultsdb_api_url = https://taskotron.fedoraproject.org/resultsdb_api/
+# resultsdb_api_url = https://taskotron.fedoraproject.org/resultsdb_api/
 
-fedmenu.url = https://apps.fedoraproject.org/fedmenu
-fedmenu.data_url = https://apps.fedoraproject.org/js/data.js
+# fedmenu.url = https://apps.fedoraproject.org/fedmenu
+# fedmenu.data_url = https://apps.fedoraproject.org/js/data.js
 
-# Koji certs
+# Koji client authentication
+# krb_principal =
+# krb_keytab =
+# krb_ccache=
 #client_cert =
 #clientca_cert =
 #serverca_cert =
@@ -275,12 +268,12 @@ fedmenu.data_url = https://apps.fedoraproject.org/js/data.js
 ## 'pagure', which will query the pagure_url below, or 'dummy', which will
 ## always return guest credentials (used for local development).
 ##
-acl_system = dummy
+# acl_system = dummy
 
 ##
 ## Package DB
 ##
-pkgdb_url = https://admin.fedoraproject.org/pkgdb
+# pkgdb_url = https://admin.fedoraproject.org/pkgdb
 
 ##
 ## Pagure
@@ -294,23 +287,24 @@ pkgdb_url = https://admin.fedoraproject.org/pkgdb
 
 # We used to get our package tags from pkgdb, but they come from tagger now.
 # https://github.com/fedora-infra/fedora-tagger/pull/74
-#pkgtags_url = https://apps.fedoraproject.org/tagger/api/v1/tag/sqlitebuildtags/
+# pkgtags_url = https://apps.fedoraproject.org/tagger/api/v1/tag/sqlitebuildtags/
 
 ##
 ## Bug tracker settings
 ##
-#bugtracker = bugzilla
+# Set this to bugzilla to turn on Bugzilla integration.
+# bugtracker = bugzilla
 
-initial_bug_msg = %s has been submitted as an update to %s. %s
-stable_bug_msg = %s has been pushed to the %s repository. If problems still persist, please make note of it in this bug report.
-testing_bug_msg =
-    See https://fedoraproject.org/wiki/QA:Updates_Testing for
-    instructions on how to install test updates.
-    You can provide feedback for this update here: %s
-testing_bug_epel_msg =
-    See https://fedoraproject.org/wiki/QA:Updates_Testing for
-    instructions on how to install test updates.
-    You can provide feedback for this update here: %s
+# initial_bug_msg = %s has been submitted as an update to %s. %s
+# stable_bug_msg = %s has been pushed to the %s repository. If problems still persist, please make note of it in this bug report.
+# testing_bug_msg =
+#     See https://fedoraproject.org/wiki/QA:Updates_Testing for
+#     instructions on how to install test updates.
+#     You can provide feedback for this update here: %s
+# testing_bug_epel_msg =
+#     See https://fedoraproject.org/wiki/QA:Updates_Testing for
+#     instructions on how to install test updates.
+#     You can provide feedback for this update here: %s
 
 ##
 ## Bugzilla settings.
@@ -319,13 +313,13 @@ testing_bug_epel_msg =
 # The username/password for our bugzilla account comes
 # from the bodhi_{email,password} fields.
 
-bz_server = https://bugzilla.redhat.com/xmlrpc.cgi
+# bz_server = https://bugzilla.redhat.com/xmlrpc.cgi
 #bz_cookie =
 
-# Bodhi will avoid touching bugs that are not against the following products
-bz_products = Fedora,Fedora EPEL
+# Bodhi will avoid touching bugs that are not against the following comma-separated products.
+# bz_products = Fedora,Fedora EPEL
 
-buglink = https://bugzilla.redhat.com/show_bug.cgi?id=%s
+# buglink = https://bugzilla.redhat.com/show_bug.cgi?id=%s
 
 ##
 ## Packages that should suggest a reboot
@@ -341,21 +335,21 @@ reboot_pkgs = kernel kernel-smp kernel-xen-hypervisor kernel-PAE kernel-xen0 ker
 # Database by setting this value to `pkgdb` or the Product Definition
 # Center by setting this value to `pdc`. If it isn't set, it'll just use the
 # hardcoded list below.
-#critpath.type = pkgdb
+# critpath.type =
 
 # You can hardcode a list of critical path packages instead of using the PkgDB
 # or PDC
-critpath_pkgs = kernel
+# critpath_pkgs = kernel
 
 # The number of admin approvals it takes to be able to push a critical path
 # update to stable for a pending release.
-critpath.num_admin_approvals = 0
+# critpath.num_admin_approvals = 2
 
 # The net karma required to submit a critial path update to a pending release)
-critpath.min_karma = 2
+# critpath.min_karma = 2
 
 # Allow critpath to submit for stable after 2 weeks with no negative karma
-critpath.stable_after_days_without_negative_karma = 14
+# critpath.stable_after_days_without_negative_karma = 14
 
 # The minimum amount of time an update must spend in testing before
 # it can reach the stable repository
@@ -398,29 +392,29 @@ buildroot_overrides.expire_after = 1
 # When a user logs in, bodhi will look for any of these groups and associate #
 # them with the user. They will then appear as the users effective principals in
 # the format "group:groupname" and can be used in Pyramid ACE's.
-important_groups = proventesters provenpackager releng security_respons packager bodhiadmin
+# important_groups = proventesters provenpackager releng security_respons packager bodhiadmin
 
 # Groups that can push updates for any package
-admin_packager_groups = provenpackager releng security_respons
+# admin_packager_groups = provenpackager releng security_respons
 
 # User must be a member of this group to submit updates
-mandatory_packager_groups = packager
+# mandatory_packager_groups = packager
 
 ##
 ## updateinfo.xml configuraiton
 ##
-updateinfo_rights = Copyright (C) 2015 Red Hat, Inc. and others.
+# updateinfo_rights = Copyright (C) {CURRENT_YEAR} Red Hat, Inc. and others.
 
 ##
 ## Authentication & Authorization
 ##
 
 # pyramid.openid
-openid.success_callback = bodhi.server.security:remember_me
-openid.provider = https://id.fedoraproject.org/openid/
-openid.url = https://id.fedoraproject.org/
-openid_template = {username}.id.fedoraproject.org
-openid.sreg_required = email
+# openid.success_callback = bodhi.server.security:remember_me
+# openid.provider = https://id.fedoraproject.org/openid/
+# openid.url = https://id.fedoraproject.org/
+# openid_template = {username}.id.fedoraproject.org
+# openid.sreg_required = email
 
 # CORS allowed origins for cornice services
 # This can be wide-open.  read-only, we don't care as much about.
@@ -453,7 +447,7 @@ sqlalchemy.url = sqlite:///%(here)s/bodhi.db
 ##
 ## Templates
 ##
-mako.directories = bodhi:server/templates
+# mako.directories = bodhi:server/templates
 
 ##
 ## Authentication & Sessions

--- a/production.ini
+++ b/production.ini
@@ -1,5 +1,14 @@
+# The commented values in this config file represent the defaults.
+
 [app:main]
 use = egg:bodhi-server
+
+##
+## Atomic OSTree support
+## This will compose Atomic OSTrees during the push process using the fedmsg-atomic-composer
+## https://github.com/fedora-infra/fedmsg-atomic-composer
+## This may be set to False or True.
+# compose_atomic_trees = False
 
 ##
 ## Messages
@@ -11,49 +20,49 @@ frontpage_notice =
 # A notice to flash on the New Update page
 newupdate_notice =
 
-testing_approval_msg = This update has reached %d days in testing and can be pushed to stable now if the maintainer wishes
-not_yet_tested_msg = This update has not yet met the minimum testing requirements defined in the <a href="https://fedoraproject.org/wiki/Package_update_acceptance_criteria">Package Update Acceptance Criteria</a>
-not_yet_tested_epel_msg = This update has not yet met the minimum testing requirements defined in the <a href="https://fedoraproject.org/wiki/EPEL_Updates_Policy">EPEL Update Policy</a>
+# testing_approval_msg = This update has reached %d days in testing and can be pushed to stable now if the maintainer wishes
+# not_yet_tested_msg = This update has not yet met the minimum testing requirements defined in the <a href="https://fedoraproject.org/wiki/Package_update_acceptance_criteria">Package Update Acceptance Criteria</a>
+# not_yet_tested_epel_msg = This update has not yet met the minimum testing requirements defined in the <a href="https://fedoraproject.org/wiki/EPEL_Updates_Policy">EPEL Update Policy</a>
 stablekarma_comment = This update has reached the stable karma threshold and will be pushed to the stable updates repository
 
-testing_approval_msg_based_on_karma = This update has reached the stable karma threshold and can be pushed to stable now if the maintainer wishes.
+# testing_approval_msg_based_on_karma = This update has reached the stable karma threshold and can be pushed to stable now if the maintainer wishes.
 not_yet_tested_msg_based_on_karma = This update has not reached the stable karma threshold.
 
-disable_automatic_push_to_stable = Bodhi is disabling automatic push to stable due to negative karma. The maintainer may push manually if they determine that the issue is not severe.
+# disable_automatic_push_to_stable = Bodhi is disabling automatic push to stable due to negative karma. The maintainer may push manually if they determine that the issue is not severe.
 
 # Libravatar - If this is true libravatar will work as normal. Otherwise, all
 # libravatar links will be replaced with the string "libravatar.org" so that
 # the tests can still pass.
-libravatar_enabled = True
+# libravatar_enabled = True
 # Set this to true if you want to do federated dns libravatar lookup
-libravatar_dns = False
+# libravatar_dns = False
 
 # Set this to True in order to send fedmsg messages.
-#fedmsg_enabled = True
+# fedmsg_enabled = False
 
 
-# Captcha - if 'captcha.secret' is not None, then it will be used for comments
-# captcha.secret must be 32 url-safe base64-encoded bytes
-# you can generate afresh with >>> cryptography.fernet.Fernet.generate_key()
-captcha.secret = CHANGEME
+# Captcha - if 'captcha.secret' is set, then it will be used for comments. Comment it to turn it
+# off. captcha.secret must be 32 url-safe base64-encoded bytes.
+# You can generate one with >>> cryptography.fernet.Fernet.generate_key()
+# captcha.secret = CHANGEME
 # Dimensions
-captcha.image_width = 300
-captcha.image_height = 80
+# captcha.image_width = 300
+# captcha.image_height = 80
 # Any truetype font will do.
-# This font lives in pcaro-hermit-fonts package
-captcha.font_path = /usr/share/fonts/pcaro-hermit/Hermit-medium.otf
-captcha.font_size = 36
+# /usr/share/fonts/liberation/LiberationMono-Regular.ttf lives in liberation-mono-fonts.
+# /usr/share/fonts/pcaro-hermit/Hermit-medium.otf lives in pcaro-hermit-fonts package.
+# captcha.font_path = /usr/share/fonts/liberation/LiberationMono-Regular.ttf
+# captcha.font_size = 36
 # Colors
-captcha.font_color = #000000
-captcha.background_color = #ffffff
+# captcha.font_color = #000000
+# captcha.background_color = #ffffff
 # In pixels
-captcha.padding = 5
+# captcha.padding = 5
 # If a captcha sits around for this many seconds, it will stop working.
-captcha.ttl = 300
+# captcha.ttl = 300
 
-#datagrepper_url = http://localhost:5000
-datagrepper_url = https://apps.fedoraproject.org/datagrepper
-badge_ids = binary-star|both-bull-and-self-transcended-tester-viii|catching-the-bull-tester-iv|corporate-drone|corporate-overlord|corporate-shill|discovery-of-the-footprints-tester-ii|in-search-of-the-bull-tester-i|is-this-thing-on-updates-testing-i|is-this-thing-on-updates-testing-ii|is-this-thing-on-updates-testing-iii|is-this-thing-on-updates-testing-iv|it-still-works!|like-a-rock-updates-stable-i|like-a-rock-updates-stable-ii|like-a-rock-updates-stable-iii|like-a-rock-updates-stable-iv|mic-check!-updates-testing-v|missed-the-train|override,-you-say|perceiving-the-bull-tester-iii|reaching-the-source-tester-ix|return-to-society-tester-x|riding-the-bull-home-tester-vi|stop-that-update!|take-this-and-call-me-in-the-morning|taming-the-bull-tester-v|tectonic!-updates-stable-v|the-bull-transcended-tester-vii|what-goes-around-comes-around-karma-i|what-goes-around-comes-around-karma-ii|what-goes-around-comes-around-karma-iii|what-goes-around-comes-around-karma-iv|white-hat|you-can-pry-it-from-my-cold,-dead-hands
+# datagrepper_url = https://apps.fedoraproject.org/datagrepper
+# badge_ids = binary-star|both-bull-and-self-transcended-tester-viii|catching-the-bull-tester-iv|corporate-drone|corporate-overlord|corporate-shill|discovery-of-the-footprints-tester-ii|in-search-of-the-bull-tester-i|is-this-thing-on-updates-testing-i|is-this-thing-on-updates-testing-ii|is-this-thing-on-updates-testing-iii|is-this-thing-on-updates-testing-iv|it-still-works!|like-a-rock-updates-stable-i|like-a-rock-updates-stable-ii|like-a-rock-updates-stable-iii|like-a-rock-updates-stable-iv|mic-check!-updates-testing-v|missed-the-train|override,-you-say|perceiving-the-bull-tester-iii|reaching-the-source-tester-ix|return-to-society-tester-x|riding-the-bull-home-tester-vi|stop-that-update!|take-this-and-call-me-in-the-morning|taming-the-bull-tester-v|tectonic!-updates-stable-v|the-bull-transcended-tester-vii|what-goes-around-comes-around-karma-i|what-goes-around-comes-around-karma-ii|what-goes-around-comes-around-karma-iii|what-goes-around-comes-around-karma-iv|white-hat|you-can-pry-it-from-my-cold,-dead-hands
 
 
 ##
@@ -61,22 +70,22 @@ badge_ids = binary-star|both-bull-and-self-transcended-tester-viii|catching-the-
 ##
 
 ## Query the wiki for test cases
-query_wiki_test_cases = False
-wiki_url = https://fedoraproject.org/w/api.php
-test_case_base_url = https://fedoraproject.org/wiki/
+# query_wiki_test_cases = False
+# wiki_url = https://fedoraproject.org/w/api.php
+# test_case_base_url = https://fedoraproject.org/wiki/
 
 # Email domain to prepend usernames to
-default_email_domain = fedoraproject.org
+# default_email_domain = fedoraproject.org
 
 # domain for generated message IDs
-message_id_email_domain = admin.fedoraproject.org
+# message_id_email_domain = admin.fedoraproject.org
 
 ##
 ## Mash settings
 ##
 
 # If defined, the bodhi masher will ensure that messages are signed with the given cert
-#releng_fedmsg_certname = releng-releng04.phx2.fedoraproject.org
+# releng_fedmsg_certname = releng-releng04.phx2.fedoraproject.org
 
 # The masher is a bodhi instance that is responsible for composing the update
 # repositories, regenerating metrics, sending update notices, closing bugs,
@@ -86,12 +95,12 @@ message_id_email_domain = admin.fedoraproject.org
 #masher = None
 
 # Where to initially mash repositories
-mash_dir = %(here)s/masher/mash/
+# mash_dir = %(here)s/masher/mash/
 
 # Where to symlink the latest repos by their tag name
-mash_stage_dir = %(here)s/masher/
+# mash_stage_dir = %(here)s/masher/
 
-mash_conf = /etc/mash/mash.conf
+# mash_conf = /etc/mash/mash.conf
 
 createrepo_cache_dir = /var/cache/createrepo
 
@@ -100,14 +109,14 @@ createrepo_cache_dir = /var/cache/createrepo
 jobs = cache_release_data refresh_metrics approve_testing_updates
 
 ## Comps configuration
-comps_dir = /usr/share/bodhi/
-comps_url = https://git.fedorahosted.org/comps.git
+# comps_dir = /usr/share/bodhi/
+# comps_url = https://git.fedorahosted.org/comps.git
 
 ##
 ## Mirror settings
 ##
 # file_url: Used in the repo metadata to set RPM URLs.
-file_url = https://download.fedoraproject.org/pub/fedora/linux/updates
+# file_url = https://download.fedoraproject.org/pub/fedora/linux/updates
 
 # {release}_{request}_master_repomd: This is used by the masher to determine when a
 #     primary architecture push has been synchronized to the master mirror for a given release and
@@ -117,10 +126,10 @@ file_url = https://download.fedoraproject.org/pub/fedora/linux/updates
 #     arches listed in {release}_{version}_primary_arches when it is defined, else used for all
 #     arches. You must put two %s's in this setting - the first will be replaced with the release
 #     version and the second will be replaced with the architecture.
-fedora_stable_master_repomd = http://download01.phx2.fedoraproject.org/pub/fedora/linux/updates/%s/%s/repodata/repomd.xml
-fedora_testing_master_repomd = http://download01.phx2.fedoraproject.org/pub/fedora/linux/updates/testing/%s/%s/repodata/repomd.xml
-fedora_epel_stable_master_repomd = http://download01.phx2.fedoraproject.org/pub/epel/%s/%s/repodata/repomd.xml
-fedora_epel_testing_master_repomd = http://download01.phx2.fedoraproject.org/pub/epel/testing/%s/%s/repodata/repomd.xml
+# fedora_stable_master_repomd = http://download01.phx2.fedoraproject.org/pub/fedora/linux/updates/%s/%s/repodata/repomd.xml
+# fedora_testing_master_repomd = http://download01.phx2.fedoraproject.org/pub/fedora/linux/updates/testing/%s/%s/repodata/repomd.xml
+# fedora_epel_stable_master_repomd = http://download01.phx2.fedoraproject.org/pub/epel/%s/%s/repodata/repomd.xml
+# fedora_epel_testing_master_repomd = http://download01.phx2.fedoraproject.org/pub/epel/testing/%s/%s/repodata/repomd.xml
 
 # {release}_{request}_alt_master_repomd: This is used by the masher to determine when a
 #     secondary architecture push has been synchronized to the master mirror for a given release and
@@ -130,12 +139,12 @@ fedora_epel_testing_master_repomd = http://download01.phx2.fedoraproject.org/pub
 #     arches listed in {release}_{version}_secondary_arches if it is defined. You must put two %s's
 #     in this setting - the first will be replaced with the release version and the second will be
 #     replaced with the architecture.
-fedora_stable_alt_master_repomd = http://download01.phx2.fedoraproject.org/pub/fedora-secondary/updates/%s/%s/repodata/repomd.xml
-fedora_testing_alt_master_repomd = http://download01.phx2.fedoraproject.org/pub/fedora-secondary/updates/testing/%s/%s/repodata/repomd.xml
+# fedora_stable_alt_master_repomd = http://download01.phx2.fedoraproject.org/pub/fedora-secondary/updates/%s/%s/repodata/repomd.xml
+# fedora_testing_alt_master_repomd = http://download01.phx2.fedoraproject.org/pub/fedora-secondary/updates/testing/%s/%s/repodata/repomd.xml
 
 
 ## The base url of this application
-base_address = https://admin.fedoraproject.org/updates/
+# base_address = https://admin.fedoraproject.org/updates/
 
 ## Supported update types
 update_types = bugfix enhancement security newpackage
@@ -150,45 +159,46 @@ update_types = bugfix enhancement security newpackage
 ##      Bodhi looks for primary arches with the {release}_{request}_master_repomd setting above, and
 ##      for alternative arches at the {release}_{request}_alt_master_repomd setting above. If this
 ##      is not set, Bodhi will assume the release only has primary arches.
-fedora_26_primary_arches = armhfp x86_64
+# fedora_26_primary_arches = armhfp x86_64
 
 ##
 ## Email setting
 ##
 
-smtp_server = bastion
+# smtp_server =
 
 # The updates system itself.  This email address is used in fetching Bugzilla
 # information, as well as email notifications
-bodhi_email = updates@fedoraproject.org
-#bodhi_password =
+# bodhi_email = updates@fedoraproject.org
+# bodhi_password =
 
 # The address that gets the requests
-release_team_address = bodhiadmin-members@fedoraproject.org
+# release_team_address = bodhiadmin-members@fedoraproject.org
 
 # The address to notify when security updates are initially added to bodhi
 security_team = security_respons-members@fedoraproject.org
 
-# Public announcement lists
-fedora_announce_list = package-announce@lists.fedoraproject.org
-fedora_test_announce_list = test@lists.fedoraproject.org
-fedora_epel_announce_list = epel-package-announce@lists.fedoraproject.org
-fedora_epel_test_announce_list = epel-devel@lists.fedoraproject.org
+# Public lists where we send update announcements.
+# These variables should be named per: Release.prefix_id.lower()_announce_list.
+# fedora_announce_list = package-announce@lists.fedoraproject.org
+# fedora_test_announce_list = test@lists.fedoraproject.org
+# fedora_epel_announce_list = epel-package-announce@lists.fedoraproject.org
+# fedora_epel_test_announce_list = epel-devel@lists.fedoraproject.org
 
 # Superuser groups
-admin_groups = proventesters security_respons bodhiadmin sysadmin-main
+# admin_groups = proventesters security_respons bodhiadmin sysadmin-main
 
 # Users that we don't want to show up in the "leaderboard(s)"
-stats_blacklist = bodhi anonymous autoqa taskotron
+# stats_blacklist = bodhi anonymous autoqa taskotron
 
 # A list of non-person users
-system_users = bodhi autoqa taskotron
+# system_users = bodhi autoqa taskotron
 
 # The max length for an update title before we truncate it in the web ui
-max_update_length_for_ui = 70
+# max_update_length_for_ui = 30
 
 # The number of days used for calculating the 'top testers' metric
-top_testers_timeframe = 900
+# top_testers_timeframe = 7
 
 # The email address of the proventesters
 proventesters_email = proventesters-members@fedoraproject.org
@@ -197,31 +207,23 @@ proventesters_email = proventesters-members@fedoraproject.org
 # because, while you can create stacks, you can't automatically create updates
 # *from* a stack (which was the whole point).  We'll work on that for a later
 # release.
-stacks_enabled = False
+# stacks_enabled = False
 
 
 # These are the default requirements that we apply to stacks, packages, and
 # updates.  Users have free-reign to override them for each kind of entity.  At
 # the end of the day, we only consider the requirements defined by single
 # updates themselves when gating in the backend masher process.
-site_requirements = depcheck upgradepath
-## Some day we'll have rpmgrill, and that will be cool.  Ask tflink.
-#site_requirements = depcheck upgradepath rpmgrill
-
-# Where do we send update announcements to ?
-# These variables should be named per: Release.prefix_id.lower()_announce_list
-#fedora_announce_list =
-#fedora_test_announce_list =
-#fedora_epel_announce_list =
-#fedora_epel_test_announce_list =
+# Some day we'll have rpmgrill, and that will be cool.  Ask tflink.
+# site_requirements = depcheck upgradepath
 
 # Cache settings
-dogpile.cache.backend = dogpile.cache.dbm
-dogpile.cache.expiration_time = 100
-dogpile.cache.arguments.filename = /var/cache/bodhi-dogpile-cache.dbm
+# dogpile.cache.backend = dogpile.cache.dbm
+# dogpile.cache.expiration_time = 100
+# dogpile.cache.arguments.filename = /var/cache/bodhi-dogpile-cache.dbm
 
 # Exclude sending emails to these users
-exclude_mail = autoqa taskotron
+# exclude_mail = autoqa taskotron
 
 ##
 ## Buildsystem settings
@@ -230,25 +232,28 @@ exclude_mail = autoqa taskotron
 # What buildsystem do we want to use?  For development, we'll use a fake
 # buildsystem that always does what we tell it to do.  For production, we'll
 # want to use 'koji'.
-buildsystem = dev
+# buildsystem = dev
 
 # Koji's XML-RPC hub
-koji_hub = https://koji.stg.fedoraproject.org/kojihub
+# koji_hub = https://koji.stg.fedoraproject.org/kojihub
 
 # Root url of the Koji instance to point to. No trailing slash
 koji_url = http://koji.stg.fedoraproject.org
 
 # URL of where users should go to set up their notifications
-fmn_url = https://apps.fedoraproject.org/notifications/
+# fmn_url = https://apps.fedoraproject.org/notifications/
 
 # URL of the resultsdb for integrating checks and stuff
 resultsdb_url = https://taskotron.fedoraproject.org/resultsdb/
-resultsdb_api_url = https://taskotron.fedoraproject.org/resultsdb_api/
+# resultsdb_api_url = https://taskotron.fedoraproject.org/resultsdb_api/
+
+# fedmenu.url = https://apps.fedoraproject.org/fedmenu
+# fedmenu.data_url = https://apps.fedoraproject.org/js/data.js
 
 # Koji krb5
-#krb_principal =
-#krb_keytab =
-#krb_ccache=
+# krb_principal =
+# krb_keytab =
+# krb_ccache=
 
 ##
 ## ACL system
@@ -256,12 +261,12 @@ resultsdb_api_url = https://taskotron.fedoraproject.org/resultsdb_api/
 ## 'pagure', which will query the pagure_url below, or 'dummy', which will
 ## always return guest credentials (used for local development).
 ##
-acl_system = dummy
+# acl_system = dummy
 
 ##
 ## Package DB
 ##
-pkgdb_url = https://admin.fedoraproject.org/pkgdb
+# pkgdb_url = https://admin.fedoraproject.org/pkgdb
 
 ##
 ## Pagure
@@ -275,23 +280,24 @@ pkgdb_url = https://admin.fedoraproject.org/pkgdb
 
 # We used to get our package tags from pkgdb, but they come from tagger now.
 # https://github.com/fedora-infra/fedora-tagger/pull/74
-#pkgtags_url = https://apps.fedoraproject.org/tagger/api/v1/tag/sqlitebuildtags/
+# pkgtags_url = https://apps.fedoraproject.org/tagger/api/v1/tag/sqlitebuildtags/
 
 ##
 ## Bug tracker settings
 ##
-#bugtracker = bugzilla
+# Set this to bugzilla to turn on Bugzilla integration.
+# bugtracker =
 
-initial_bug_msg = %s has been submitted as an update to %s. %s
-stable_bug_msg = %s has been pushed to the %s repository. If problems still persist, please make note of it in this bug report.
-testing_bug_msg =
-    See https://fedoraproject.org/wiki/QA:Updates_Testing for
-    instructions on how to install test updates.
-    You can provide feedback for this update here: %s
-testing_bug_epel_msg =
-    See https://fedoraproject.org/wiki/QA:Updates_Testing for
-    instructions on how to install test updates.
-    You can provide feedback for this update here: %s
+# initial_bug_msg = %s has been submitted as an update to %s. %s
+# stable_bug_msg = %s has been pushed to the %s repository. If problems still persist, please make note of it in this bug report.
+# testing_bug_msg =
+#     See https://fedoraproject.org/wiki/QA:Updates_Testing for
+#     instructions on how to install test updates.
+#     You can provide feedback for this update here: %s
+# testing_bug_epel_msg =
+#     See https://fedoraproject.org/wiki/QA:Updates_Testing for
+#     instructions on how to install test updates.
+#     You can provide feedback for this update here: %s
 
 ##
 ## Bugzilla settings.
@@ -300,13 +306,13 @@ testing_bug_epel_msg =
 # The username/password for our bugzilla account comes
 # from the bodhi_{email,password} fields.
 
-bz_server = https://bugzilla.redhat.com/xmlrpc.cgi
+# bz_server = https://bugzilla.redhat.com/xmlrpc.cgi
 #bz_cookie =
 
-# Bodhi will avoid touching bugs that are not against the following products
-bz_products = Fedora,Fedora EPEL
+# Bodhi will avoid touching bugs that are not against the following comma-separated products.
+# bz_products = Fedora,Fedora EPEL
 
-buglink = https://bugzilla.redhat.com/show_bug.cgi?id=%s
+# buglink = https://bugzilla.redhat.com/show_bug.cgi?id=%s
 
 ##
 ## Packages that should suggest a reboot
@@ -322,21 +328,21 @@ reboot_pkgs = kernel kernel-smp kernel-xen-hypervisor kernel-PAE kernel-xen0 ker
 # Database by setting this value to `pkgdb` or the Product Definition
 # Center by setting this value to `pdc`. If it isn't set, it'll just use the
 # hardcoded list below.
-#critpath.type = pkgdb
+# critpath.type =
 
 # You can hardcode a list of critical path packages instead of using the PkgDB
 # or PDC
-critpath_pkgs = kernel
+# critpath_pkgs = kernel
 
 # The number of admin approvals it takes to be able to push a critical path
 # update to stable for a pending release.
-critpath.num_admin_approvals = 0
+# critpath.num_admin_approvals = 2
 
 # The net karma required to submit a critial path update to a pending release)
-critpath.min_karma = 2
+# critpath.min_karma = 2
 
 # Allow critpath to submit for stable after 2 weeks with no negative karma
-critpath.stable_after_days_without_negative_karma = 14
+# critpath.stable_after_days_without_negative_karma = 14
 
 # The minimum amount of time an update must spend in testing before
 # it can reach the stable repository
@@ -379,27 +385,29 @@ buildroot_overrides.expire_after = 1
 # When a user logs in, bodhi will look for any of these groups and associate #
 # them with the user. They will then appear as the users effective principals in
 # the format "group:groupname" and can be used in Pyramid ACE's.
-important_groups = proventesters provenpackager releng security_respons packager bodhiadmin
+# important_groups = proventesters provenpackager releng security_respons packager bodhiadmin
 
 # Groups that can push updates for any package
-admin_packager_groups = provenpackager releng security_respons
+# admin_packager_groups = provenpackager releng security_respons
 
 # User must be a member of this group to submit updates
-mandatory_packager_groups = packager
+# mandatory_packager_groups = packager
 
 ##
 ## updateinfo.xml configuraiton
 ##
-updateinfo_rights = Copyright (C) 2015 Red Hat, Inc. and others.
+# updateinfo_rights = Copyright (C) {CURRENT_YEAR} Red Hat, Inc. and others.
 
 ##
 ## Authentication & Authorization
 ##
 
 # pyramid.openid
-openid.success_callback = bodhi.server.security:remember_me
-openid.provider = https://id.fedoraproject.org/openid/
-openid_template = {username}.id.fedoraproject.org
+# openid.success_callback = bodhi.server.security:remember_me
+# openid.provider = https://id.fedoraproject.org/openid/
+# openid.url = https://id.fedoraproject.org/
+# openid_template = {username}.id.fedoraproject.org
+# openid.sreg_required = email
 
 # CORS allowed origins for cornice services
 # This can be wide-open.  read-only, we don't care as much about.
@@ -432,16 +440,16 @@ sqlalchemy.url = sqlite:////var/cache/bodhi.db
 ##
 ## Templates
 ##
-mako.directories = bodhi:server/templates
+# mako.directories = bodhi:server/templates
 
 ##
 ## Authentication & Sessions
 ##
 
 # CHANGE THESE IN PRODUCTION!
-authtkt.secret = changethisinproduction!
-session.secret = ChangeThisSecret!!1
-authtkt.secure = false
+# authtkt.secret = CHANGEME
+# session.secret = CHANGEME
+# authtkt.secure = True
 # How long should an authorization ticket be valid for, in seconds? Defaults to one day.
 # authtkt.timeout = 86400
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,7 +2,7 @@
 cover-erase=TRUE
 cover-html=TRUE
 cover-inclusive=TRUE
-cover-min-percentage=84
+cover-min-percentage=87
 cover-package=bodhi
 cover-xml=TRUE
 with-coverage=TRUE


### PR DESCRIPTION
This pull request has two commits. The first is the primary goal of the PR, and gives Bodhi a central config validation system. This is a significant refactor, and a technical debt payment. I recommend reading its commit message for further details.

The first commit happened to raise test coverage to 85%, so the second commit requires test coverage to remain at 85%.

fixes #1489