### PR TITLE
remove old get_age methods

### DIFF
--- a/bodhi/server/models.py
+++ b/bodhi/server/models.py
@@ -43,7 +43,7 @@ from bodhi.server import bugs, buildsys, log, mail, notifications, Session
 from bodhi.server.config import config
 from bodhi.server.exceptions import BodhiException, LockedUpdateException
 from bodhi.server.util import (
-    avatar as get_avatar, build_evr, flash_log, get_age, get_age_in_days, get_critpath_pkgs,
+    avatar as get_avatar, build_evr, flash_log, get_critpath_pkgs,
     get_nvr, get_rpm_header, header, tokenize)
 import bodhi.server.util
 
@@ -1823,24 +1823,6 @@ class Update(Base):
                 session.save(cve)
                 self.cves.append(cve)
         session.flush()
-
-    def get_pushed_age(self):
-        return get_age(self.date_pushed)
-
-    def get_submitted_age(self):
-        return get_age(self.date_submitted)
-
-    def get_pushed_color(self):
-        age = get_age_in_days(self.date_pushed)
-        if age == 0 or self.karma < 0:
-            color = '#ff0000'  # red
-        elif age < 4:
-            color = '#ff6600'  # orange
-        elif age < 7:
-            color = '#ffff00'  # yellow
-        else:
-            color = '#00ff00'  # green
-        return color
 
     def obsolete_if_unstable(self, db):
         """

--- a/bodhi/server/util.py
+++ b/bodhi/server/util.py
@@ -18,7 +18,6 @@ Random functions that don't fit elsewhere
 
 from collections import defaultdict
 from contextlib import contextmanager
-from datetime import datetime
 from os.path import join, dirname, basename, isfile
 import collections
 import functools
@@ -55,13 +54,6 @@ _ = TranslationStringFactory('bodhi')
 def header(x):
     """Display a given message as a heading."""
     return u"%s\n     %s\n%s\n" % ('=' * 80, x, '=' * 80)
-
-
-def pluralize(val, name):
-    """
-    Returns name if val == 1, or returns name with an 's' appended to the end if val != 1.
-    """
-    return val == 1 and name or "%ss" % name
 
 
 def get_rpm_header(nvr, tries=0):
@@ -111,27 +103,6 @@ def mkmetadatadir(path):
     if not os.path.isdir(path):
         os.makedirs(path)
     subprocess.check_call(['createrepo_c', '--xz', '--database', '--quiet', path])
-
-
-def get_age(date):
-    age = datetime.utcnow() - date
-    if age.days == 0:
-        if age.seconds < 60:
-            return "%d %s" % (age.seconds, pluralize(age.seconds, "second"))
-        minutes = int(age.seconds / 60)
-        if minutes >= 60:
-            hours = int(minutes / 60)
-            return "%d %s" % (hours, pluralize(hours, "hour"))
-        return "%d %s" % (minutes, pluralize(minutes, "minute"))
-    return "%d %s" % (age.days, pluralize(age.days, "day"))
-
-
-def get_age_in_days(date):
-    if date:
-        age = datetime.utcnow() - date
-        return age.days
-    else:
-        return 0
 
 
 def flash_log(msg):


### PR DESCRIPTION
We now use the "age" method in util.py to get relative
dates and times (i.e. 3h hours ago), which uses the arrow
library.

There are two methods in util.py, get_age() and get_age_in_days()
that we dont use anymore, as we use the age() method instead.

pluralize() in util.py is also removed, as the only place we
used this was in the get_ages, and we do other pluralizations
in JS now anyway.

The only other places that get_age() and get_age_in_days() were used
were a handful of methods in models.py, but these were not used anymore
either.