### PR TITLE
switch requirements from depcheck to rpmdeplint, rework resultsdb queries

### DIFF
--- a/bodhi/client/bindings.py
+++ b/bodhi/client/bindings.py
@@ -165,8 +165,8 @@ class BodhiClient(OpenIdBaseClient):
         :kwarg severity: The severity of this update (``urgent``, ``high``,
             ``medium``, ``low``)
         :kwarg requirements: A list of required Taskotron tests that must pass
-            for this update to reach stable. (``depcheck``, ``upgradepath``,
-            ``rpmlint``)
+            for this update to reach stable. (e.g. ``dist.rpmdeplint``,
+            ``dist.upgradepath``, ``dist.rpmlint``, etc)
         :kwarg require_bugs: A boolean to require that all of the bugs in your
             update have been confirmed by testers.
         :kwarg require_testcases: A boolean to require that this update passes

--- a/bodhi/server/config.py
+++ b/bodhi/server/config.py
@@ -498,7 +498,7 @@ class BodhiConfig(dict):
             'value': 'CHANGEME',
             'validator': _validate_secret},
         'site_requirements': {
-            'value': 'depcheck upgradepath',
+            'value': 'dist.rpmdeplint dist.upgradepath',
             'validator': unicode},
         'smtp_server': {
             'value': None,

--- a/bodhi/server/models.py
+++ b/bodhi/server/models.py
@@ -2258,27 +2258,54 @@ class Update(Base):
             # https://github.com/fedora-infra/bodhi/issues/362
             since = self.last_modified.isoformat().rsplit('.', 1)[0]
         except Exception as e:
+            log.exception("Failed to determine last_modified from %r : %r",
+                          self.last_modified, e.message)
             return False, "Failed to determine last_modified: %r" % e.message
 
         try:
-            query = dict(title=self.title, since=since)
+            # query results for this update
+            query = dict(type='bodhi_update', item=self.alias, since=since,
+                         testcases=','.join(requirements))
             results = bodhi.server.util.taskotron_results(settings, **query)
-        except IOError as e:
-            return False, "Failed to talk to taskotron: %r" % e.message
+
+            # query results for each build
+            # retrieve timestamp for each build so that queries can be optimized
+            koji = buildsys.get_session()
+            koji.multicall = True
+            for build in self.builds:
+                koji.getBuild(build.nvr)
+            buildinfos = koji.multiCall()
+
+            for index, build in enumerate(self.builds):
+                buildinfo = buildinfos[index]
+                if not isinstance(buildinfo, dict):
+                    log.warn("Koji build info doesn't seem correct: %r",
+                             buildinfo)
+                ts = datetime.utcfromtimestamp(buildinfo['completion_ts']).isoformat()
+
+                query = dict(type='koji_build', item=build.nvr, since=ts,
+                             testcases=','.join(requirements))
+                build_results = bodhi.server.util.taskotron_results(settings, **query)
+                results.extend(build_results)
+
+        except Exception as e:
+            log.exception("Failed retrieving requirements results: %r", e.message)
+            return False, "Failed retrieving requirements results: %r" % e.message
 
         for testcase in requirements:
             relevant = [result for result in results
                         if result['testcase']['name'] == testcase]
 
             if not relevant:
-                return False, 'No result found for required %s' % testcase
+                return False, 'No result found for required testcase %s' % testcase
 
             by_arch = defaultdict(list)
-            for r in relevant:
-                by_arch[r['result_data'].get('arch', ['noarch'])[0]].append(r)
+            for result in relevant:
+                arch = result['data'].get('arch', ['noarch'])[0]
+                by_arch[arch].append(result)
 
             for arch, results in by_arch.items():
-                latest = results[0]  # TODO - do these need to be sorted still?
+                latest = results[0]  # resultsdb results are ordered chronologically
                 if latest['outcome'] not in ['PASSED', 'INFO']:
                     return False, "Required task %s returned %s" % (
                         latest['testcase']['name'], latest['outcome'])
@@ -2342,7 +2369,7 @@ class Update(Base):
         """ Return the last time this update was edited or created.
 
         This gets used specifically by taskotron/resultsdb queries so we only
-        query for depcheck runs that occur *after* the last time this update
+        query for test runs that occur *after* the last time this update
         (in its current form) was in play.
         """
 

--- a/bodhi/server/models.py
+++ b/bodhi/server/models.py
@@ -2255,7 +2255,7 @@ class Update(Base):
         requirements = list(requirements)
 
         if not requirements:
-            return True, "All checks pass."
+            return True, "No checks required."
 
         try:
             # https://github.com/fedora-infra/bodhi/issues/362
@@ -2284,7 +2284,7 @@ class Update(Base):
                 if (not isinstance(multicall_response, list) or
                         not isinstance(multicall_response[0], dict)):
                     msg = ("Error retrieving data from Koji for %r: %r" %
-                           build.nvr, multicall_response)
+                           (build.nvr, multicall_response))
                     log.error(msg)
                     raise TypeError(msg)
 
@@ -2312,8 +2312,8 @@ class Update(Base):
                 arch = result['data'].get('arch', ['noarch'])[0]
                 by_arch[arch].append(result)
 
-            for arch, results in by_arch.items():
-                latest = results[0]  # resultsdb results are ordered chronologically
+            for arch, result in by_arch.items():
+                latest = relevant[0]  # resultsdb results are ordered chronologically
                 if latest['outcome'] not in ['PASSED', 'INFO']:
                     return False, "Required task %s returned %s" % (
                         latest['testcase']['name'], latest['outcome'])

--- a/bodhi/server/templates/update.html
+++ b/bodhi/server/templates/update.html
@@ -103,10 +103,6 @@ ${update.type} update for ${update.beautify_title(amp=True) | n}
       // the latest ones for each arch.  So, prune like this:
       $.each(data.data, function(i, result) {
 
-        // However, we want to skip over any ABORTED results:
-        // https://github.com/fedora-infra/bodhi/issues/167
-        if (result.outcome == 'ABORTED') return;
-
         var name = result.testcase.name;
         // we want to stash results by scenario when there is one, use name
         // when there isn't
@@ -257,12 +253,8 @@ ${update.type} update for ${update.beautify_title(amp=True) | n}
       request_results(base_url+"results/latest?item="+builds[index]+"&type=koji_build&testcases:like=dist.*");
     }
 
-    var oqaquery = "?item=${update.alias}&type=bodhi_update&testcases:like=update.*&since=";
-    % if update.date_modified:
-    oqaquery += "${update.date_modified.isoformat()}";
-    % else:
-    oqaquery += "${update.date_submitted.isoformat()}";
-    % endif
+    var oqaquery = "?item=${update.alias}&type=bodhi_update&"+
+                   "testcases:like=update.*&since=${update.last_modified.isoformat()}";
     request_results(base_url+"results/latest"+oqaquery);
   });
 </script>

--- a/bodhi/server/util.py
+++ b/bodhi/server/util.py
@@ -657,8 +657,8 @@ def taskotron_results(settings, entity='results/latest', max_queries=10, **kwarg
             if max_queries and queries >= max_queries and url:
                 log.debug('Too many result pages, aborting at: %r' % url)
                 break
-    except Exception:
-        log.exception("Problem talking to %r" % url)
+    except Exception as e:
+        log.exception("Problem talking to %r : %r" % (url, e.message))
 
 
 class TransactionalSessionMaker(object):

--- a/bodhi/server/util.py
+++ b/bodhi/server/util.py
@@ -654,8 +654,8 @@ def taskotron_results(settings, entity='results/latest', max_queries=10, **kwarg
 
             url = json.get('next')
             queries += 1
-            if queries >= max_queries and url:
-                log.warn('Too many result pages, aborting at: %r' % url)
+            if max_queries and queries >= max_queries and url:
+                log.debug('Too many result pages, aborting at: %r' % url)
                 break
     except Exception:
         log.exception("Problem talking to %r" % url)

--- a/bodhi/server/validators.py
+++ b/bodhi/server/validators.py
@@ -990,7 +990,8 @@ def validate_stack(request):
 
 def _get_valid_requirements(request):
     """ Returns a list of valid testcases from taskotron. """
-    for testcase in taskotron_results(config, 'testcases'):
+    for testcase in taskotron_results(config, 'testcases',
+                                      max_queries=None, limit=100):
         yield testcase['name']
 
 

--- a/bodhi/server/views/generic.py
+++ b/bodhi/server/views/generic.py
@@ -258,15 +258,15 @@ def latest_candidates(request):
                 koji.listTagged(release.pending_testing_tag, **kwargs)
                 koji.listTagged(release.pending_signing_tag, **kwargs)
 
-        builds = koji.multiCall() or []  # Protect against None
+        response = koji.multiCall() or []  # Protect against None
 
-        for build in builds:
-            if isinstance(build, dict):
+        for taglist in response:
+            if isinstance(taglist, dict):
                 continue
-            if build and build[0] and build[0][0]:
+            for build in taglist[0]:
                 item = {
-                    'nvr': build[0][0]['nvr'],
-                    'id': build[0][0]['id'],
+                    'nvr': build['nvr'],
+                    'id': build['id'],
                 }
                 # Prune duplicates
                 # https://github.com/fedora-infra/bodhi/issues/450

--- a/bodhi/tests/server/consumers/test_masher.py
+++ b/bodhi/tests/server/consumers/test_masher.py
@@ -42,7 +42,7 @@ mock_taskotron_results = {
     'target': 'bodhi.server.util.taskotron_results',
     'return_value': [{
         "outcome": "PASSED",
-        "result_data": {},
+        "data": {},
         "testcase": {"name": "rpmlint"}
     }],
 }
@@ -51,7 +51,7 @@ mock_failed_taskotron_results = {
     'target': 'bodhi.server.util.taskotron_results',
     'return_value': [{
         "outcome": "FAILED",
-        "result_data": {},
+        "data": {},
         "testcase": {"name": "rpmlint"}
     }],
 }

--- a/bodhi/tests/server/services/test_updates.py
+++ b/bodhi/tests/server/services/test_updates.py
@@ -153,7 +153,7 @@ class TestNewUpdate(bodhi.tests.server.functional.base.BaseWSGICase):
         update = self.get_update()
         update['requirements'] = 'rpmlint silly-dilly'
         res = self.app.post_json('/updates/', update, status=400)
-        assert 'Invalid requirement' in res, res
+        assert "Required check doesn't exist" in res, res
 
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')

--- a/bodhi/tests/server/services/test_updates.py
+++ b/bodhi/tests/server/services/test_updates.py
@@ -54,7 +54,7 @@ mock_taskotron_results = {
     'target': 'bodhi.server.util.taskotron_results',
     'return_value': [{
         "outcome": "PASSED",
-        "result_data": {},
+        "data": {},
         "testcase": {"name": "rpmlint"}
     }],
 }
@@ -63,7 +63,7 @@ mock_failed_taskotron_results = {
     'target': 'bodhi.server.util.taskotron_results',
     'return_value': [{
         "outcome": "FAILED",
-        "result_data": {},
+        "data": {},
         "testcase": {"name": "rpmlint"}
     }],
 }

--- a/bodhi/tests/server/test_validators.py
+++ b/bodhi/tests/server/test_validators.py
@@ -35,9 +35,19 @@ class TestGetValidRequirements(unittest.TestCase):
             {'next': '/something?', 'data': [{'name': 'one'}, {'name': 'two'}]},
             {'next': None, 'data': []}]
 
-        result = list(validators._get_valid_requirements(None))
+        result = list(validators._get_valid_requirements(request=None,
+                                                         requirements=['one', 'two']))
 
         self.assertEqual(result, ['one', 'two'])
+
+    @mock.patch('bodhi.server.util.taskotron_results')
+    def test_no_requirements(self, mock_taskotron_results):
+        """Empty requirements means empty output"""
+        result = list(validators._get_valid_requirements(request=None,
+                                                         requirements=[]))
+
+        mock_taskotron_results.assert_not_called()
+        self.assertEqual(result, [])
 
 
 @mock.patch.dict(

--- a/development.ini.example
+++ b/development.ini.example
@@ -192,8 +192,7 @@ fedora_epel_test_announce_list = epel-devel@lists.fedoraproject.org
 # updates.  Users have free-reign to override them for each kind of entity.  At
 # the end of the day, we only consider the requirements defined by single
 # updates themselves when gating in the backend masher process.
-# Some day we'll have rpmgrill, and that will be cool.  Ask tflink.
-# site_requirements = depcheck upgradepath
+# site_requirements = dist.rpmdeplint dist.upgradepath
 
 # Cache settings
 # dogpile.cache.backend = dogpile.cache.dbm

--- a/production.ini
+++ b/production.ini
@@ -192,8 +192,7 @@ use = egg:bodhi-server
 # updates.  Users have free-reign to override them for each kind of entity.  At
 # the end of the day, we only consider the requirements defined by single
 # updates themselves when gating in the backend masher process.
-# Some day we'll have rpmgrill, and that will be cool.  Ask tflink.
-# site_requirements = depcheck upgradepath
+# site_requirements = dist.rpmdeplint dist.upgradepath
 
 # Cache settings
 # dogpile.cache.backend = dogpile.cache.dbm


### PR DESCRIPTION
Depcheck is replaced by rpmdeplint, update the code. Also fix queries to
resultsdb:
* use API 2.0
* ask for both bodhi_update and koji_build results
* do very specific queries (only request required testcases, use
timestamps)
* use results/latest endpoint by default
* give up if there are too many results for a given item (doesn't affect
results/latest endpoint, only results endpoint)
* use larger pages when retrieving testcases

There are known issues with the current results/latest endpoint
approach, in particular it doesn't display results for all architectures
(for rpmdeplint). Since rpmdeplint is currently only executed for
x86_64, it isn't a huge problem atm, but will need to be resolved in the
future.

----

Hello, this is a preliminary patch for testing and discussion. Rpmdeplint is only run in dev at the moment, we'll be pushing it into production after Beta freeze (so this patch doesn't make sense before that). Furthermore, this patch is completely untested. I used a development VM using vagrant, but I have no idea how to actually test this backend stuff. (I probably broke the unit tests as well). Can you please test it?

Is the code in `check_requirements()` even used at all? And when it is used? How can I trigger it when using vagrant dev env?

I assume that `check_requirements()` should block karma autopush in case any of those testcases specified in `site_requirements` are not passed. Is that correct? Is it being used at the moment? (Because it seems to me that this must've been broken for some time).

Thanks.