### PR TITLE
fix BaseException.message warning in tests

### DIFF
--- a/bodhi/tests/server/test_models.py
+++ b/bodhi/tests/server/test_models.py
@@ -994,7 +994,7 @@ class TestUpdate(ModelTest):
             pass
         eq_(self.obj.request, UpdateRequest.testing)
         eq_(self.obj.status, UpdateStatus.pending)
-        eq_(e.message, config.get('not_yet_tested_msg'))
+        eq_(str(e), config.get('not_yet_tested_msg'))
 
     @mock.patch('bodhi.server.notifications.publish')
     def test_set_request_stable_after_week_in_testing(self, publish):


### PR DESCRIPTION
previously, when running the tests, the following warning was shown:

/bodhi/bodhi/tests/server/test_models.py:997: DeprecationWarning: BaseException.message has been deprecated as of Python 2.6
  eq_(e.message, config.get('not_yet_tested_msg'))

this fixes this issue.