### PR TITLE
fix SAWarning when testing

### DIFF
--- a/bodhi/server/views/generic.py
+++ b/bodhi/server/views/generic.py
@@ -37,7 +37,7 @@ def get_top_testers(request):
         sa.func.count(models.User.comments).label(u'count_1')
     ).join(models.Comment)
     query = query\
-        .order_by(u'count_1 desc')\
+        .order_by(sa.text(u'count_1 desc'))\
         .filter(models.Comment.timestamp > start_time)
 
     for user in blacklist:


### PR DESCRIPTION
Previously, the following warning appeared when running the tests:

/usr/lib64/python2.7/site-packages/sqlalchemy/sql/compiler.py:575: SAWarning: Can't resolve label reference u'count_1 desc'; converting to text()

this fixes that issue