### PR TITLE
Use bleach instead of python-markdown's Safe Mode

### DIFF
--- a/bodhi/server/util.py
+++ b/bodhi/server/util.py
@@ -33,6 +33,7 @@ from kitchen.iterutils import iterate
 from pyramid.i18n import TranslationStringFactory
 from pyramid.settings import asbool
 import arrow
+import bleach
 import colander
 import libravatar
 import markdown
@@ -297,9 +298,23 @@ def hostname(context=None):
 
 
 def markup(context, text):
-    return markdown.markdown(text, safe_mode="replace",
-                             html_replacement_text="--RAW HTML NOT ALLOWED--",
-                             extensions=['markdown.extensions.fenced_code'])
+    """
+    Return HTML from a markdown string
+
+    Args:
+        context (mako.runtime.Context)
+        text (basestring): markdown text to be converted to HTML
+
+    Return:
+        basestring: HTML representation of the markdown text
+    """
+
+    # previously, we used the Safe Mode in python-markdown to strip all HTML
+    # tags. Safe Mode is deprecated, so we now use Bleach to sanitize all HTML
+    # tags before running it through the markdown parser
+    sanitized_text = bleach.clean(text, tags=[])
+
+    return markdown.markdown(sanitized_text, extensions=['markdown.extensions.fenced_code'])
 
 
 def status2html(context, status):

--- a/bodhi/tests/server/functional/test_generic.py
+++ b/bodhi/tests/server/functional/test_generic.py
@@ -198,7 +198,7 @@ class TestGenericViews(bodhi.tests.server.functional.base.BaseWSGICase):
         self.assertEquals(
             res.json_body['html'],
             "<div class='markdown'>"
-            '<p>--RAW HTML NOT ALLOWED--bold--RAW HTML NOT ALLOWED--</p>'
+            '<p>&lt;b&gt;bold&lt;/b&gt;</p>'
             "</div>"
         )
 

--- a/bodhi/tests/server/test_utils.py
+++ b/bodhi/tests/server/test_utils.py
@@ -52,7 +52,7 @@ class TestUtils(object):
         html = util.markup(None, text)
         assert html == (
             "<div class='markdown'>"
-            '<p>--RAW HTML NOT ALLOWED--bold--RAW HTML NOT ALLOWED--</p>'
+            '<p>&lt;b&gt;bold&lt;/b&gt;</p>'
             "</div>"
         ), html
 

--- a/devel/ansible/roles/dev/tasks/main.yml
+++ b/devel/ansible/roles/dev/tasks/main.yml
@@ -24,6 +24,7 @@
       - python
       - python-alembic
       - python-arrow
+      - python-bleach
       - python-bugzilla
       - python-bunch
       - python-click

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -11,6 +11,12 @@ Features
   (`#1325 <https://github.com/fedora-infra/bodhi/issues/1325>`_ and
   `#1326 <https://github.com/fedora-infra/bodhi/issues/1326>`_).
 
+New Dependencies
+^^^^^^^^^^^^^^^^
+
+* Bodhi now uses Bleach to sanitize markdown input from the user.
+  python-bleach 1.x is a new dependency in this release of Bodhi.
+
 
 2.7.0
 -----

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 arrow
 bunch
+bleach<2
 click
 colander
 cornice<2


### PR DESCRIPTION
Previously, we used the Safe Mode of python-markdown to
replace HTML tags in the markdown input from the user. It
replaced all text with a Raw HTML not allowed message.

However, the Safe Mode feature in python-markdown was deprecated,
and they recomended that Bleach be used instead.

This commit passes the markdown input from the user through
Bleach -- before it renders the markdown to html -- escaping all
HTML tags.