### PR TITLE
Issue #882 Strip subjects in email

### DIFF
--- a/bodhi/server/mail.py
+++ b/bodhi/server/mail.py
@@ -484,7 +484,7 @@ def send(to, msg_type, update, sender=None, agent=None):
             "X-Bodhi-Update-Release": update.release.name,
             "X-Bodhi-Update-Status": update.status.description,
             "X-Bodhi-Update-Builds": ",".join([b.nvr for b in update.builds]),
-            "X-Bodhi-Update-Title": update.title,
+            "X-Bodhi-Update-Title": update.beautify_title(),
             "X-Bodhi-Update-Pushed": update.pushed,
             "X-Bodhi-Update-Submitter": update.user.name,
         }
@@ -502,7 +502,7 @@ def send(to, msg_type, update, sender=None, agent=None):
 
     subject_template = '[Fedora Update] %s[%s] %s'
     for person in iterate(to):
-        subject = subject_template % (critpath, msg_type, update.title)
+        subject = subject_template % (critpath, msg_type, update.beautify_title())
         fields = MESSAGES[msg_type]['fields'](agent, update)
         body = MESSAGES[msg_type]['body'] % fields
         send_mail(sender, person, subject, body, headers=headers)

--- a/bodhi/server/models.py
+++ b/bodhi/server/models.py
@@ -44,7 +44,7 @@ from bodhi.server.config import config
 from bodhi.server.exceptions import BodhiException, LockedUpdateException
 from bodhi.server.util import (
     avatar as get_avatar, build_evr, flash_log, get_critpath_components,
-    get_nvr, get_rpm_header, header, tokenize, pagure_api_get)
+    get_nvr, get_rpm_header, header, packagename_from_nvr, tokenize, pagure_api_get)
 import bodhi.server.util
 
 
@@ -1548,6 +1548,30 @@ class Update(Base):
                     elif feedback.karma < 0:
                         bad += 1
         return bad * -1, good
+
+    def beautify_title(self, amp=False):
+        """Will shorten the title according to its length.
+
+        This is used mostly in subject of a update notification email and
+        displaying the title in html. If there are 3 or more builds per title
+        the title be:
+
+            "package1, package, 2 and XXX more"
+
+        If the "amp" parameter is specified it will replace the and with and
+        &amp; html entity
+        """
+        if len(self.builds) > 2:
+            title = ", ".join([packagename_from_nvr(self, build.nvr) for build in self.builds[:2]])
+            if amp:
+                title += ", &amp; "
+            else:
+                title += ", and "
+            title += str(len(self.builds) - 2)
+            title += " more"
+            return title
+        else:
+            return " and ".join([packagename_from_nvr(self, build.nvr) for build in self.builds])
 
     def assign_alias(self):
         """Return a randomly-suffixed update ID.

--- a/bodhi/server/templates/update.html
+++ b/bodhi/server/templates/update.html
@@ -2,37 +2,12 @@
 <%namespace name="captcha" module="bodhi.server.captcha"/>
 <%namespace name="json" module="json"/>
 
-<%def name="generateupdatetitlestring()">
-
-  % if len(update.builds) == 1:
-    % for build in update.builds:
-      ${self.util.packagename_from_nvr(build.nvr)}
-    % endfor
-  % elif len(update.builds) == 2:
-    % for build in update.builds:
-      % if loop.last:
-      and
-      % endif
-      ${self.util.packagename_from_nvr(build.nvr)}
-    % endfor
-  % elif len(update.builds) > 2:
-    % for build in update.builds:
-      % if loop.index == 0:
-      ${self.util.packagename_from_nvr(build.nvr)},
-      % elif loop.index == 1:
-      ${self.util.packagename_from_nvr(build.nvr)}
-      &amp; ${len(update.builds)-2} more
-      % endif
-    % endfor
-  % endif
-</%def>
-
 <%block name="pagetitle">
 % if update.alias:
   ${update.alias}
 % endif
 &mdash;
-${update.type} update for ${generateupdatetitlestring()}
+${update.type} update for ${update.beautify_title(amp=True) | n}
 &mdash; Fedora Updates System
 </%block>
 
@@ -471,7 +446,7 @@ $(document).ready(function(){
     <h4>
       ${update.type} update
       in ${update.release.long_name}
-      for ${generateupdatetitlestring()}
+      for ${update.beautify_title(amp=True) | n}
     </h4>
     <div>
       Status: ${self.util.status2html(update.status) | n}

--- a/bodhi/tests/server/test_models.py
+++ b/bodhi/tests/server/test_models.py
@@ -15,6 +15,7 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 """Test suite for bodhi.server.models"""
 from datetime import datetime, timedelta
+from HTMLParser import HTMLParser
 import json
 import time
 import unittest
@@ -869,6 +870,20 @@ class TestUpdate(ModelTest):
 
     def test_title(self):
         eq_(self.obj.title, u'TurboGears-1.0.8-3.fc11')
+
+    def test_beautify_title(self):
+        update = self.get_update()
+        rpm_build = update.builds[0]
+        eq_(update.beautify_title(), u'TurboGears')
+
+        update.builds.append(rpm_build)
+        eq_(update.beautify_title(), u'TurboGears and TurboGears')
+
+        update.builds.append(rpm_build)
+        eq_(update.beautify_title(), u'TurboGears, TurboGears, and 1 more')
+
+        p = HTMLParser()
+        eq_(p.unescape(update.beautify_title(amp=True)), u'TurboGears, TurboGears, & 1 more')
 
     def test_pkg_str(self):
         """ Ensure str(pkg) is correct """


### PR DESCRIPTION
Hi All,

i have added a a beautify_title method into the update model as discussed in issue https://github.com/fedora-infra/bodhi/issues/882. I added the shortened subject also to mail module to the send method. Is there some other place where the shortened update.title is desirable? So WDYT?