### PR TITLE
Add diff-cover to setup.py and add documentation on how to use it

### DIFF
--- a/devel/ansible/roles/dev/tasks/main.yml
+++ b/devel/ansible/roles/dev/tasks/main.yml
@@ -30,6 +30,7 @@
       - python-cornice
       - python-cornice-sphinx
       - python-devel
+      - python3-diff-cover
       - python-dogpile-cache
       - python-fedora
       - python-ipdb

--- a/docs/developer_docs.rst
+++ b/docs/developer_docs.rst
@@ -12,7 +12,8 @@ Before you submit a pull request to Bodhi, please ensure that it meets these cri
 
 * All tests must pass.
 * New code must have 100% test coverage. This one is particularly important, as we don't want to
-  deploy any broken code into production.
+  deploy any broken code into production. After you've run `btest`, you can verify your new code's
+  test coverage with `diff-cover coverage.xml --compare-branch=origin/develop --fail-under=100`.
 * New functions, methods, and classes must have docblocks that explain what the code block is, and
   describing any parameters it accepts and what it returns (if anything). You can use the
   ``pydocstyle`` utility to automatically check your code for this. There is a

--- a/setup.py
+++ b/setup.py
@@ -87,7 +87,8 @@ setup(
         'nose',
         'nose-cov',
         'webtest',
-        'mock'
+        'mock',
+        'diff-cover'
     ],
     test_suite="nose.collector")
 


### PR DESCRIPTION
I'm proposing we add `diff-cover` to Bodhi's development environment and contribution documentation so that developers can easily tell if their code changes are covered by tests.

We can consider putting this as part of `btest`, however, we would have to always assume that the branch to compare it to is `origin/develop` and that may not always be the case. I will leave that up to the maintainers of Bodhi to decide.