### PR TITLE
Move acl parameters out of the method definitions

### DIFF
--- a/bodhi/server/services/overrides.py
+++ b/bodhi/server/services/overrides.py
@@ -39,6 +39,7 @@ override = Service(name='override', path='/overrides/{nvr}',
 
 overrides = Service(name='overrides', path='/overrides/',
                     description='Buildroot Overrides',
+                    acl=bodhi.server.security.packagers_allowed_acl,
                     # Note, this 'rw' is not a typo.  the @comments service has
                     # a ``post`` section at the bottom.
                     cors_origins=bodhi.server.security.cors_origins_rw)
@@ -155,7 +156,7 @@ def query_overrides(request):
 
 
 @overrides.post(schema=bodhi.server.schemas.SaveOverrideSchema,
-                acl=bodhi.server.security.packagers_allowed_acl,
+                permission='edit',
                 accept=("application/json", "text/json"), renderer='json',
                 error_handler=bodhi.server.services.errors.json_handler,
                 validators=(
@@ -163,7 +164,7 @@ def query_overrides(request):
                     validate_expiration_date,
                 ))
 @overrides.post(schema=bodhi.server.schemas.SaveOverrideSchema,
-                acl=bodhi.server.security.packagers_allowed_acl,
+                permission='edit',
                 accept=("application/javascript"), renderer="jsonp",
                 error_handler=bodhi.server.services.errors.jsonp_handler,
                 validators=(

--- a/bodhi/server/services/releases.py
+++ b/bodhi/server/services/releases.py
@@ -46,6 +46,7 @@ release = Service(name='release', path='/releases/{name}',
                   cors_origins=bodhi.server.security.cors_origins_ro)
 releases = Service(name='releases', path='/releases/',
                    description='Fedora Releases',
+                   acl=bodhi.server.security.admin_only_acl,
                    # Note, this 'rw' is not a typo.  the @comments service has
                    # a ``post`` section at the bottom.
                    cors_origins=bodhi.server.security.cors_origins_rw)
@@ -230,7 +231,7 @@ def query_releases_json(request):
 
 
 @releases.post(schema=bodhi.server.schemas.SaveReleaseSchema,
-               acl=bodhi.server.security.admin_only_acl, renderer='json',
+               permission='admin', renderer='json',
                error_handler=bodhi.server.services.errors.json_handler,
                validators=(validate_tags, validate_enums)
                )

--- a/bodhi/server/services/stacks.py
+++ b/bodhi/server/services/stacks.py
@@ -30,12 +30,14 @@ import bodhi.server.services.errors
 
 
 stack = Service(name='stack', path='/stacks/{name}',
+                acl=bodhi.server.security.packagers_allowed_acl,
                 validators=(validate_stack,),
                 description='Bodhi Stacks',
                 # Note, this 'rw' is not a typo.  there are deletes and posts.
                 cors_origins=bodhi.server.security.cors_origins_rw)
 stacks = Service(name='stacks', path='/stacks/',
                  description='Bodhi Stacks',
+                 acl=bodhi.server.security.packagers_allowed_acl,
                  # Not a typo.  there are deletes and posts in here.
                  cors_origins=bodhi.server.security.cors_origins_rw)
 
@@ -99,7 +101,7 @@ def query_stacks(request):
 
 
 @stacks.post(schema=bodhi.server.schemas.SaveStackSchema,
-             acl=bodhi.server.security.packagers_allowed_acl,
+             permission='edit',
              validators=(validate_requirements,), renderer='json',
              error_handler=bodhi.server.services.errors.json_handler)
 def save_stack(request):
@@ -170,7 +172,7 @@ def save_stack(request):
     return dict(stack=stack)
 
 
-@stack.delete(acl=bodhi.server.security.packagers_allowed_acl, renderer='json',
+@stack.delete(permission='edit', renderer='json',
               error_handler=bodhi.server.services.errors.json_handler)
 def delete_stack(request):
     """Delete a stack"""


### PR DESCRIPTION
Cornice has deprecated the use of the acl parameter in method
definitions. This caused the following warnings to show when
running the tests:

/usr/lib/python2.7/site-packages/cornice/service.py:295:
DeprecationWarning: Warning: Using acl in method definitions is
deprecated.Use service or resource instead.

This commit moves the acls into the Service calls.

Related: #1522