### PR TITLE
Issue #780 Duplicate test cases when viewing an update

### DIFF
--- a/bodhi/server/templates/fragments.html
+++ b/bodhi/server/templates/fragments.html
@@ -60,7 +60,7 @@
           % endfor
 
           % if comment.testcase_feedback:
-            % for feedback in comment.testcase_feedback:
+            % for feedback in comment.unique_testcase_feedback:
             % if feedback.karma:
             <span class="nowrap">${util.testcase_link(feedback.testcase, short=True) | n}: ${util.karma2html(feedback.karma) | n}</span>
             % endif


### PR DESCRIPTION
Hi All, 

fixed the issue with the duplicates displaying in bodhi on test cases and assigned correct karma to them. Right now the test cases and karma is displayed correctly. Don`t really know why the dupes appeared in the DB. Current code base does not allow duplicate entries of test cases. At least this happened only for 4 packages and 22 test cases what i can tell.