### PR TITLE
Sort builds in the update by the NVR of the build

### DIFF
--- a/bodhi/server/models.py
+++ b/bodhi/server/models.py
@@ -1119,7 +1119,8 @@ class Update(Base):
     # One-to-many relationships
     comments = relationship('Comment', backref=backref('update', lazy='joined'), lazy='joined',
                             order_by='Comment.timestamp')
-    builds = relationship('Build', backref=backref('update', lazy='joined'), lazy='joined')
+    builds = relationship('Build', backref=backref('update', lazy='joined'), lazy='joined',
+                          order_by='Build.nvr')
 
     # Many-to-many relationships
     bugs = relationship('Bug', secondary=update_bug_table, backref='updates')

--- a/bodhi/tests/server/test_push.py
+++ b/bodhi/tests/server/test_push.py
@@ -468,8 +468,8 @@ class TestPush(base.BaseTestCase):
         glob.assert_called_once_with('/mnt/koji/mash/updates/MASHING-*')
         publish.assert_called_once_with(
             topic='masher.start',
-            msg={'updates': ['python-nose-1.3.7-11.fc17', 'python-paste-deploy-1.5.2-8.fc17',
-                             'ejabberd-16.09-4.fc17'],
+            msg={'updates': ['ejabberd-16.09-4.fc17', 'python-nose-1.3.7-11.fc17',
+                             'python-paste-deploy-1.5.2-8.fc17'],
                  'resume': False, 'agent': 'bowlofeggs'},
             force=True)
         mock_file.assert_called_once_with('/mnt/koji/mash/updates/MASHING-f17-updates')


### PR DESCRIPTION
Adds sorting to the model for updates, sorting the builds by the NVR.

Note that this also changes the output of the titles that we generate for the update, as well as the order in the builds tab.

Before:
![before](https://user-images.githubusercontent.com/592259/26963537-62e392e8-4d30-11e7-9040-1a4046807308.png)

After:
![after](https://user-images.githubusercontent.com/592259/26963543-70b4b96a-4d30-11e7-8c0a-25df9c6b59e0.png)

Fixes: #1441 

