### PR TITLE
not show the override form if not logged in

### DIFF
--- a/bodhi/server/templates/override.html
+++ b/bodhi/server/templates/override.html
@@ -1,6 +1,7 @@
 <%namespace name="util" module="bodhi.server.util"/>
 <%inherit file="master.html"/>
 <div class="container">
+%if request.user:
 <div class="row">
   <div id='js-warning' class="col-md-6 col-md-offset-3 m-t-3">
     <div class="alert alert-warning">
@@ -20,14 +21,26 @@
   </div>
 
   <script>$("#js-warning").addClass('hidden');</script>
-
-  <div id="new-override-form" class="col-md-12 hidden m-t-3">
+%endif
+  %if override is UNDEFINED:
+  <h2 class="pull-left m-t-3">New Override</h2>
+  %else:
+  <div class="col-md-12 m-t-3">
+    <h2>Buildroot Override for <code>${override.build.nvr}</code></h2>
+    <p>Submitted by
+      <a href="${request.route_url('user', name=override.submitter.name)}">
+        <img class="img-circle" src="${util.avatar(override.submitter.name, size=24)}"/>
+        ${override.submitter.name}
+      </a>
+    </p>
+  </div>
+  %endif
+%if request.user:
+  <div id="new-override-form" class="col-md-12 hidden">
 
     <div class="row">
       %if override is UNDEFINED:
-      <div class="col-md-12">
-        <h2 class="pull-left">New Override</span>
-      </div>
+
       %elif override.expired_date is None:
       <div class="alert alert-info col-sm-8 col-sm-offset-2">
         <p>Use the following to ensure the override is active:</p>
@@ -158,6 +171,16 @@
     </div> <!-- end row -->
 
   </div>
+  %elif not request.user and override is not UNDEFINED:
+  <div class="row">
+    <div class="col-md-12 m-t-3">
+      <h4 class="m-t-2">
+        Notes
+      </h4>
+      ${self.util.markup(override.notes) | n}
+    </div>
+  </div>
+  %endif
 </div>
 </div>
 <script src="${request.static_url('bodhi:server/static/js/override_form.js')}"></script>


### PR DESCRIPTION
Previously, the full edit override form was shown when
looking at an override, even if the user was not logged
in. This commit changes the override template so the
form is not shown to the non-logged in user. Instead
they get just the info about the override.

Fixes: #1541

This also adds some tests to test the above funtionality,
as well as a few extra tests on the overrides views in
html where we didnt test in the past, fixing #946