### PR TITLE
Remove an unneeded conditional import.

### DIFF
--- a/bodhi/server/util.py
+++ b/bodhi/server/util.py
@@ -36,15 +36,11 @@ import colander
 import libravatar
 import markdown
 import requests
+import rpm
 
 from bodhi.server import log, buildsys, Session
 from bodhi.server.config import config
 from bodhi.server.exceptions import RepodataException
-
-try:
-    import rpm
-except ImportError:
-    log.warning("Could not import 'rpm'")
 
 
 _ = TranslationStringFactory('bodhi')


### PR DESCRIPTION
Other parts of bodhi already hard-depend on rpm being available
(such as bodhi.server.models), so there's no reason to
conditionally import it.

fixes #1166

Signed-off-by: Randy Barlow <randy@electronsweatshop.com>