### PR TITLE
Provide messenging if user tries to create a new override that already exists

### DIFF
--- a/bodhi/client/__init__.py
+++ b/bodhi/client/__init__.py
@@ -537,7 +537,16 @@ def save_buildroot_overrides(user, password, url, staging, **kwargs):
         staging (bool): Whether to use the staging server or not.
         kwargs (dict): Other keyword arguments passed to us by click.
     """
-    _save_override(url=url, user=user, password=password, staging=staging, **kwargs)
+
+    try:
+        _save_override(url=url, user=user, password=password, staging=staging, **kwargs)
+    except bindings.BodhiClientException as e:
+        if str(e) == "Buildroot override for %s already exists" % (kwargs['nvr']):
+            click.echo(str(e))
+            click.echo("The `overrides save` command is used for creating a new override.")
+            click.echo("Use `overrides edit` to edit an existing override.")
+        else:
+            raise
 
 
 @overrides.command('edit')


### PR DESCRIPTION
This commit provides better error messages to the user if they try
to create an override with bodhi-client that already exists.

fixes #1377