### PR TITLE
Add a masher/mash/.1611 file.

### DIFF
--- a/masher/mash/.1611
+++ b/masher/mash/.1611
@@ -1,0 +1,6 @@
+This file is here to fix #1611:
+
+https://github.com/fedora-infra/bodhi/issues/1611
+
+It will ensure that the masher/mash folder exists for git checkouts, so tests will pass on the first
+run.


### PR DESCRIPTION
By creating this file, we can ensure that new git checkouts will
pass the tests upon the first run.

fixes #1611

Signed-off-by: Randy Barlow <randy@electronsweatshop.com>