### PR TITLE
Remove diff-cover from test requirements, since it is not required.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -88,7 +88,6 @@ setup(
         'nose-cov',
         'webtest',
         'mock',
-        'diff-cover'
     ],
     test_suite="nose.collector")
 


### PR DESCRIPTION
The tests pass just fine without diff-cover. It is merely a tool to
aid in comparing test coverage between branches. Thus, it is not a
requirement.

Signed-off-by: Randy Barlow <randy@electronsweatshop.com>