### PR TITLE
mash_dir and mash_stage_dir default to None.

### DIFF
--- a/bodhi/server/config.py
+++ b/bodhi/server/config.py
@@ -435,11 +435,11 @@ class BodhiConfig(dict):
             'value': '/etc/mash/mash.conf',
             'validator': unicode},
         'mash_dir': {
-            'value': os.path.join(os.path.dirname(__file__), '..', '..', 'masher', 'mash'),
-            'validator': _validate_path},
+            'value': None,
+            'validator': _validate_none_or(_validate_path)},
         'mash_stage_dir': {
-            'value': os.path.join(os.path.dirname(__file__), '..', '..', 'masher'),
-            'validator': _validate_path},
+            'value': None,
+            'validator': _validate_none_or(_validate_path)},
         'max_update_length_for_ui': {
             'value': 30,
             'validator': int},

--- a/bodhi/tests/server/consumers/test_masher.py
+++ b/bodhi/tests/server/consumers/test_masher.py
@@ -96,6 +96,13 @@ def makemsg(body=None):
 class TestMasher(unittest.TestCase):
 
     def setUp(self):
+        self._new_mash_stage_dir = tempfile.mkdtemp()
+        self._mash_stage_dir = config['mash_stage_dir']
+        self._mash_dir = config['mash_dir']
+        config['mash_stage_dir'] = self._new_mash_stage_dir
+        config['mash_dir'] = os.path.join(config['mash_stage_dir'], 'mash')
+        os.makedirs(config['mash_dir'])
+
         buildsys.setup_buildsystem({'buildsystem': 'dev'})
 
         fd, self.db_filename = tempfile.mkstemp(prefix='bodhi-testing-', suffix='.db')
@@ -138,6 +145,9 @@ class TestMasher(unittest.TestCase):
         except:
             pass
         buildsys.teardown_buildsystem()
+        config['mash_stage_dir'] = self._mash_stage_dir
+        config['mash_dir'] = self._mash_dir
+        shutil.rmtree(self._new_mash_stage_dir)
 
     def set_stable_request(self, title):
         with self.db_factory() as session:

--- a/bodhi/tests/server/test_metadata.py
+++ b/bodhi/tests/server/test_metadata.py
@@ -118,16 +118,17 @@ class TestAddUpdate(base.BaseTestCase):
 
 class TestExtendedMetadata(unittest.TestCase):
 
-    def __init__(self, *args, **kw):
-        super(TestExtendedMetadata, self).__init__(*args, **kw)
-        repo_path = os.path.join(config.get('mash_dir'), 'f17-updates-testing')
-        if not os.path.exists(repo_path):
-            os.makedirs(repo_path)
-
     def setUp(self):
+        self._new_mash_stage_dir = tempfile.mkdtemp()
+        self._mash_stage_dir = config['mash_stage_dir']
+        self._mash_dir = config['mash_dir']
+        config['mash_stage_dir'] = self._new_mash_stage_dir
+        config['mash_dir'] = os.path.join(config['mash_stage_dir'], 'mash')
+        os.makedirs(os.path.join(config['mash_dir'], 'f17-updates-testing'))
+
         setup_buildsystem({'buildsystem': 'dev'})
-        config = {'sqlalchemy.url': DB_PATH}
-        engine = initialize_db(config)
+        app_config = {'sqlalchemy.url': DB_PATH}
+        engine = initialize_db(app_config)
         log.debug('Creating all models for %s' % engine)
         Base.metadata.bind = engine
         Base.metadata.create_all(engine)
@@ -160,6 +161,9 @@ class TestExtendedMetadata(unittest.TestCase):
         get_session().clear()
         shutil.rmtree(self.tempdir)
         teardown_buildsystem()
+        config['mash_stage_dir'] = self._mash_stage_dir
+        config['mash_dir'] = self._mash_dir
+        shutil.rmtree(self._new_mash_stage_dir)
 
     def _verify_updateinfo(self, repodata):
         updateinfos = glob.glob(join(repodata, "*-updateinfo.xml*"))

--- a/development.ini.example
+++ b/development.ini.example
@@ -85,11 +85,12 @@ badge_ids = binary-star|both-bull-and-self-transcended-tester-viii|catching-the-
 ## Mash settings
 ##
 
-# Where to initially mash repositories
-# mash_dir = %(here)s/masher/mash/
+# Where to initially mash repositories. You can use %(here)s to reference the location of this file.
+# mash_dir =
 
-# Where to symlink the latest repos by their tag name
-# mash_stage_dir = %(here)s/masher/
+# Where to symlink the latest repos by their tag name. You can use %(here)s to reference the
+# location of this file.
+# mash_stage_dir =
 
 # mash_conf = /etc/mash/mash.conf
 

--- a/production.ini
+++ b/production.ini
@@ -87,11 +87,12 @@ use = egg:bodhi-server
 ## Mash settings
 ##
 
-# Where to initially mash repositories
-# mash_dir = %(here)s/masher/mash/
+# Where to initially mash repositories. You can use %(here)s to reference the location of this file.
+# mash_dir =
 
-# Where to symlink the latest repos by their tag name
-# mash_stage_dir = %(here)s/masher/
+# Where to symlink the latest repos by their tag name. You can use %(here)s to reference the
+# location of this file.
+# mash_stage_dir =
 
 # mash_conf = /etc/mash/mash.conf
 


### PR DESCRIPTION
Previously, mash_dir and mash_stage_dir defaulted to a path
relative to the source code checkout, but this causes problems
when that path does not exist. Additionally, it does not make sense
for all Bodhi servers to have these settings defined, since the web
front end does not need to mash (nor do the various CLI tools).

With this change, the setting defaults to None and will only be
validated to exist if defined in the config file.

fixes #1611

Signed-off-by: Randy Barlow <randy@electronsweatshop.com>