### PR TITLE
Add a timeout in taskotron_results

### DIFF
--- a/bodhi/server/util.py
+++ b/bodhi/server/util.py
@@ -641,7 +641,7 @@ def taskotron_results(settings, entity='results/latest', max_queries=10, **kwarg
     try:
         while data and url:
             log.debug("Grabbing %r" % url)
-            response = requests.get(url)
+            response = requests.get(url, timeout=60)
             if response.status_code != 200:
                 raise IOError("status code was %r" % response.status_code)
             json = response.json()


### PR DESCRIPTION
Add a timeout to requests.get() , now prevents bodhi.server.util.taskotron_results from hanging indefinitely.

Closes: https://github.com/fedora-infra/bodhi/issues/1597