### PR TITLE
add pending releases to the frontpage

### DIFF
--- a/bodhi/server/templates/home.html
+++ b/bodhi/server/templates/home.html
@@ -17,10 +17,18 @@
     </script>
   </div>-->
 
-  % for r in request.releases['current']:
+  % for r in request.releases['pending'] + request.releases['current']:
   <div class="row front-release">
-    <h3><a class="notblue" href="${request.route_url('releases')}${r['name']}">
-${r['long_name']}</a></h3>
+    <div class="col-md-12">
+      <h3>
+        <a class="notblue" href="${request.route_url('releases')}${r['name']}">
+  ${r['long_name']}
+        </a>
+        %if r['state'] == 'pending':
+          <span class="label label-default">prerelease</span>
+        %endif
+      </h3>
+    </div>
       <div class="col-md-4">
         <div class="front-count">
         <div class="front-count-total">

--- a/bodhi/server/views/generic.py
+++ b/bodhi/server/views/generic.py
@@ -208,7 +208,7 @@ def home(request):
         critpath_updates = get_latest_updates(request, True, False)
         security_updates = get_latest_updates(request, False, True)
         release_updates_counts = {}
-        for release in request.releases['current']:
+        for release in request.releases['current'] + request.releases['pending']:
             release_updates_counts[release["name"]] = get_update_counts(request, release["name"])
 
         return {


### PR DESCRIPTION
Previously, the new frontpage only included 'current' releases. This commit adds pending releases also, with pending releases having a label 'prerelease' in next to the release name.

Fixes: #1619 