### PR TITLE
remove extra whitespace making the tests fail

### DIFF
--- a/bodhi/tests/client/test_bindings.py
+++ b/bodhi/tests/client/test_bindings.py
@@ -1030,7 +1030,7 @@ class TestBodhiClient_parse_file(unittest.TestCase):
 
         client = bindings.BodhiClient()
         updates = client.parse_file("sad")
-        
+
         self.assertEqual(len(updates), 1)
         self.assertEqual(len(updates[0]), 12)
         self.assertEqual(updates[0]['close_bugs'], True)


### PR DESCRIPTION
PR #1596 made the tests fail due to PEP-8, and some
extra whitespace. This fixes this issue, and the tests
now pass.