### PR TITLE
Get CI working

### DIFF
--- a/alembic/env.py
+++ b/alembic/env.py
@@ -86,6 +86,7 @@ def run_migrations_online():
     finally:
         connection.close()
 
+
 if context.is_offline_mode():
     run_migrations_offline()
 else:

--- a/bodhi/server/__init__.py
+++ b/bodhi/server/__init__.py
@@ -119,6 +119,7 @@ def exception_filter(response, request):
         log.exception('Unhandled exception raised:  %r' % response)
     return response
 
+
 DEFAULT_FILTERS.insert(0, exception_filter)
 
 

--- a/bodhi/server/util.py
+++ b/bodhi/server/util.py
@@ -214,6 +214,7 @@ def age(context, date, nuke_ago=False):
     else:
         return humanized
 
+
 hardcoded_avatars = {
     'bodhi': 'https://apps.fedoraproject.org/img/icons/bodhi-{size}.png',
     # Taskotron may have a new logo at some point.  Check this out:

--- a/bodhi/tests/server/scripts/test_approve_testing.py
+++ b/bodhi/tests/server/scripts/test_approve_testing.py
@@ -38,8 +38,7 @@ class TestMain(BaseTestCase):
         update.request = None
         update.stable_karma = 10
         update.status = models.UpdateStatus.testing
-        update.date_testing = datetime.now() - timedelta(days=7)
-        self.db.flush()
+        update.date_testing = datetime.utcnow() - timedelta(days=7)
 
         with patch('bodhi.server.scripts.approve_testing.initialize_db'):
             with patch('bodhi.server.scripts.approve_testing.get_appsettings', return_value=''):
@@ -67,7 +66,7 @@ class TestMain(BaseTestCase):
         update.autokarma = True
         update.request = None
         update.status = models.UpdateStatus.testing
-        update.date_testing = datetime.now() - timedelta(days=7)
+        update.date_testing = datetime.utcnow() - timedelta(days=7)
         # Let's delete all the comments to make our assertion at the end of this simpler.
         for c in update.comments:
             self.db.delete(c)
@@ -91,7 +90,7 @@ class TestMain(BaseTestCase):
         update.request = None
         update.status = models.UpdateStatus.testing
         # 6 days isn't enough time to meet the testing requirements.
-        update.date_testing = datetime.now() - timedelta(days=6)
+        update.date_testing = datetime.utcnow() - timedelta(days=6)
         # Let's delete all the comments to make our assertion at the end of this simpler.
         for c in update.comments:
             self.db.delete(c)
@@ -122,7 +121,7 @@ class TestMain(BaseTestCase):
         # code path.
         update.critpath = True
         # It's been in testing long enough to get the comment from bodhi that it can be pushed.
-        update.date_testing = datetime.now() - timedelta(days=15)
+        update.date_testing = datetime.utcnow() - timedelta(days=15)
         update.request = None
         update.stable_karma = 1
         update.status = models.UpdateStatus.testing
@@ -291,7 +290,7 @@ class TestMain(BaseTestCase):
         update.request = None
         update.stable_karma = 10
         update.status = models.UpdateStatus.testing
-        update.date_testing = datetime.now() - timedelta(days=7)
+        update.date_testing = datetime.utcnow() - timedelta(days=7)
         update.comment(self.db, u'testing', author=u'hunter2', anonymous=False, karma=1)
 
         with patch('bodhi.server.scripts.approve_testing.initialize_db'):
@@ -345,7 +344,7 @@ class TestMain(BaseTestCase):
         update = self.db.query(models.Update).all()[0]
         update.request = None
         update.status = models.UpdateStatus.testing
-        update.date_testing = datetime.now() - timedelta(days=14)
+        update.date_testing = datetime.utcnow() - timedelta(days=14)
         self.db.flush()
 
         with patch('bodhi.server.scripts.approve_testing.initialize_db'):

--- a/devel/ci/run_tests.sh
+++ b/devel/ci/run_tests.sh
@@ -1,9 +1,64 @@
-#!/usr/bin/bash
+#!/usr/bin/bash -ex
+
+sed -i '/pyramid_debugtoolbar/d' setup.py
+sed -i '/pyramid_debugtoolbar/d' development.ini.example
 
 sudo yum install -y epel-release
 
-sudo yum install -y python2-fedmsg-atomic-composer python-flake8 python-nose python-webtest python-mock python-pyramid python-pyramid-mako python-pyramid-tm python-waitress python-colander python-cornice python-openid python-pyramid-fas-openid python-sqlalchemy python-webhelpers python-progressbar python-bunch python-cryptography python-pillow python-kitchen python-pylibravatar python-fedora python-pydns python-dogpile-cache python-arrow python-markdown python-librepo python-createrepo_c createrepo_c python-bugzilla python-simplemediawiki fedmsg python-click python-webob1.4
+# gcc is used to build some dependencies pulled from pypi for coverage.
+# git is needed for diff_cover to work.
+# python-devel is needed for some of the pypi deps when gcc is run.
+# pip is needed to install some things below.
+sudo yum install -y gcc git python-devel python2-pip
+
+# We want a newer version of flake8 than EL 7 has, because the EL 7 version fails and we only really
+# care about it for devs, who use Fedora.
+sudo pip install diff_cover flake8
+
+sudo yum install -y\
+    createrepo_c\
+    fedmsg\
+    koji\
+    liberation-mono-fonts\
+    packagedb-cli\
+    python-alembic\
+    python-arrow\
+    python-bleach\
+    python-bugzilla\
+    python-bunch\
+    python-click\
+    python-colander\
+    python-cornice\
+    python-createrepo_c\
+    python-cryptography\
+    python-dogpile-cache\
+    python-fedora\
+    python-kitchen\
+    python-librepo\
+    python-markdown\
+    python-mock\
+    python-nose\
+    python-openid\
+    python-pillow\
+    python-progressbar\
+    python-pydns\
+    python-pylibravatar\
+    python-pyramid-fas-openid\
+    python-pyramid-mako\
+    python-pyramid-tm\
+    python-pyramid\
+    python-simplemediawiki\
+    python-sqlalchemy\
+    python-waitress\
+    python-webhelpers\
+    python-webob1.4\
+    python-webtest\
+    python2-fedmsg-atomic-composer\
 
 mv development.ini.example development.ini
 
-PYTHONPATH=. /usr/bin/python setup.py nosetests
+sudo /usr/bin/python setup.py develop
+
+/usr/bin/python setup.py nosetests
+
+diff-cover coverage.xml --compare-branch=origin/develop --fail-under=100


### PR DESCRIPTION
This pull request has three commits. The first commit reworks the new CI run_tests.sh script so that it does everything needed for the tests to pass. It also enforces diff-coverage now. The next two commits fix test failures that happen in CentOS CI that don't happen in the Vagrant dev environment.

Signed-off-by: Randy Barlow <randy@electronsweatshop.com>