### PR TITLE
Fix the pkgtags_url default

### DIFF
--- a/bodhi/server/config.py
+++ b/bodhi/server/config.py
@@ -483,7 +483,7 @@ class BodhiConfig(dict):
             'value': 'https://admin.fedoraproject.org/pkgdb',
             'validator': unicode},
         'pkgtags_url': {
-            'value': 'https://apps.fedoraproject.org/tagger/api/v1/tag/sqlitebuildtags/',
+            'value': '',
             'validator': unicode},
         'query_wiki_test_cases': {
             'value': False,

--- a/development.ini.example
+++ b/development.ini.example
@@ -252,7 +252,8 @@ dogpile.cache.arguments.filename = %(here)s/dogpile-cache.dbm
 
 # We used to get our package tags from pkgdb, but they come from tagger now.
 # https://github.com/fedora-infra/fedora-tagger/pull/74
-# pkgtags_url = https://apps.fedoraproject.org/tagger/api/v1/tag/sqlitebuildtags/
+# Fedora's pkgtags can be found at https://apps.fedoraproject.org/tagger/api/v1/tag/sqlitebuildtags/
+# pkgtags_url =
 
 ##
 ## Bug tracker settings

--- a/production.ini
+++ b/production.ini
@@ -252,7 +252,8 @@ use = egg:bodhi-server
 
 # We used to get our package tags from pkgdb, but they come from tagger now.
 # https://github.com/fedora-infra/fedora-tagger/pull/74
-# pkgtags_url = https://apps.fedoraproject.org/tagger/api/v1/tag/sqlitebuildtags/
+# Fedora's pkgtags can be found at https://apps.fedoraproject.org/tagger/api/v1/tag/sqlitebuildtags/
+# pkgtags_url =
 
 ##
 ## Bug tracker settings


### PR DESCRIPTION
Before the new config system, not specifying a configuration option would set it
to an empty string or None.

The pkgtags code is entirely broken, since it overwrites the updateinfo entry in
repomd.xml because modifyrpeo only takes a filename, and then update updateinfo with
that.
Before, this was not a problem since we just did not configure pkgtags_url, which
means that pagure.server.metadata's insert_pkgtags would not do anything.
With the new config code, this code now gets used, which broke all repos.

NOTE: We should make *VERY* sure there are no other such places where code was not
used because config.get(foobar) returned None, and now returns the default value,
with an incorrect default value.

Signed-off-by: Patrick Uiterwijk <puiterwijk@redhat.com>