### PR TITLE
Add python-click's bash completion activation script

### DIFF
--- a/bodhi-complete.sh
+++ b/bodhi-complete.sh
@@ -1,0 +1,8 @@
+_bodhi_completion() {
+    COMPREPLY=( $( env COMP_WORDS="${COMP_WORDS[*]}" \
+                   COMP_CWORD=$COMP_CWORD \
+                   _BODHI_COMPLETE=complete $1 ) )
+    return 0
+}
+
+complete -F _bodhi_completion -o default bodhi;

--- a/devel/ansible/roles/dev/tasks/main.yml
+++ b/devel/ansible/roles/dev/tasks/main.yml
@@ -178,3 +178,9 @@
       name: fedmsg-tail
       state: started
       enabled: yes
+
+- name: Link the bodhi bash completion script
+  file:
+    src: /home/vagrant/bodhi/bodhi-complete.sh
+    dest: /etc/bash_completion.d/bodhi-complete.sh
+    state: link


### PR DESCRIPTION
This commit will allow users to enable bash completion via shipping an activation script. 

To activate the activation script, the user would simply need to place the following line somewhere in his/her/their vagrant .bashrc:
`. ~/bodhi/bodhi-complete.sh`

If the user does not add the previous line to his/her/their .bashrc, no errors will occur, bash completion will simply not be enabled.


For a flawless UI experience, it should be recommended that the user also ignore python warnings by changing the following line in the .bashrc

`export PYTHONWARNINGS="once"
`

to

`export PYTHONWARNINGS="ignore"
`

Example:
![image](https://user-images.githubusercontent.com/13953722/27401170-be2910a8-567f-11e7-8744-28931ee3ac74.png)


_Please note that this PR does not intend to provide total and dynamic bash completion, as python-click has yet to implement the ability of dynamic completion._



Examples of Bodhi using python-click's available bash completion:

![image](https://user-images.githubusercontent.com/13953722/27401185-c90128f8-567f-11e7-8d65-23578aef0643.png)

![image](https://user-images.githubusercontent.com/13953722/27401191-cb799c00-567f-11e7-8bb7-b6bffbfb3418.png)



source: http://click.pocoo.org/5/bashcomplete/