### PR TITLE
Change a heading in the release notes to be the right level.

### DIFF
--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -5,7 +5,7 @@ Release notes
 -----
 
 Bugs
-----
+^^^^
 
 * Restore defaults for three settings back to the values they had in Bodhi 2.7.0 (
   `#1633 <https://github.com/fedora-infra/bodhi/pull/1633>`_,


### PR DESCRIPTION
A Bugs heading in the release notes as at the same level as the
versions and so was rendering next to the versions in the table of
contents.

Signed-off-by: Randy Barlow <randy@electronsweatshop.com>