### PR TITLE
show info count for automated results

### DIFF
--- a/bodhi/server/templates/update.html
+++ b/bodhi/server/templates/update.html
@@ -203,12 +203,17 @@ ${update.type} update for ${update.beautify_title(amp=True) | n}
       // add the count of tests to the automated tests tab
 
       var successcount = $('.row-automatedtests.table-success').length;
+      var infocount = $('.row-automatedtests.table-info').length;
       var warningcount = $('.row-automatedtests.table-warning').length;
       var failedcount = $('.row-automatedtests.table-danger').length;
 
 
       if (successcount > 0){
       $("#tab-automatedtests").append(" <span class='label label-success'><span class='fa fa-check-circle'></span> "+successcount+"</span>");
+      }
+
+      if (infocount > 0){
+      $("#tab-automatedtests").append(" <span class='label label-info'><span class='fa fa-info-circle'></span> "+infocount+"</span>");
       }
 
       if (warningcount > 0 ){


### PR DESCRIPTION
Info icon for the Automated Results tab was missing.

----

You can compare e.g. with:
![snimek z 2017-06-28 10-05-03](https://user-images.githubusercontent.com/755451/27626708-531fc062-5be9-11e7-8a94-7d31c6ae75b9.png)
https://bodhi.fedoraproject.org/updates/FEDORA-2017-9e1037e7e8
and
![snimek z 2017-06-28 10-05-09](https://user-images.githubusercontent.com/755451/27626710-56d18a10-5be9-11e7-9853-f6384d8b9d52.png)
http://localhost:6543/updates/FEDORA-2017-9e1037e7e8
