### PR TITLE
Default to 2 GB in the Vagrant box.

### DIFF
--- a/Vagrantfile.example
+++ b/Vagrantfile.example
@@ -58,7 +58,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
         domain.cpus = 4
         domain.graphics_type = "spice"
         # The unit tests use a lot of RAM.
-        domain.memory = 5120
+        domain.memory = 2048
         domain.video_type = "qxl"
 
         # Uncomment the following line if you would like to enable libvirt's unsafe cache


### PR DESCRIPTION
Now that @jeremycline has made our tests much more memory
efficient, it is possible to run the tests while using under 1 GB
of memory. I'm giving the default host 2 GB so there's a little
room for nonsense if needed.

Signed-off-by: Randy Barlow <randy@electronsweatshop.com>