### PR TITLE
[WIP] [DO NOT MERGE] Adds usage of pungi for mashing

### DIFF
--- a/bodhi/server/consumers/masher.py
+++ b/bodhi/server/consumers/masher.py
@@ -333,9 +333,11 @@ class MasherThread(threading.Thread):
                 uinfo.insert_pkgtags()
                 uinfo.cache_repodata()
 
-            # Compose OSTrees from our freshly mashed repos
-            if config.get('compose_atomic_trees'):
-                self.compose_atomic_trees()
+            # Do the following if we are not using pungi
+            if not config.get('use_pungi_in_bodhi'):
+                # Compose OSTrees from our freshly mashed repos
+                if config.get('compose_atomic_trees'):
+                    self.compose_atomic_trees()
 
             if not self.skip_mash:
                 self.sanity_check_repo()
@@ -1027,12 +1029,21 @@ class MashThread(threading.Thread):
         self.tag = tag
         self.log = log
         self.success = False
-        mash_cmd = 'mash -o {outputdir} -c {config} -f {compsfile} {tag}'
-        mash_conf = config.get('mash_conf')
-        if os.path.exists(previous):
-            mash_cmd += ' -p {}'.format(previous)
-        self.mash_cmd = mash_cmd.format(outputdir=outputdir, config=mash_conf,
-                                        compsfile=comps, tag=self.tag).split()
+        if not config.get('use_pungi_in_bodhi'):
+
+            mash_cmd = 'mash -o {outputdir} -c {config} -f {compsfile} {tag}'
+            mash_conf = config.get('mash_conf')
+            if os.path.exists(previous):
+                mash_cmd += ' -p {}'.format(previous)
+            self.mash_cmd = mash_cmd.format(outputdir=outputdir, config=mash_conf,
+                                            compsfile=comps, tag=self.tag).split()
+
+        else:  # We are going to use pungi in this run
+            pungi_cmd = "pungi-koji  --config={config} --old-composes={outputdir}"
+            pungi_cmd += " --target-dir={outputdir}"
+            pungi_conf = config.get('pungi_conf')
+            # We are using the same name so that no new changes required in th code
+            self.mash_cmd = pungi_cmd.format(config=pungi_conf, outputdir=outputdir)
         # Set our thread's "name" so it shows up nicely in the logs.
         # https://docs.python.org/2/library/threading.html#thread-objects
         self.name = tag


### PR DESCRIPTION
Now to actually use this, we will require a few more changes.

* Release Engineering should first write the set of punig config files which we can use for  this use case
* The bodhi config should have `pungi_config` variable, which should point to the right location of the config file based on the current tag we are mashing.
* The bodhi config should also have a new variable `use_pungi_in_bodhi`, if only this is true, then we will use pungi, or else we can safely use the old code.

I have already asked for the pungi configs at https://pagure.io/releng/issue/6893 from rel-eng.

According to the lsedlar, we will also have to pass  `--label=somevalue` or `--no-label` to the command line. But, I will need more guidance about that argument.

The current patch will not remove any old code, we will do that only after everything is well tested with pungi.