### PR TITLE
[WIP] Add script and tests for moving a batched request to a stable request

### DIFF
--- a/bodhi/client/__init__.py
+++ b/bodhi/client/__init__.py
@@ -59,7 +59,7 @@ new_edit_options = [
     click.option('--bugs', help='Comma-separated list of bug numbers', default=''),
     click.option('--close-bugs', default=True, is_flag=True, help='Automatically close bugs'),
     click.option('--request', help='Requested repository',
-                 type=click.Choice(['testing', 'stable', 'unpush'])),
+                 type=click.Choice(['testing', 'stable', 'unpush', 'batched'])),
     click.option('--autokarma', is_flag=True, help='Enable karma automatism'),
     click.option('--stable-karma', type=click.INT, help='Stable karma threshold'),
     click.option('--unstable-karma', type=click.INT, help='Unstable karma threshold'),
@@ -274,7 +274,7 @@ def edit(user, password, url, **kwargs):
 @click.option('--releases', help='Updates for specific releases')
 @click.option('--locked', help='Updates that are in a locked state')
 @click.option('--request', help='Updates with a specific request',
-              type=click.Choice(['testing', 'stable', 'unpush']))
+              type=click.Choice(['testing', 'stable', 'unpush', 'batched']))
 @click.option('--submitted-since',
               help='Updates that have been submitted since a certain time')
 @click.option('--status', help='Filter by update status',
@@ -324,7 +324,7 @@ def request(update, state, user, password, url, **kwargs):
     UPDATE: The title of the update (e.g. FEDORA-2017-f8e0ef2850)
 
     STATE: The state you wish to change the update\'s request to. Valid options are
-    testing, stable, obsolete, unpush, and revoke.
+    testing, stable, obsolete, unpush, batched, and revoke.
     """
 
     # Developer Docs

--- a/bodhi/server/config.py
+++ b/bodhi/server/config.py
@@ -510,6 +510,9 @@ class BodhiConfig(dict):
             'value': ('%s has been pushed to the %s repository. If problems still persist, please '
                       'make note of it in this bug report.'),
             'validator': unicode},
+        'stable_from_batched_msg': {
+            'value': ('This update has been dequeued from batched and is now entering stable.'),
+            'validator': unicode},
         'stacks_enabled': {
             'value': False,
             'validator': _validate_bool},

--- a/bodhi/server/scripts/dequeue_stable.py
+++ b/bodhi/server/scripts/dequeue_stable.py
@@ -1,0 +1,46 @@
+# -*- coding: utf-8 -*-
+# Copyright © 2017 Caleigh Runge-Hottman
+#
+# This file is part of Bodhi.
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+"""This script is responsible for moving all updates with a batched request to a stable request."""
+
+import sys
+
+import click
+
+from bodhi.server import buildsys, config, models, Session, initialize_db
+
+
+@click.command()
+@click.version_option(message='%(version)s')
+def dequeue_stable():
+    """Convert all batched requests to stable requests."""
+    initialize_db(config.config)
+    buildsys.setup_buildsystem(config.config)
+    db = Session()
+
+    try:
+        batched = db.query(models.Update).filter_by(request=models.UpdateRequest.batched).all()
+        for update in batched:
+            update.set_request(db, models.UpdateRequest.stable, u'bodhi')
+        db.commit()
+
+    except Exception as e:
+        print(str(e))
+        db.rollback()
+        Session.remove()
+        sys.exit(1)

--- a/bodhi/server/services/updates.py
+++ b/bodhi/server/services/updates.py
@@ -137,7 +137,7 @@ def set_request(request):
                            "Can't change request for an archived release")
         return
 
-    if action is UpdateRequest.stable:
+    if action in (UpdateRequest.stable, UpdateRequest.batched):
         settings = request.registry.settings
         result, reason = update.check_requirements(request.db, settings)
         if not result:

--- a/bodhi/server/templates/update.html
+++ b/bodhi/server/templates/update.html
@@ -273,7 +273,7 @@ $(document).ready(function() {
     $("#updatebuttons #edit").attr('href',
         '${request.route_url("update_edit", id=update.alias)}');
 
-    $.each(['testing', 'stable', 'unpush', 'revoke'], function(i, action) {
+    $.each(['testing', 'stable', 'batched', 'unpush', 'revoke'], function(i, action) {
       $("#updatebuttons #" + action).click(function() {
           $("#updatebuttons a").addClass('disabled');
           cabbage.spin(); // for real!
@@ -411,8 +411,10 @@ $(document).ready(function(){
               <a id='testing' class="btn btn-sm btn-success"><span class="fa fa-fw fa-arrow-circle-right"></span> Push to Testing</a>
               % endif
               % if update.status.description not in ['stable', 'obsolete']:
-                <a id='stable' class="btn btn-sm btn-success"><span class="fa fa-fw fa-arrow-circle-right"></span> Push to Stable</a>
+		<a id='batched' class="btn btn-sm btn-success"><span class="fa fa-fw fa-arrow-circle-right"></span> Push to Batched</a>
               % endif
+	    % elif update.request.description == 'batched':
+                <a id='stable' class="btn btn-sm btn-success"><span class="fa fa-fw fa-arrow-circle-right"></span> Push to Stable</a>
             % else:
               <a id='revoke' class="btn btn-sm btn-danger"><span class="fa fa-fw fa-arrow-circle-left"></span> Revoke</a>
             % endif

--- a/bodhi/server/util.py
+++ b/bodhi/server/util.py
@@ -468,6 +468,7 @@ def request2html(context, request):
         'obsolete': 'default',
         'testing': 'warning',
         'stable': 'success',
+        'batched': 'success',
     }.get(request)
 
     return "<span class='label label-%s'>%s</span>" % (cls, request)

--- a/bodhi/server/validators.py
+++ b/bodhi/server/validators.py
@@ -1034,7 +1034,7 @@ def validate_request(request):
     if 'request' not in request.validated:
         # Invalid request. Let the colander error from our schemas.py bubble up.
         return
-    if request.validated['request'] is UpdateRequest.stable:
+    if request.validated['request'] in (UpdateRequest.stable, UpdateRequest.batched):
         target = UpdateStatus.stable
     elif request.validated['request'] is UpdateRequest.testing:
         target = UpdateStatus.testing

--- a/bodhi/tests/server/consumers/test_masher.py
+++ b/bodhi/tests/server/consumers/test_masher.py
@@ -1053,7 +1053,7 @@ References:
 
             # Ensure the masher set the autokarma once the push is done
             self.assertEquals(up.locked, False)
-            self.assertEquals(up.request, UpdateRequest.stable)
+            self.assertEquals(up.request, UpdateRequest.batched)
 
     @mock.patch(**mock_taskotron_results)
     @mock.patch('bodhi.server.consumers.masher.MasherThread.update_comps')

--- a/bodhi/tests/server/scripts/test_dequeue_stable.py
+++ b/bodhi/tests/server/scripts/test_dequeue_stable.py
@@ -1,0 +1,65 @@
+# -*- coding: utf-8 -*-
+# Copyright © 2017 Caleigh Runge-Hottman
+#
+# This file is part of Bodhi.
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+"""
+This module contains tests for the bodhi.server.scripts.dequeue_stable module.
+"""
+from datetime import datetime, timedelta
+
+from click import testing
+
+from bodhi.server import models
+from bodhi.server.scripts import dequeue_stable
+from bodhi.tests.server.base import BaseTestCase
+
+
+class TestDequeueStable(BaseTestCase):
+    """
+    This class contains tests for the dequeue_stable() function.
+    """
+    def test_dequeue_stable(self):
+        """
+        Assert that dequeue_stable moves only the batched updates to stable.
+        """
+        runner = testing.CliRunner()
+
+        update = self.db.query(models.Update).all()[0]
+        update.request = models.UpdateRequest.batched
+        update.locked = False
+        update.date_testing = datetime.utcnow() - timedelta(days=7)
+        self.db.commit()
+
+        result = runner.invoke(dequeue_stable.dequeue_stable, [])
+        self.assertEqual(result.exit_code, 0)
+
+        update = self.db.query(models.Update).all()[0]
+        self.assertEqual(update.request, models.UpdateRequest.stable)
+
+    def test_dequeue_stable_exception(self):
+        """
+        Assert that a locked update triggers an exception, and doesn't move to stable.
+        """
+        runner = testing.CliRunner()
+        update = self.db.query(models.Update).all()[0]
+        update.request = models.UpdateRequest.batched
+        self.db.commit()
+
+        result = runner.invoke(dequeue_stable.dequeue_stable, [])
+
+        self.assertEqual(result.exit_code, 1)
+        self.assertEqual(result.output, u"Can't change the request on a locked update\n")

--- a/bodhi/tests/server/test_models.py
+++ b/bodhi/tests/server/test_models.py
@@ -1313,7 +1313,7 @@ class TestUpdate(ModelTest):
         self.assertEqual(update.request, None)
         update.comment(self.db, u"foo", 1, u'biz')
         self.assertEqual(update.karma, 3)
-        self.assertEqual(update.request, UpdateRequest.stable)
+        self.assertEqual(update.request, UpdateRequest.batched)
         publish.assert_called_with(topic='update.comment', msg=mock.ANY)
 
     @mock.patch('bodhi.server.notifications.publish')

--- a/setup.py
+++ b/setup.py
@@ -154,6 +154,7 @@ setup(
     initialize_bodhi_db = bodhi.server.scripts.initializedb:main
     bodhi-babysit-ci = bodhi.server.scripts.babysit_ci:babysit
     bodhi-clean-old-mashes = bodhi.server.scripts.clean_old_mashes:clean_up
+    bodhi-dequeue-stable = bodhi.server.scripts.dequeue_stable:dequeue_stable
     bodhi-push = bodhi.server.push:push
     bodhi-expire-overrides = bodhi.server.scripts.expire_overrides:main
     bodhi-untag-branched = bodhi.server.scripts.untag_branched:main


### PR DESCRIPTION

This will require a cron job added to https://infrastructure.fedoraproject.org/cgit/ansible.git/tree/roles/bodhi2/backend/tasks/main.yml

```
- name: bodhi-dequeue-stable cron job.
  cron: name="bodhi-dequeue-stable" weekday="1" hour="6" minute=0 user="apache"
        job="/usr/bin/bodhi-dequeue-stable /etc/bodhi/production.ini > /dev/null"
        cron_file=bodhi-dequeue-stable-job
  when: inventory_hostname.startswith('bodhi-backend02') and env == "production"
  tags:
  - config
  - bodhi
  - cron
```
_Note: Monday was arbirtarily suggested following #1157. Times are arbirtrarily selected as well and will likely require review/further discussion._