### PR TITLE
Recreate the flake8 env to avoid webob sadness

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -28,6 +28,7 @@ commands=
 
 
 [testenv:flake8]
+recreate=True
 sitepackages=False
 deps =
     flake8 > 3.0


### PR DESCRIPTION
tox would fail to install bodhi on the second run because of
pkg_resources and webob.

@crungehottman this should address your issue with btest.

Signed-off-by: Jeremy Cline <jeremy@jcline.org>