### PR TITLE
Implement new search api

### DIFF
--- a/bodhi/server/schemas.py
+++ b/bodhi/server/schemas.py
@@ -235,6 +235,12 @@ class SearchableSchema(colander.MappingSchema):
         missing=None,
     )
 
+    search = colander.SchemaNode(
+        colander.String(),
+        location="querystring",
+        missing=None,
+    )
+
 
 class ListReleaseSchema(PaginatedSchema):
     name = colander.SchemaNode(

--- a/bodhi/server/services/overrides.py
+++ b/bodhi/server/services/overrides.py
@@ -126,6 +126,11 @@ def query_overrides(request):
             RpmBuild.nvr.like('%%%s%%' % like)
         ]))
 
+    search = data.get('search')
+    if search is not None:
+        query = query.join(BuildrootOverride.build)
+        query = query.filter(Build.nvr.ilike('%%%s%%' % search))
+
     submitter = data.get('user')
     if submitter is not None:
         query = query.filter(BuildrootOverride.submitter == submitter)

--- a/bodhi/server/services/packages.py
+++ b/bodhi/server/services/packages.py
@@ -15,6 +15,7 @@ import math
 
 from cornice import Service
 from sqlalchemy import func, distinct
+from sqlalchemy.sql.expression import case
 
 from bodhi.server.models import RpmPackage, Package
 import bodhi.server.schemas
@@ -48,6 +49,7 @@ def query_packages(request):
     search = data.get('search')
     if search is not None:
         query = query.filter(Package.name.ilike('%%%s%%' % search))
+        query = query.order_by(case([(Package.name == search, Package.name)]))
 
     # We can't use ``query.count()`` here because it is naive with respect to
     # all the joins that we're doing above.

--- a/bodhi/server/services/packages.py
+++ b/bodhi/server/services/packages.py
@@ -16,7 +16,7 @@ import math
 from cornice import Service
 from sqlalchemy import func, distinct
 
-from bodhi.server.models import RpmPackage
+from bodhi.server.models import RpmPackage, Package
 import bodhi.server.schemas
 import bodhi.server.security
 import bodhi.server.services.errors
@@ -44,6 +44,10 @@ def query_packages(request):
     like = data.get('like')
     if like is not None:
         query = query.filter(RpmPackage.name.like('%%%s%%' % like))
+
+    search = data.get('search')
+    if search is not None:
+        query = query.filter(Package.name.ilike('%%%s%%' % search))
 
     # We can't use ``query.count()`` here because it is naive with respect to
     # all the joins that we're doing above.

--- a/bodhi/server/services/updates.py
+++ b/bodhi/server/services/updates.py
@@ -260,6 +260,10 @@ def query_updates(request):
             Update.title.like('%%%s%%' % like)
         ]))
 
+    search = data.get('search')
+    if search is not None:
+        query = query.filter(Update.title.ilike('%%%s%%' % search))
+
     locked = data.get('locked')
     if locked is not None:
         query = query.filter(Update.locked == locked)

--- a/bodhi/server/services/updates.py
+++ b/bodhi/server/services/updates.py
@@ -262,7 +262,8 @@ def query_updates(request):
 
     search = data.get('search')
     if search is not None:
-        query = query.filter(Update.title.ilike('%%%s%%' % search))
+        query = query.filter(or_(Update.title.ilike('%%%s%%' % search),
+                                 Update.alias.ilike('%%%s%%' % search)))
 
     locked = data.get('locked')
     if locked is not None:

--- a/bodhi/server/services/user.py
+++ b/bodhi/server/services/user.py
@@ -102,6 +102,10 @@ def query_users(request):
             User.name.like('%%%s%%' % like)
         ]))
 
+    search = data.get('search')
+    if search is not None:
+        query = query.filter(User.name.ilike('%%%s%%' % search))
+
     name = data.get('name')
     if name is not None:
         query = query.filter(User.name.like(name))

--- a/bodhi/server/static/css/site.css
+++ b/bodhi/server/static/css/site.css
@@ -158,6 +158,10 @@ form#search, form#search input, .twitter-typeahead {
   color:#fff;
 }
 
+.tt-suggestion.tt-cursor span.text-muted, .tt-suggestion:hover span.text-muted{
+  color: rgba(255,255,255,0.6);
+}
+
 .tt-suggestion a{
   color:black;
   display:block;

--- a/bodhi/server/static/js/search.js
+++ b/bodhi/server/static/js/search.js
@@ -109,7 +109,7 @@ $(document).ready(function() {
                 '</div>'
             ].join('\n'),
             suggestion: function(datum) {
-                return '<p><a href="'+ resultUrl(datum)+'">'+datum.title+'</a></p>';
+                return '<p><a href="'+ resultUrl(datum)+'">'+datum.title+' <span class="text-muted">'+datum.alias+'</span></a></p>';
             },
         },
     },

--- a/bodhi/server/static/js/search.js
+++ b/bodhi/server/static/js/search.js
@@ -7,7 +7,7 @@ $(document).ready(function() {
         queryTokenizer: Bloodhound.tokenizers.whitespace,
         remote: {
             wildcard: '%QUERY',
-            url: 'packages/?like=%QUERY',
+            url: 'packages/?search=%QUERY',
             transform: function(response) { return response.packages; },
         }
     });
@@ -16,7 +16,7 @@ $(document).ready(function() {
         queryTokenizer: Bloodhound.tokenizers.whitespace,
         remote: {
             wildcard: '%QUERY',
-            url: 'updates/?like=%QUERY',
+            url: 'updates/?search=%QUERY',
             transform: function(response) { return response.updates; },
         }
     });
@@ -25,7 +25,7 @@ $(document).ready(function() {
         queryTokenizer: Bloodhound.tokenizers.whitespace,
         remote: {
             wildcard: '%QUERY',
-            url: 'users/?like=%QUERY',
+            url: 'users/?search=%QUERY',
             transform: function(response) { return response.users; },
         }
     });
@@ -34,7 +34,7 @@ $(document).ready(function() {
         queryTokenizer: Bloodhound.tokenizers.whitespace,
         remote: {
             wildcard: '%QUERY',
-            url: 'overrides/?like=%QUERY',
+            url: 'overrides/?search=%QUERY',
             transform: function(response) { return response.overrides; },
         }
     });

--- a/bodhi/tests/server/functional/test_overrides.py
+++ b/bodhi/tests/server/functional/test_overrides.py
@@ -180,6 +180,46 @@ class TestOverridesService(base.BaseTestCase):
         self.assertEquals(errors[0]['description'],
                           "Invalid user specified: santa")
 
+    def test_list_overrides_by_like(self):
+        """
+        Test that the overrides/?like= endpoint works as expected
+        """
+
+        # test that like works
+        res = self.app.get('/overrides/', {"like": "bodh"})
+        body = res.json_body
+        self.assertEquals(len(body['overrides']), 1)
+        override = body['overrides'][0]
+        self.assertEquals(override['build']['nvr'], "bodhi-2.0-1.fc17")
+
+        # test a like that yields nothing
+        res = self.app.get('/overrides/', {"like": "corebird"})
+        body = res.json_body
+        self.assertEquals(len(body['overrides']), 0)
+
+    def test_list_overrides_by_search(self):
+        """
+        Test that the overrides/?search= endpoint works as expected
+        """
+
+        # test that search works
+        res = self.app.get('/overrides/', {"search": "bodh"})
+        body = res.json_body
+        self.assertEquals(len(body['overrides']), 1)
+        override = body['overrides'][0]
+        self.assertEquals(override['build']['nvr'], "bodhi-2.0-1.fc17")
+
+        # test a search that is case-insensitive
+        res = self.app.get('/overrides/', {"search": "Bodh"})
+        self.assertEquals(len(body['overrides']), 1)
+        override = body['overrides'][0]
+        self.assertEquals(override['build']['nvr'], "bodhi-2.0-1.fc17")
+
+        # test a search that yields nothing
+        res = self.app.get('/overrides/', {"search": "corebird"})
+        body = res.json_body
+        self.assertEquals(len(body['overrides']), 0)
+
     @mock.patch('bodhi.server.notifications.publish')
     def test_create_override(self, publish):
         release = Release.get(u'F17', self.db)

--- a/bodhi/tests/server/functional/test_packages.py
+++ b/bodhi/tests/server/functional/test_packages.py
@@ -46,3 +46,24 @@ class TestRpmPackagesService(base.BaseTestCase):
         resp = self.app.get('/packages/', dict(like='odh'))
         body = resp.json_body
         self.assertEquals(len(body['packages']), 1)
+
+    def test_filter_by_search(self):
+        """ Test filtering by search
+        """
+        self.db.add(RpmPackage(name=u'a_second_package'))
+        self.db.commit()
+
+        # test search
+        resp = self.app.get('/packages/', dict(search='bodh'))
+        body = resp.json_body
+        self.assertEquals(len(body['packages']), 1)
+
+        # test the search is case-insensitive
+        resp = self.app.get('/packages/', dict(search='Bodh'))
+        body = resp.json_body
+        self.assertEquals(len(body['packages']), 1)
+
+        # test a search that yields nothing
+        resp = self.app.get('/packages/', dict(search='corebird'))
+        body = resp.json_body
+        self.assertEquals(len(body['packages']), 0)

--- a/bodhi/tests/server/functional/test_users.py
+++ b/bodhi/tests/server/functional/test_users.py
@@ -98,7 +98,7 @@ class TestUsersService(base.BaseTestCase):
         self.assertIn('bodhi', res)
         self.assertIn('guest', res)
 
-    def test_search_users(self):
+    def test_like_users(self):
         res = self.app.get('/users/', {'like': 'odh'})
         body = res.json_body
         self.assertEquals(len(body['users']), 1)
@@ -107,6 +107,30 @@ class TestUsersService(base.BaseTestCase):
         self.assertEquals(user['name'], u'bodhi')
 
         res = self.app.get('/users/', {'like': 'wat'})
+        body = res.json_body
+        self.assertEquals(len(body['users']), 0)
+
+    def test_search_users(self):
+        """
+        Test that the overrides/?search= endpoint works as expected
+        """
+
+        # test that search works
+        res = self.app.get('/users/', {'search': 'bodh'})
+        body = res.json_body
+        self.assertEquals(len(body['users']), 1)
+        user = body['users'][0]
+        self.assertEquals(user['name'], u'bodhi')
+
+        # test that the search is case insensitive
+        res = self.app.get('/users/', {'search': 'Bodh'})
+        body = res.json_body
+        self.assertEquals(len(body['users']), 1)
+        user = body['users'][0]
+        self.assertEquals(user['name'], u'bodhi')
+
+        # test a search that yields nothing
+        res = self.app.get('/users/', {'search': 'wat'})
         body = res.json_body
         self.assertEquals(len(body['users']), 0)
 

--- a/bodhi/tests/server/services/test_updates.py
+++ b/bodhi/tests/server/services/test_updates.py
@@ -1031,7 +1031,7 @@ class TestUpdatesService(base.BaseTestCase):
         self.assertIn('bodhi-2.0-1.fc17', res)
         self.assertIn('&copy;', res)
 
-    def test_search_updates(self):
+    def test_updates_like(self):
         res = self.app.get('/updates/', {'like': 'odh'})
         body = res.json_body
         self.assertEquals(len(body['updates']), 1)
@@ -1040,6 +1040,30 @@ class TestUpdatesService(base.BaseTestCase):
         self.assertEquals(up['title'], u'bodhi-2.0-1.fc17')
 
         res = self.app.get('/updates/', {'like': 'wat'})
+        body = res.json_body
+        self.assertEquals(len(body['updates']), 0)
+
+    def test_updates_search(self):
+        """
+        Test that the updates/?search= endpoint works as expected
+        """
+
+        # test that the search works
+        res = self.app.get('/updates/', {'search': 'bodh'})
+        body = res.json_body
+        self.assertEquals(len(body['updates']), 1)
+        up = body['updates'][0]
+        self.assertEquals(up['title'], u'bodhi-2.0-1.fc17')
+
+        # test that the search is case insensitive
+        res = self.app.get('/updates/', {'search': 'Bodh'})
+        body = res.json_body
+        self.assertEquals(len(body['updates']), 1)
+        up = body['updates'][0]
+        self.assertEquals(up['title'], u'bodhi-2.0-1.fc17')
+
+        # test a search that yields nothing
+        res = self.app.get('/updates/', {'search': 'wat'})
         body = res.json_body
         self.assertEquals(len(body['updates']), 0)
 

--- a/bodhi/tests/server/services/test_updates.py
+++ b/bodhi/tests/server/services/test_updates.py
@@ -1067,6 +1067,13 @@ class TestUpdatesService(base.BaseTestCase):
         body = res.json_body
         self.assertEquals(len(body['updates']), 0)
 
+        # test a search for an alias
+        res = self.app.get('/updates/', {'search': 'FEDORA-2017-a3bbe1a8f2'})
+        body = res.json_body
+        self.assertEquals(len(body['updates']), 1)
+        up = body['updates'][0]
+        self.assertEquals(up['title'], u'bodhi-2.0-1.fc17')
+
     @mock.patch(**mock_valid_requirements)
     def test_list_updates_pagination(self, *args):
 


### PR DESCRIPTION
As recommended in #997 this implements a new API item 'search' for updates/, packages/, users/, and overrides/. It utilises `ilike` rather than `like` to make the search case insensitive. The search JS is also updated to use the new search API

Additionally, this PR adds the ability to search for an update by update alias (e.g. FEDORA-2017-a3bbe1a8f2) 

Finally, when searching packages, if there is an exact match to the package name, that package is always returned first. So when searching for "python", the "python" package is returned first, then all the other python packages.

