### PR TITLE
make the autokarma checkbox on edit update persistent

### DIFF
--- a/bodhi/server/templates/new_update.html
+++ b/bodhi/server/templates/new_update.html
@@ -231,7 +231,7 @@ ${update.notes}
                   <dt data-toggle="tooltip" title="If checked, this option allows bodhi to automatically move your update from testing to stable once enough positive karma has been given.">
                   Auto-request stable?</dt>
                   <dd> <input type="checkbox" name="autokarma" data-singleton="true"
-                      % if update and update.stable_karma != None and update.unstable_karma != None:
+                      % if update and update.autokarma:
                       checked
                       % elif not update:
                       checked


### PR DESCRIPTION
Previously, the autokarma checkbox in the edit update form
was always set to on, regardless of the value set in the DB.
This commit fixes this, so the checkboxis set with the value
in the db for the update.

fixes #1692
fixes #1482
fixes #1308