### PR TITLE
Greenwave integration

### DIFF
--- a/alembic/versions/33a416e03f50_add_greenwave_fields.py
+++ b/alembic/versions/33a416e03f50_add_greenwave_fields.py
@@ -1,0 +1,41 @@
+"""Add the fields for caching the Greenwave decision for each update.
+
+Revision ID: 33a416e03f50
+Revises: 2a10629168e4
+Create Date: 2017-07-06 13:52:50.892504
+"""
+from alembic import op
+from sqlalchemy import Column, Enum, Unicode, UnicodeText
+
+
+# revision identifiers, used by Alembic.
+revision = '33a416e03f50'
+down_revision = '2a10629168e4'
+
+
+def upgrade():
+    op.execute(
+        "CREATE TYPE ck_test_gating_status AS ENUM "
+        "('ignored', 'queued', 'running', 'passed', 'failed', 'waiting')")
+    op.add_column(
+        'updates',
+        Column(
+            'test_gating_status',
+            Enum(
+                'ignored', 'queued', 'running', 'passed', 'failed', 'waiting',
+                name='ck_test_gating_status'),
+            nullable=True
+        )
+    )
+    op.add_column('updates', Column('greenwave_summary_string', Unicode(255)))
+    op.add_column(
+        'updates',
+        Column('test_gating_url', UnicodeText, nullable=True)
+    )
+
+
+def downgrade():
+    op.drop_column('updates', 'test_gating_status')
+    op.execute("DROP TYPE ck_test_gating_status")
+    op.drop_column('updates', 'greenwave_summary_string')
+    op.drop_column('updates', 'test_gating_url')

--- a/bodhi/server/config.py
+++ b/bodhi/server/config.py
@@ -407,6 +407,9 @@ class BodhiConfig(dict):
         'initial_bug_msg': {
             'value': '%s has been submitted as an update to %s. %s',
             'validator': unicode},
+        'greenwave_api_url': {
+            'value': 'https://greenwave.fedoraproject.org/api/v1.0',
+            'validator': unicode},
         'koji_hub': {
             'value': 'https://koji.stg.fedoraproject.org/kojihub',
             'validator': str},

--- a/bodhi/server/config.py
+++ b/bodhi/server/config.py
@@ -547,6 +547,12 @@ class BodhiConfig(dict):
         'top_testers_timeframe': {
             'value': 7,
             'validator': int},
+        'test_gating.required': {
+            'value': False,
+            'validator': _validate_bool},
+        'test_gating.url': {
+            'value': '',
+            'validator': unicode},
         'updateinfo_rights': {
             'value': 'Copyright (C) {} Red Hat, Inc. and others.'.format(datetime.now().year),
             'validator': unicode},

--- a/bodhi/server/models.py
+++ b/bodhi/server/models.py
@@ -1804,6 +1804,8 @@ class Update(Base):
                         (config.get('critpath.min_karma') -
                             config.get('critpath.num_admin_approvals')),
                         config.get('critpath.stable_after_days_without_negative_karma'))
+                    if config.get('test_gating.required'):
+                        stern_note += ' Additionally, it must pass automated tests.'
                     notes.append(stern_note)
 
                     if self.status is UpdateStatus.testing:

--- a/bodhi/server/scripts/check_policies.py
+++ b/bodhi/server/scripts/check_policies.py
@@ -1,0 +1,72 @@
+# -*- coding: utf-8 -*-
+# Copyright © 2017 Red Hat, Inc.
+#
+# This file is part of Bodhi.
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+"""
+Check the enforced policies by Greenwave for each open update.
+
+Ideally, this should be done in a fedmsg consumer but we currently do not have any
+messages in the message bus yet.
+"""
+import click
+from sqlalchemy.sql.expression import false
+
+from bodhi.server import config, initialize_db, models, Session
+from bodhi.server.util import greenwave_api_post
+
+
+@click.command()
+@click.version_option(message='%(version)s')
+def check():
+    """Check the enforced policies by Greenwave for each open update."""
+    initialize_db(config.config)
+    session = Session()
+    updates = models.Update.query.filter(models.Update.pushed == false())\
+        .filter(models.Update.status.in_(
+                [models.UpdateStatus.pending, models.UpdateStatus.testing]))
+    for update in updates:
+        subjects = [build.nvr for build in update.builds]
+        data = {
+            'product_version': update.product_version,
+            'decision_context': u'bodhi_update_push_stable',
+            'subject': subjects
+        }
+        api_url = '{}/decision'.format(
+            config.config.get('greenwave_api_url').rstrip('/'))
+        try:
+            decision = greenwave_api_post(api_url, data)
+            if decision['policies_satisified']:
+                # If an unrestricted policy is applied and no tests are required
+                # on this update, let's set the test gating as ignored in Bodhi.
+                if decision['summary'] == 'no tests are required':
+                    update.test_gating_status = models.TestGatingStatus.ignored
+                else:
+                    update.test_gating_status = models.TestGatingStatus.passed
+            else:
+                update.test_gating_status = models.TestGatingStatus.failed
+            update.greenwave_summary_string = decision['summary']
+            if session.is_modified(update):
+                session.commit()
+        except Exception as e:
+            # If there is a problem talking to Greenwave server, print the error.
+            click.echo(str(e))
+            session.rollback()
+
+
+if __name__ == '__main__':
+    check()

--- a/bodhi/server/templates/update.html
+++ b/bodhi/server/templates/update.html
@@ -25,7 +25,7 @@ ${update.type} update for ${update.beautify_title(amp=True) | n}
       NEEDS_INSPECTION: 'warning',
       ABORTED: 'warning',
       CRASHED: 'warning',
-      ABSENT: 'warning',
+      ABSENT: 'danger',
     }
     var icons = {
       PASSED: 'check-circle',
@@ -48,6 +48,51 @@ ${update.type} update for ${update.beautify_title(amp=True) | n}
 
     // These are the required taskotron tests
     var requirements = ${update.requirements_json | n};
+    // show the Greenwave decision
+    var greenwave_api_url = '${request.registry.settings["greenwave_api_url"]}';
+    var missing_tests = {};
+    // handle Greenwave decision
+    var handle_unsatisfied_reqs = function(data){
+        $.each(data['unsatisfied_requirements'], function(i, req) {
+            if (req.type == 'test-result-missing') {
+                if (missing_tests[req.item] === undefined)
+                    missing_tests[req.item]= [];
+                missing_tests[req.item].push(req);
+            }
+            // the user may have already specified this in the required taskotron tests
+            if ($.inArray(req.testcase, requirements) == -1) {
+                requirements.push(req.testcase);
+            }
+        });
+    };
+    var get_unsatisfied_reqs = function(data) {
+        $.ajax({
+            url: greenwave_api_url + '/decision',
+            type: 'POST',
+            contentType: 'application/json',
+            data: JSON.stringify(data),
+            success: function(data) {
+                handle_unsatisfied_reqs(data);
+            },
+            error: function (jqxhr, status, error) {
+               $('#resultsdb h3').after(
+                  '<h4 class="text-danger">Failed to talk to Greenwave.</h4>');
+            },
+        });
+    };
+
+    var test_gating_passed = '${update.test_gating_passed}';
+    var test_gating_required = '${request.registry.settings.get("test_gating.required")}';
+    if (test_gating_required == 'True' && test_gating_passed == 'False') {
+        var summary = '${update.greenwave_summary_string}';
+        $('#resultsdb h3').after(
+           '<div class="alert alert-danger">The update can not be pushed: ' + summary + '</div>');
+        get_unsatisfied_reqs({
+            'product_version': '${update.product_version}',
+            'decision_context': 'bodhi_update_push_stable',
+            'subject': builds
+        });
+    }
 
     var make_row = function(outcome, testcase, note, arch, time, url, flavor) {
       var icon = '<span data-toggle="tooltip" data-placement="top" ' +
@@ -82,15 +127,20 @@ ${update.type} update for ${update.beautify_title(amp=True) | n}
       if (note == null){
         note = '';
       }
-      return '<tr class="row-automatedtests table-' + classes[outcome] + '" ' +
-        'style="cursor: pointer;"' +
-        'data-href="' + url + '">' +
+      html = '<tr class="row-automatedtests table-' + classes[outcome];
+      if (outcome == 'ABSENT') {
+          html += ' absent-automatedtest"';
+      } else {
+          html += '" style="cursor: pointer;" data-href="' + url + '"';
+      }
+      html += '>' +
         '<td>' + required + '</td>' +
         '<td>' + icon + '</td>' +
         '<td class="nowrap">' + testcase + '</td>' +
         '<td class="stretch-table-column text-xs-right">' + note + '</td>' +
         '<td class="nowrap">' + age + '</td>' +
         '</tr>';
+      return html;
     };
 
     var latest = {};
@@ -163,36 +213,72 @@ ${update.type} update for ${update.beautify_title(amp=True) | n}
       if (activeResultsAjaxCalls == 0){
       var data = [];
       var count = 0;
-      $.each(latest, function(buildname, obj1) {
-        count = count +1;
-        $("#resultsdb").append("<h4 class='p-t-1'>"+buildname+
-        "</h4><table class='table table-hover' id='buildresults"+count+
-        "'></table>")
-        $.each(obj1, function(testcase, obj2) {
-          $.each(obj2, function(arch, obj3) {
-            $.each(obj3, function(scenario, result) {
-              var flavor;
-              if (scenario.includes("updates-server")) {
-                flavor = "server";
+      // if there are no results in ResultsDB yet and we have already got the Greenwave decision
+      // to say that some tests are missing, let's just show them.
+      if (Object.keys(latest).length == 0) {
+          $.each(builds, function(i, buildname) {
+              count = count +1;
+              if (buildname in missing_tests) {
+                  $("#resultsdb").append("<h4 class='p-t-1'>"+buildname+
+                  "</h4><table class='table table-hover' id='buildresults"+count+
+                  "'></table>");
+                  $.each(missing_tests[buildname], function(i, result) {
+                      $('#buildresults'+count).append(make_row(
+                          'ABSENT',
+                          result.testcase,
+                          '',
+                          '',
+                          ''
+                      ));
+                  });
+              } else {
+                  $("#resultsdb").append("<h4 class='p-t-1'>"+buildname+
+                  "</h4><p>No results reported for this build.</p>");
               }
-              else if (scenario.includes("updates-workstation")) {
-                flavor = "workstation";
-              }
-              $('#buildresults'+count).append(make_row(
-                  result.outcome,
-                  result.testcase.name,
-                  result.note,
-                  // note: this is a single-item array
-                  result.data.arch,
-                  result.submit_time,
-                  result.ref_url,
-                  flavor
-              ));
+          });
+      } else {
+          $.each(latest, function(buildname, obj1) {
+            count = count +1;
+            $("#resultsdb").append("<h4 class='p-t-1'>"+buildname+
+            "</h4><table class='table table-hover' id='buildresults"+count+
+            "'></table>")
+            // We show missing tests first
+            if (buildname in missing_tests) {
+                $.each(missing_tests[buildname], function(i, result) {
+                    $('#buildresults'+count).append(make_row(
+                        'ABSENT',
+                        result.testcase,
+                        '',
+                        '',
+                        ''
+                    ));
+                });
+            }
+            $.each(obj1, function(testcase, obj2) {
+              $.each(obj2, function(arch, obj3) {
+                $.each(obj3, function(scenario, result) {
+                  var flavor;
+                  if (scenario.includes("updates-server")) {
+                    flavor = "server";
+                  }
+                  else if (scenario.includes("updates-workstation")) {
+                    flavor = "workstation";
+                  }
+                  $('#buildresults'+count).append(make_row(
+                      result.outcome,
+                      result.testcase.name,
+                      result.note,
+                      // note: this is a single-item array
+                      result.data.arch,
+                      result.submit_time,
+                      result.ref_url,
+                      flavor
+                  ));
+                });
+              });
             });
           });
-        });
-      });
-
+      }
       finish();
     };
     };
@@ -226,16 +312,14 @@ ${update.type} update for ${update.beautify_title(amp=True) | n}
         $("#tab-automatedtests").append(" <span class='label label-danger'><span class='fa fa-minus-circle'></span> "+failedcount+"</span>");
       }
 
-      // Make each cell clickable and awesome
-      $('#resultsdb tr').off().click(function(event, row) {
+      // Make each cell clickable and awesome except the missing tests
+      $('#resultsdb tr').not('.absent-automatedtest').off().click(function(event, row) {
         window.open($(this).attr('data-href'));
       });
 
       // And, re-do tooltips for newly created spans.
       $('#resultsdb span').tooltip();
     }
-
-
 
     var request_results = function(url) {
       $.ajax(url, {
@@ -369,6 +453,12 @@ $(document).ready(function(){
       $("#comment-textarea").hide();
     }
      $(this).button('toggle');
+  });
+
+  /*open the automated tests tab*/
+  $('.gating-summary').click(function(e){
+    e.preventDefault();
+    $('.nav-tabs a[href="' + this.getAttribute('href') + '"]').tab('show');
   });
 
 });
@@ -685,19 +775,20 @@ $(document).ready(function(){
                 </div>
               </div>
 
-              % if request.registry.settings.get('ci.required'):
+              % if request.registry.settings.get('test_gating.required'):
               <div class="p-b-1">
                 <div>
-                  % if request.registry.settings.get('ci.url'):
-                    <a href="${request.registry.settings.get('ci.url')}" title="More information about CI">
-                      <strong>CI Status</strong>
+                  % if request.registry.settings.get('test_gating.url'):
+                    <a href="${request.registry.settings.get('test_gating.url')}" title="More information about test gating">
+                      <strong>Test Gating Status</strong>
                     </a>
                   % else:
-                    <strong>CI Status</strong>
+                    <strong>Test Gating Status</strong>
                   % endif
                 </div>
                 <div>
-                  ${self.util.ci_status2html(update.ci_status.description) | n}
+                  ${self.util.test_gating_status2html(update.test_gating_status,
+                    update.greenwave_summary_string) | n}
                 </div>
               </div>
               % endif
@@ -879,15 +970,6 @@ $(document).ready(function(){
             <a href="https://koji.fedoraproject.org/koji/search?terms=${build.nvr}&type=build&match=glob" target="_blank">
                 ${build.nvr}</a>
           </td>
-          % if request.registry.settings.get('ci.required'):
-            <td>
-              % if build.ci_url:
-                <a href="${build.ci_url}">${self.util.ci_status2html(build.ci_status.description) | n}</a>
-              % else:
-                ${self.util.ci_status2html(build.ci_status.description) | n}
-              % endif
-            </td>
-          % endif
           <td class="pull-right">
             % if build.signed:
               <span class="fa fa-key text-muted" aria-hidden="true" data-toggle="tooltip" data-placement="top" title="Build signed"></span>

--- a/bodhi/server/util.py
+++ b/bodhi/server/util.py
@@ -318,30 +318,38 @@ def status2html(context, status):
     return "<span class='label label-%s'>%s</span>" % (cls, status)
 
 
-def ci_status2html(context, status):
+def test_gating_status2html(context, status, reason=None):
     """ Convert the specified status into a html string used to present the
-    CI status in a human friendly way.
+    test gating status in a human friendly way.
 
     Args:
         context (mako.runtime.Context): Unused.
-        status (unicode): The description of the CI status
+        status (unicode): The test gating status
+        reason (unicode): A short text explains why the test gating is not passed.
 
     Returns:
-        unicode: A human friendly HTML label of the CI status
+        unicode: A human friendly HTML label of the test gating status
 
     """
-    cls = {
-        'Ignored': 'success',
-        'Running': 'warning',
-        'Passed': 'success',
-        'Failed': 'danger',
-        'Queued': 'info',
-        'Waiting': 'info',
-        'None': 'primary',
-    }[str(status)]
-    if status is None:
-        status = 'not running'
-    return u"<span class='label label-%s'>Tests %s</span>" % (cls, status)
+    if status:
+        label_class = {
+            'Ignored': 'success',
+            'Running': 'warning',
+            'Passed': 'success',
+            'Failed': 'danger',
+            'Queued': 'info',
+            'Waiting': 'info'
+        }[status.description]
+        description = status.description
+    else:
+        # status could be None when test_gating.required was not set to True
+        description = 'not running'
+        label_class = 'primary'
+    html = u'<span class="label label-%s">Tests %s</span>' % (label_class, description)
+    from bodhi.server.models import TestGatingStatus
+    if status not in [None, TestGatingStatus.ignored, TestGatingStatus.passed] and reason:
+        html += u'<p><a class="gating-summary" href="#automatedtests">%s</a></p>' % reason
+    return html
 
 
 def state2class(context, state):

--- a/bodhi/tests/server/scripts/test_check_policies.py
+++ b/bodhi/tests/server/scripts/test_check_policies.py
@@ -1,0 +1,113 @@
+# -*- coding: utf-8 -*-
+# Copyright © 2017 Red Hat, Inc.
+#
+# This file is part of Bodhi.
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+"""This module contains tests for the bodhi.server.scripts.check_policies module."""
+
+from click import testing
+from mock import patch
+
+from bodhi.server import models
+from bodhi.server.scripts import check_policies
+from bodhi.tests.server.base import BaseTestCase
+from bodhi.server.config import config
+
+
+class TestCheckPolicies(BaseTestCase):
+    """This class contains tests for the check_policies() function."""
+    @patch.dict(config, [('greenwave_api_url', 'http://domain.local')])
+    def test_policies_satisfied(self):
+        """Assert correct behavior when the policies enforced by Greenwave are satisfied"""
+        runner = testing.CliRunner()
+        update = self.db.query(models.Update).all()[0]
+        update.status = models.UpdateStatus.testing
+        self.db.commit()
+        with patch('bodhi.server.scripts.check_policies.greenwave_api_post') as mock_greenwave:
+            greenwave_response = {
+                'policies_satisified': True,
+                'summary': 'All tests passed',
+                'applicable_policies': ['taskotron_release_critical_tasks'],
+                'unsatisfied_requirements': []
+            }
+            mock_greenwave.return_value = greenwave_response
+            result = runner.invoke(check_policies.check, [])
+            self.assertEqual(result.exit_code, 0)
+            update = self.db.query(models.Update).filter(models.Update.id == update.id).one()
+            self.assertEqual(update.test_gating_status, models.TestGatingStatus.passed)
+            self.assertEqual(update.greenwave_summary_string, 'All tests passed')
+
+    @patch.dict(config, [('greenwave_api_url', 'http://domain.local')])
+    def test_policies_unsatisfied(self):
+        """Assert correct behavior when the policies enforced by Greenwave are unsatisfied"""
+        runner = testing.CliRunner()
+        update = self.db.query(models.Update).all()[0]
+        update.status = models.UpdateStatus.testing
+        self.db.commit()
+        with patch('bodhi.server.scripts.check_policies.greenwave_api_post') as mock_greenwave:
+            greenwave_response = {
+                'policies_satisified': False,
+                'summary': '1 of 2 tests are failed',
+                'applicable_policies': ['taskotron_release_critical_tasks'],
+                'unsatisfied_requirements': [{
+                    'item': "glibc-1.0-1.f26",
+                    'result_id': "123",
+                    'testcase': 'dist.depcheck',
+                    'type': 'test-result-failed'
+                }]
+            }
+            mock_greenwave.return_value = greenwave_response
+            result = runner.invoke(check_policies.check, [])
+            self.assertEqual(result.exit_code, 0)
+            update = self.db.query(models.Update).filter(models.Update.id == update.id).one()
+            self.assertEqual(update.test_gating_status, models.TestGatingStatus.failed)
+            self.assertEqual(update.greenwave_summary_string, '1 of 2 tests are failed')
+
+    @patch.dict(config, [('greenwave_api_url', 'http://domain.local')])
+    def test_no_policies_enforced(self):
+        """Assert correct behavior when policies are not enforced"""
+        runner = testing.CliRunner()
+        update = self.db.query(models.Update).all()[0]
+        update.status = models.UpdateStatus.testing
+        self.db.commit()
+        self.assertFalse(update.test_gating_status)
+        with patch('bodhi.server.scripts.check_policies.greenwave_api_post') as mock_greenwave:
+            mock_greenwave.return_value = RuntimeError('The error was blablabla')
+            result = runner.invoke(check_policies.check, [])
+            self.assertEqual(result.exit_code, 0)
+            update = self.db.query(models.Update).filter(models.Update.id == update.id).one()
+            # The test_gating_status should still be None.
+            self.assertFalse(update.test_gating_status)
+
+    @patch.dict(config, [('greenwave_api_url', 'http://domain.local')])
+    def test_unrestricted_policy(self):
+        """Assert correct behavior when an unrestricted policy is applied"""
+        runner = testing.CliRunner()
+        update = self.db.query(models.Update).all()[0]
+        update.status = models.UpdateStatus.testing
+        self.db.commit()
+        with patch('bodhi.server.scripts.check_policies.greenwave_api_post') as mock_greenwave:
+            greenwave_response = {
+                'policies_satisified': True,
+                'summary': 'no tests are required',
+                'applicable_policies': ['bodhi-unrestricted'],
+            }
+            mock_greenwave.return_value = greenwave_response
+            result = runner.invoke(check_policies.check, [])
+            self.assertEqual(result.exit_code, 0)
+            update = self.db.query(models.Update).filter(models.Update.id == update.id).one()
+            self.assertEqual(update.test_gating_status, models.TestGatingStatus.ignored)
+            self.assertEqual(update.greenwave_summary_string, 'no tests are required')

--- a/bodhi/tests/server/test_models.py
+++ b/bodhi/tests/server/test_models.py
@@ -30,7 +30,7 @@ from bodhi.server.config import config
 from bodhi.server.exceptions import BodhiException
 from bodhi.server.models import (
     BugKarma, ReleaseState, UpdateRequest, UpdateSeverity, UpdateStatus,
-    UpdateSuggestion, UpdateType, CiStatus)
+    UpdateSuggestion, UpdateType, CiStatus, TestGatingStatus)
 from bodhi.tests.server.base import BaseTestCase
 
 
@@ -822,91 +822,91 @@ class TestUpdate(ModelTest):
 
         self.assertEqual(update.days_to_stable, 3)
 
-    @mock.patch.dict('bodhi.server.config.config', {'ci.required': True})
-    def test_ci_failed_no_testing_requirements(self):
+    @mock.patch.dict('bodhi.server.config.config', {'test_gating.required': True})
+    def test_test_gating_faild_no_testing_requirements(self):
         """
-        The Update.meets_testing_requirements() should return False if the
-        builds of an update did not pass CI.
+        The Update.meets_testing_requirements() should return False, if the test gating
+        status of an update is failed.
         """
         update = self.obj
         update.autokarma = False
         update.stable_karma = 1
-        update.builds[0].ci_status = CiStatus.failed
+        update.test_gating_status = TestGatingStatus.failed
         update.comment(self.db, u'I found $100 after applying this update.', karma=1,
                        author=u'bowlofeggs')
         # Assert that our preconditions from the docblock are correct.
         self.assertEqual(update.meets_testing_requirements, False)
 
-    @mock.patch.dict('bodhi.server.config.config', {'ci.required': True})
-    def test_ci_queued_no_testing_requirements(self):
+    @mock.patch.dict('bodhi.server.config.config', {'test_gating.required': True})
+    def test_test_gating_queued_no_testing_requirements(self):
         """
-        The Update.meets_testing_requirements() should return False if the
-        builds of an update did not pass CI.
+        The Update.meets_testing_requirements() should return False, if the test gating
+        status of an update is queued.
         """
         update = self.obj
         update.autokarma = False
         update.stable_karma = 1
-        update.builds[0].ci_status = CiStatus.queued
+        update.test_gating_status = TestGatingStatus.queued
         update.comment(self.db, u'I found $100 after applying this update.', karma=1,
                        author=u'bowlofeggs')
         # Assert that our preconditions from the docblock are correct.
         self.assertEqual(update.meets_testing_requirements, False)
 
-    @mock.patch.dict('bodhi.server.config.config', {'ci.required': True})
-    def test_ci_running_no_testing_requirements(self):
+    @mock.patch.dict('bodhi.server.config.config', {'test_gating.required': True})
+    def test_test_gating_running_no_testing_requirements(self):
         """
-        The Update.meets_testing_requirements() should return False if the
-        builds of an update did not pass CI.
+        The Update.meets_testing_requirements() should return False, if the test gating
+        status of an update is running.
         """
         update = self.obj
         update.autokarma = False
         update.stable_karma = 1
-        update.builds[0].ci_status = CiStatus.running
+        update.test_gating_status = TestGatingStatus.running
         update.comment(self.db, u'I found $100 after applying this update.', karma=1,
                        author=u'bowlofeggs')
         # Assert that our preconditions from the docblock are correct.
         self.assertEqual(update.meets_testing_requirements, False)
 
-    @mock.patch.dict('bodhi.server.config.config', {'ci.required': True})
-    def test_ci_missing_testing_requirements(self):
+    @mock.patch.dict('bodhi.server.config.config', {'test_gating.required': True})
+    def test_test_gating_missing_testing_requirements(self):
         """
-        The Update.meets_testing_requirements() should return False if the
-        builds of an update did not pass CI.
+        The Update.meets_testing_requirements() should return True, if the test gating
+        status of an update is missing.
         """
         update = self.obj
         update.autokarma = False
         update.stable_karma = 1
-        update.builds[0].ci_status = None
+        update.test_gating_status = None
         update.comment(self.db, u'I found $100 after applying this update.', karma=1,
                        author=u'bowlofeggs')
         # Assert that our preconditions from the docblock are correct.
         self.assertEqual(update.meets_testing_requirements, True)
 
-    @mock.patch.dict('bodhi.server.config.config', {'ci.required': True})
-    def test_ci_waiting_testing_requirements(self):
+    @mock.patch.dict('bodhi.server.config.config', {'test_gating.required': True})
+    def test_test_gating_waiting_testing_requirements(self):
         """
-        The Update.meets_testing_requirements() should return False if the
-        builds of an update did not pass CI.
+        The Update.meets_testing_requirements() should return False, if the test gating
+        status of an update is waiting.
         """
         update = self.obj
         update.autokarma = False
         update.stable_karma = 1
-        update.builds[0].ci_status = CiStatus.waiting
+        update.test_gating_status = TestGatingStatus.waiting
         update.comment(self.db, u'I found $100 after applying this update.', karma=1,
                        author=u'bowlofeggs')
         # Assert that our preconditions from the docblock are correct.
         self.assertEqual(update.meets_testing_requirements, False)
 
-    @mock.patch.dict('bodhi.server.config.config', {'ci.required': False})
-    def test_ci_ci_required_off(self):
+    @mock.patch.dict('bodhi.server.config.config', {'test_gating.required': False})
+    def test_test_gating_off(self):
         """
-        The Update.meets_testing_requirements() should return False if the
-        builds of an update did not pass CI.
+        The Update.meets_testing_requirements() should return True if the
+        testing gating is not required, regardless of its test gating status.
         """
         update = self.obj
         update.autokarma = False
         update.stable_karma = 1
-        update.builds[0].ci_status = CiStatus.running
+        update.test_gating_status = TestGatingStatus.running
         update.comment(self.db, u'I found $100 after applying this update.', karma=1,
                        author=u'bowlofeggs')
         # Assert that our preconditions from the docblock are correct.
@@ -1421,6 +1421,41 @@ class TestUpdate(ModelTest):
         self.assertEqual(len(req.errors), 0)
         publish.assert_called_once_with(
             topic='update.request.stable', msg=mock.ANY)
+
+    @mock.patch.dict('bodhi.server.config.config', {'test_gating.required': True})
+    def test_set_request_stable_for_critpath_update_when_test_gating_enabled(self):
+        """
+        Ensure that we can't submit a critpath update for stable if it hasn't passed the
+        test gating and return the error message as expected.
+        """
+        req = DummyRequest()
+        req.errors = cornice.Errors()
+        req.koji = buildsys.get_session()
+        req.user = model.User(name='bob')
+
+        self.obj.status = UpdateStatus.testing
+        self.obj.request = None
+        self.obj.critpath = True
+        self.obj.test_gating_satus = TestGatingStatus.failed
+        try:
+            self.obj.set_request(self.db, UpdateRequest.stable, req.user.name)
+            assert False
+        except BodhiException, e:
+            pass
+        expected_msg = (
+            'This critical path update has not yet been approved for pushing to the '
+            'stable repository.  It must first reach a karma of %s, consisting of %s '
+            'positive karma from proventesters, along with %d additional karma from '
+            'the community. Or, it must spend %s days in testing without any negative '
+            'feedback')
+        expected_msg = expected_msg % (
+            config.get('critpath.min_karma'),
+            config.get('critpath.num_admin_approvals'),
+            (config.get('critpath.min_karma') -
+                config.get('critpath.num_admin_approvals')),
+            config.get('critpath.stable_after_days_without_negative_karma'))
+        expected_msg += ' Additionally, it must pass automated tests.'
+        self.assertEqual(str(e), expected_msg)
 
     @mock.patch('bodhi.server.notifications.publish')
     def test_met_testing_requirements_at_7_days_after_bodhi_comment(self, publish):

--- a/bodhi/tests/server/test_utils.py
+++ b/bodhi/tests/server/test_utils.py
@@ -20,6 +20,7 @@ import pkgdb2client
 from bodhi.server import util
 from bodhi.server.buildsys import setup_buildsystem, teardown_buildsystem
 from bodhi.server.config import config
+from bodhi.server.models import TestGatingStatus
 
 
 class TestUtils(unittest.TestCase):
@@ -505,40 +506,43 @@ class TestUtils(unittest.TestCase):
         splitspacestring = util.splitter("build-0.1 build-0.2")
         self.assertEqual(splitspacestring, ['build-0.1', 'build-0.2'])
 
-    def test_ci_status2html_ignored(self):
-        """ Test the ci_status2html method with a status: Ignored. """
-        output = util.ci_status2html(None, 'Ignored')
-        assert output == "<span class='label label-success'>Tests Ignored</span>"
+    def test_test_gating_status2html_ignored(self):
+        """ Test the test_gating_status2html method with a status: Ignored. """
+        output = util.test_gating_status2html(None, TestGatingStatus.ignored)
+        assert output == '<span class="label label-success">Tests Ignored</span>'
 
-    def test_ci_status2html_running(self):
-        """ Test the ci_status2html method with a status: Running. """
-        output = util.ci_status2html(None, 'Running')
-        assert output == "<span class='label label-warning'>Tests Running</span>"
+    def test_test_gating_status2html_running(self):
+        """ Test the test_gating_status2html method with a status: Running. """
+        output = util.test_gating_status2html(None, TestGatingStatus.running)
+        assert output == '<span class="label label-warning">Tests Running</span>'
 
-    def test_ci_status2html_passed(self):
-        """ Test the ci_status2html method with a status: Passed. """
-        output = util.ci_status2html(None, 'Passed')
-        assert output == "<span class='label label-success'>Tests Passed</span>"
+    def test_test_gating_status2html_passed(self):
+        """ Test the test_gating_status2html method with a status: Passed. """
+        output = util.test_gating_status2html(None, TestGatingStatus.passed)
+        assert output == '<span class="label label-success">Tests Passed</span>'
 
-    def test_ci_status2html_failed(self):
-        """ Test the ci_status2html method with a status: Failed. """
-        output = util.ci_status2html(None, 'Failed')
-        assert output == "<span class='label label-danger'>Tests Failed</span>"
+    def test_test_gating_status2html_failed(self):
+        """ Test the test_gating_status2html method with a status: Failed. """
+        output = util.test_gating_status2html(None, TestGatingStatus.failed, '1 of 3 tests failed')
+        expected = ('<span class="label label-danger">Tests Failed</span>'
+                    '<p><a class="gating-summary" href="#automatedtests">'
+                    '1 of 3 tests failed</a></p>')
+        assert output == expected
 
-    def test_ci_status2html_queued(self):
-        """ Test the ci_status2html method with a status: Queued. """
-        output = util.ci_status2html(None, 'Queued')
-        assert output == "<span class='label label-info'>Tests Queued</span>"
+    def test_test_gating_status2html_queued(self):
+        """ Test the test_gating_status2html method with a status: Queued. """
+        output = util.test_gating_status2html(None, TestGatingStatus.queued)
+        assert output == '<span class="label label-info">Tests Queued</span>'
 
-    def test_ci_status2html_waiting(self):
-        """ Test the ci_status2html method with a status: Waiting. """
-        output = util.ci_status2html(None, 'Waiting')
-        assert output == "<span class='label label-info'>Tests Waiting</span>"
+    def test_test_gating_status2html_waiting(self):
+        """ Test the test_gating_status2html method with a status: Waiting. """
+        output = util.test_gating_status2html(None, TestGatingStatus.waiting)
+        assert output == '<span class="label label-info">Tests Waiting</span>'
 
-    def test_ci_status2html_missing(self):
-        """ Test the ci_status2html method with a status: None. """
-        output = util.ci_status2html(None, None)
-        assert output == "<span class='label label-primary'>Tests not running</span>"
+    def test_test_gating_status2html_missing(self):
+        """ Test the test_gating_status2html method with a status: None. """
+        output = util.test_gating_status2html(None, None)
+        assert output == '<span class="label label-primary">Tests not running</span>'
 
     @mock.patch('bodhi.server.util.requests.get')
     @mock.patch('bodhi.server.util.log.exception')

--- a/development.ini.example
+++ b/development.ini.example
@@ -67,6 +67,9 @@ badge_ids = binary-star|both-bull-and-self-transcended-tester-viii|catching-the-
 # URL of the resultsdb for integrating checks and stuff
 # resultsdb_api_url = https://taskotron.fedoraproject.org/resultsdb_api/
 
+# The url of Greenwave for performing gating on the automated tests.
+# greenwave_api_url = https://greenwave.fedoraproject.org/api/v1.0
+
 # Set this to True to enable gating based on Continuous Integration test results. If you set this to
 # True, be sure to add a cron job to run the bodhi-babysit-ci-status CLI periodically.
 # ci.required = False

--- a/development.ini.example
+++ b/development.ini.example
@@ -67,7 +67,15 @@ badge_ids = binary-star|both-bull-and-self-transcended-tester-viii|catching-the-
 # URL of the resultsdb for integrating checks and stuff
 # resultsdb_api_url = https://taskotron.fedoraproject.org/resultsdb_api/
 
-# The url of Greenwave for performing gating on the automated tests.
+# Set this to True to enable gating based on policies enforced by Greenwave. If you set this to True,
+# be sure to add a cron job to run the bodhi-check-policies CLI periodically.
+# test_gating.required = False
+
+# If this is set to a URL, a "More information about test gating" link will appear on update pages for users
+# to click and learn more.
+# test_gating.url =
+
+# The API url of Greenwave.
 # greenwave_api_url = https://greenwave.fedoraproject.org/api/v1.0
 
 # Set this to True to enable gating based on Continuous Integration test results. If you set this to

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -223,7 +223,9 @@ man_pages = [
      ['Randy Barlow'], 1),
     ('man_pages/bodhi-push', 'bodhi-push', u'push Fedora updates', ['Randy Barlow'], 1),
     ('man_pages/initialize_bodhi_db', 'initialize_bodhi_db', u'intialize bodhi\'s database',
-     ['Randy Barlow'], 1)
+     ['Randy Barlow'], 1),
+    ('man_pages/bodhi-check-policies', 'bodhi-check-policies', u'check policies',
+     ['Matt Jia'], 1)
 ]
 
 # If true, show URL addresses after external links.

--- a/docs/man_pages/bodhi-check-policies.rst
+++ b/docs/man_pages/bodhi-check-policies.rst
@@ -1,0 +1,38 @@
+====================
+bodhi-check-policies
+====================
+
+Synopsis
+========
+
+``bodhi-check-policies``
+
+
+Description
+===========
+
+``bodhi-check-policies`` iterates over Updates to check the policies enforced by
+Greewave for each update.
+
+
+Options
+=======
+
+``--help``
+
+    Display help text.
+
+``--version``
+
+    Report the Bodhi version and exit.
+
+
+Help
+====
+
+If you find bugs in bodhi (or in the man page), please feel free to file a bug report or a pull
+request:
+
+    https://github.com/fedora-infra/bodhi
+
+Bodhi's documentation is available online: https://bodhi.fedoraproject.org/docs

--- a/docs/man_pages/index.rst
+++ b/docs/man_pages/index.rst
@@ -10,3 +10,4 @@ Man pages
    bodhi-babysit-ci
    bodhi-push
    initialize_bodhi_db
+   bodhi-check-policies

--- a/production.ini
+++ b/production.ini
@@ -69,9 +69,16 @@ use = egg:bodhi-server
 # URL of the resultsdb for integrating checks and stuff
 # resultsdb_api_url = https://taskotron.fedoraproject.org/resultsdb_api/
 
-# The url of Greenwave for performing gating on the automated tests.
-# greenwave_api_url = https://greenwave.fedoraproject.org/api/v1.0
+# Set this to True to enable gating based on policies enforced by Greenwave. If you set this to True,
+# be sure to add a cron job to run the bodhi-check-policies CLI periodically.
+# test_gating.required = False
 
+# If this is set to a URL, a "More information about test gating" link will appear on update pages for users
+# to click and learn more.
+# test_gating.url =
+
+# The API url of Greenwave.
+# greenwave_api_url = https://greenwave.fedoraproject.org/api/v1.0
 
 # Set this to True to enable gating based on Continuous Integration test results. If you set this to
 # True, be sure to add a cron job to run the bodhi-babysit-ci-status CLI periodically.

--- a/production.ini
+++ b/production.ini
@@ -69,6 +69,10 @@ use = egg:bodhi-server
 # URL of the resultsdb for integrating checks and stuff
 # resultsdb_api_url = https://taskotron.fedoraproject.org/resultsdb_api/
 
+# The url of Greenwave for performing gating on the automated tests.
+# greenwave_api_url = https://greenwave.fedoraproject.org/api/v1.0
+
+
 # Set this to True to enable gating based on Continuous Integration test results. If you set this to
 # True, be sure to add a cron job to run the bodhi-babysit-ci-status CLI periodically.
 # ci.required = False

--- a/setup.py
+++ b/setup.py
@@ -159,6 +159,7 @@ setup(
     bodhi-untag-branched = bodhi.server.scripts.untag_branched:main
     bodhi-approve-testing = bodhi.server.scripts.approve_testing:main
     bodhi-manage-releases = bodhi.server.scripts.manage_releases:main
+    bodhi-check-policies = bodhi.server.scripts.check_policies:check
     [moksha.consumer]
     masher = bodhi.server.consumers.masher:Masher
     updates = bodhi.server.consumers.updates:UpdatesHandler


### PR DESCRIPTION
Highlights for this PR:
* enabling Greenwave integration in bodhi will make the application gate on the automated test resutls
* CI integration will no longer make the application gate on CI results
* display ‘Gating Status’ on the update page on the UI and link people to the automated test tab in order to help debug which tests are blocking if the policies are not satisfied.
* a new command is added to get a decision for each opening update(an update is not pushed and the status of the update is either pending or testing). If we have a message-bus driven process to cache Greenwave's decision, we could use this command in a cron job to update the cache frequently in case messages were missed along the way.