### PR TITLE
Pungi masher for modules

### DIFF
--- a/bodhi/server/config.py
+++ b/bodhi/server/config.py
@@ -480,7 +480,7 @@ class BodhiConfig(dict):
             'value': 'https://admin.fedoraproject.org/pkgdb',
             'validator': unicode},
         'pungi_modular_config_path': {
-            'value': '/etc/bodhi/pungi/fedora-modular.conf',
+            'value': '/etc/bodhi/pungi/{release}-modular.conf',
             'validator': unicode},
         'query_wiki_test_cases': {
             'value': False,

--- a/bodhi/server/config.py
+++ b/bodhi/server/config.py
@@ -479,6 +479,9 @@ class BodhiConfig(dict):
         'pkgdb_url': {
             'value': 'https://admin.fedoraproject.org/pkgdb',
             'validator': unicode},
+        'pungi_modular_config_path': {
+            'value': '/etc/bodhi/pungi/fedora-modular.conf',
+            'validator': unicode},
         'query_wiki_test_cases': {
             'value': False,
             'validator': _validate_bool},

--- a/bodhi/server/consumers/masher.py
+++ b/bodhi/server/consumers/masher.py
@@ -1160,6 +1160,26 @@ class PungiMashThread(threading.Thread):
     """ A pungi masher thread. Is used for mashing modules with pungi. """
 
     def __init__(self, compose_id, target_dir, pungi_conf, variants_conf, log):
+        """
+        Initializes the mash thread
+
+        Args:
+            compose_id (str): id of the compose also the id of the thread
+            target_dir (str): mash dir where the compose will take place
+            pungi_conf (dict): the pungi conf in a dictionary
+            variants_conf (VariantsConfig object): object which represents the variants config
+            for the pungi compose
+            log (logger): bodhi server logger
+
+        Attributes:
+            success (bool): tells you if the compose was a success or not
+            compose_dir (str): path to to the dir where the compose will took place. This
+            needs to be run through init_compose_dir method to initialize also some metadata
+            files
+            compose (pungi.compose.Compose): main compose object
+            name (str): name of the thread
+
+        """
         super(PungiMashThread, self).__init__()
         self.success = False
         self.compose_id = compose_id

--- a/bodhi/server/consumers/masher.py
+++ b/bodhi/server/consumers/masher.py
@@ -39,10 +39,13 @@ import fedmsg.consumers
 from bodhi.server import bugs, log, buildsys, notifications, mail, util
 from bodhi.server.config import config
 from bodhi.server.exceptions import BodhiException
-from bodhi.server.metadata import ExtendedMetadata
+from bodhi.server.metadata import ExtendedMetadata, PungiMetadata
 from bodhi.server.models import (Update, UpdateRequest, UpdateType, Release,
                                  UpdateStatus, ReleaseState, Base)
 from bodhi.server.util import sorted_updates, sanity_check_repodata, transactional_session_maker
+import pungi.notifier
+from pungi.compose import Compose
+from pungi_wrapper import PungiWrapper, VariantsConfig, get_pungi_conf
 
 
 def checkpoint(method):
@@ -197,9 +200,19 @@ Once mash is done:
                     if request == req:
                         self.log.info('Starting thread for %s %s for %d updates',
                                       release, request, len(updates))
-                        thread = MasherThread(release, request, updates, agent,
-                                              self.log, self.db_factory,
-                                              self.mash_dir, resume)
+                        if "modular" not in release:
+                            thread = MasherThread(
+                                release, request, updates, agent,
+                                self.log, self.db_factory,
+                                self.mash_dir, resume
+                            )
+                        else:
+                            thread = PungiMasherThread(
+                                release, request, updates, agent,
+                                self.log, self.db_factory,
+                                self.mash_dir, resume
+                            )
+
                         threads.append(thread)
                         thread.start()
                 for thread in threads:
@@ -428,6 +441,12 @@ class MasherThread(threading.Thread):
                 continue
 
     def perform_gating(self):
+
+        if 'modular' in self.id:
+            # We can/should enable gating for modules after we work out kinks.
+            self.log.warn("SKIPPING gating check for %r" % self.id)
+            return
+
         self.log.debug('Performing gating.')
         for update in list(self.updates):
             result, reason = update.check_requirements(self.db, config)
@@ -639,6 +658,12 @@ class MasherThread(threading.Thread):
         Update our comps git module and merge the latest translations so we can
         pass it to mash insert into the repodata.
         """
+
+        if 'modular' in self.id:
+            # Comps for the modular repo doesn't make any sense.
+            self.log.warn("SKIPPING comps update for %r" % self.id)
+            return
+
         self.log.info("Updating comps")
         comps_url = config.get('comps_url')
 
@@ -920,6 +945,12 @@ class MasherThread(threading.Thread):
     @checkpoint
     def compose_atomic_trees(self):
         """Compose Atomic OSTrees for each tag that we mashed."""
+
+        if 'modular' in self.id:
+            # We can start building atomic trees for modules later.  One thing at a time.
+            self.log.warn("SKIPPING compose of atomic trees for %r" % self.id)
+            return
+
         composer = AtomicComposer()
         mashed_repos = dict([('-'.join(os.path.basename(repo).split('-')[:-1]), repo)
                              for repo in self.state['completed_repos']])
@@ -1052,4 +1083,122 @@ class MashThread(threading.Thread):
             raise Exception('mash failed')
         else:
             self.success = True
-        return out, err, returncode
+
+
+class PungiMasherThread(MasherThread):
+    """ Like the MasherThread, but with pungi, for modules. """
+
+    def _get_compose_dir(self, mash_path, variant_id="Server"):
+        """ Return the compose directory
+
+        Args:
+            mash_path (str): A path on disk.
+            variant_id (str): The variant to compose.
+        Returns:
+            str: The directory in the mash path for the compose.
+        """
+        return os.path.join(mash_path, "compose", variant_id)
+
+    def sanity_check_repo(self):
+        """Sanity check our repo.
+
+            - sanity check our repodata
+        """
+        mash_path = os.path.join(self.path, self.id)
+        self.log.info("Running sanity checks on %s" % mash_path)
+
+        compose_dir = self._get_compose_dir(mash_path)
+        dir_blacklist = ['source']
+        arches = [d for d in os.listdir(compose_dir) if d not in dir_blacklist]
+        for arch in arches:
+            try:
+                repodata = os.path.join(compose_dir, arch, "os", 'repodata')
+                sanity_check_repodata(repodata)
+            except Exception as e:
+                self.log.error("Repodata sanity check failed!\n%s" % str(e))
+                raise
+
+        return True
+
+    def mash(self):
+        """ Kick off the PungiMashThread and return a reference. """
+
+        if self.path in self.state['completed_repos']:
+            self.log.info('Skipping completed repo: %s', self.path)
+            return
+
+        self.pungi_conf_path = config.get("pungi_modular_config_path")
+        self.pungi_conf = get_pungi_conf(self.pungi_conf_path)
+
+        self.variants_conf = VariantsConfig(self.updates, self.release.builds)
+        mash_thread = PungiMashThread(
+            self.id,
+            self.path,
+            self.pungi_conf,
+            self.variants_conf,
+            self.log
+        )
+        mash_thread.start()
+        return mash_thread
+
+    def generate_updateinfo(self):
+        """
+        Generates and object which represents data for updateinfo.xml file.
+
+        Returns:
+            PungiMetadata object: represents pungi metadata object
+        """
+        self.log.info('Generating updateinfo for %s' % self.release.name)
+        mash_path = os.path.join(self.path, self.id)
+        compose_dir = self._get_compose_dir(mash_path)
+        uinfo = PungiMetadata(self.release, self.request, self.db, self.path, compose_dir)
+        self.log.info('Updateinfo generation for %s complete' % self.release.name)
+        return uinfo
+
+
+class PungiMashThread(threading.Thread):
+    """ A pungi masher thread. Is used for mashing modules with pungi. """
+
+    def __init__(self, compose_id, target_dir, pungi_conf, variants_conf, log):
+        super(PungiMashThread, self).__init__()
+        self.success = False
+        self.compose_id = compose_id
+        self.compose_type = "nightly"
+        self.pungi_conf = pungi_conf
+        self.variants_conf = variants_conf
+        self.log = log
+        self.compose_dir = PungiWrapper.init_compose_dir(
+            target_dir,
+            self.pungi_conf,
+            compose_id,
+            compose_type=self.compose_type,
+        )
+        notifier = pungi.notifier.PungiNotifier(None)
+        self.compose = Compose(
+            self.pungi_conf,
+            topdir=self.compose_dir,
+            debug=True,
+            skip_phases=["productimg"],
+            just_phases=[],
+            old_composes=None,
+            koji_event=None,
+            supported=False,
+            logger=self.log,
+            notifier=notifier
+        )
+        self.name = compose_id
+
+    def run(self):
+        """Perform the mash in a subprocess."""
+        start = time.time()
+        self.log.info('Mashing %s', self.compose_id)
+        try:
+            pungi_wrapper = PungiWrapper(self.compose, self.variants_conf)
+            pungi_wrapper.compose_repo()
+        except Exception as ex:
+            self.log.error('There was a problem running mash (%s)' % ex.message)
+            raise
+
+        self.log.info('Took %s seconds to mash %s', time.time() - start,
+                      self.compose_id)
+        self.success = True

--- a/bodhi/server/consumers/pungi_wrapper.py
+++ b/bodhi/server/consumers/pungi_wrapper.py
@@ -297,6 +297,7 @@ class VariantsConfig(object):
         self.modules = self._generate_module_list()
         self.arches = arches
         self.headers = [
+            # https://pagure.io/pungi/blob/master/f/share/variants.dtd
             '<?xml version="1.0" encoding="UTF-8"?>',
             ('<!DOCTYPE variants PUBLIC "-//Red Hat, Inc.//DTD '
              'Variants info//EN" "variants2012.dtd">'),

--- a/bodhi/server/consumers/pungi_wrapper.py
+++ b/bodhi/server/consumers/pungi_wrapper.py
@@ -274,6 +274,7 @@ class PungiWrapper(object):
             os.symlink(self.compose_dir, symlink)
         except Exception as ex:
             self.compose.log_error("Couldn't create latest symlink: %s" % ex)
+            raise
 
 
 class VariantsConfig(object):

--- a/bodhi/server/consumers/pungi_wrapper.py
+++ b/bodhi/server/consumers/pungi_wrapper.py
@@ -1,0 +1,380 @@
+# -*- coding: utf-8 -*-
+# Copyright © 2017 Red Hat, Inc.
+#
+# This file is part of Bodhi.
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+"""
+Our Very Own Pungi Wrapper.
+
+This module comprises tools that wrap pungi providing a kind of "API" we use
+internally.  Once pungi gets its own proper API, this module will either need
+to be refactored or abandoned.
+"""
+
+import errno
+import os
+import time
+import cStringIO
+import shutil
+
+import pungi.checks
+import pungi.phases
+import pungi.metadata
+import pungi.notifier
+import kobo.conf
+from bodhi.server import log
+from productmd.composeinfo import ComposeInfo
+from pungi.wrappers.variants import VariantsXmlParser
+from pungi.util import makedirs
+
+from bodhi.server.config import _validate_bool as asbool
+
+
+class PungiWrapper(object):
+    """Pungi Wrapper which wraps the pungi package functionality."""
+
+    def __init__(self, compose, variants_conf):
+        self.phases = {}
+        self.compose = compose
+        self.variants_conf = variants_conf
+
+    @staticmethod
+    def init_compose_dir(topdir, conf, compose_id, compose_type="production"):
+        """                                                                      
+        Pungi method which needed to be changed to work with bodhi. Creates         
+        necessary directories and files for the compose to be succesfull         
+        
+        Args:
+            topdir (str) - mash dir
+            conf (dict) - pungi conf
+            compose_id (str) - compose id
+            compose_type (str) - type of the compose                                                                      
+        Returns:                                                                 
+            str: Path to the compose_dir                                         
+        """               
+        compose_date=None 
+        compose_respin=None
+        compose_label=None
+        already_exists_callbacks=None
+        
+        already_exists_callbacks = already_exists_callbacks or []
+
+        # create an incomplete composeinfo to generate compose ID
+        ci = ComposeInfo()
+        ci.release.name = conf["release_name"]
+        ci.release.short = conf["release_short"]
+        ci.release.version = conf["release_version"]
+        ci.release.is_layered = asbool(conf.get("release_is_layered", False))
+        ci.release.type = conf.get("release_type", "ga").lower()
+        ci.release.internal = asbool(conf.get("release_internal", False))
+        if ci.release.is_layered:
+            ci.base_product.name = conf["base_product_name"]
+            ci.base_product.short = conf["base_product_short"]
+            ci.base_product.version = conf["base_product_version"]
+            ci.base_product.type = conf.get("base_product_type", "ga").lower()
+
+        ci.compose.label = compose_label
+        ci.compose.type = compose_type
+        ci.compose.date = compose_date or time.strftime("%Y%m%d", time.gmtime())
+        ci.compose.respin = compose_respin or 0
+
+        ci.compose.id = ci.create_compose_id()
+
+        compose_dir = os.path.join(topdir, compose_id)
+
+        os.makedirs(compose_dir)
+
+        with open(os.path.join(compose_dir, "COMPOSE_ID"), "w") as fd:
+            fd.write(ci.compose.id)
+        work_dir = os.path.join(compose_dir, "work", "global")
+        makedirs(work_dir)
+        ci.dump(os.path.join(work_dir, "composeinfo-base.json"))
+        return compose_dir
+
+    def compose_repo(self):
+        """                                                                      
+        Wrapper method which start the compose process with loading the variants 
+        config and executing all the phases necessary for a pungi compose        
+        """       
+        self.load_variants_config()
+        self.execute_phases()
+
+    def execute_phases(self):
+        """
+        This method is inspired by the pungi-koji binary. It composes a dnf repo
+        according to the compose object provided.
+        """
+        init_phase = pungi.phases.InitPhase(self.compose)
+        pkgset_phase = pungi.phases.PkgsetPhase(self.compose)
+        buildinstall_phase = pungi.phases.BuildinstallPhase(self.compose)
+        gather_phase = pungi.phases.GatherPhase(self.compose, pkgset_phase)
+        extrafiles_phase = pungi.phases.ExtraFilesPhase(self.compose, pkgset_phase)
+        createrepo_phase = pungi.phases.CreaterepoPhase(self.compose)
+        ostree_installer_phase = pungi.phases.OstreeInstallerPhase(self.compose)
+        ostree_phase = pungi.phases.OSTreePhase(self.compose)
+        productimg_phase = pungi.phases.ProductimgPhase(self.compose, pkgset_phase)
+        createiso_phase = pungi.phases.CreateisoPhase(self.compose)
+        liveimages_phase = pungi.phases.LiveImagesPhase(self.compose)
+        livemedia_phase = pungi.phases.LiveMediaPhase(self.compose)
+        image_build_phase = pungi.phases.ImageBuildPhase(self.compose)
+        osbs_phase = pungi.phases.OSBSPhase(self.compose)
+        image_checksum_phase = pungi.phases.ImageChecksumPhase(self.compose)
+        test_phase = pungi.phases.TestPhase(self.compose)
+
+        errors = []
+        # check if all config options are set
+        for phase in (init_phase, pkgset_phase, createrepo_phase,
+                      buildinstall_phase, productimg_phase, gather_phase,
+                      extrafiles_phase, createiso_phase, liveimages_phase,
+                      livemedia_phase, image_build_phase, image_checksum_phase,
+                      test_phase, ostree_phase, ostree_installer_phase,
+                      osbs_phase):
+            if phase.skip():
+                continue
+            try:
+                phase.validate()
+            except ValueError as ex:
+                for i in str(ex).splitlines():
+                    errors.append("%s: %s" % (phase.name.upper(), i))
+        if errors:
+            for i in errors:
+                self.compose.log_error(i)
+            raise RuntimeError(errors)
+
+        # INIT phase
+        init_phase.start()
+        init_phase.stop()
+
+        # PKGSET phase
+        pkgset_phase.start()
+        pkgset_phase.stop()
+
+        # BUILDINSTALL phase - start, we can run gathering, extra files and
+        # createrepo while buildinstall is in progress.
+        buildinstall_phase.start()
+
+        # If any of the following three phases fail, we must ensure that
+        # buildinstall is stopped. Otherwise the whole process will hang.
+        try:
+            gather_phase.start()
+            gather_phase.stop()
+
+            extrafiles_phase.start()
+            extrafiles_phase.stop()
+
+            createrepo_phase.start()
+            createrepo_phase.stop()
+
+        finally:
+            buildinstall_phase.stop()
+
+        if not buildinstall_phase.skip():
+            buildinstall_phase.copy_files()
+
+        ostree_phase.start()
+        ostree_phase.stop()
+
+        # PRODUCTIMG phase
+        productimg_phase.start()
+        productimg_phase.stop()
+
+        self.write_repo_metadata()
+
+        # Start all phases for image artifacts
+        pungi.phases.run_all([createiso_phase, liveimages_phase,
+                              image_build_phase, livemedia_phase,
+                              ostree_installer_phase, osbs_phase])
+
+        image_checksum_phase.start()
+        image_checksum_phase.stop()
+
+        pungi.metadata.write_compose_info(self.compose)
+        self.compose.im.dump(self.compose.paths.compose.metadata("images.json"))
+
+        osbs_phase.dump_metadata()
+
+        # TEST phase
+        test_phase.start()
+        test_phase.stop()
+
+        self.compose.write_status("FINISHED")
+
+        self.create_latest_repo_links()
+
+        self.compose.log_info("Compose finished: %s" % self.compose.topdir)
+
+    def load_variants_config(self):
+        """
+        This is a workaround so we dont have to provide a path of the variants
+        config to pungi. We provide a generated file object which then is injected
+        into pungi compose object.
+        """
+        variants_file_obj = cStringIO.StringIO(self.variants_conf.xml)
+        parser = VariantsXmlParser(variants_file_obj)
+        self.compose.variants = parser.parse()
+        self.compose.all_variants = {}
+        for variant in self.compose.get_variants():
+            self.compose.all_variants[variant.uid] = variant
+        # After the variants object is injected into the pungi compose object
+        # we will write it to disk in the repo.
+        variants_file = self.compose.paths.work.variants_file(arch="global")
+        variants_file_obj.seek(0)
+        # Create create the variants file on disk
+        with open(variants_file, 'w') as fd:
+            shutil.copyfileobj(variants_file_obj, fd)
+            variants_file_obj.close()
+
+    def write_repo_metadata(self):
+        # write treeinfo before ISOs are created
+        for variant in self.compose.get_variants():
+            for arch in variant.arches + ["src"]:
+                pungi.metadata.write_tree_info(self.compose, arch, variant)
+
+        # write .discinfo and media.repo before ISOs are created
+        for variant in self.compose.get_variants():
+            for arch in variant.arches + ["src"]:
+                timestamp = pungi.metadata.write_discinfo(self.compose, arch, variant)
+                pungi.metadata.write_media_repo(self.compose, arch, variant, timestamp)
+
+    def create_latest_repo_links(self):
+        """                                                                      
+        Creates symlinks for the newly created compose                           
+        """      
+        self.compose_dir = os.path.basename(self.compose.topdir)
+        symlink_name = "latest-%s-%s" % (
+            self.compose.conf["release_short"],
+            self.compose.conf["release_version"]
+        )
+        if self.compose.conf["release_is_layered"]:
+            symlink_name += "-%s-%s" % (
+                self.compose.conf["base_product_short"],
+                self.compose.conf["base_product_version"]
+            )
+        symlink = os.path.join(self.compose.topdir, "..", symlink_name)
+
+        try:
+            os.unlink(symlink)
+        except OSError as ex:
+            if ex.errno != errno.ENOENT:
+                raise Exception(ex)
+        try:
+            os.symlink(self.compose_dir, symlink)
+        except Exception as ex:
+            self.compose.log_error("Couldn't create latest symlink: %s" % ex)
+
+
+class VariantsConfig(object):
+
+    """
+    This class generates a variants config which can be used with the compose
+    object to generate a dnf repo. Right now it only works with modules.
+    """
+
+    def __init__(self, updates, builds, variant_id="Server",
+                 arches=['x86_64', 'armhfp', 'aarch64', 'i386', 'ppc64', 'ppc64le', 's390x']):
+        """
+        Args:
+              updates (list) - list of Update objects                                      
+              builds (list) - list of ModularBuild objects                                 
+              variant_id (str) - the type of variant which will be composed                
+              arches (list) - architectures which should be included in compose
+        """ 
+        self.updates = updates
+        self.builds = builds
+        self.modules = self._generate_module_list()
+        self.arches = arches
+        self.headers = [
+            '<?xml version="1.0" encoding="UTF-8"?>',
+            ('<!DOCTYPE variants PUBLIC "-//Red Hat, Inc.//DTD '
+             'Variants info//EN" "variants2012.dtd">'),
+        ]
+        self.body = [
+            '<variants>',
+            '<variant id="%s" name="%s" type="variant">' % (variant_id, variant_id),
+            '<arches>',
+            ''.join(['<arch>%s</arch>' % arch for arch in self.arches]),
+            '</arches>',
+            '<modules>',
+            ''.join(['<module>%s</module>' % module for module in self.modules]),
+            '</modules>',
+            '</variant>',
+            '</variants>'
+        ]
+
+    def _generate_module_list(self):
+        """
+        Generates a list of NSV which should be used for pungi modular compose   
+                                                                               
+        Returns:                                                                 
+          list: list of NSV string which should be composed 
+        """
+        newest_builds = {}
+        # we loop through builds so we get rid of older builds and get only
+        # a dict with the newest builds
+        for build in self.builds:
+            nsv = build.nvr.rsplit('-', 1)
+            ns = nsv[0]
+            version = nsv[1]
+
+            if ns in newest_builds:
+                curr_version = newest_builds[ns]
+                if int(curr_version) < int(version):
+                    newest_builds[ns] = version
+            else:
+                newest_builds[ns] = version
+
+        # make sure that the modules we want to update get their correct versions
+        for update in self.updates:
+            nsv = update.builds[0].nvr.rsplit('-', 1)
+            ns = nsv[0]
+            version = nsv[1]
+            newest_builds[ns] = version
+
+        module_list = ["%s-%s" % (nstream, v) for nstream, v in newest_builds.iteritems()]
+        return module_list
+
+    @property
+    def xml(self):
+        """
+        Returns string xml representation of the object.
+
+        Returns:
+            str: xml string
+        """
+        headers_str = "".join(self.headers)
+        body_str = "".join(self.body)
+        return str(headers_str + body_str)
+
+
+def get_pungi_conf(path):
+        """ 
+        Reads the config from the provided path 
+
+        Args:
+            path (string) - this holds the path to the config file.
+        """
+        config = kobo.conf.PyConfigParser()
+        config.load_from_file(path)
+        errors, warnings = pungi.checks.validate(config)
+        if warnings:
+            for warning in warnings:
+                log.warning(warning)
+
+        if errors:
+            for error in errors:
+                log.error(error)
+            raise Exception(str(errors))
+        return config

--- a/bodhi/server/consumers/pungi_wrapper.py
+++ b/bodhi/server/consumers/pungi_wrapper.py
@@ -363,21 +363,21 @@ class VariantsConfig(object):
 
 
 def get_pungi_conf(path):
-        """
-        Reads the config from the provided path
+    """
+    Reads the config from the provided path
 
-        Args:
-            path (string) - this holds the path to the config file.
-        """
-        config = kobo.conf.PyConfigParser()
-        config.load_from_file(path)
-        errors, warnings = pungi.checks.validate(config)
-        if warnings:
-            for warning in warnings:
-                log.warning(warning)
+    Args:
+        path (string) - this holds the path to the config file.
+    """
+    config = kobo.conf.PyConfigParser()
+    config.load_from_file(path)
+    errors, warnings = pungi.checks.validate(config)
+    if warnings:
+        for warning in warnings:
+            log.warning(warning)
 
-        if errors:
-            for error in errors:
-                log.error(error)
-            raise Exception(str(errors))
-        return config
+    if errors:
+        for error in errors:
+            log.error(error)
+        raise Exception(str(errors))
+    return config

--- a/bodhi/server/consumers/pungi_wrapper.py
+++ b/bodhi/server/consumers/pungi_wrapper.py
@@ -53,23 +53,23 @@ class PungiWrapper(object):
 
     @staticmethod
     def init_compose_dir(topdir, conf, compose_id, compose_type="production"):
-        """                                                                      
-        Pungi method which needed to be changed to work with bodhi. Creates         
-        necessary directories and files for the compose to be succesfull         
-        
+        """
+        Pungi method which needed to be changed to work with bodhi. Creates
+        necessary directories and files for the compose to be succesfull
+
         Args:
             topdir (str) - mash dir
             conf (dict) - pungi conf
             compose_id (str) - compose id
-            compose_type (str) - type of the compose                                                                      
-        Returns:                                                                 
-            str: Path to the compose_dir                                         
-        """               
-        compose_date=None 
-        compose_respin=None
-        compose_label=None
-        already_exists_callbacks=None
-        
+            compose_type (str) - type of the compose
+        Returns:
+            str: Path to the compose_dir
+        """
+        compose_date = None
+        compose_respin = None
+        compose_label = None
+        already_exists_callbacks = None
+
         already_exists_callbacks = already_exists_callbacks or []
 
         # create an incomplete composeinfo to generate compose ID
@@ -105,10 +105,10 @@ class PungiWrapper(object):
         return compose_dir
 
     def compose_repo(self):
-        """                                                                      
-        Wrapper method which start the compose process with loading the variants 
-        config and executing all the phases necessary for a pungi compose        
-        """       
+        """
+        Wrapper method which start the compose process with loading the variants
+        config and executing all the phases necessary for a pungi compose
+        """
         self.load_variants_config()
         self.execute_phases()
 
@@ -250,9 +250,9 @@ class PungiWrapper(object):
                 pungi.metadata.write_media_repo(self.compose, arch, variant, timestamp)
 
     def create_latest_repo_links(self):
-        """                                                                      
-        Creates symlinks for the newly created compose                           
-        """      
+        """
+        Creates symlinks for the newly created compose
+        """
         self.compose_dir = os.path.basename(self.compose.topdir)
         symlink_name = "latest-%s-%s" % (
             self.compose.conf["release_short"],
@@ -287,11 +287,11 @@ class VariantsConfig(object):
                  arches=['x86_64', 'armhfp', 'aarch64', 'i386', 'ppc64', 'ppc64le', 's390x']):
         """
         Args:
-              updates (list) - list of Update objects                                      
-              builds (list) - list of ModularBuild objects                                 
-              variant_id (str) - the type of variant which will be composed                
+              updates (list) - list of Update objects
+              builds (list) - list of ModularBuild objects
+              variant_id (str) - the type of variant which will be composed
               arches (list) - architectures which should be included in compose
-        """ 
+        """
         self.updates = updates
         self.builds = builds
         self.modules = self._generate_module_list()
@@ -316,10 +316,10 @@ class VariantsConfig(object):
 
     def _generate_module_list(self):
         """
-        Generates a list of NSV which should be used for pungi modular compose   
-                                                                               
-        Returns:                                                                 
-          list: list of NSV string which should be composed 
+        Generates a list of NSV which should be used for pungi modular compose
+
+        Returns:
+          list: list of NSV string which should be composed
         """
         newest_builds = {}
         # we loop through builds so we get rid of older builds and get only
@@ -360,8 +360,8 @@ class VariantsConfig(object):
 
 
 def get_pungi_conf(path):
-        """ 
-        Reads the config from the provided path 
+        """
+        Reads the config from the provided path
 
         Args:
             path (string) - this holds the path to the config file.

--- a/bodhi/server/consumers/pungi_wrapper.py
+++ b/bodhi/server/consumers/pungi_wrapper.py
@@ -339,10 +339,11 @@ class VariantsConfig(object):
 
         # make sure that the modules we want to update get their correct versions
         for update in self.updates:
-            nsv = update.builds[0].nvr.rsplit('-', 1)
-            ns = nsv[0]
-            version = nsv[1]
-            newest_builds[ns] = version
+            for build in update.builds:
+                nsv = build.nvr.rsplit('-', 1)
+                ns = nsv[0]
+                version = nsv[1]
+                newest_builds[ns] = version
 
         module_list = ["%s-%s" % (nstream, v) for nstream, v in newest_builds.iteritems()]
         return module_list

--- a/bodhi/server/metadata.py
+++ b/bodhi/server/metadata.py
@@ -326,3 +326,38 @@ class ExtendedMetadata(object):
             shutil.rmtree(cache)
         shutil.copytree(repodata, cache)
         log.info('%s cached to %s' % (repodata, cache))
+
+
+class PungiMetadata(ExtendedMetadata):
+    """ Class which represents updateinfo metadata for pungi. """
+
+    def __init__(self, release, request, db, path, compose_dir):
+        """ 
+        Same as its parent class only with the addition of compose_dir arg.
+        
+        Args:
+            compose_dir - path to the pungi compose
+        """
+        super(PungiMetadata, self).__init__(release, request, db, path)
+        self.compose_dir = compose_dir
+
+    def modifyrepo(self, filename):
+        """Inject a file into the repodata for each architecture"""
+        dir_blacklist = ['source']
+        arches = [d for d in os.listdir(self.compose_dir) if d not in dir_blacklist]
+
+        for arch in arches:
+            repodata = os.path.join(self.compose_dir, arch, 'os', 'repodata')
+            log.info('Inserting %s into %s', filename, repodata)
+            uinfo_xml = os.path.join(repodata, 'updateinfo.xml')
+            shutil.copyfile(filename, uinfo_xml)
+            repomd_xml = os.path.join(repodata, 'repomd.xml')
+            repomd = cr.Repomd(repomd_xml)
+            uinfo_rec = cr.RepomdRecord('updateinfo', uinfo_xml)
+            uinfo_rec_comp = uinfo_rec.compress_and_fill(self.hash_type, self.comp_type)
+            uinfo_rec_comp.rename_file()
+            uinfo_rec_comp.type = 'updateinfo'
+            repomd.set_record(uinfo_rec_comp)
+            with file(repomd_xml, 'w') as repomd_file:
+                repomd_file.write(repomd.xml_dump())
+            os.unlink(uinfo_xml)

--- a/bodhi/server/metadata.py
+++ b/bodhi/server/metadata.py
@@ -288,7 +288,7 @@ class ExtendedMetadata(object):
             filename (basestring): the actual name of the metadata file which will be inserted
                 (createrepo_c takes this as one of its arguments so the ouput file will be
                 {hash}-{filename}.xz)
-            tempfile (basestring): a temp file path. File holds the dump of metadata untill
+            tempfile (basestring): a temp file path. The file holds the dump of metadata until
                 copied to the repodata folder.
         """
         for arch in os.listdir(self.repo_path):

--- a/bodhi/server/metadata.py
+++ b/bodhi/server/metadata.py
@@ -332,9 +332,9 @@ class PungiMetadata(ExtendedMetadata):
     """ Class which represents updateinfo metadata for pungi. """
 
     def __init__(self, release, request, db, path, compose_dir):
-        """ 
+        """
         Same as its parent class only with the addition of compose_dir arg.
-        
+
         Args:
             compose_dir - path to the pungi compose
         """

--- a/bodhi/server/metadata.py
+++ b/bodhi/server/metadata.py
@@ -341,7 +341,7 @@ class PungiMetadata(ExtendedMetadata):
         super(PungiMetadata, self).__init__(release, request, db, path)
         self.compose_dir = compose_dir
 
-    def modifyrepo(self, filename):
+    def modifyrepo(self, filetype, filename, tempfile):
         """Inject a file into the repodata for each architecture"""
         dir_blacklist = ['source']
         arches = [d for d in os.listdir(self.compose_dir) if d not in dir_blacklist]
@@ -349,14 +349,14 @@ class PungiMetadata(ExtendedMetadata):
         for arch in arches:
             repodata = os.path.join(self.compose_dir, arch, 'os', 'repodata')
             log.info('Inserting %s into %s', filename, repodata)
-            uinfo_xml = os.path.join(repodata, 'updateinfo.xml')
-            shutil.copyfile(filename, uinfo_xml)
+            uinfo_xml = os.path.join(repodata, filename)
+            shutil.copyfile(tempfile, uinfo_xml)
             repomd_xml = os.path.join(repodata, 'repomd.xml')
             repomd = cr.Repomd(repomd_xml)
-            uinfo_rec = cr.RepomdRecord('updateinfo', uinfo_xml)
+            uinfo_rec = cr.RepomdRecord(filetype, uinfo_xml)
             uinfo_rec_comp = uinfo_rec.compress_and_fill(self.hash_type, self.comp_type)
             uinfo_rec_comp.rename_file()
-            uinfo_rec_comp.type = 'updateinfo'
+            uinfo_rec_comp.type = filetype
             repomd.set_record(uinfo_rec_comp)
             with file(repomd_xml, 'w') as repomd_file:
                 repomd_file.write(repomd.xml_dump())

--- a/bodhi/server/models.py
+++ b/bodhi/server/models.py
@@ -879,20 +879,6 @@ class Build(Base):
                 koji.moveBuild(tag, release.candidate_tag, self.nvr)
 
 
-class ModuleBuild(Build):
-    """
-    Represents a Module build.
-
-    Note that this model uses single-table inheritance with its Build superclass.
-
-    Attributes:
-        nvr (unicode): A unique Koji identifier for the module build.
-    """
-    __mapper_args__ = {
-        'polymorphic_identity': ContentType.module,
-    }
-
-
 class RpmBuild(Build):
     """
     Represents an RPM build.
@@ -993,6 +979,20 @@ class RpmBuild(Build):
                                       descrip[i])
             i += 1
         return str
+
+
+class ModuleBuild(RpmBuild):
+    """
+    Represents a Module build.
+
+    Note that this model uses single-table inheritance with its Build superclass.
+
+    Attributes:
+        nvr (unicode): A unique Koji identifier for the module build.
+    """
+    __mapper_args__ = {
+        'polymorphic_identity': ContentType.module,
+    }
 
 
 class Update(Base):

--- a/bodhi/tests/server/consumers/test_masher.py
+++ b/bodhi/tests/server/consumers/test_masher.py
@@ -1355,7 +1355,6 @@ References:
         assert os.path.isfile(updateinfo_path)
 
 
-
 class MasherThreadBaseTestCase(base.BaseTestCase):
     """
     This test class has common setUp() and tearDown() methods that are useful for testing the

--- a/bodhi/tests/server/consumers/test_pungi_wrapper.py
+++ b/bodhi/tests/server/consumers/test_pungi_wrapper.py
@@ -299,15 +299,18 @@ class TestPungiWrapper(object):
     @mock.patch("pungi.phases")
     def test_execute_phases_exception(self, pungi_phases, *args):
         init_phase = pungi_phases.InitPhase()
-        init_phase.validate.side_effect = ValueError("Test Error")
+        msg_err = "Test Error"
+        init_phase.validate.side_effect = ValueError(msg_err)
         init_phase.skip.return_value = False
         init_phase.name = "init phase"
         compose = mock.Mock()
         variants_conf = mock.Mock()
         wrapper = PungiWrapper(compose, variants_conf)
 
-        with pytest.raises(Exception):
+        with pytest.raises(Exception) as ex:
             wrapper.execute_phases()
+            assert ex is init_phase.validate.side_effect
+            assert ex.message is msg_err
 
     @mock.patch("pungi.util")
     def test_init_compose_dir(self, util, tmpdir):

--- a/bodhi/tests/server/consumers/test_pungi_wrapper.py
+++ b/bodhi/tests/server/consumers/test_pungi_wrapper.py
@@ -443,6 +443,7 @@ class TestPungiWrapper(object):
         ex.errno = 1
         symlink.side_effect = ex
         compose.log_error = mock.Mock()
-        wrapper.create_latest_repo_links()
-        compose.log_error.assert_called_once_with(
-            "Couldn't create latest symlink: %s" % ex.message)
+        with pytest.raises(Exception) as ex:
+            wrapper.create_latest_repo_links()
+            compose.log_error.assert_called_once_with(
+                "Couldn't create latest symlink: %s" % ex.message)

--- a/bodhi/tests/server/consumers/test_pungi_wrapper.py
+++ b/bodhi/tests/server/consumers/test_pungi_wrapper.py
@@ -1,0 +1,423 @@
+# -*- coding: utf-8 -*-
+# Copyright © 2017 Red Hat, Inc.
+#
+# This file is part of Bodhi.
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+import mock
+import os
+
+from pungi.compose import Compose
+import pytest
+
+from bodhi.server.consumers.pungi_wrapper import (
+    PungiWrapper, PungiConfig, VariantsConfig
+)
+
+
+@pytest.mark.usefixture("get_pungi_conf")
+@pytest.fixture(scope="module")
+def get_compose(pungi_conf, compose_dir):
+
+    logger = mock.Mock()
+
+    compose = Compose(pungi_conf, topdir=compose_dir, debug=True, skip_phases=["productimg"],
+                      just_phases=[], old_composes=None, koji_event=None, supported=False,
+                      logger=logger, notifier=mock.Mock())
+
+    return compose
+
+
+@pytest.fixture(scope="module")
+def get_pungi_conf(tmpdir, config_str=None):
+    conf = tmpdir.mkdir("conf").join("pungi.conf")
+    config_data = """ # RELEASE
+    release_name = "Fedora"
+    release_short = "Fedora"
+    release_version = "23"
+
+    # GENERAL SETTINGS
+    comps_file = "comps-f23.xml"
+    variants_file = "variants-f23.xml"
+
+    # KOJI
+    koji_profile = "koji"
+    runroot = False
+
+    # PKGSET
+    sigkeys = [None]
+    pkgset_source = "koji"
+    pkgset_koji_tag = "f23"
+
+    # CREATEREPO
+    createrepo_checksum = "sha256"
+
+    # GATHER
+    gather_source = "comps"
+    gather_method = "deps"
+    greedy_method = "build"
+    check_deps = False
+
+    # BUILDINSTALL
+    bootable = True
+    buildinstall_method = "lorax"
+    release_is_layered = True
+
+    base_product_name = "Fedora"
+    base_product_short = "Fedora"
+    base_product_version = "23" """
+    if config_str:
+        config_data = config_str
+    conf.write(config_data)
+
+    return conf
+
+
+@pytest.mark.usefixture("get_pungi_conf")
+class TestPungiConfig(object):
+
+    def test_load_config_from_file(self, tmpdir):
+        logger = mock.Mock()
+        pungi_conf = get_pungi_conf(tmpdir)
+
+        conf_xml = PungiConfig(path=str(pungi_conf), logger=logger)
+        assert isinstance(conf_xml, dict)
+        assert isinstance(conf_xml["sigkeys"], list)
+        assert conf_xml["release_name"] == "Fedora"
+        assert conf_xml["release_version"] == "23"
+
+    def test_valid_pungi_config(self, tmpdir):
+        logger = mock.Mock()
+        config_data = """ # RELEASE
+        release_name = "Fedora"
+        release_short = "Fedora"
+        release_version = "23" """
+        pungi_conf = get_pungi_conf(tmpdir, config_data)
+
+        with pytest.raises(Exception):
+            PungiConfig(path=str(pungi_conf), logger=logger)
+
+
+@pytest.fixture(scope="module")
+def get_updates_and_builds():
+    updates = [u'host-master-20170830200108', u'platform-master-20170818100407']
+    builds = [
+        u'platform-master-20160818100407',
+        u'platform-master-20160818100408',
+        u'shim-master-20160502110605',
+        u'shim-master-20160502110601',
+        u'host-master-20170830200108',
+        u'host-master-20170830200109',
+        u'installer-master-20170822180922',
+        u'installer-master-20170822180920'
+    ]
+    mock_updates = []
+    mock_builds = []
+    for update in updates:
+        mock_update = mock.Mock()
+        mock_update.title = update
+        mock_updates.append(mock_update)
+
+    for build in builds:
+        mock_build = mock.Mock()
+        mock_build.nvr = build
+        mock_builds.append(mock_build)
+
+    return mock_updates, mock_builds
+
+
+@pytest.mark.usefixture("get_updates_and_builds")
+class TestVariantsConfig(object):
+
+    def test_generate_module_list(self):
+        updates, builds = get_updates_and_builds()
+        variants_conf = VariantsConfig(updates, builds)
+
+        module_list = variants_conf._generate_module_list()
+        assert isinstance(module_list, list)
+        assert len(module_list) == 4
+
+    def test_create_an_updated_variants_conf(self):
+        updates, builds = get_updates_and_builds()
+        variants_conf = VariantsConfig(updates, builds)
+
+        assert isinstance(variants_conf, VariantsConfig)
+        assert isinstance(variants_conf.xml, str)
+        assert 'id="Server"' in variants_conf.xml
+        assert '<module>host-master-20170830200108</module>' in variants_conf.xml
+        assert '<module>platform-master-20170818100407</module>' in variants_conf.xml
+        assert '<module>shim-master-20160502110605</module>' in variants_conf.xml
+        assert '<module>installer-master-20170822180922</module>' in variants_conf.xml
+
+
+@pytest.mark.usefixture("get_compose")
+@pytest.mark.usefixture("get_updates_and_builds")
+class TestPungiWrapper(object):
+
+    """ This set of tests test the wrapper created around pungi for the masher. """
+
+    @staticmethod
+    def _test_phase_start_stop(phase_instance):
+        return phase_instance.start.assert_called_once() and \
+            phase_instance.stop.assert_called_once()
+
+    @mock.patch("pungi.metadata")
+    @mock.patch("bodhi.server.consumers.pungi_wrapper.PungiWrapper.write_repo_metadata")
+    @mock.patch("bodhi.server.consumers.pungi_wrapper.PungiWrapper.create_latest_repo_links")
+    @mock.patch("pungi.phases")
+    def test_execute_phases(self, pungi_phases, create_latest_repo_links,
+                            write_repo_metadata, pungi_metadata):
+        compose = mock.Mock()
+        variants_conf = mock.Mock()
+
+        wrapper = PungiWrapper(compose, variants_conf)
+
+        wrapper.execute_phases()
+
+        phases = [
+            {"pkgset": False, "class": pungi_phases.InitPhase},
+            {"pkgset": False, "class": pungi_phases.PkgsetPhase},
+            {"pkgset": False, "class": pungi_phases.BuildinstallPhase},
+            {"pkgset": True, "class": pungi_phases.GatherPhase},
+            {"pkgset": True, "class": pungi_phases.ExtraFilesPhase},
+            {"pkgset": False, "class": pungi_phases.CreaterepoPhase},
+            {"pkgset": False, "class": pungi_phases.OstreeInstallerPhase},
+            {"pkgset": False, "class": pungi_phases.OSTreePhase},
+            {"pkgset": True, "class": pungi_phases.ProductimgPhase},
+            {"pkgset": False, "class": pungi_phases.CreateisoPhase},
+            {"pkgset": False, "class": pungi_phases.LiveImagesPhase},
+            {"pkgset": False, "class": pungi_phases.LiveMediaPhase},
+            {"pkgset": False, "class": pungi_phases.ImageBuildPhase},
+            {"pkgset": False, "class": pungi_phases.OSBSPhase},
+            {"pkgset": False, "class": pungi_phases.ImageChecksumPhase},
+            {"pkgset": False, "class": pungi_phases.TestPhase}
+        ]
+        phases_start_stop = [
+            pungi_phases.InitPhase,
+            pungi_phases.PkgsetPhase,
+            pungi_phases.BuildinstallPhase,
+            pungi_phases.GatherPhase,
+            pungi_phases.ExtraFilesPhase,
+            pungi_phases.CreaterepoPhase,
+            pungi_phases.OSTreePhase,
+            pungi_phases.ProductimgPhase,
+            pungi_phases.ImageChecksumPhase,
+            pungi_phases.TestPhase
+        ]
+        for phase in phases:
+            if phase["pkgset"]:
+                phase["class"].assert_called_once_with(compose, pungi_phases.PkgsetPhase())
+            else:
+                phase["class"].assert_called_once_with(compose)
+
+        for phase in phases_start_stop:
+            phase_instance = phase()
+            self._test_phase_start_stop(phase_instance)
+
+        pungi_phases.run_all.assert_called_once()
+        args, kwargs = pungi_phases.run_all.call_args
+        assert len(args[0]) == 6
+        create_latest_repo_links.assert_called_once()
+        write_repo_metadata.assert_called_once()
+
+    @mock.patch("pungi.metadata")
+    @mock.patch("bodhi.server.consumers.pungi_wrapper.PungiWrapper.write_repo_metadata")
+    @mock.patch("bodhi.server.consumers.pungi_wrapper.PungiWrapper.create_latest_repo_links")
+    @mock.patch("pungi.phases")
+    def test_execute_phases_validate(self, pungi_phases, *args):
+        compose = mock.Mock()
+        variants_conf = mock.Mock()
+        phases = [
+            {"pkgset": False, "class": pungi_phases.InitPhase},
+            {"pkgset": False, "class": pungi_phases.PkgsetPhase},
+            {"pkgset": False, "class": pungi_phases.BuildinstallPhase},
+            {"pkgset": True, "class": pungi_phases.GatherPhase},
+            {"pkgset": True, "class": pungi_phases.ExtraFilesPhase},
+            {"pkgset": False, "class": pungi_phases.CreaterepoPhase},
+            {"pkgset": False, "class": pungi_phases.OstreeInstallerPhase},
+            {"pkgset": False, "class": pungi_phases.OSTreePhase},
+            {"pkgset": True, "class": pungi_phases.ProductimgPhase},
+            {"pkgset": False, "class": pungi_phases.CreateisoPhase},
+            {"pkgset": False, "class": pungi_phases.LiveImagesPhase},
+            {"pkgset": False, "class": pungi_phases.LiveMediaPhase},
+            {"pkgset": False, "class": pungi_phases.ImageBuildPhase},
+            {"pkgset": False, "class": pungi_phases.OSBSPhase},
+            {"pkgset": False, "class": pungi_phases.ImageChecksumPhase},
+            {"pkgset": False, "class": pungi_phases.TestPhase}
+        ]
+        for phase in phases:
+            phase_instance = phase["class"]()
+            phase_instance.skip.return_value = False
+
+        wrapper = PungiWrapper(compose, variants_conf)
+
+        wrapper.execute_phases()
+
+        for phase in phases:
+            phase_instance = phase["class"]()
+            phase_instance.validate.assert_called_once()
+
+    @mock.patch("pungi.metadata")
+    @mock.patch("bodhi.server.consumers.pungi_wrapper.PungiWrapper.write_repo_metadata")
+    @mock.patch("bodhi.server.consumers.pungi_wrapper.PungiWrapper.create_latest_repo_links")
+    @mock.patch("pungi.phases")
+    def test_execute_phases_exception(self, pungi_phases, *args):
+        init_phase = pungi_phases.InitPhase()
+        init_phase.validate.side_effect = ValueError("Test Error")
+        init_phase.skip.return_value = False
+        init_phase.name = "init phase"
+        compose = mock.Mock()
+        variants_conf = mock.Mock()
+        wrapper = PungiWrapper(compose, variants_conf)
+
+        with pytest.raises(Exception):
+            wrapper.execute_phases()
+
+    @mock.patch("pungi.util")
+    def test_init_compose_dir(self, util, tmpdir):
+        compose = mock.Mock()
+        variants_conf = mock.Mock()
+        logger = mock.Mock()
+        wrapper = PungiWrapper(compose, variants_conf)
+
+        topdir = str(tmpdir.mkdir("mash-dir"))
+        pungi_conf_path = get_pungi_conf(tmpdir)
+        pungi_conf = PungiConfig(str(pungi_conf_path), logger)
+        compose_id = "f27-modular-updates"
+        compose_dir = wrapper.init_compose_dir(topdir, pungi_conf, compose_id)
+
+        assert compose_dir == os.path.join(topdir, compose_id)
+
+    @mock.patch("bodhi.server.consumers.pungi_wrapper.PungiWrapper.load_variants_config")
+    @mock.patch("bodhi.server.consumers.pungi_wrapper.PungiWrapper.execute_phases")
+    def test_compose_repo(self, load_variants_config, execute_phases):
+        compose = mock.Mock()
+        variants_conf = mock.Mock()
+
+        wrapper = PungiWrapper(compose, variants_conf)
+
+        wrapper.compose_repo()
+
+        load_variants_config.assert_called_once_with()
+        execute_phases.assert_called_once_with()
+
+    @mock.patch("shutil.copyfileobj")
+    def test_load_variants_config(self, copyfileobj, tmpdir):
+        logger = mock.Mock()
+        topdir = str(tmpdir.mkdir("mash_dir"))
+        compose_id = "f27-modular-updates"
+        pungi_conf_path = get_pungi_conf(tmpdir)
+        pungi_conf = PungiConfig(str(pungi_conf_path), logger)
+        compose_dir = PungiWrapper.init_compose_dir(topdir, pungi_conf, compose_id)
+
+        compose = get_compose(pungi_conf, compose_dir)
+        updates, builds = get_updates_and_builds()
+        variants_conf = VariantsConfig(updates, builds)
+        topdir = compose.topdir
+
+        wrapper = PungiWrapper(compose, variants_conf)
+        wrapper.load_variants_config()
+
+        assert len(wrapper.compose.all_variants)
+        copyfileobj.assert_called_once()
+
+    @mock.patch("pungi.metadata")
+    def test_write_repo_metadata(self, pungi_metadata, tmpdir):
+        logger = mock.Mock()
+        topdir = str(tmpdir.mkdir("mash_dir"))
+        compose_id = "f27-modular-updates"
+        pungi_conf_path = get_pungi_conf(tmpdir)
+        pungi_conf = PungiConfig(str(pungi_conf_path), logger)
+        compose_dir = PungiWrapper.init_compose_dir(topdir, pungi_conf, compose_id)
+
+        compose = get_compose(pungi_conf, compose_dir)
+        updates, builds = get_updates_and_builds()
+        variants_conf = VariantsConfig(updates, builds)
+        topdir = compose.topdir
+
+        wrapper = PungiWrapper(compose, variants_conf)
+        wrapper.load_variants_config()
+        wrapper.write_repo_metadata()
+        assert pungi_metadata.write_tree_info.call_count == 8
+        assert pungi_metadata.write_discinfo.call_count == 8
+        assert pungi_metadata.write_media_repo.call_count == 8
+
+    @mock.patch("os.symlink")
+    @mock.patch("os.unlink")
+    def test_create_latest_symlinks(self, unlink, symlink, tmpdir):
+        logger = mock.Mock()
+        topdir = str(tmpdir.mkdir("mash_dir"))
+        compose_id = "f27-modular-updates"
+        pungi_conf_path = get_pungi_conf(tmpdir)
+        pungi_conf = PungiConfig(str(pungi_conf_path), logger)
+        compose_dir = PungiWrapper.init_compose_dir(topdir, pungi_conf, compose_id)
+
+        compose = get_compose(pungi_conf, compose_dir)
+        updates, builds = get_updates_and_builds()
+        variants_conf = VariantsConfig(updates, builds)
+        topdir = compose.topdir
+
+        wrapper = PungiWrapper(compose, variants_conf)
+        wrapper.create_latest_repo_links()
+        unlink.assert_called_once()
+        symlink.assert_called_once()
+
+    @mock.patch("os.symlink")
+    @mock.patch("os.unlink")
+    def test_create_latest_symlinks_unlink_exception(self, unlink, symlink, tmpdir):
+        logger = mock.Mock()
+        topdir = str(tmpdir.mkdir("mash_dir"))
+        compose_id = "f27-modular-updates"
+        pungi_conf_path = get_pungi_conf(tmpdir)
+        pungi_conf = PungiConfig(str(pungi_conf_path), logger)
+        compose_dir = PungiWrapper.init_compose_dir(topdir, pungi_conf, compose_id)
+
+        compose = get_compose(pungi_conf, compose_dir)
+        updates, builds = get_updates_and_builds()
+        variants_conf = VariantsConfig(updates, builds)
+        topdir = compose.topdir
+
+        wrapper = PungiWrapper(compose, variants_conf)
+
+        with pytest.raises(Exception):
+            ex = OSError("Test error")
+            ex.errno = 1
+            unlink.side_effect = ex
+            wrapper.create_latest_repo_links()
+
+    @mock.patch("os.symlink")
+    @mock.patch("os.unlink")
+    def test_create_latest_symlinks_symlink_exception(self, unlink, symlink, tmpdir):
+        logger = mock.Mock()
+        topdir = str(tmpdir.mkdir("mash_dir"))
+        compose_id = "f27-modular-updates"
+        pungi_conf_path = get_pungi_conf(tmpdir)
+        pungi_conf = PungiConfig(str(pungi_conf_path), logger)
+        compose_dir = PungiWrapper.init_compose_dir(topdir, pungi_conf, compose_id)
+
+        compose = get_compose(pungi_conf, compose_dir)
+        updates, builds = get_updates_and_builds()
+        variants_conf = VariantsConfig(updates, builds)
+        topdir = compose.topdir
+
+        wrapper = PungiWrapper(compose, variants_conf)
+
+        ex = Exception("Test error")
+        ex.errno = 1
+        symlink.side_effect = ex
+        compose.log_error = mock.Mock()
+        wrapper.create_latest_repo_links()
+        compose.log_error.assert_called_once()

--- a/bodhi/tests/server/test_metadata.py
+++ b/bodhi/tests/server/test_metadata.py
@@ -589,7 +589,7 @@ class TestPungiMetadata(object):
         rmd.xml_dump.return_value = "test"
 
         uinfo = PungiMetadata(release, request, db, path, compose_dir)
-        uinfo.modifyrepo(tmpfile_path)
+        uinfo.modifyrepo('updateinfo', 'updateinfo.xml', tmpfile_path)
 
         assert uinfo.compose_dir == compose_dir
         fetch_updates.assert_called_once

--- a/devel/ansible/roles/dev/tasks/main.yml
+++ b/devel/ansible/roles/dev/tasks/main.yml
@@ -72,6 +72,7 @@
       - redhat-rpm-config
       - vim-enhanced
       - zlib-devel
+      - pungi
 
 # This isn't packaged in Fedora yet, but it's only a development tool (we should still add it)
 - name: pip install debugtoolbar

--- a/devel/ci/Dockerfile-header
+++ b/devel/ci/Dockerfile-header
@@ -12,3 +12,4 @@ RUN dnf install -y \
     python2-createrepo_c \
     python2-koji \
     python2-librepo \
+    pungi \

--- a/devel/pungi/fedora-modular-example.conf
+++ b/devel/pungi/fedora-modular-example.conf
@@ -1,0 +1,203 @@
+# PRODUCT INFO
+release_name = 'Fedora-Modular'
+release_short = 'Fedora-Modular'
+release_version = 'Rawhide'
+release_is_layered = False
+
+# GENERAL SETTINGS
+bootable = True
+
+variants_file='variants-modular.xml'
+#sigkeys = ['FDB19C98', 'E372E838'] # None = unsigned
+# We are using unsigned here temporarily for rawhide until we setup
+# auto-signing.
+#sigkeys = ['a3cc4e62']
+sigkeys = [None]
+
+hashed_directories = True
+
+# RUNROOT settings
+runroot = True
+runroot_channel = 'compose'
+runroot_tag = 'module-bootstrap-rawhide'
+
+# PDC settings
+pdc_url = 'https://pdc.fedoraproject.org/rest_api/v1'
+pdc_insecure = False
+pdc_develop = True
+
+# PKGSET
+pkgset_source = 'koji' # koji, repos
+
+# PKGSET - KOJI
+# pkgset_koji_tag is not used by the modular compose, but Pungi needs this
+# option to appear in a config, otherwise it fails. Once this is fixed, we can
+# remove this option completely.
+pkgset_koji_tag = 'unknown'
+pkgset_koji_inherit = False
+
+filter_system_release_packages = False
+
+# GATHER
+gather_source = 'module'
+gather_method = 'nodeps'
+check_deps = False
+greedy_method = 'build'
+
+# fomat: [(variant_uid_regex, {arch|*: [repos]})]
+# gather_lookaside_repos = []
+
+# GATHER - JSON
+# format: {variant_uid: {arch: package: [arch1, arch2, None (for any arch)]}}
+#gather_source_mapping = '/path/to/mapping.json'
+
+
+# CREATEREPO
+createrepo_c = True
+createrepo_checksum = 'sha256'
+createrepo_deltas = False #True
+
+# CHECKSUMS
+media_checksums = ['sha256']
+media_checksum_one_file = True
+media_checksum_base_filename = '%(release_short)s-%(variant)s-%(version)s-%(arch)s-%(date)s%(type_suffix)s.%(respin)s'
+#jigdo
+create_jigdo = False
+
+# OK, we have the anaconda module now.  Let's try buildinstall, but still skip
+# the phases which depend on it.
+# NOTE: Added buildinstall and image_build phases
+skip_phases= ["buildinstall", "live_media", "image_build" "live_images", "ostree"]
+
+# BUILDINSTALL
+buildinstall_method = 'lorax'
+
+# Enables macboot on x86_64 for all variants and disables upgrade image building
+# # everywhere.
+lorax_options = [
+  ('^.*$', {
+     'x86_64': {
+         'nomacboot': False
+     },
+     '*': {
+         'noupgrade': True
+     }
+  })
+]
+
+# fomat: [(variant_uid_regex, {arch|*: [packages]})]
+additional_packages = [
+
+]
+
+filter_packages = [
+    # TODO - autogenerate this from the modulemd someday.
+]
+
+createiso_skip = [
+        ('^base-runtime$', {
+            '*': True,
+            'src': True
+        }),
+        ('^Server$', {
+            '*': True,
+            'src': True
+        }),
+    ]
+
+# Image name respecting Fedora's image naming policy
+image_name_format = '%(release_short)s-%(variant)s-%(disc_type)s-%(arch)s-%(version)s-%(date)s%(type_suffix)s.%(respin)s.iso'
+# # Use the same format for volume id
+image_volid_formats = [
+     '%(release_short)s-%(variant)s-%(disc_type)s-%(arch)s-%(version)s'
+     ]
+# No special handling for layered products, use same format as for regular images
+image_volid_layered_product_formats = []
+# Replace 'Cloud' with 'C' in volume id etc.
+volume_id_substitutions = {
+         'Atomic': 'AH',
+        'Rawhide': 'rawh',
+         'Images': 'img',
+    'MATE_Compiz': 'MATE',
+       'Security': 'Sec',
+ 'Electronic_Lab': 'Elec',
+       'Robotics': 'Robo',
+ 'Scientific_KDE': 'SciK',
+  'Astronomy_KDE': 'AstK',
+   'Design_suite': 'Dsgn',
+          'Games': 'Game',
+        'Jam_KDE': 'Jam',
+    'Workstation': 'WS',
+     'Everything': 'E',
+         'Server': 'S',
+          'Cloud': 'C',
+          'Alpha': 'A',
+           'Beta': 'B',
+             'TC': 'T',
+        'Modular': 'M',
+}
+
+disc_types = {
+    'boot': 'netinst',
+    'live': 'Live',
+}
+
+global_ksurl = 'git+https://pagure.io/fedora-kickstarts.git?#HEAD'
+global_release = '!RELEASE_FROM_LABEL_DATE_TYPE_RESPIN'
+global_version = 'Rawhide'
+# live_images ignores this in favor of live_target
+global_target = 'module-bootstrap-rawhide'
+
+image_build = {
+    '^Server$': [
+        {
+            'image-build': {
+                'format': [('docker', 'tar.xz')],
+                'name': 'Fedora-Modular-Docker-Base',
+                # https://pagure.io/fedora-kickstarts/pull-request/257
+                'kickstart': 'fedora-modular-docker-base-minimal.ks',
+                'distro': 'Fedora-27',
+                'disk_size': 4,
+                'arches': ['x86_64'],
+                'install_tree_from': 'Server',
+                'subvariant': 'Docker_Base',
+            },
+            'factory-parameters': {
+                'dockerversion': '1.10.1',
+                'docker_cmd': '[ "/bin/bash" ]',
+                'docker_env': '[ "DISTTAG=f27container_modular", "FGC=f27-modular" ]',
+                'docker_label': '{"name": "fedora", "license": "MIT", "vendor": "Fedora Project", "version": "27-modular"}',
+            },
+        },
+        {
+            'image-build': {
+                'format': [('qcow2','qcow2'), ('raw-xz','raw.xz')],
+                'name': 'Fedora-Modular-Server',
+                'kickstart': 'fedora-modular-disk-minimal.ks',
+                'distro': 'Fedora-27',
+                'disk_size': 8,
+                'arches': ['x86_64'],
+                'repo': 'Server',
+                'install_tree_from': 'Server',
+                'subvariant': 'Server',
+                'failable': ['*'],
+             }
+        },
+    ],
+}
+
+translate_paths = [
+   ('/mnt/koji/compose/', 'http://kojipkgs.fedoraproject.org/compose/'),
+]
+
+failable_deliverables = [
+    ('^.*$', {
+        # Buildinstall can fail on any variant and any arch
+        '*': ['buildinstall', 'iso', 'image-build', 'live-media', 'live', 'ostree', 'ostree-installer'],
+        'src': ['buildinstall'],
+        # Nothing on i386 blocks the compose
+        'i386': ['buildinstall', 'iso', 'live'],
+    })
+]
+
+koji_profile = 'compose_koji'

--- a/devel/pungi/fedora-modular-example.conf
+++ b/devel/pungi/fedora-modular-example.conf
@@ -4,9 +4,6 @@ release_short = 'Fedora-Modular'
 release_version = 'Rawhide'
 release_is_layered = False
 
-# GENERAL SETTINGS
-bootable = True
-
 variants_file='variants-modular.xml'
 #sigkeys = ['FDB19C98', 'E372E838'] # None = unsigned
 # We are using unsigned here temporarily for rawhide until we setup
@@ -69,22 +66,6 @@ create_jigdo = False
 # NOTE: Added buildinstall and image_build phases
 skip_phases= ["buildinstall", "live_media", "image_build" "live_images", "ostree"]
 
-# BUILDINSTALL
-buildinstall_method = 'lorax'
-
-# Enables macboot on x86_64 for all variants and disables upgrade image building
-# # everywhere.
-lorax_options = [
-  ('^.*$', {
-     'x86_64': {
-         'nomacboot': False
-     },
-     '*': {
-         'noupgrade': True
-     }
-  })
-]
-
 # fomat: [(variant_uid_regex, {arch|*: [packages]})]
 additional_packages = [
 
@@ -137,12 +118,6 @@ volume_id_substitutions = {
         'Modular': 'M',
 }
 
-disc_types = {
-    'boot': 'netinst',
-    'live': 'Live',
-}
-
-global_ksurl = 'git+https://pagure.io/fedora-kickstarts.git?#HEAD'
 global_release = '!RELEASE_FROM_LABEL_DATE_TYPE_RESPIN'
 global_version = 'Rawhide'
 # live_images ignores this in favor of live_target

--- a/development.ini.example
+++ b/development.ini.example
@@ -103,7 +103,7 @@ badge_ids = binary-star|both-bull-and-self-transcended-tester-viii|catching-the-
 # comps_url = https://git.fedorahosted.org/comps.git
 
 ## Pungi configuration files
-# pungi_modular_config_path = /etc/bodhi/pungi/fedora-modular.conf
+# pungi_modular_config_path = /etc/bodhi/pungi/{release}-modular.conf
 
 
 ##

--- a/development.ini.example
+++ b/development.ini.example
@@ -102,6 +102,10 @@ badge_ids = binary-star|both-bull-and-self-transcended-tester-viii|catching-the-
 # comps_dir = %(here)s/masher/comps
 # comps_url = https://git.fedorahosted.org/comps.git
 
+## Pungi configuration files
+# pungi_conf_dir = /etc/bodhi/pungi/
+
+
 ##
 ## Mirror settings
 ##

--- a/development.ini.example
+++ b/development.ini.example
@@ -103,7 +103,7 @@ badge_ids = binary-star|both-bull-and-self-transcended-tester-viii|catching-the-
 # comps_url = https://git.fedorahosted.org/comps.git
 
 ## Pungi configuration files
-# pungi_conf_dir = /etc/bodhi/pungi/
+# pungi_modular_config_path = /etc/bodhi/pungi/fedora-modular.conf
 
 
 ##

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -4,10 +4,13 @@ Release notes
 develop
 -------
 
-New dependency
-^^^^^^^^^^^^^^
+New dependencies
+^^^^^^^^^^^^^^^^
 
-This version of Bodhi now requires pungi >= 4.1.18.
+* This version of Bodhi now requires pungi >= 4.1.18.
+* As pungi 4 is not available in EPEL 7, this release of Bodhi formally drops support for EL 7. The
+  supported operating systems only include active Fedora releases now, and are documented on Bodhi's
+  docs' front page.
 
 
 Special instructions

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -4,6 +4,12 @@ Release notes
 develop
 -------
 
+New dependency
+^^^^^^^^^^^^^^
+
+This version of Bodhi now requires pungi >= 4.1.18.
+
+
 Special instructions
 ^^^^^^^^^^^^^^^^^^^^
 

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -8,9 +8,8 @@ New dependencies
 ^^^^^^^^^^^^^^^^
 
 * This version of Bodhi now requires pungi >= 4.1.18.
-* As pungi 4 is not available in EPEL 7, this release of Bodhi formally drops support for EL 7. The
-  supported operating systems only include active Fedora releases now, and are documented on Bodhi's
-  docs' front page.
+* This release of Bodhi formally drops support for EL 7. The supported operating systems only 
+  include active Fedora releases now, and are documented on Bodhi's docs' front page.
 
 
 Special instructions

--- a/production.ini
+++ b/production.ini
@@ -105,7 +105,7 @@ use = egg:bodhi-server
 # comps_url = https://git.fedorahosted.org/comps.git
 
 ## Pungi configuration files
-# pungi_modular_config_path = /etc/bodhi/pungi/fedora-modular.conf
+# pungi_modular_config_path = /etc/bodhi/pungi/{release}-modular.conf
 
 ##
 ## Mirror settings

--- a/production.ini
+++ b/production.ini
@@ -105,7 +105,7 @@ use = egg:bodhi-server
 # comps_url = https://git.fedorahosted.org/comps.git
 
 ## Pungi configuration files
-# pungi_conf_dir = /etc/bodhi/pungi/
+# pungi_modular_config_path = /etc/bodhi/pungi/fedora-modular.conf
 
 ##
 ## Mirror settings

--- a/production.ini
+++ b/production.ini
@@ -104,6 +104,9 @@ use = egg:bodhi-server
 # comps_dir = /usr/share/bodhi/
 # comps_url = https://git.fedorahosted.org/comps.git
 
+## Pungi configuration files
+# pungi_conf_dir = /etc/bodhi/pungi/
+
 ##
 ## Mirror settings
 ##

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,4 +28,4 @@ simplemediawiki
 sqlalchemy
 waitress
 webhelpers
-pungi
+pungi >= 4.1.18

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,3 +28,4 @@ simplemediawiki
 sqlalchemy
 waitress
 webhelpers
+pungi


### PR DESCRIPTION
Hi All,

this PR is highly WIP, so keep in mind that in the code there still a lot of stuff missing (doc strings, remnants from devel etc.). This implementation is mostly here for the demonstration that implementing pungi into bodhi is possible. I will update this as i will add new features. The idea for now is that both the new masher and the old masher would coexist side by side. The new masher would be used only for modules for now. Also i will try to use most of the code from the old masher as much as possible (mostly regarding code which communicates with bodhi.) The code is inspired by/copied from the file pungi-koji. Next iteration would be to get rid of the hardcoded configs, generate variants file from bodhi according to fedmsg msg + tests.

@ralphbean @bowlofeggs Can you please include more people whom may be interested in this?
