### PR TITLE
Add more query parameters to client overrides query

### DIFF
--- a/bodhi/client/__init__.py
+++ b/bodhi/client/__init__.py
@@ -499,13 +499,20 @@ def overrides():
 
 @overrides.command('query')
 @click.option('--user', default=None,
-              help='Updates submitted by a specific user')
+              help='Overrides submitted by a specific user')
 @click.option('--staging', help='Use the staging bodhi instance',
               is_flag=True, default=False)
 @click.option('--mine', is_flag=True,
               help='Show only your overrides.')
+@click.option('--packages', default=None,
+              help='Query by comma-separated package name(s)')
+@click.option('--expired/--active', default=None,
+              help='show only expired or active overrides')
+@click.option('--releases', default=None,
+              help='Query by release shortname(s). e.g. F26')
 @url_option
-def query_buildroot_overrides(url, user=None, mine=False, **kwargs):
+def query_buildroot_overrides(url, user=None, mine=False, packages=None,
+                              expired=None, releases=None, **kwargs):
     # Docs that show in the --help
     """
     Query the buildroot overrides.
@@ -521,6 +528,9 @@ def query_buildroot_overrides(url, user=None, mine=False, **kwargs):
         mine (bool): Whether to use the --mine flag was given.
         url (unicode): The URL of a Bodhi server to create the update on. Ignored if staging is
                        True.
+        packages (unicode): If supplied, the overrides for these package are queried
+        expired (bool): If supplied, True returns only expired overrides, False only active.
+        releases (unicode): If supplied, the overrides for these releases are queried.
         kwargs (dict): Other keyword arguments passed to us by click.
     """
     client = bindings.BodhiClient(base_url=url, staging=kwargs['staging'])
@@ -530,7 +540,7 @@ def query_buildroot_overrides(url, user=None, mine=False, **kwargs):
         else:
             client.init_username()
             user = client.username
-    resp = client.list_overrides(user=user)
+    resp = client.list_overrides(user=user, packages=packages, expired=expired, releases=releases)
     print_resp(resp, client)
 
 

--- a/bodhi/client/bindings.py
+++ b/bodhi/client/bindings.py
@@ -322,15 +322,24 @@ class BodhiClient(OpenIdBaseClient):
             'overrides/', verb='POST', auth=True, data=data)
 
     @errorhandled
-    def list_overrides(self, user=None):
+    def list_overrides(self, user=None, packages=None, expired=None, releases=None):
         """ List buildroot overrides.
 
         :kwarg user: A username whose buildroot overrides you want returned.
+        :kwarg package: package name to filter buildroot overrides by.
+        :kwarg expired: True to return only expired overrides, False for only Active.
+        :kwarg releases: release shortnames to filter buildroot overrides by.
 
         """
         params = {}
         if user:
             params['user'] = user
+        if packages:
+            params['packages'] = packages
+        if expired is not None:
+            params['expired'] = expired
+        if releases:
+            params['releases'] = releases
         return self.send_request('overrides/', verb='GET', params=params)
 
     def init_username(self):

--- a/bodhi/tests/client/test_bindings.py
+++ b/bodhi/tests/client/test_bindings.py
@@ -387,9 +387,9 @@ class TestBodhiClient_list_overrides(unittest.TestCase):
         client.send_request.assert_called_once_with('overrides/', verb='GET',
                                                     params={'user': 'bowlofeggs'})
 
-    def test_without_user(self):
+    def test_without_parameters(self):
         """
-        Test without the user parameter.
+        Test without the parameters.
         """
         client = bindings.BodhiClient()
         client.send_request = mock.MagicMock(return_value='response')
@@ -398,6 +398,58 @@ class TestBodhiClient_list_overrides(unittest.TestCase):
 
         self.assertEqual(response, 'response')
         client.send_request.assert_called_once_with('overrides/', verb='GET', params={})
+
+    def test_with_package(self):
+        """
+        Test with the package parameter.
+        """
+        client = bindings.BodhiClient()
+        client.send_request = mock.MagicMock(return_value='response')
+
+        response = client.list_overrides(packages='bodhi')
+
+        self.assertEqual(response, 'response')
+        client.send_request.assert_called_once_with('overrides/', verb='GET',
+                                                    params={'packages': 'bodhi'})
+
+    def test_with_expired(self):
+        """
+        Test --expired with the expired/active click boolean parameter.
+        """
+        client = bindings.BodhiClient()
+        client.send_request = mock.MagicMock(return_value='response')
+
+        response = client.list_overrides(expired=True)
+
+        self.assertEqual(response, 'response')
+        client.send_request.assert_called_once_with('overrides/', verb='GET',
+                                                    params={'expired': True})
+
+    def test_with_active(self):
+        """
+        Test --active with the expired/active click boolean parameter.
+        """
+        client = bindings.BodhiClient()
+        client.send_request = mock.MagicMock(return_value='response')
+
+        response = client.list_overrides(expired=False)
+
+        self.assertEqual(response, 'response')
+        client.send_request.assert_called_once_with('overrides/', verb='GET',
+                                                    params={'expired': False})
+
+    def test_with_releases(self):
+        """
+        Test with the releases parameter.
+        """
+        client = bindings.BodhiClient()
+        client.send_request = mock.MagicMock(return_value='response')
+
+        response = client.list_overrides(releases='F24')
+
+        self.assertEqual(response, 'response')
+        client.send_request.assert_called_once_with('overrides/', verb='GET',
+                                                    params={'releases': 'F24'})
 
 
 class TestBodhiClient_override_str(unittest.TestCase):

--- a/docs/man_pages/bodhi.rst
+++ b/docs/man_pages/bodhi.rst
@@ -81,6 +81,23 @@ The ``overrides`` command allows users to manage build overrides.
 
         Show only your overrides.
 
+    ``--active``
+
+        Filter for only active overrides
+
+    ``--expired``
+
+        Filter for only expired overrides
+
+    ``--packages <packagename>``
+
+        Query for overrides related to the given packages, given as a comma-separated list.
+
+    ``--releases <releases>``
+
+        Query for overrides related to a list of releases, given as a comma-separated list.
+        <releases> is the release shortname, for example: F26 or F26,F25
+
     ``--user <username>``
 
         Filter for overrides by the given username.


### PR DESCRIPTION
This adds support in the Bodhi CLI for querying buildroot overrides by expired/active status, release, and package name.

Fixes #1679