### PR TITLE
use the ilike search for search on enter in searchbar

### DIFF
--- a/bodhi/server/static/js/search.js
+++ b/bodhi/server/static/js/search.js
@@ -176,7 +176,7 @@ $(document).ready(function() {
         if (e.which == 13) {
             cabbage.spin();
             var value = $("form#search .tt-input").val();
-            window.location.href = '/updates/?packages=' + encodeURIComponent(value);
+            window.location.href = '/updates/?search=' + encodeURIComponent(value);
         }
     });
 });


### PR DESCRIPTION
Previously, if the user skipped the search suggestions
in the searchbar in the webui, and just pressed enter,
we returned results for whole packages only
(i.e. /updates/?packages=).

This commit changes the endpoint we point to when the
user presses enter on the search to be /updates/?search=
and now more obvious results are returned.

Fixes: #870