### PR TITLE
Add builds parameter for overrides list

### DIFF
--- a/bodhi/client/__init__.py
+++ b/bodhi/client/__init__.py
@@ -510,9 +510,11 @@ def overrides():
               help='show only expired or active overrides')
 @click.option('--releases', default=None,
               help='Query by release shortname(s). e.g. F26')
+@click.option('--builds', default=None,
+              help='Query by comma-separated build id(s)')
 @url_option
 def query_buildroot_overrides(url, user=None, mine=False, packages=None,
-                              expired=None, releases=None, **kwargs):
+                              expired=None, releases=None, builds=None, **kwargs):
     # Docs that show in the --help
     """
     Query the buildroot overrides.
@@ -531,6 +533,7 @@ def query_buildroot_overrides(url, user=None, mine=False, packages=None,
         packages (unicode): If supplied, the overrides for these package are queried
         expired (bool): If supplied, True returns only expired overrides, False only active.
         releases (unicode): If supplied, the overrides for these releases are queried.
+        builds (unicode): If supplied, the overrides for these builds are queried.
         kwargs (dict): Other keyword arguments passed to us by click.
     """
     client = bindings.BodhiClient(base_url=url, staging=kwargs['staging'])
@@ -540,7 +543,8 @@ def query_buildroot_overrides(url, user=None, mine=False, packages=None,
         else:
             client.init_username()
             user = client.username
-    resp = client.list_overrides(user=user, packages=packages, expired=expired, releases=releases)
+    resp = client.list_overrides(user=user, packages=packages,
+                                 expired=expired, releases=releases, builds=builds)
     print_resp(resp, client)
 
 

--- a/bodhi/client/bindings.py
+++ b/bodhi/client/bindings.py
@@ -322,7 +322,8 @@ class BodhiClient(OpenIdBaseClient):
             'overrides/', verb='POST', auth=True, data=data)
 
     @errorhandled
-    def list_overrides(self, user=None, packages=None, expired=None, releases=None):
+    def list_overrides(self, user=None, packages=None,
+                       expired=None, releases=None, builds=None):
         """ List buildroot overrides.
 
         :kwarg user: A username whose buildroot overrides you want returned.
@@ -340,6 +341,8 @@ class BodhiClient(OpenIdBaseClient):
             params['expired'] = expired
         if releases:
             params['releases'] = releases
+        if builds:
+            params['builds'] = builds
         return self.send_request('overrides/', verb='GET', params=params)
 
     def init_username(self):

--- a/bodhi/server/schemas.py
+++ b/bodhi/server/schemas.py
@@ -649,6 +649,13 @@ class ListCommentSchema(PaginatedSchema, SearchableSchema):
 
 
 class ListOverrideSchema(PaginatedSchema, SearchableSchema, Cosmetics):
+    builds = Builds(
+        colander.Sequence(accept_scalar=True),
+        location="querystring",
+        missing=None,
+        preparer=[util.splitter],
+    )
+
     expired = colander.SchemaNode(
         colander.Boolean(true_choices=('true', '1')),
         location="querystring",

--- a/bodhi/server/services/overrides.py
+++ b/bodhi/server/services/overrides.py
@@ -109,6 +109,11 @@ def query_overrides(request):
         else:
             query = query.filter(BuildrootOverride.expired_date.is_(None))
 
+    builds = data.get('builds')
+    if builds is not None:
+        query = query.join(BuildrootOverride.build)
+        query = query.filter(or_(*[Build.nvr == bld for bld in builds]))
+
     packages = data.get('packages')
     if packages is not None:
         query = query.join(BuildrootOverride.build).join(Build.package)

--- a/bodhi/tests/client/test_bindings.py
+++ b/bodhi/tests/client/test_bindings.py
@@ -451,6 +451,19 @@ class TestBodhiClient_list_overrides(unittest.TestCase):
         client.send_request.assert_called_once_with('overrides/', verb='GET',
                                                     params={'releases': 'F24'})
 
+    def test_with_builds(self):
+        """
+        Test with the builds parameter.
+        """
+        client = bindings.BodhiClient()
+        client.send_request = mock.MagicMock(return_value='response')
+
+        response = client.list_overrides(builds='python-1.5.6-3.fc26')
+
+        self.assertEqual(response, 'response')
+        client.send_request.assert_called_once_with('overrides/', verb='GET',
+                                                    params={'builds': 'python-1.5.6-3.fc26'})
+
 
 class TestBodhiClient_override_str(unittest.TestCase):
     """

--- a/bodhi/tests/server/functional/test_overrides.py
+++ b/bodhi/tests/server/functional/test_overrides.py
@@ -122,6 +122,17 @@ class TestOverridesService(base.BaseTestCase):
         self.assertEquals(override['submitter']['name'], 'guest')
         self.assertEquals(override['notes'], 'blah blah blah')
 
+    def test_list_overrides_by_builds(self):
+        res = self.app.get('/overrides/', {'builds': 'bodhi-2.0-1.fc17'})
+
+        body = res.json_body
+        self.assertEquals(len(body['overrides']), 1)
+
+        override = body['overrides'][0]
+        self.assertEquals(override['build']['nvr'], "bodhi-2.0-1.fc17")
+        self.assertEquals(override['submitter']['name'], 'guest')
+        self.assertEquals(override['notes'], 'blah blah blah')
+
     def test_list_overrides_by_releases_without_override(self):
         self.db.add(Release(name=u'F42', long_name=u'Fedora 42',
                             id_prefix=u'FEDORA', version=u'42',

--- a/docs/man_pages/bodhi.rst
+++ b/docs/man_pages/bodhi.rst
@@ -98,6 +98,11 @@ The ``overrides`` command allows users to manage build overrides.
         Query for overrides related to a list of releases, given as a comma-separated list.
         <releases> is the release shortname, for example: F26 or F26,F25
 
+    ``--builds <builds>``
+
+        Query for overrides for a list of builds, given as a comma-separated list.
+        <builds> is the build NVR, for example: corebird-1.3-0.fc24
+
     ``--user <username>``
 
         Filter for overrides by the given username.


### PR DESCRIPTION
This commit adds the new `builds` parameter when querying overrides.
This allows the overrides to be queried by a comma-seperated list of
build NVRs. For example:
`/overrides/?builds=embree-2.16.4-1.fc24,embree-2.16.4-1.fc25`

This commit also adds support for using this new parameter in the client
CLI, adding the `--builds` parameter to `bodhi overrides query`