### PR TITLE
Test bodhi.server.metadata

### DIFF
--- a/bodhi/server/config.py
+++ b/bodhi/server/config.py
@@ -482,9 +482,6 @@ class BodhiConfig(dict):
         'pkgdb_url': {
             'value': 'https://admin.fedoraproject.org/pkgdb',
             'validator': unicode},
-        'pkgtags_url': {
-            'value': '',
-            'validator': unicode},
         'query_wiki_test_cases': {
             'value': False,
             'validator': _validate_bool},

--- a/bodhi/server/consumers/masher.py
+++ b/bodhi/server/consumers/masher.py
@@ -330,7 +330,6 @@ class MasherThread(threading.Thread):
                 self.wait_for_mash(mash_thread)
 
                 uinfo.insert_updateinfo()
-                uinfo.insert_pkgtags()
                 uinfo.cache_repodata()
 
             # Compose OSTrees from our freshly mashed repos

--- a/bodhi/server/metadata.py
+++ b/bodhi/server/metadata.py
@@ -60,14 +60,9 @@ class ExtendedMetadata(object):
         self.comp_type = cr.XZ
 
         if release.id_prefix == u'FEDORA-EPEL':
-            # yum on py2.4 doesn't support sha256 (#1080373)
-            if 'el5' in self.repo or '5E' in self.repo:
-                self.hash_type = cr.SHA1
-                self.comp_type = cr.GZ
-            else:
-                # FIXME: I'm not sure which versions of RHEL support xz metadata
-                # compression, so use the lowest common denominator for now.
-                self.comp_type = cr.BZ2
+            # FIXME: I'm not sure which versions of RHEL support xz metadata
+            # compression, so use the lowest common denominator for now.
+            self.comp_type = cr.BZ2
 
         # Load from the cache if it exists
         self.cached_repodata = os.path.join(self.repo, '..', self.tag +

--- a/bodhi/server/metadata.py
+++ b/bodhi/server/metadata.py
@@ -17,7 +17,6 @@ import shutil
 import tempfile
 
 from kitchen.text.converters import to_bytes
-from urlgrabber.grabber import urlgrab
 import createrepo_c as cr
 
 from bodhi.server.buildsys import get_session
@@ -295,21 +294,6 @@ class ExtendedMetadata(object):
             with file(repomd_xml, 'w') as repomd_file:
                 repomd_file.write(repomd.xml_dump())
             os.unlink(uinfo_xml)
-
-    def insert_pkgtags(self):
-        """Download and inject the pkgtags sqlite from fedora-tagger"""
-        if config.get('pkgtags_url'):
-            try:
-                tags_url = config.get('pkgtags_url')
-                tempdir = tempfile.mkdtemp('bodhi')
-                local_tags = os.path.join(tempdir, 'pkgtags.sqlite')
-                log.info('Downloading %s' % tags_url)
-                urlgrab(tags_url, filename=local_tags)
-                self.modifyrepo(local_tags)
-            except:
-                log.exception("There was a problem injecting pkgtags")
-            finally:
-                shutil.rmtree(tempdir)
 
     def cache_repodata(self):
         arch = os.listdir(self.repo_path)[0]  # Take the first arch

--- a/bodhi/tests/server/test_metadata.py
+++ b/bodhi/tests/server/test_metadata.py
@@ -1,3 +1,8 @@
+# -*- coding: utf-8 -*-
+# Copyright 2007-2017 Red Hat, Inc. and others.
+#
+# This file is part of Bodhi.
+#
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation; either version 2 of the License, or
@@ -25,7 +30,7 @@ import createrepo_c
 from bodhi.server.buildsys import (setup_buildsystem, teardown_buildsystem,
                                    DevBuildsys)
 from bodhi.server.config import config
-from bodhi.server.models import (RpmPackage, Update, RpmBuild, UpdateRequest, UpdateStatus,
+from bodhi.server.models import (Release, RpmPackage, Update, RpmBuild, UpdateRequest, UpdateStatus,
                                  UpdateType)
 from bodhi.server.metadata import ExtendedMetadata
 from bodhi.server.util import mkmetadatadir
@@ -210,6 +215,22 @@ class TestExtendedMetadata(base.BaseTestCase):
         notice = self.get_notice(uinfo, update.title)
         # Since 'x' made it into the xml, we know it didn't use the cache.
         self.assertEquals(notice.description, u'x')  # not u'Useful details!'
+
+    def test___init___uses_bz2_for_epel(self):
+        """Assert that the __init__() method sets the comp_type attribute to cr.BZ2 for EPEL."""
+        epel_7 = Release(id_prefix="FEDORA-EPEL", stable_tag='epel7')
+
+        md = ExtendedMetadata(epel_7, UpdateRequest.stable, self.db, '/some/path')
+
+        self.assertEqual(md.comp_type, createrepo_c.BZ2)
+
+    def test___init___uses_xz_for_fedore(self):
+        """Assert that the __init__() method sets the comp_type attribute to cr.XZ for Fedora."""
+        fedora = Release.query.one()
+
+        md = ExtendedMetadata(fedora, UpdateRequest.stable, self.db, '/some/path')
+
+        self.assertEqual(md.comp_type, createrepo_c.XZ)
 
     def test_extended_metadata(self):
         update = self.db.query(Update).one()

--- a/development.ini.example
+++ b/development.ini.example
@@ -250,10 +250,6 @@ dogpile.cache.arguments.filename = %(here)s/dogpile-cache.dbm
 ##
 # pdc_url = https://pdc.fedoraproject.org/
 
-# We used to get our package tags from pkgdb, but they come from tagger now.
-# https://github.com/fedora-infra/fedora-tagger/pull/74
-# Fedora's pkgtags can be found at https://apps.fedoraproject.org/tagger/api/v1/tag/sqlitebuildtags/
-# pkgtags_url =
 
 ##
 ## Bug tracker settings

--- a/production.ini
+++ b/production.ini
@@ -250,10 +250,6 @@ use = egg:bodhi-server
 ##
 # pdc_url = https://pdc.fedoraproject.org/
 
-# We used to get our package tags from pkgdb, but they come from tagger now.
-# https://github.com/fedora-infra/fedora-tagger/pull/74
-# Fedora's pkgtags can be found at https://apps.fedoraproject.org/tagger/api/v1/tag/sqlitebuildtags/
-# pkgtags_url =
 
 ##
 ## Bug tracker settings


### PR DESCRIPTION
This pull request has three commits on ```bodhi.server.metadata```. The first removes some EL 5 specific code that is no longer needed since EPEL 5 is retired. The second adds some test coverage to the module. The third removes a feature that breaks Bodhi's repositories in a devastating way if it is enabled.

Overall, all three of these also increase Bodhi's test coverage (either by adding tests or removing untested code.