### PR TITLE
Test bodhi.client.bindings

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -6,7 +6,7 @@ omit =
 
 [report]
 precision = 2
-fail_under = 88
+fail_under = 89
 exclude_lines =
     pragma: no cover
     def __repr__

--- a/bodhi/client/bindings.py
+++ b/bodhi/client/bindings.py
@@ -600,8 +600,7 @@ class BodhiClient(OpenIdBaseClient):
         This method is a generator that returns a list of koji builds that
         could potentially be pushed as updates.
         """
-        if not self.username:
-            raise BodhiClientException('You must specify a username')
+        self.init_username()
         builds = []
         data = self.get_releases()
         koji = self.get_koji_session()

--- a/bodhi/client/bindings.py
+++ b/bodhi/client/bindings.py
@@ -36,6 +36,7 @@ import re
 import textwrap
 
 from six.moves import configparser
+import dnf
 import six
 
 from fedora.client import AuthError, OpenIdBaseClient, FedoraClientError
@@ -447,7 +448,6 @@ class BodhiClient(OpenIdBaseClient):
 
         Only works on systems with dnf.
         """
-        import dnf
         base = dnf.Base()
         sack = base.fill_sack(load_system_repo=True)
         query = sack.query()

--- a/bodhi/client/bindings.py
+++ b/bodhi/client/bindings.py
@@ -580,7 +580,7 @@ class BodhiClient(OpenIdBaseClient):
                 {"dist_tag": "dist-f12", "id_prefix": "FEDORA",
                  "locked": false, "name": "F12", "long_name": "Fedora 12"}]}
         """
-        return self.send_request('releases/', params=kwargs)
+        return self.send_request('releases/', verb='GET', params=kwargs)
 
     def get_koji_session(self):
         """ Return an authenticated koji session """

--- a/bodhi/client/bindings.py
+++ b/bodhi/client/bindings.py
@@ -35,6 +35,7 @@ import os
 import re
 import textwrap
 
+from six.moves import configparser
 import six
 
 from fedora.client import AuthError, OpenIdBaseClient, FedoraClientError
@@ -402,8 +403,6 @@ class BodhiClient(OpenIdBaseClient):
         can be directly passed to the ``save`` method.
 
         """
-        from six.moves import configparser
-
         if not os.path.exists(input_file):
             raise ValueError("No such file or directory: %s" % input_file)
 

--- a/bodhi/tests/client/test_bindings.py
+++ b/bodhi/tests/client/test_bindings.py
@@ -1057,6 +1057,29 @@ class TestUpdateNotFound(unittest.TestCase):
         self.assertEqual(unicode(exc), 'Update not found: bodhi-2.2.4-1.el7')
 
 
+class TestBodhiClient_get_releases(unittest.TestCase):
+    """
+    Test the BodhiClient.get_releases() method.
+    """
+    @mock.patch('bodhi.client.bindings.BodhiClient._load_cookies', mock.MagicMock())
+    def test_get_releases(self):
+        """Assert correct behavior from the get_releases() method."""
+        client = bindings.BodhiClient()
+        client.send_request = mock.MagicMock(
+            return_value={'releases': [{'candidate_tag': 'f25-updates-testing'},
+                                       {'candidate_tag': 'f26-updates-testing'}]})
+
+        results = client.get_releases(some_param='some_value')
+
+        self.assertEqual(
+            results,
+            {'releases': [
+                {'candidate_tag': 'f25-updates-testing'},
+                {'candidate_tag': 'f26-updates-testing'}]})
+        client.send_request.assert_called_once_with(
+            'releases/', params={'some_param': 'some_value'}, verb='GET')
+
+
 class TestBodhiClient_parse_file(unittest.TestCase):
     """
     Test the BodhiClient.parse_file() method.

--- a/bodhi/tests/client/test_bindings.py
+++ b/bodhi/tests/client/test_bindings.py
@@ -1,5 +1,8 @@
 # -*- coding: utf-8 -*-
-
+# Copyright 2008-2017 Red Hat, Inc. and others.
+#
+# This file is part of Bodhi.
+#
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
 # as published by the Free Software Foundation; either version 2
@@ -1058,6 +1061,23 @@ class TestBodhiClient_parse_file(unittest.TestCase):
     """
     Test the BodhiClient.parse_file() method.
     """
+    @mock.patch('bodhi.client.bindings.BodhiClient._load_cookies')
+    @mock.patch('bodhi.client.bindings.configparser.SafeConfigParser.read')
+    @mock.patch('bodhi.client.bindings.os.path.exists')
+    def test_parsing_invalid_file(self, exists, read, _load_cookies):
+        """
+        Test parsing an invalid update template file.
+        """
+        exists.return_value = True
+        # This happens when we don't have permission to read the file.
+        read.return_value = []
+        client = bindings.BodhiClient()
+
+        with self.assertRaises(ValueError) as exc:
+            client.parse_file("sad")
+
+        self.assertEqual(unicode(exc.exception), 'Invalid input file: sad')
+
     @mock.patch('__builtin__.open', create=True)
     @mock.patch('bodhi.client.bindings.BodhiClient._load_cookies')
     @mock.patch('bodhi.client.bindings.os.path.exists')

--- a/devel/ansible/roles/dev/tasks/main.yml
+++ b/devel/ansible/roles/dev/tasks/main.yml
@@ -58,6 +58,7 @@
       - python2-colander
       - python2-createrepo_c
       - python2-cryptography
+      - python2-dnf
       - python2-fedmsg-atomic-composer
       - python2-fedmsg-commands
       - python2-fedmsg-consumers

--- a/devel/ci/run_tests.sh
+++ b/devel/ci/run_tests.sh
@@ -31,6 +31,7 @@ sudo yum install -y\
     python-cornice\
     python-createrepo_c\
     python-cryptography\
+    python-dnf\
     python-dogpile-cache\
     python-fedora\
     python-kitchen\

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -1,6 +1,18 @@
 Release notes
 =============
 
+develop
+-------
+
+Dependency changes
+------------------
+
+dnf is now a required dependency for the Python bindings. Technically, it was needed before for some
+of the functionality, and it would traceback if that functionality was used without dnf being
+present. With this change, the module will fail to import without dnf, and dnf is a formal
+dependency.
+
+
 2.9.0
 -----
 


### PR DESCRIPTION
This pull request has 5 atomic commits that focus on adding test coverage to ```bodhi.client.bindings```. They also remove some unusable code, and fix two issues. The commit messages give more detail.