### PR TITLE
Tidy up bleach sanitizing & add compatibity code for Bleach2

### DIFF
--- a/bodhi/server/ffmarkdown.py
+++ b/bodhi/server/ffmarkdown.py
@@ -50,15 +50,7 @@ def bug_url(tracker, idx):
 def inject():
     """ Hack out python-markdown to do the autolinking that we want. """
 
-    # First, make it so that bare links get automatically linkified.
-    markdown.inlinepatterns.AUTOLINK_RE = '(%s)' % '|'.join([
-        r'<(?:f|ht)tps?://[^>]*>',
-        r'\b(?:f|ht)tps?://[^)<>\s]+[^.,)<>\s]',
-        r'\bwww\.[^)<>\s]+[^.,)<>\s]',
-        r'[^(<\s]+\.(?:com|net|org)\b',
-    ])
-
-    # Second, build some Pattern objects for @mentions, #bugs, etc...
+    # build some Pattern objects for @mentions, #bugs, etc...
     class MentionPattern(markdown.inlinepatterns.Pattern):
         def handleMatch(self, m):
             el = markdown.util.etree.Element("a")
@@ -81,14 +73,14 @@ def inject():
             el.text = idx
             return el
 
-    MENTION_RE = r'(@\w+)'
+    MENTION_RE = r'(?<!\S)(@\w+)'
     BUGZILLA_RE = r'([\S]+)(#[0-9]{5,})'
 
     class SurroundProcessor(markdown.postprocessors.Postprocessor):
         def run(self, text):
             return "<div class='markdown'>" + text + "</div>"
 
-    # Lastly, monkey-patch the build_inlinepatterns func to insert our patterns
+    # monkey-patch the build_inlinepatterns func to insert our patterns
     original_pattern_builder = markdown.build_inlinepatterns
 
     def extended_pattern_builder(md_instance, **kwargs):

--- a/bodhi/server/util.py
+++ b/bodhi/server/util.py
@@ -295,6 +295,28 @@ def markup(context, text):
     Return:
         basestring: HTML representation of the markdown text
     """
+
+    # determine the major component of the bleach version installed.
+    # this is similar to the approach that Pagure uses to determine the bleach version
+    # https://pagure.io/pagure/pull-request/2269#request_diff
+    bleach_major_v = int(bleach.__version__.split('.')[0])
+
+    # the only difference in the bleach API that we use between v1 and v2 is
+    # the formatting of the attributes parameter. Bleach 1 only allowed you
+    # to specify attributes to be whitelisted for all whitelisted tags.
+    # Bleach 2 requires you to specify the list of attributes whitelisted for
+    # specific tags.
+    if bleach_major_v >= 2:
+        markdown_attrs = {
+            "img": ["src", "alt", "title"],
+            "a": ["href", "alt", "title"],
+            "div": ["class"],
+        }
+    else:
+        markdown_attrs = [
+            "src", "href", "alt", "title", "class"
+        ]
+
     markdown_tags = [
         "h1", "h2", "h3", "h4", "h5", "h6",
         "b", "i", "strong", "em", "tt",
@@ -303,10 +325,6 @@ def markup(context, text):
         "ul", "ol", "li", "dd", "dt",
         "img",
         "a",
-    ]
-
-    markdown_attrs = [
-        "src", "href", "alt", "title", "class"
     ]
 
     markdown_text = markdown.markdown(text, extensions=['markdown.extensions.fenced_code'])

--- a/bodhi/server/util.py
+++ b/bodhi/server/util.py
@@ -295,13 +295,30 @@ def markup(context, text):
     Return:
         basestring: HTML representation of the markdown text
     """
+    markdown_tags = [
+        "h1", "h2", "h3", "h4", "h5", "h6",
+        "b", "i", "strong", "em", "tt",
+        "p", "br",
+        "span", "div", "blockquote", "code", "hr", "pre",
+        "ul", "ol", "li", "dd", "dt",
+        "img",
+        "a",
+    ]
+
+    markdown_attrs = [
+        "src", "href", "alt", "title", "class"
+    ]
+
+    markdown_text = markdown.markdown(text, extensions=['markdown.extensions.fenced_code'])
+
+    # previously, we linkified text in ffmarkdown.py, but this was causing issues like #1721
+    # so now we use the bleach linkifier to do this for us.
+    markdown_text = bleach.linkify(markdown_text, parse_email=True)
 
     # previously, we used the Safe Mode in python-markdown to strip all HTML
     # tags. Safe Mode is deprecated, so we now use Bleach to sanitize all HTML
-    # tags before running it through the markdown parser
-    sanitized_text = bleach.clean(text, tags=[])
-
-    return markdown.markdown(sanitized_text, extensions=['markdown.extensions.fenced_code'])
+    # tags after running it through the markdown parser
+    return bleach.clean(markdown_text, tags=markdown_tags, attributes=markdown_attrs)
 
 
 def status2html(context, status):

--- a/bodhi/tests/server/test_utils.py
+++ b/bodhi/tests/server/test_utils.py
@@ -357,7 +357,7 @@ class TestUtils(unittest.TestCase):
         for element in result:
             assert isinstance(element, unicode)
 
-    def test_markup(self):
+    def test_markup_escapes(self):
         """Ensure we correctly parse markdown & escape HTML"""
         text = (
             '# this is a header\n'
@@ -370,6 +370,46 @@ class TestUtils(unittest.TestCase):
             '<p>this is some <strong>text</strong>\n'
             '&lt;script&gt;alert("pants")&lt;/script&gt;</p></div>'
         ), html
+
+    @mock.patch('bodhi.server.util.bleach.clean', return_value='cleaned text')
+    @mock.patch.object(util.bleach, '__version__', u'1.4.3')
+    def test_markup_with_bleach_1(self, clean):
+        """Use mocking to ensure we correctly use the bleach 1 API."""
+        text = '# this is a header\nthis is some **text**'
+
+        result = util.markup(None, text)
+
+        self.assertEqual(result, 'cleaned text')
+        expected_text = (
+            u'<div class="markdown"><h1>this is a header</h1>\n<p>this is some <strong>text'
+            u'</strong></p></div>')
+        expected_tags = [
+            "h1", "h2", "h3", "h4", "h5", "h6", "b", "i", "strong", "em", "tt", "p", "br", "span",
+            "div", "blockquote", "code", "hr", "pre", "ul", "ol", "li", "dd", "dt", "img", "a"]
+        # The bleach 1 API shoudl get these attrs passed.
+        clean.assert_called_once_with(expected_text, tags=expected_tags,
+                                      attributes=["src", "href", "alt", "title", "class"])
+
+    @mock.patch('bodhi.server.util.bleach.clean', return_value='cleaned text')
+    @mock.patch.object(util.bleach, '__version__', u'2.0')
+    def test_markup_with_bleach_2(self, clean):
+        """Use mocking to ensure we correctly use the bleach 2 API."""
+        text = '# this is a header\nthis is some **text**'
+
+        result = util.markup(None, text)
+
+        self.assertEqual(result, 'cleaned text')
+        expected_text = (
+            u'<div class="markdown"><h1>this is a header</h1>\n<p>this is some <strong>text'
+            u'</strong></p></div>')
+        expected_tags = [
+            "h1", "h2", "h3", "h4", "h5", "h6", "b", "i", "strong", "em", "tt", "p", "br", "span",
+            "div", "blockquote", "code", "hr", "pre", "ul", "ol", "li", "dd", "dt", "img", "a"]
+        expected_attributes = {
+            "img": ["src", "alt", "title"], "a": ["href", "alt", "title"], "div": ["class"]}
+        # The bleach 2 API shoudl get these attrs passed.
+        clean.assert_called_once_with(expected_text, tags=expected_tags,
+                                      attributes=expected_attributes)
 
     def test_rpm_header(self):
         h = util.get_rpm_header('libseccomp')

--- a/bodhi/tests/server/test_utils.py
+++ b/bodhi/tests/server/test_utils.py
@@ -358,13 +358,17 @@ class TestUtils(unittest.TestCase):
             assert isinstance(element, unicode)
 
     def test_markup(self):
-        """Ensure we escape HTML"""
-        text = '<b>bold</b>'
+        """Ensure we correctly parse markdown & escape HTML"""
+        text = (
+            '# this is a header\n'
+            'this is some **text**\n'
+            '<script>alert("pants")</script>'
+        )
         html = util.markup(None, text)
         assert html == (
-            "<div class='markdown'>"
-            '<p>&lt;b&gt;bold&lt;/b&gt;</p>'
-            "</div>"
+            '<div class="markdown"><h1>this is a header</h1>\n'
+            '<p>this is some <strong>text</strong>\n'
+            '&lt;script&gt;alert("pants")&lt;/script&gt;</p></div>'
         ), html
 
     def test_rpm_header(self):

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -21,6 +21,8 @@ Features
   (`#461 <https://github.com/fedora-infra/bodhi/issues/461>`_).
 * Pending releases are now displayed on the home page
   (`#1619 <https://github.com/fedora-infra/bodhi/issues/1619>`_).
+* Links without an explicit scheme can now be detected as links
+  (`#1721 <https://github.com/fedora-infra/bodhi/issues/1721>`_).
 
 
 Bugs
@@ -44,6 +46,8 @@ Bugs
   (`#1659 <https://github.com/fedora-infra/bodhi/issues/1659>`_).
 * The UI now properly urlencodes search URLs to properly escape characters such as "+"
   (`#1015 <https://github.com/fedora-infra/bodhi/issues/1015>`_).
+* e-mail addresses are now properly processed by the markdown system
+  (`#1656 <https://github.com/fedora-infra/bodhi/issues/1656>`_).
 
 
 Development improvements
@@ -67,6 +71,8 @@ Development improvements
   refactor, Bodhi's tests now consume about 450 MB instead of about 4.5 GB. As a result, the example
   Vagrantfile now uses 2 GB of RAM instead of 5 GB. It is likely possible to squeeze it down to 1 GB
   or so, if desired.
+* Bodhi now supports both the bleach 1 and bleach 2 APIs
+  (`#1718 <https://github.com/fedora-infra/bodhi/issues/1718>`_).
 
 
 Release contributors

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 arrow
 bunch
-bleach<2
+bleach
 click
 colander
 cornice<2


### PR DESCRIPTION
This PR has two commits:

# Tidy up bleach sanitizing & markdown parsing

Previously, we sanitized markdown input from the user before we sent it
through the markdown parser, removing all html markup. This commit
changes this so we now santize the html output generated by
python-markdown ( & the extra fedora-flavoured markdown stuff) rather
than before. This sanitization now includes a whitelisted set of tags
and attributes that are allowed, rather than blocking all tags.
Sanitizing before was causing issues like #1656 where things were
escaped weirdly.

This commit also changes the regex in ffmarkdown.py to not match
@usernames with characters directly before them (e.g. ryan@redhat) as it
was matching email addresses.

Finally, this commit makes the markdown support to use bleach's linkify
feature, rather than the link-checking regex that was in ffmarkdown.py.
This fixes issues like #1721

Fixes #1656
Fixes #1721

# Add compatibility code for Bleach2 #
The Bleach API differs slightly from bleach1 to bleach2. This commit handles these differences

Fixes #1718 