### PR TITLE
fix docstring for the email param in bodhi.client.bindings.comment

### DIFF
--- a/bodhi/client/bindings.py
+++ b/bodhi/client/bindings.py
@@ -289,7 +289,8 @@ class BodhiClient(OpenIdBaseClient):
         :arg update: The title of the update comment on.
         :arg comment: The text of the comment.
         :kwarg karma: The karma of this comment (-1, 0, 1)
-        :kwarg email: Whether or not to trigger email notifications
+        :kwarg email: Email address for an anonymous user. if an email address is
+            supplied here, the comment is added as anonymous (i.e. not a logged in user)
 
         """
         return self.send_request(


### PR DESCRIPTION
Previously, the docstring for the email parameter in
bodhi.client.bindings.comment() incorrently stated the param
controlled email notifications. The presence of an email address
in the email= parameter makes bodhi submit the comment anonomously,
rather than by a logged in user.

This commit changes the docstring to fix this.

Fixes #289