### PR TITLE
link directly to libravatar login page rather than send a POST

### DIFF
--- a/bodhi/server/templates/user.html
+++ b/bodhi/server/templates/user.html
@@ -67,10 +67,9 @@
   <div class="col-md-12">
     <div class="pull-left">
       % if request.user and user['name'] == request.user.name:
-        <form method="POST" action="https://www.libravatar.org/openid/login/">
-          <input type="hidden" name="openid_identifier" value="${request.user.openid}"/>
-          <input type="image" class="img-thumbnail" src="${self.util.avatar(user['name'], size=128)}" style="outline: none;"/>
-        </form>
+        <a href="https://www.libravatar.org/openid/login/?openid_identifier=${request.user.openid}">
+          <img class="img-thumbnail" src="${self.util.avatar(user['name'], size=128)}"/>
+        </a>
       % else:
         <img class="img-thumbnail" src="${self.util.avatar(user['name'], size=128)}"/>
       % endif


### PR DESCRIPTION
Previously, bodhi was sending a POST request to the libravatar
openid login page from the user profile page for the logged in
user to change their avatar. However, this was causing issues
with CSRF protection on libravatar. This commit links to the
libravatar login page rather than sending a POST request.

Fixes: #1674