### PR TITLE
fix regex for matching bugtrackers in markdown input

### DIFF
--- a/bodhi/server/ffmarkdown.py
+++ b/bodhi/server/ffmarkdown.py
@@ -74,7 +74,7 @@ def inject():
             return el
 
     MENTION_RE = r'(?<!\S)(@\w+)'
-    BUGZILLA_RE = r'([\S]+)(#[0-9]{5,})'
+    BUGZILLA_RE = r'([a-zA-Z]+)(#[0-9]{5,})'
 
     class SurroundProcessor(markdown.postprocessors.Postprocessor):
         def run(self, text):

--- a/bodhi/tests/server/functional/test_generic.py
+++ b/bodhi/tests/server/functional/test_generic.py
@@ -228,6 +228,23 @@ class TestGenericViews(base.BaseTestCase):
             "</div>"
         )
 
+    def test_markdown_with_prefixed_bugzilla_in_braces(self):
+        """
+        Assert that bug tracker prefixes wrapped in chars other than letters
+        get matched. E.g. (RHBZ#12345)
+        """
+        res = self.app.get('/markdown', {
+            'text': 'Crazy.  (RHBZ#12345) is still busted.',
+        }, status=200)
+        self.assertEquals(
+            res.json_body['html'],
+            '<div class="markdown">'
+            '<p>Crazy.  '
+            '(<a href="https://bugzilla.redhat.com/show_bug.cgi?id=12345">'
+            '#12345</a>) is still busted.</p>'
+            "</div>"
+        )
+
     def test_markdown_with_unknown_prefixed_bugzilla(self):
         res = self.app.get('/markdown', {
             'text': 'Crazy.  upstream#12345 is still busted.',
@@ -236,6 +253,22 @@ class TestGenericViews(base.BaseTestCase):
             res.json_body['html'],
             '<div class="markdown">'
             '<p>Crazy.  upstream#12345 is still busted.</p>'
+            "</div>"
+        )
+
+    def test_markdown_with_unknown_prefix_known_substring(self):
+        """
+        Assert that bugtracker prefixes that contain a valid prefix
+        as a substring but contain other alpha characters are not
+        matched
+        """
+        res = self.app.get('/markdown', {
+            'text': 'Crazy.  aRHBZa#12345 is still busted.',
+        }, status=200)
+        self.assertEquals(
+            res.json_body['html'],
+            '<div class="markdown">'
+            '<p>Crazy.  aRHBZa#12345 is still busted.</p>'
             "</div>"
         )
 


### PR DESCRIPTION
Previously, the regex to match bugtracker keywords (e.g. RHBZ#12345)
was using /S to match the bugtracker keyword. Consequently, if the
keyword was wrapped in braces, it would not match e.g. (RHBZ#12345).
This commit makes the regex use [a-zA-Z] to match the keyword now.

Fixes: #1406