### PR TITLE
Make update form package search use the new typeahead APIs

### DIFF
--- a/bodhi/server/static/js/update_form.js
+++ b/bodhi/server/static/js/update_form.js
@@ -41,8 +41,9 @@ $(document).ready(function() {
         datumTokenizer: Bloodhound.tokenizers.obj.whitespace('value'),
         queryTokenizer: Bloodhound.tokenizers.whitespace,
         remote: {
+            wildcard: '%QUERY',
             url: base + prefix + '%QUERY' + suffix,
-            filter: function (response) {
+            transform: function (response) {
                 return $.map(response.rows, function(row) {
                     return {'name': $('<p>' + row.name + '</p>').text()}
                 });


### PR DESCRIPTION
We recently updated to a newer version of the typeahead JS
library, and the API changed. The package search in the
new / edit update form was still using the old calls, so this
commit updates it to use the new API.

Fixes #1731