### PR TITLE
Remove an unnecessary guard against a call to commit().

### DIFF
--- a/bodhi/server/scripts/check_policies.py
+++ b/bodhi/server/scripts/check_policies.py
@@ -64,8 +64,7 @@ def check():
             else:
                 update.test_gating_status = models.TestGatingStatus.failed
             update.greenwave_summary_string = decision['summary']
-            if session.is_modified(update):
-                session.commit()
+            session.commit()
         except Exception as e:
             # If there is a problem talking to Greenwave server, print the error.
             click.echo(str(e))


### PR DESCRIPTION
Signed-off-by: Randy Barlow <randy@electronsweatshop.com>

This ```if``` statement was unnecessary, as the ```commit()``` will be a no-op if nothing is changed. I am not aware of any testing that would make sense for this change, since the effective behavior of the script is not being changed.