### PR TITLE
Update the Greenwave JavaScript to use the new API.

### DIFF
--- a/bodhi/server/models.py
+++ b/bodhi/server/models.py
@@ -1,5 +1,8 @@
-# encoding: utf-8
-
+# -*- coding: utf-8 -*-
+# Copyright © 2011-2017 Red Hat, Inc. and others.
+#
+# This file is part of Bodhi.
+#
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
 # as published by the Free Software Foundation; either version 2
@@ -1239,6 +1242,31 @@ class Update(Base):
                 return True
 
         return False
+
+    @property
+    def greenwave_subject(self):
+        """
+        Form and return the proper Greenwave API subject field for this Update.
+
+        Returns:
+            list: A list of dictionaries that are appropriate to be passed to the Greenwave API
+                subject field for a decision about this Update.
+        """
+        # See discussion on https://pagure.io/greenwave/issue/34 for why we use these subjects.
+        subject = [{'item': build.nvr, 'type': 'koji_build'} for build in self.builds]
+        subject.append({'item': self.alias, 'type': 'bodhi_update'})
+        return subject
+
+    @property
+    def greenwave_subject_json(self):
+        """
+        Form and return the proper Greenwave API subject field for this Update as JSON.
+
+        Returns:
+            basestring: A JSON list of objects that are appropriate to be passed to the Greenwave
+                API subject field for a decision about this Update.
+        """
+        return json.dumps(self.greenwave_subject)
 
     @classmethod
     def new(cls, request, data):

--- a/bodhi/server/scripts/check_policies.py
+++ b/bodhi/server/scripts/check_policies.py
@@ -41,13 +41,10 @@ def check():
         .filter(models.Update.status.in_(
                 [models.UpdateStatus.pending, models.UpdateStatus.testing]))
     for update in updates:
-        # See discussion on https://pagure.io/greenwave/issue/34 for why we use these subjects.
-        subjects = [{'item': build.nvr, 'type': 'koji_build'} for build in update.builds]
-        subjects.append({'item': update.alias, 'type': 'bodhi_update'})
         data = {
             'product_version': update.product_version,
             'decision_context': u'bodhi_update_push_stable',
-            'subject': subjects
+            'subject': update.greenwave_subject
         }
         api_url = '{}/decision'.format(
             config.config.get('greenwave_api_url').rstrip('/'))

--- a/bodhi/server/templates/update.html
+++ b/bodhi/server/templates/update.html
@@ -90,7 +90,7 @@ ${update.type} update for ${update.beautify_title(amp=True) | n}
         get_unsatisfied_reqs({
             'product_version': '${update.product_version}',
             'decision_context': 'bodhi_update_push_stable',
-            'subject': builds
+            'subject': ${ update.greenwave_subject_json | n }
         });
     }
 

--- a/bodhi/tests/server/test_models.py
+++ b/bodhi/tests/server/test_models.py
@@ -697,6 +697,27 @@ class TestUpdate(ModelTest):
     def test_content_type(self):
         self.assertEqual(self.obj.content_type, model.ContentType.rpm)
 
+    def test_greenwave_subject(self):
+        """Ensure that the greenwave_subject property returns the correct value."""
+        self.obj.assign_alias()
+
+        self.assertEqual(
+            self.obj.greenwave_subject,
+            [{'item': u'TurboGears-1.0.8-3.fc11', 'type': 'koji_build'},
+             {'item': self.obj.alias, 'type': 'bodhi_update'}])
+
+    def test_greenwave_subject_json(self):
+        """Ensure that the greenwave_subject_json property returns the correct value."""
+        self.obj.assign_alias()
+
+        subject = self.obj.greenwave_subject_json
+
+        self.assertTrue(isinstance(subject, basestring))
+        self.assertEqual(
+            json.loads(subject),
+            [{'item': u'TurboGears-1.0.8-3.fc11', 'type': 'koji_build'},
+             {'item': self.obj.alias, 'type': 'bodhi_update'}])
+
     def test_mandatory_days_in_testing_critpath(self):
         """
         The Update.mandatory_days_in_testing method should be the configured value


### PR DESCRIPTION
The Greenwave JavaScript code needed to be updated to use the new
Greenwave API for update decisions. This commit refactors the
existing Python code to move the subject generating code into the
Update model so that it can be shared between the check_policies
script and the JavaScript, and updates the JavaScript to use a
special _json version of it.

fixes #1758

Signed-off-by: Randy Barlow <randy@electronsweatshop.com>