### PR TITLE
Extend greenwave subject to include new atomic ci stuff.

### DIFF
--- a/bodhi/server/models.py
+++ b/bodhi/server/models.py
@@ -1254,6 +1254,9 @@ class Update(Base):
         """
         # See discussion on https://pagure.io/greenwave/issue/34 for why we use these subjects.
         subject = [{'item': build.nvr, 'type': 'koji_build'} for build in self.builds]
+        # Additionally add some subject entries for "CI"
+        # https://pagure.io/greenwave/issue/61
+        subject.extend([{'original_spec_nvr': build.nvr} for build in self.builds])
         subject.append({'item': self.alias, 'type': 'bodhi_update'})
         return subject
 

--- a/bodhi/tests/server/scripts/test_check_policies.py
+++ b/bodhi/tests/server/scripts/test_check_policies.py
@@ -53,6 +53,7 @@ class TestCheckPolicies(BaseTestCase):
         expected_query = {
             'product_version': 'fedora-17', 'decision_context': 'bodhi_update_push_stable',
             'subject': [{'item': u'bodhi-2.0-1.fc17', 'type': 'koji_build'},
+                        {'original_spec_nvr': u'bodhi-2.0-1.fc17'},
                         {'item': u'FEDORA-2017-a3bbe1a8f2', 'type': 'bodhi_update'}]}
         mock_greenwave.assert_called_once_with(config['greenwave_api_url'] + '/decision',
                                                expected_query)
@@ -86,6 +87,7 @@ class TestCheckPolicies(BaseTestCase):
         expected_query = {
             'product_version': 'fedora-17', 'decision_context': 'bodhi_update_push_stable',
             'subject': [{'item': u'bodhi-2.0-1.fc17', 'type': 'koji_build'},
+                        {'original_spec_nvr': u'bodhi-2.0-1.fc17'},
                         {'item': u'FEDORA-2017-a3bbe1a8f2', 'type': 'bodhi_update'}]}
         mock_greenwave.assert_called_once_with(config['greenwave_api_url'] + '/decision',
                                                expected_query)
@@ -114,6 +116,7 @@ class TestCheckPolicies(BaseTestCase):
         expected_query = {
             'product_version': 'fedora-17', 'decision_context': 'bodhi_update_push_stable',
             'subject': [{'item': u'bodhi-2.0-1.fc17', 'type': 'koji_build'},
+                        {'original_spec_nvr': u'bodhi-2.0-1.fc17'},
                         {'item': u'FEDORA-2017-a3bbe1a8f2', 'type': 'bodhi_update'}]}
         mock_greenwave.assert_called_once_with(config['greenwave_api_url'] + '/decision',
                                                expected_query)
@@ -141,6 +144,7 @@ class TestCheckPolicies(BaseTestCase):
         expected_query = {
             'product_version': 'fedora-17', 'decision_context': 'bodhi_update_push_stable',
             'subject': [{'item': u'bodhi-2.0-1.fc17', 'type': 'koji_build'},
+                        {'original_spec_nvr': u'bodhi-2.0-1.fc17'},
                         {'item': u'FEDORA-2017-a3bbe1a8f2', 'type': 'bodhi_update'}]}
         mock_greenwave.assert_called_once_with(config['greenwave_api_url'] + '/decision',
                                                expected_query)

--- a/bodhi/tests/server/test_models.py
+++ b/bodhi/tests/server/test_models.py
@@ -704,6 +704,7 @@ class TestUpdate(ModelTest):
         self.assertEqual(
             self.obj.greenwave_subject,
             [{'item': u'TurboGears-1.0.8-3.fc11', 'type': 'koji_build'},
+             {'original_spec_nvr': u'TurboGears-1.0.8-3.fc11'},
              {'item': self.obj.alias, 'type': 'bodhi_update'}])
 
     def test_greenwave_subject_json(self):
@@ -716,6 +717,7 @@ class TestUpdate(ModelTest):
         self.assertEqual(
             json.loads(subject),
             [{'item': u'TurboGears-1.0.8-3.fc11', 'type': 'koji_build'},
+             {'original_spec_nvr': u'TurboGears-1.0.8-3.fc11'},
              {'item': self.obj.alias, 'type': 'bodhi_update'}])
 
     def test_mandatory_days_in_testing_critpath(self):


### PR DESCRIPTION
See https://pagure.io/greenwave/issue/61

The Atomic CI pipeline folks landed on an identifier.