### PR TITLE
Make bodhi distinguish about updates going to testing vs stable when asking greenwave

### DIFF
--- a/bodhi/server/scripts/check_policies.py
+++ b/bodhi/server/scripts/check_policies.py
@@ -41,9 +41,17 @@ def check():
         .filter(models.Update.status.in_(
                 [models.UpdateStatus.pending, models.UpdateStatus.testing]))
     for update in updates:
+        # We retrieve updates going to testing (status=pending) and updates
+        # (status=testing) going to stable.
+        # If the update is pending, we want to know if it can go to testing
+        decision_context = u'bodhi_update_push_testing'
+        if update.status == models.UpdateStatus.testing:
+            # Update is already in testing, let's ask if it can go to stable
+            decision_context = u'bodhi_update_push_stable'
+
         data = {
             'product_version': update.product_version,
-            'decision_context': u'bodhi_update_push_stable',
+            'decision_context': decision_context,
             'subject': update.greenwave_subject
         }
         api_url = '{}/decision'.format(


### PR DESCRIPTION
This will allow us and greenwave to apply different policies for
depending on which repo is update is going (updates-testing vs updates)
which is required to integrate some of the more useful taskotron tests.

Signed-off-by: Pierre-Yves Chibon <pingou@pingoured.fr>