### PR TITLE
WIP: Add 'rerun test' button

### DIFF
--- a/bodhi/server/schemas.py
+++ b/bodhi/server/schemas.py
@@ -602,6 +602,14 @@ class UpdateRequestSchema(CSRFProtectedSchema, colander.MappingSchema):
     )
 
 
+class RerunTestSchema(CSRFProtectedSchema, colander.MappingSchema):
+    test = colander.SchemaNode(
+        colander.String(),
+    )
+    scenario = colander.SchemaNode(
+        colander.String(),
+    )
+
 class ListCommentSchema(PaginatedSchema, SearchableSchema):
     updates = Updates(
         colander.Sequence(accept_scalar=True),

--- a/bodhi/server/services/updates.py
+++ b/bodhi/server/services/updates.py
@@ -25,7 +25,7 @@ from cornice import Service
 from sqlalchemy import func, distinct
 from sqlalchemy.sql import or_
 
-from bodhi.server import log
+from bodhi.server import log, notifications
 from bodhi.server.exceptions import BodhiException, LockedUpdateException
 from bodhi.server.models import (
     Update,
@@ -83,6 +83,11 @@ update_request = Service(name='update_request', path='/updates/{id}/request',
                          description='Update request service',
                          acl=bodhi.server.security.packagers_allowed_acl,
                          cors_origins=bodhi.server.security.cors_origins_rw)
+
+update_rerun_test = Service(
+    name='update_rerun_test', path='/updates/{id}/rerun_test', validators=(validate_update_id,),
+    description='Update test rerun service', acl=bodhi.server.security.packagers_allowed_acl,
+    cors_origins=bodhi.server.security.cors_origins_rw)
 
 
 @update.get(accept=('application/json', 'text/json'), renderer='json',
@@ -187,6 +192,36 @@ def set_request(request):
         request.errors.add('body', 'request', str(e))
 
     return dict(update=update)
+
+
+@update_rerun_test.post(schema=bodhi.server.schemas.RerunTestSchema,
+                     validators=(
+                         validate_update_id,
+                         validate_acls,
+                     ),
+                     permission='edit', renderer='json',
+                     error_handler=bodhi.server.services.errors.json_handler)
+def rerun_test(request):
+    """
+    Send fedmsg request that a specific test for a specific update be re-run.
+
+    Args:
+        request (pyramid.request): The current request.
+    Returns:
+        dict: A dictionary with at least the following key mappings:
+            update: The update for which the rerun was requested.
+            test: The test for which the rerun was requested.
+            scenario: The scenario for which the rerun was requested.
+    """
+    data = request.validated
+    update = data['update']
+    test = data['test']
+    scenario = data['scenario']
+    log.info("Requesting rerun of test %s, scenario %s for update %s",
+             test, scenario, update)
+    msgdict = {'update': update, 'test': test, 'scenario': scenario}
+    notifications.publish(topic="test.rerun", msg=msgdict, force=True)
+    return msgdict
 
 
 validators = (

--- a/bodhi/server/templates/update.html
+++ b/bodhi/server/templates/update.html
@@ -127,6 +127,10 @@ ${update.type} update for ${update.beautify_title(amp=True) | n}
       if (note == null){
         note = '';
       }
+
+      var rerun = '<span data-toggle="tooltip" data-placement="top" ' +
+        'title="Rerun test"' + 'class="fa fa-refresh">' + '</span>';
+
       html = '<tr class="row-automatedtests table-' + classes[outcome];
       if (outcome == 'ABSENT') {
           html += ' absent-automatedtest"';
@@ -138,7 +142,7 @@ ${update.type} update for ${update.beautify_title(amp=True) | n}
         '<td>' + icon + '</td>' +
         '<td class="nowrap">' + testcase + '</td>' +
         '<td class="stretch-table-column text-xs-right">' + note + '</td>' +
-        '<td class="nowrap">' + age + '</td>' +
+        '<td class="nowrap">' + age + '</td>' + '<td>' + rerun + '<td/>' +
         '</tr>';
       return html;
     };


### PR DESCRIPTION
This adds a 'rerun test' button to the 'Automated Tests' tab,
which causes Bodhi to send out a fedmsg requesting that the
test system re-run the test.

Well.

That's what I WANT it to do. What it actually does is add an
API endpoint for doing that, and add an icon that does nothing
at all to the 'Automated Tests' tab. Cleanly having that icon
act as a button that sends the post request is apparently beyond
my (more or less non-existent) Javascript skills right now, so
if someone wants to show me how to do that, I'd be grateful...

Also, no tests yet, will do that soon.