### PR TITLE
CLI prints a hint about how to use koji wait-repo on overrides.

### DIFF
--- a/bodhi/server/models.py
+++ b/bodhi/server/models.py
@@ -791,7 +791,7 @@ class Build(Base):
     """
     __tablename__ = 'builds'
     __exclude_columns__ = ('id', 'package', 'package_id', 'release',
-                           'release_id', 'update_id', 'update', 'override')
+                           'update_id', 'update', 'override')
     __get_by__ = ('nvr',)
 
     nvr = Column(Unicode(100), unique=True, nullable=False)

--- a/bodhi/server/schemas.py
+++ b/bodhi/server/schemas.py
@@ -90,6 +90,12 @@ class Releases(colander.SequenceSchema):
     release = colander.SchemaNode(colander.String())
 
 
+class ReleaseIds(colander.SequenceSchema):
+    """A SequenceSchema to validate a list of Release ID objects."""
+
+    release_id = colander.SchemaNode(colander.Integer())
+
+
 class Groups(colander.SequenceSchema):
     """A SequenceSchema to validate a list of Group objects."""
 
@@ -291,6 +297,13 @@ class ListReleaseSchema(PaginatedSchema):
     This schema is used by bodhi.server.services.releases.query_releases_html() and
     bodhi.server.services.releases.query_releases_json().
     """
+
+    ids = ReleaseIds(
+        colander.Sequence(accept_scalar=True),
+        location="querystring",
+        missing=None,
+        preparer=[util.splitter],
+    )
 
     name = colander.SchemaNode(
         colander.String(),

--- a/bodhi/server/services/releases.py
+++ b/bodhi/server/services/releases.py
@@ -236,6 +236,10 @@ def query_releases_json(request):
     data = request.validated
     query = db.query(Release)
 
+    ids = data.get('ids')
+    if ids is not None:
+        query = query.filter(or_(*[Release.id == _id for _id in ids]))
+
     name = data.get('name')
     if name is not None:
         query = query.filter(Release.name.like(name))

--- a/bodhi/tests/client/__init__.py
+++ b/bodhi/tests/client/__init__.py
@@ -73,7 +73,8 @@ EXAMPLE_OVERRIDE_MUNCH = Munch({
     u'build_id': 108570, u'submission_date': u'2017-02-28 23:05:32', u'caveats': [],
     u'nvr': u'js-tag-it-2.0-1.fc25', u'expiration_date': u'2017-03-07 23:05:31',
     u'notes': u'No explanation given...', u'submitter_id': 2897,
-    u'build': Munch({u'epoch': 0, u'nvr': u'js-tag-it-2.0-1.fc25', u'signed': True}),
+    u'build': Munch(
+        {u'epoch': 0, u'nvr': u'js-tag-it-2.0-1.fc25', u'signed': True, 'release_id': 15}),
     u'expired_date': None, u'submitter': Munch({
         u'openid': None, u'name': u'bowlofeggs', u'show_popups': True, u'id': 2897, u'avatar': None,
         u'groups': [Munch({u'name': u'packager'})], u'email': u'email@example.com'})})
@@ -413,6 +414,36 @@ EXAMPLE_QUERY_OVERRIDES_MUNCH = Munch({
     u'rows_per_page': 20,
     u'total': 11})
 
+
+EXAMPLE_QUERY_SINGLE_OVERRIDE_MUNCH = Munch({
+    u'chrome': True,
+    u'display_user': True,
+    u'overrides': [Munch(
+        {u'build': Munch({
+            u'epoch': 0,
+            u'nvr': u'js-tag-it-2.0-1.fc25',
+            u'release_id': 15,
+            u'signed': True}),
+         u'build_id': 108565,
+         u'expiration_date': u'2017-03-07 23:05:31',
+         u'expired_date': None,
+         u'notes': u'No explanation given...',
+         u'nvr': u'nodejs-grunt-wrap-0.3.0-2.fc25',
+         u'submission_date': u'2017-02-28 14:30:37',
+         u'submitter': {u'avatar': u'AVATAR_URL',
+                        u'email': u'email@example.com',
+                        u'groups': [{u'name': u'packager'}],
+                        u'id': 2897,
+                        u'name': u'bowlofeggs',
+                        u'openid': u'bowlofeggs.id.fedoraproject.org',
+                        u'show_popups': True},
+         u'submitter_id': 2897})],
+    u'page': 1,
+    u'pages': 1,
+    u'rows_per_page': 20,
+    u'total': 1})
+
+
 # Expected output when print_resp renders EXAMPLE_QUERY_OVERRIDES_MUNCH
 EXPECTED_QUERY_OVERRIDES_OUTPUT = """bowlofeggs's nodejs-grunt-wrap-0.3.0-2.fc25 override (expires 2017-03-07 14:30:36)
 bowlofeggs's python-pyramid-1.5.6-3.el7 override (expires 2017-02-17 00:00:00)
@@ -484,6 +515,19 @@ EXAMPLE_UPDATE_MUNCH = Munch({
     u'content_type': u'rpm'})
 
 
+EXAMPLE_GET_RELEASE_15 = Munch(
+    {u'rows_per_page': 20, u'total': 1, u'pages': 1,
+     u'releases': [
+         Munch({u'dist_tag': u'f25', u'name': u'F25', u'testing_tag': u'f25-updates-testing',
+                u'pending_stable_tag': u'f25-updates-pending',
+                u'pending_signing_tag': u'f25-signing-pending', u'long_name': u'Fedora 25',
+                u'state': u'current', u'version': u'25', u'override_tag': u'f25-override',
+                u'branch': u'f25', u'id_prefix': u'FEDORA',
+                u'pending_testing_tag': u'f25-updates-testing-pending',
+                u'stable_tag': u'f25-updates', u'candidate_tag': u'f25-updates-candidate'})],
+     u'page': 1})
+
+
 # EXAMPLE_UPDATE_MUNCH is expected to generate this output in update_str
 EXPECTED_UPDATE_OUTPUT = u"""================================================================================
      bodhi-2.2.4-1.el7
@@ -511,13 +555,22 @@ Content Type: rpm
   http://example.com/tests/updates/FEDORA-EPEL-2016-3081a94111
 """
 
-EXPECTED_OVERRIDES_OUTPUT = u"""============================================================
+EXPECTED_OVERRIDE_STR_OUTPUT = u"""============================================================
      js-tag-it-2.0-1.fc25
 ============================================================
   Submitter: bowlofeggs
   Expiration Date: 2017-03-07 23:05:31
   Notes: No explanation given...
   Expired: False
+"""
+
+
+EXPECTED_OVERRIDES_OUTPUT = EXPECTED_OVERRIDE_STR_OUTPUT + """
+
+Use the following to ensure the override is active:
+
+\t$ koji wait-repo f25-build --build=js-tag-it-2.0-1.fc25
+
 """
 
 EXPECTED_EXPIRED_OVERRIDES_OUTPUT = u"""============================================================

--- a/bodhi/tests/client/test_bindings.py
+++ b/bodhi/tests/client/test_bindings.py
@@ -496,7 +496,7 @@ class TestBodhiClient_override_str(unittest.TestCase):
 
         override = bindings.BodhiClient.override_str(override, minimal=False)
 
-        self.assertEqual(override, client_test_data.EXPECTED_OVERRIDES_OUTPUT.rstrip())
+        self.assertEqual(override, client_test_data.EXPECTED_OVERRIDE_STR_OUTPUT.rstrip())
 
     def test_with_str(self):
         """

--- a/bodhi/tests/server/services/test_releases.py
+++ b/bodhi/tests/server/services/test_releases.py
@@ -93,6 +93,28 @@ class TestReleasesService(base.BaseTestCase):
         self.assertEquals(len(body['releases']), 1)
         self.assertEquals(body['releases'][0]['name'], 'F22')
 
+    def test_list_releases_by_ids_unknown(self):
+        res = self.app.get('/releases/', {"ids": [9234872348923467]})
+
+        self.assertEquals(len(res.json_body['releases']), 0)
+
+    def test_list_releases_by_ids_plural(self):
+        releases = Release.query.all()
+
+        res = self.app.get('/releases/', {"ids": [release.id for release in releases]})
+
+        self.assertEquals(len(res.json_body['releases']), len(releases))
+        self.assertEquals(set([r['name'] for r in res.json_body['releases']]),
+                          set([release.name for release in releases]))
+
+    def test_list_releases_by_ids_singular(self):
+        release = Release.query.all()[0]
+
+        res = self.app.get('/releases/', {"ids": release.id})
+
+        self.assertEquals(len(res.json_body['releases']), 1)
+        self.assertEquals(res.json_body['releases'][0]['name'], release.name)
+
     def test_list_releases_by_name(self):
         res = self.app.get('/releases/', {"name": 'F22'})
         body = res.json_body

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -11,6 +11,18 @@ Special instructions
   In order to run the new migrations, you should ensure your alembic.ini has
   ``script_location = bodhi:server/migrations``.
 
+
+Features
+^^^^^^^^
+
+* It is now possible to query for Releases by a list of primary keys, by using the querystring
+  ``ids`` with the ``releases/`` API.
+* Builds now serialize their ``release_id`` field.
+* The CLI now prints a helpful hint about how to use ``koji wait-repo`` when creating or editing a
+  buildroot override, or when a query for overrides returns exactly one result
+  (`#1376 <https://github.com/fedora-infra/bodhi/pull/1376>`_).
+
+
 Development improvements
 ^^^^^^^^^^^^^^^^^^^^^^^^
 


### PR DESCRIPTION
The web interface has long printed a message to users about how to
use ``koji wait-repo`` to monitor the progress of created buildroot
overrides, which was a feature gap in the CLI. This commit gives
the CLI the same ability when users create or edit an override, or
when they query for overrides and a single result is matched.

In order to accomplish this, it was necessary to be able to match
the override Build object with a release so the CLI could print the
correct tag to wait for. To accomplish this, Builds now serialize
their release_id field, and releases can now be queried with a new
ids parameter.

fixes #1376

Signed-off-by: Randy Barlow <randy@electronsweatshop.com>