### PR TITLE
Don't install python-dnf in the CI tester.

### DIFF
--- a/devel/ci/run_tests.sh
+++ b/devel/ci/run_tests.sh
@@ -31,7 +31,6 @@ sudo yum install -y\
     python-cornice\
     python-createrepo_c\
     python-cryptography\
-    python-dnf\
     python-dogpile-cache\
     python-fedora\
     python-kitchen\


### PR DESCRIPTION
Signed-off-by: Randy Barlow <randy@electronsweatshop.com>