### PR TITLE
bodhi.server.util.call_api now uses connection pooling

### DIFF
--- a/bodhi/server/util.py
+++ b/bodhi/server/util.py
@@ -48,6 +48,8 @@ from bodhi.server.exceptions import RepodataException
 
 _ = TranslationStringFactory('bodhi')
 
+http_session = requests.Session()
+
 
 def header(x):
     """Display a given message as a heading."""
@@ -1162,15 +1164,15 @@ def call_api(api_url, service_name, error_key=None, method='GET', data=None):
         base_error_msg = (
             'Bodhi failed to send POST request to {0} at the following URL '
             '"{1}". The status code was "{2}".')
-        rv = requests.post(api_url,
-                           headers={'Content-Type': 'application/json'},
-                           data=json.dumps(data),
-                           timeout=60)
+        rv = http_session.post(api_url,
+                               headers={'Content-Type': 'application/json'},
+                               data=json.dumps(data),
+                               timeout=60)
     else:
         base_error_msg = (
             'Bodhi failed to get a resource from {0} at the following URL '
             '"{1}". The status code was "{2}".')
-        rv = requests.get(api_url, timeout=60)
+        rv = http_session.get(api_url, timeout=60)
     if rv.status_code == 200:
         return rv.json()
     elif rv.status_code == 500:

--- a/bodhi/tests/server/test_models.py
+++ b/bodhi/tests/server/test_models.py
@@ -409,8 +409,9 @@ class TestRpmPackage(ModelTest, unittest.TestCase):
         # This should not raise any Exception.
         self.db.flush()
 
+    @mock.patch('bodhi.server.util.http_session')
     @mock.patch('bodhi.server.util.requests.get')
-    def test_get_pkg_committers_from_pagure(self, mock_get):
+    def test_get_pkg_committers_from_pagure(self, mock_get, session):
         """ Ensure that the package committers can be found using the Pagure
         API.
         """
@@ -445,13 +446,14 @@ class TestRpmPackage(ModelTest, unittest.TestCase):
                 "name": "mprahl"
             }
         }
-        mock_get.return_value.json.return_value = json_output
-        mock_get.return_value.status_code = 200
+        session.get.return_value.json.return_value = json_output
+        session.get.return_value.status_code = 200
         rv = self.package.get_pkg_committers_from_pagure()
         assert rv == (['mprahl'], ['factory2']), rv
 
+    @mock.patch('bodhi.server.util.http_session')
     @mock.patch('bodhi.server.util.requests.get')
-    def test_get_pkg_committers_container_from_pagure(self, mock_get):
+    def test_get_pkg_committers_container_from_pagure(self, mock_get, session):
         """ Ensure that the container committers can be found using the Pagure
         API.
         """
@@ -484,8 +486,8 @@ class TestRpmPackage(ModelTest, unittest.TestCase):
                 "name": "mprahl"
             }
         }
-        mock_get.return_value.json.return_value = json_output
-        mock_get.return_value.status_code = 200
+        session.get.return_value.json.return_value = json_output
+        session.get.return_value.status_code = 200
         # Even though Bodhi doesn't support containers yet, let's mock this
         # package to have the type set to `container` to make sure the code in
         # get_pkg_committers_from_pagure works with containers in the future.
@@ -983,17 +985,18 @@ class TestUpdate(ModelTest):
         # No bugs should have been closed
         self.assertEqual(close.call_count, 0)
 
+    @mock.patch('bodhi.server.util.http_session')
     @mock.patch('bodhi.server.util.requests.get')
     @mock.patch.dict(util.config, {
         'critpath.type': 'pdc',
         'pdc_url': 'http://domain.local'
     })
-    def test_contains_critpath_component(self, mock_get):
+    def test_contains_critpath_component(self, mock_get, session):
         """ Verifies that the static function of contains_critpath_component
         determines that one of the builds has a critpath component.
         """
-        mock_get.return_value.status_code = 200
-        mock_get.return_value.json.return_value = {
+        session.get.return_value.status_code = 200
+        session.get.return_value.json.return_value = {
             'count': 2,
             'next': None,
             'previous': None,
@@ -1022,17 +1025,18 @@ class TestUpdate(ModelTest):
         self.assertTrue(update.contains_critpath_component(
             update.builds, update.release.name))
 
+    @mock.patch('bodhi.server.util.http_session')
     @mock.patch('bodhi.server.util.requests.get')
     @mock.patch.dict(util.config, {
         'critpath.type': 'pdc',
         'pdc_url': 'http://domain.local'
     })
-    def test_contains_critpath_component_not_critpath(self, mock_get):
+    def test_contains_critpath_component_not_critpath(self, mock_get, session):
         """ Verifies that the static function of contains_critpath_component
         determines that none of the builds are critpath components.
         """
-        mock_get.return_value.status_code = 200
-        mock_get.return_value.json.return_value = {
+        session.get.return_value.status_code = 200
+        session.get.return_value.json.return_value = {
             'count': 2,
             'next': None,
             'previous': None,

--- a/bodhi/tests/server/test_models.py
+++ b/bodhi/tests/server/test_models.py
@@ -410,8 +410,7 @@ class TestRpmPackage(ModelTest, unittest.TestCase):
         self.db.flush()
 
     @mock.patch('bodhi.server.util.http_session')
-    @mock.patch('bodhi.server.util.requests.get')
-    def test_get_pkg_committers_from_pagure(self, mock_get, session):
+    def test_get_pkg_committers_from_pagure(self, session):
         """ Ensure that the package committers can be found using the Pagure
         API.
         """
@@ -452,8 +451,7 @@ class TestRpmPackage(ModelTest, unittest.TestCase):
         assert rv == (['mprahl'], ['factory2']), rv
 
     @mock.patch('bodhi.server.util.http_session')
-    @mock.patch('bodhi.server.util.requests.get')
-    def test_get_pkg_committers_container_from_pagure(self, mock_get, session):
+    def test_get_pkg_committers_container_from_pagure(self, session):
         """ Ensure that the container committers can be found using the Pagure
         API.
         """
@@ -986,12 +984,11 @@ class TestUpdate(ModelTest):
         self.assertEqual(close.call_count, 0)
 
     @mock.patch('bodhi.server.util.http_session')
-    @mock.patch('bodhi.server.util.requests.get')
     @mock.patch.dict(util.config, {
         'critpath.type': 'pdc',
         'pdc_url': 'http://domain.local'
     })
-    def test_contains_critpath_component(self, mock_get, session):
+    def test_contains_critpath_component(self, session):
         """ Verifies that the static function of contains_critpath_component
         determines that one of the builds has a critpath component.
         """
@@ -1026,12 +1023,11 @@ class TestUpdate(ModelTest):
             update.builds, update.release.name))
 
     @mock.patch('bodhi.server.util.http_session')
-    @mock.patch('bodhi.server.util.requests.get')
     @mock.patch.dict(util.config, {
         'critpath.type': 'pdc',
         'pdc_url': 'http://domain.local'
     })
-    def test_contains_critpath_component_not_critpath(self, mock_get, session):
+    def test_contains_critpath_component_not_critpath(self, session):
         """ Verifies that the static function of contains_critpath_component
         determines that none of the builds are critpath components.
         """

--- a/bodhi/tests/server/test_util.py
+++ b/bodhi/tests/server/test_util.py
@@ -145,12 +145,11 @@ class TestUtils(unittest.TestCase):
         assert critpath_pkgs == pkgs, pkgs
 
     @mock.patch('bodhi.server.util.http_session')
-    @mock.patch('bodhi.server.util.requests.get')
     @mock.patch.dict(util.config, {
         'critpath.type': 'pdc',
         'pdc_url': 'http://domain.local'
     })
-    def test_get_critpath_components_pdc_error(self, mock_get, session):
+    def test_get_critpath_components_pdc_error(self, session):
         """ Ensure an error is thrown in Bodhi if there is an error in PDC
         getting the critpath packages.
         """
@@ -182,12 +181,11 @@ class TestUtils(unittest.TestCase):
         mock_log.warning.assert_called_once_with(warning)
 
     @mock.patch('bodhi.server.util.http_session')
-    @mock.patch('bodhi.server.util.requests.get')
     @mock.patch.dict(util.config, {
         'critpath.type': 'pdc',
         'pdc_url': 'http://domain.local'
     })
-    def test_get_critpath_components_pdc_success(self, mock_get, session):
+    def test_get_critpath_components_pdc_success(self, session):
         """ Ensure that critpath packages can be found using PDC.
         """
         pdc_url = \
@@ -241,8 +239,7 @@ class TestUtils(unittest.TestCase):
             session.get.return_value.json.call_count
 
     @mock.patch('bodhi.server.util.http_session')
-    @mock.patch('bodhi.server.util.requests.get')
-    def test_pagure_api_get(self, mock_get, session):
+    def test_pagure_api_get(self, session):
         """ Ensure that an API request to Pagure works as expected.
         """
         session.get.return_value.status_code = 200
@@ -282,8 +279,7 @@ class TestUtils(unittest.TestCase):
         assert rv == expected_json, rv
 
     @mock.patch('bodhi.server.util.http_session')
-    @mock.patch('bodhi.server.util.requests.get')
-    def test_pagure_api_get_non_500_error(self, mock_get, session):
+    def test_pagure_api_get_non_500_error(self, session):
         """ Ensure that an API request to Pagure that raises an error that is
         not a 500 error returns the actual error message from the JSON.
         """
@@ -305,8 +301,7 @@ class TestUtils(unittest.TestCase):
         assert actual_error == expected_error, actual_error
 
     @mock.patch('bodhi.server.util.http_session')
-    @mock.patch('bodhi.server.util.requests.get')
-    def test_pagure_api_get_500_error(self, mock_get, session):
+    def test_pagure_api_get_500_error(self, session):
         """ Ensure that an API request to Pagure that triggers a 500 error
         raises the expected error message.
         """
@@ -324,8 +319,7 @@ class TestUtils(unittest.TestCase):
         assert actual_error == expected_error, actual_error
 
     @mock.patch('bodhi.server.util.http_session')
-    @mock.patch('bodhi.server.util.requests.get')
-    def test_pagure_api_get_non_500_error_no_json(self, mock_get, session):
+    def test_pagure_api_get_non_500_error_no_json(self, session):
         """ Ensure that an API request to Pagure that raises an error that is
         not a 500 error and has no JSON returns an error.
         """
@@ -344,8 +338,7 @@ class TestUtils(unittest.TestCase):
         assert actual_error == expected_error, actual_error
 
     @mock.patch('bodhi.server.util.http_session')
-    @mock.patch('bodhi.server.util.requests.get')
-    def test_pdc_api_get(self, mock_get, session):
+    def test_pdc_api_get(self, session):
         """ Ensure that an API request to PDC works as expected.
         """
         session.get.return_value.status_code = 200
@@ -375,8 +368,7 @@ class TestUtils(unittest.TestCase):
         assert rv == expected_json, rv
 
     @mock.patch('bodhi.server.util.http_session')
-    @mock.patch('bodhi.server.util.requests.get')
-    def test_pdc_api_get_500_error(self, mock_get, session):
+    def test_pdc_api_get_500_error(self, session):
         """ Ensure that an API request to PDC that triggers a 500 error
         raises the expected error message.
         """
@@ -395,8 +387,7 @@ class TestUtils(unittest.TestCase):
         assert actual_error == expected_error, actual_error
 
     @mock.patch('bodhi.server.util.http_session')
-    @mock.patch('bodhi.server.util.requests.get')
-    def test_pdc_api_get_non_500_error(self, mock_get, session):
+    def test_pdc_api_get_non_500_error(self, session):
         """ Ensure that an API request to PDC that raises an error that is
         not a 500 error returns the returned JSON.
         """
@@ -419,8 +410,7 @@ class TestUtils(unittest.TestCase):
         assert actual_error == expected_error, actual_error
 
     @mock.patch('bodhi.server.util.http_session')
-    @mock.patch('bodhi.server.util.requests.get')
-    def test_pdc_api_get_non_500_error_no_json(self, mock_get, session):
+    def test_pdc_api_get_non_500_error_no_json(self, session):
         """ Ensure that an API request to PDC that raises an error that is
         not a 500 error and has no JSON returns an error.
         """
@@ -448,8 +438,7 @@ class TestUtils(unittest.TestCase):
             assert isinstance(element, unicode)
 
     @mock.patch('bodhi.server.util.http_session')
-    @mock.patch('bodhi.server.util.requests.post')
-    def test_greenwave_api_post(self, mock_post, session):
+    def test_greenwave_api_post(self, session):
         """ Ensure that a POST request to Greenwave works as expected.
         """
         session.post.return_value.status_code = 200
@@ -470,8 +459,7 @@ class TestUtils(unittest.TestCase):
         assert decision == expected_json, decision
 
     @mock.patch('bodhi.server.util.http_session')
-    @mock.patch('bodhi.server.util.requests.post')
-    def test_greenwave_api_post_500_error(self, mock_post, session):
+    def test_greenwave_api_post_500_error(self, session):
         """ Ensure that a POST request to Greenwave that triggers a 500 error
         raises the expected error message.
         """
@@ -494,8 +482,7 @@ class TestUtils(unittest.TestCase):
         assert actual_error == expected_error, actual_error
 
     @mock.patch('bodhi.server.util.http_session')
-    @mock.patch('bodhi.server.util.requests.post')
-    def test_greenwave_api_post_non_500_error(self, mock_post, session):
+    def test_greenwave_api_post_non_500_error(self, session):
         """ Ensure that a POST request to Greenwave that raises an error that is
         not a 500 error returns the returned JSON.
         """
@@ -522,8 +509,7 @@ class TestUtils(unittest.TestCase):
         assert actual_error == expected_error, actual_error
 
     @mock.patch('bodhi.server.util.http_session')
-    @mock.patch('bodhi.server.util.requests.post')
-    def test_greenwave_api_post_non_500_error_no_json(self, mock_post, session):
+    def test_greenwave_api_post_non_500_error_no_json(self, session):
         """ Ensure that a POST request to Greenwave that raises an error that is
         not a 500 error and has no JSON returns an error.
         """


### PR DESCRIPTION
This PR contains two commits. The first is from @crungehottman, and is approved by me and taken from #1767. The second is from me and removes a few mocks that are no longer needed.