### PR TITLE
100% test coverage for client/bindings.py

### DIFF
--- a/bodhi/client/bindings.py
+++ b/bodhi/client/bindings.py
@@ -592,7 +592,7 @@ class BodhiClient(OpenIdBaseClient):
             val += "\n  %s\n" % ('%supdates/%s' % (self.base_url,
                                                    update['alias']))
         else:
-            val += "\n  %s\n" % ('%s%s' % (self.base_url, update['title']))
+            val += "\n  %s\n" % ('%supdates/%s' % (self.base_url, update['title']))
         return val
 
     @errorhandled


### PR DESCRIPTION
This also fixes the following issue i found while adding the new tests:

Add updates/ to url of updates w/out alias in CLI. Previously, if an update did not have an alias,
the bodhi CLI rendered the url in the updates output as ```bodhi.fedoraproject.org/bodhi-2.2.4-1.el7```
which would result in a 404 if viewed. This update changes the URL so it renders as: ```bodhi.fedoraproject.org/updates/bodhi-2.2.4-1.el7```
