### PR TITLE
Adjust the timeout for CI.

### DIFF
--- a/devel/ci/githubprb-project.yml
+++ b/devel/ci/githubprb-project.yml
@@ -114,4 +114,4 @@
             git_repo: bodhi
             ci_project: '{name}'
             ci_cmd: "devel/ci/run_tests.sh"
-            timeout: '20m'
+            timeout: '32m'


### PR DESCRIPTION
This is needed for
https://github.com/fedora-infra/bodhi/pull/1843, as it causes tests
to run for a longer period.

Signed-off-by: Randy Barlow <randy@electronsweatshop.com>