### PR TITLE
Only list the user's updates that are still actionable

### DIFF
--- a/bodhi/server/schemas.py
+++ b/bodhi/server/schemas.py
@@ -522,6 +522,12 @@ class ListUpdateSchema(PaginatedSchema, SearchableSchema, Cosmetics):
         missing=None,
     )
 
+    active_releases = Releases(
+        colander.Boolean(true_choices=('true', '1')),
+        location="querystring",
+        missing=False,
+    )
+
     packages = Packages(
         colander.Sequence(accept_scalar=True),
         location="querystring",

--- a/bodhi/server/services/updates.py
+++ b/bodhi/server/services/updates.py
@@ -34,6 +34,7 @@ from bodhi.server.models import (
     ContentType,
     CVE,
     UpdateRequest,
+    Release,
     ReleaseState,
     Build,
     Package,
@@ -320,8 +321,15 @@ def query_updates(request):
         query = query.filter(Update.date_pushed < pushed_before)
 
     releases = data.get('releases')
+    active_releases = data.get('active_releases')
     if releases is not None:
         query = query.filter(or_(*[Update.release == r for r in releases]))
+    elif active_releases:
+        query = query.filter(
+            Update.release_id == Release.id
+        ).filter(
+            Release.state.in_([ReleaseState.current, ReleaseState.pending])
+        )
 
     # This singular version of the plural "releases" is purely for bodhi1
     # backwards compat (mostly for RSS feeds) - threebean
@@ -397,6 +405,7 @@ def query_updates(request):
         display_user=data.get('display_user', False),
         display_request=data.get('display_request', True),
         package=package,
+        active_releases=active_releases,
     )
 
 

--- a/bodhi/server/templates/updates.html
+++ b/bodhi/server/templates/updates.html
@@ -27,6 +27,23 @@ def inherit(context):
       ${tables.updates(updates, display_user, display_request)}
   % if chrome:
       ${self.pager.render(page, pages)}
+  % if active_releases:
+    <p>
+      <a href="${request.route_url('updates') + '?' \
+        + request.query_string.split('active_releases', 1)[0] \
+        + (request.query_string.split('active_releases', 1)[1].partition('&')[2] or '')}"
+         class="btn btn-sm btn-secondary">
+        Include old releases
+      </a>
+    </p>
+  % else:
+    <p>
+      <a href="${request.route_url('updates') + '?active_releases=true&' + request.query_string}"
+         class="btn btn-sm btn-secondary">
+        Exclude old releases
+      </a>
+    </p>
+  % endif
     </div>
   </div>
 </div>

--- a/bodhi/server/templates/user.html
+++ b/bodhi/server/templates/user.html
@@ -91,7 +91,7 @@
         <a href="${urls['recent_updates_rss']}">
           RSS <span class="fa fa-rss"></span>
         </a>
-        <a href="${urls['recent_updates']}&status=testing">
+        <a href="${urls['recent_updates']}&status=testing&active_releases=true">
           Testing<span class="glyphicon glyphicon-chevron-right"></span>
         </a>
         <a href="${urls['recent_updates']}&status=stable">

--- a/bodhi/tests/server/services/test_updates.py
+++ b/bodhi/tests/server/services/test_updates.py
@@ -2079,6 +2079,41 @@ class TestUpdatesService(base.BaseTestCase):
         self.assertEquals(up['alias'], u'FEDORA-%s-a3bbe1a8f2' % YEAR)
         self.assertEquals(up['karma'], 1)
 
+    def test_list_updates_by_status_active_release(self):
+        res = self.app.get(
+            '/updates/', {"status": "pending", "active_releases": 'true'})
+        body = res.json_body
+        self.assertEquals(len(body['updates']), 1)
+
+        up = body['updates'][0]
+        self.assertEquals(up['title'], u'bodhi-2.0-1.fc17')
+        self.assertEquals(up['status'], u'pending')
+        self.assertEquals(up['request'], u'testing')
+        self.assertEquals(up['user']['name'], u'guest')
+        self.assertEquals(up['release']['name'], u'F17')
+        self.assertEquals(up['type'], u'bugfix')
+        self.assertEquals(up['severity'], u'medium')
+        self.assertEquals(up['suggest'], u'unspecified')
+        self.assertEquals(up['close_bugs'], True)
+        self.assertEquals(up['notes'], u'Useful details!')
+        self.assertEquals(up['date_submitted'], u'1984-11-02 00:00:00')
+        self.assertEquals(up['date_modified'], None)
+        self.assertEquals(up['date_approved'], None)
+        self.assertEquals(up['date_pushed'], None)
+        self.assertEquals(up['locked'], False)
+        self.assertEquals(up['alias'], u'FEDORA-%s-a3bbe1a8f2' % YEAR)
+        self.assertEquals(up['karma'], 1)
+
+    def test_list_updates_by_status_inactive_release(self):
+        rel = self.db.query(Release).filter_by(name='F17').one()
+        rel.state = ReleaseState.archived
+        self.db.commit()
+
+        res = self.app.get(
+            '/updates/', {"status": "pending", "active_releases": 'true'})
+        body = res.json_body
+        self.assertEquals(len(body['updates']), 0)
+
     def test_list_updates_by_unexisting_status(self):
         res = self.app.get('/updates/', {"status": "single"},
                            status=400)


### PR DESCRIPTION
Today when listing the user's updates we also include updates that
are part of releases that have been archived or disabled.
With this commit only the updates for releases that the user can still
influence will be shown.

Signed-off-by: Pierre-Yves Chibon <pingou@pingoured.fr>