### PR TITLE
Query resultsdb for the results of the Atomic CI pipeline and display them

### DIFF
--- a/bodhi/server/templates/update.html
+++ b/bodhi/server/templates/update.html
@@ -162,6 +162,9 @@ ${update.type} update for ${update.beautify_title(amp=True) | n}
         // seem to break anything
         var arch = result.data.arch;
         var item = result.data.item;
+        if (item === undefined && testcase == 'org.centos.prod.ci.pipeline.complete'){
+            item = result.data.original_spec_nvr[0] + '#' + result.data.rev;
+        }
         var submit_time = new Date(result.submit_time);
 
 
@@ -341,6 +344,8 @@ ${update.type} update for ${update.beautify_title(amp=True) | n}
     $("#tab-automatedtests").append(" <span class='fa fa-spinner fa-spin'></span>");
 
     for (index = 0, len = builds.length; index < len; ++index) {
+      request_results(base_url+"results/latest?original_spec_nvr="
+        +builds[index]+"&testcases=org.centos.prod.ci.pipeline.complete");
       request_results(base_url+"results/latest?item="+builds[index]+"&type=koji_build&testcases:like=dist.*");
     }
 


### PR DESCRIPTION
The way bodhi was querying resultsdb for test results was relying on the
specific structure of taskotron's results which lead to the results from
the Atomic CI pipeline to not be included.
With this commit we're querying for the specific structure of the Atomic
CI results so they are included in the "Automated tests" tab of the
update page.

Signed-off-by: Pierre-Yves Chibon <pingou@pingoured.fr>