### PR TITLE
Fix CI tests

### DIFF
--- a/bodhi/tests/client/test_bindings.py
+++ b/bodhi/tests/client/test_bindings.py
@@ -998,14 +998,14 @@ class TestBodhiClient_update_str(unittest.TestCase):
             text,
             "this is a string")
 
-    @mock.patch.dict(
-        client_test_data.EXAMPLE_UPDATE_MUNCH.comments[0], {u'anonymous': True})
     def test_update_with_anon_comment(self):
         """Ensure we prepend (anonymous) to a username if an anon comment is rendered"""
         client = bindings.BodhiClient()
         client.base_url = 'http://example.com/tests/'
 
-        text = client.update_str(client_test_data.EXAMPLE_UPDATE_MUNCH)
+        with mock.patch.dict(
+                client_test_data.EXAMPLE_UPDATE_MUNCH.comments[0], {u'anonymous': True}):
+            text = client.update_str(client_test_data.EXAMPLE_UPDATE_MUNCH)
 
         self.assertEqual(text, client_test_data.EXPECTED_UPDATE_OUTPUT.replace(
             "Comments: bodhi ",

--- a/devel/ci/Dockerfile-header
+++ b/devel/ci/Dockerfile-header
@@ -1,7 +1,9 @@
 FROM registry.fedoraproject.org/fedora:FEDORA_RELEASE
 MAINTAINER "Randy Barlow" <bowlofeggs@fedoraproject.org>
 
-RUN dnf upgrade -y
+# The echo works around https://bugzilla.redhat.com/show_bug.cgi?id=1483553 and any other future dnf
+# upgrade bugs.
+RUN dnf upgrade -y || echo "We are not trying to test dnf upgrade, so ignoring dnf failure."
 RUN dnf install -y \
     git \
     liberation-mono-fonts \


### PR DESCRIPTION
This pull request has two commits. The first alters the container builds so that a failure in dnf uprgade doesn't cause a failure in CI (we don't want to CI whether dnf update works). The second alters a test so that it will pass on F26+.

Due to #1848, all pull requests will fail CI until this is merged so this is critical priority.

fixes #1848 

Signed-off-by: Randy Barlow <randy@electronsweatshop.com>