### PR TITLE
Add a -x flag to the CI run_tests.sh script to fail fast.

### DIFF
--- a/devel/ci/Dockerfile-footer
+++ b/devel/ci/Dockerfile-footer
@@ -1,5 +1,4 @@
 
 VOLUME ["/results"]
 WORKDIR /bodhi
-ENTRYPOINT ["/bodhi/devel/ci/run_tests_fedora.sh"]
-CMD [""]
+CMD ["bash"]

--- a/devel/ci/run_tests_fedora.sh
+++ b/devel/ci/run_tests_fedora.sh
@@ -13,7 +13,7 @@ cp development.ini.example development.ini
 /usr/bin/python setup.py develop
 
 /usr/bin/tox
-/usr/bin/py.test || (gather_results; exit 1)
+/usr/bin/py.test $@ || (gather_results; exit 1)
 
 gather_results
 


### PR DESCRIPTION
Signed-off-by: Randy Barlow <randy@electronsweatshop.com>