### PR TITLE
Add --allarch and --arch to bodhi updates download

### DIFF
--- a/bodhi/tests/client/test___init__.py
+++ b/bodhi/tests/client/test___init__.py
@@ -96,6 +96,49 @@ class TestDownload(unittest.TestCase):
 
     @mock.patch('bodhi.client.bindings.BodhiClient.csrf',
                 mock.MagicMock(return_value='a_csrf_token'))
+    @mock.patch('bodhi.client.bindings.BodhiClient.send_request',
+                return_value=client_test_data.EXAMPLE_QUERY_MUNCH, autospec=True)
+    @mock.patch('bodhi.client.subprocess.call', return_value=0)
+    def test_arch_flag(self, call, send_request):
+        """
+        Assert correct behavior with the --arch flag.
+        """
+        runner = testing.CliRunner()
+
+        result = runner.invoke(
+            client.download,
+            ['--builds', 'nodejs-grunt-wrap-0.3.0-2.fc25', '--arch', 'x86_64'])
+
+        self.assertEqual(result.exit_code, 0)
+        self.assertEqual(result.output,
+                         'Downloading packages from nodejs-grunt-wrap-0.3.0-2.fc25\n')
+        call.assert_called_once_with((
+            'koji', 'download-build', '--arch=noarch', '--arch=x86_64',
+            'nodejs-grunt-wrap-0.3.0-2.fc25'))
+
+    @mock.patch('bodhi.client.bindings.BodhiClient.csrf',
+                mock.MagicMock(return_value='a_csrf_token'))
+    @mock.patch('bodhi.client.bindings.BodhiClient.send_request',
+                return_value=client_test_data.EXAMPLE_QUERY_MUNCH, autospec=True)
+    @mock.patch('bodhi.client.subprocess.call', return_value=0)
+    def test_arch_all_flag(self, call, send_request):
+        """
+        Assert correct behavior with --arch all flag.
+        """
+        runner = testing.CliRunner()
+
+        result = runner.invoke(
+            client.download,
+            ['--builds', 'nodejs-grunt-wrap-0.3.0-2.fc25', '--arch', 'all'])
+
+        self.assertEqual(result.exit_code, 0)
+        self.assertEqual(result.output,
+                         'Downloading packages from nodejs-grunt-wrap-0.3.0-2.fc25\n')
+        call.assert_called_once_with((
+            'koji', 'download-build', 'nodejs-grunt-wrap-0.3.0-2.fc25'))
+
+    @mock.patch('bodhi.client.bindings.BodhiClient.csrf',
+                mock.MagicMock(return_value='a_csrf_token'))
     @mock.patch('bodhi.client.bindings.BodhiClient.send_request')
     def test_empty_options(self, send_request):
         """

--- a/docs/man_pages/bodhi.rst
+++ b/docs/man_pages/bodhi.rst
@@ -156,9 +156,14 @@ The ``updates`` command allows users to interact with bodhi updates.
 
         A comman-separated list of update IDs you would like to download.
 
-    ``--builds <nvrs``
+    ``--builds <nvrs>``
 
         A comma-separated list of NVRs that identify updates you would like to download.
+
+    ``--arch <arch>``
+
+        You can specify an architecture of packages to download. "all" will download packages for all architectures.
+        Omitting this option will download packages for the architecture you are currently running.
 
 ``bodhi updates new [options] <builds>``
 


### PR DESCRIPTION
This PR Adds support for following arguments in bodhi updates download:

--allarch - will download packages for all architectures
--arch [x86_64,i686,...] - will download package for specific architecture