### PR TITLE
 Use the Alabaster themes to make Bodhi docs prettier

### DIFF
--- a/docs/_static/logo.svg
+++ b/docs/_static/logo.svg
@@ -1,0 +1,1 @@
+../../bodhi/server/static/img/bodhi-logo.svg

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -99,7 +99,13 @@ html_theme = 'alabaster'
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
 # documentation.
-# html_theme_options = {}
+html_theme_options = {
+    'logo': 'logo.svg',
+    'logo_name': True,
+    'github_user': 'fedora-infra',
+    'github_repo': 'bodhi',
+    'page_width': '1040px',
+}
 
 # Add any paths that contain custom themes here, relative to this directory.
 # html_theme_path = []
@@ -133,8 +139,20 @@ html_static_path = ['_static']
 # typographically correct entities.
 # html_use_smartypants = True
 
-# Custom sidebar templates, maps document names to template names.
-# html_sidebars = {}
+# Custom sidebar templates, must be a dictionary that maps document names
+# to template names.
+#
+# This is required for the alabaster theme
+# refs: http://alabaster.readthedocs.io/en/latest/installation.html#sidebars
+html_sidebars = {
+    '**': [
+        'about.html',
+        'navigation.html',
+        'relations.html',  # needs 'show_related': True theme option to display
+        'searchbox.html',
+        'donate.html',
+    ]
+}
 
 # Additional templates that should be rendered to pages, maps page names to
 # template names.


### PR DESCRIPTION
I did this during Flock, but forgot about it.

Adjust some of the Alabaster theme settings to make Bodhi's docs look nicer. This adds a sidebar with docs-wide navigation (and the logo) as well as widens the docs slightly to 1040px.

Signed-off-by: Jeremy Cline <jeremy@jcline.org>