### PR TITLE
Install bzip2 in all CI containers as it is needed to tar results.

### DIFF
--- a/devel/ci/run_tests.sh
+++ b/devel/ci/run_tests.sh
@@ -25,7 +25,7 @@ tar_results() {
 
 
 sudo yum install -y epel-release
-sudo yum install -y docker parallel
+sudo yum install -y bzip2 docker parallel
 
 sudo systemctl start docker
 


### PR DESCRIPTION
Signed-off-by: Randy Barlow <randy@electronsweatshop.com>