### PR TITLE
Copy the test_results/ folder back to the Jenkins master when done.

### DIFF
--- a/devel/ci/githubprb-project.yml
+++ b/devel/ci/githubprb-project.yml
@@ -90,7 +90,7 @@
             && /usr/bin/timeout {timeout} $ssh_cmd -t "cd payload && {ci_cmd}"
             rtn_code=$?
             # Copy the archive results back to the master
-            rsync -e "ssh $sshopts" -Ha $CICO_hostname:payload/\*.xml $(pwd)/
+            rsync -e "ssh $sshopts" -Ha $CICO_hostname:payload/test_results $(pwd)/
             if [ $rtn_code -eq 0 ]; then
                 cico node done $CICO_ssid
             else


### PR DESCRIPTION
This one is needed to get CI passing on https://github.com/fedora-infra/bodhi/pull/1903 which is needed to get CI passing on all other PRs.

Basically, I had forgotten to copy the test_results/ folder back to the Jenkins master after the tests finished on the slave, and as a result Jenkins fails to find all the archived results.

This PR will necessarily fail CI because of the problem it solves (the JJB template is being changed by this commit, but Jenkins will run the tests against with with the old template.)

Signed-off-by: Randy Barlow <randy@electronsweatshop.com>