### PR TITLE
Get rid of Bunch dependency and use collections.namedtuple instead

### DIFF
--- a/bodhi/server/bugs.py
+++ b/bodhi/server/bugs.py
@@ -15,7 +15,7 @@
 import logging
 import xmlrpclib
 
-from bunch import Bunch
+from collections import namedtuple
 from kitchen.text.converters import to_unicode
 import bugzilla
 
@@ -24,6 +24,7 @@ from bodhi.server.config import config
 
 bugtracker = None
 log = logging.getLogger('bodhi')
+FakeBug = namedtuple('FakeBug', ['bug_id'])
 
 
 class BugTracker(object):
@@ -37,7 +38,7 @@ class BugTracker(object):
 class FakeBugTracker(BugTracker):
 
     def getbug(self, bug_id, *args, **kw):
-        return Bunch(bug_id=int(bug_id))
+        return FakeBug(bug_id=int(bug_id))
 
     def __noop__(self, *args, **kw):
         log.debug('__noop__(%s)' % str(args))

--- a/bodhi/tests/server/test_bugs.py
+++ b/bodhi/tests/server/test_bugs.py
@@ -17,7 +17,6 @@
 
 import unittest
 
-import bunch
 import mock
 import xmlrpclib
 
@@ -221,7 +220,7 @@ class TestFakeBugTracker(unittest.TestCase):
 
         b = bt.getbug(1234)
 
-        self.assertTrue(isinstance(b, bunch.Bunch))
+        self.assertTrue(isinstance(b, bugs.FakeBug))
         self.assertEqual(b.bug_id, 1234)
 
     @mock.patch('bodhi.server.bugs.log.debug')

--- a/devel/ansible/roles/dev/tasks/main.yml
+++ b/devel/ansible/roles/dev/tasks/main.yml
@@ -28,7 +28,6 @@
       - python-arrow
       - python-bleach
       - python-bugzilla
-      - python-bunch
       - python-click
       - python-cornice
       - python-cornice-sphinx

--- a/devel/ci/f25-packages
+++ b/devel/ci/f25-packages
@@ -1,6 +1,5 @@
     python-alembic \
     python-bugzilla \
-    python-bunch \
     python-kitchen \
     python-moksha-hub \
     python-munch \

--- a/devel/ci/f26-packages
+++ b/devel/ci/f26-packages
@@ -1,6 +1,5 @@
     python-alembic \
     python-bugzilla \
-    python-bunch \
     python-munch \
     python-openid \
     python-progressbar \

--- a/devel/ci/f27-packages
+++ b/devel/ci/f27-packages
@@ -1,6 +1,5 @@
     python-alembic \
     python-bugzilla \
-    python-bunch \
     python-munch \
     python-openid \
     python-progressbar \

--- a/devel/ci/rawhide-packages
+++ b/devel/ci/rawhide-packages
@@ -1,6 +1,5 @@
     python2-alembic \
     python2-bugzilla \
-    python2-bunch \
     python2-fedmsg \
     python2-kitchen \
     python2-munch \

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 alembic
 arrow
-bunch
 bleach
 click
 colander


### PR DESCRIPTION
As a first step of porting Bodhi to Python 3 compatible form, we have to deal with dependencies.

Bunch is a really obsolete package with the last release in December 2011 and it probably won't be ported to Python 3. Because it is used only in FakeBugTracker, I think it can be easily replaced by namedtuple from the standard library.

If it's not necessary to access `bug_id` as an attribute, I can make it more simple and use a dictionary instead namedtuple.