### PR TITLE
Remove the dependency on fedmsg-atomic-composer.

### DIFF
--- a/devel/ansible/roles/dev/tasks/main.yml
+++ b/devel/ansible/roles/dev/tasks/main.yml
@@ -60,7 +60,6 @@
       - python2-createrepo_c
       - python2-cryptography
       - python2-dnf
-      - python2-fedmsg-atomic-composer
       - python2-fedmsg-commands
       - python2-fedmsg-consumers
       - python2-flake8

--- a/devel/ci/rpm-packages
+++ b/devel/ci/rpm-packages
@@ -2,7 +2,6 @@
     python2-bleach \
     python2-cornice \
     python2-dogpile-cache \
-    python2-fedmsg-atomic-composer \
     python2-flake8 \
     python2-iniparse \
     python2-markdown \

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,6 @@ colander
 cornice<2
 cryptography
 dogpile.cache
-fedmsg-atomic-composer >= 2016.3
 fedmsg[consumers]
 kitchen
 jinja2


### PR DESCRIPTION
This will need to be backported to the 3.0 branch as well, as 3.0 will not build as-is.

Signed-off-by: Randy Barlow <randy@electronsweatshop.com>