### PR TITLE
Fix PEP8 style failures on E722

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -8,7 +8,7 @@ omit =
 
 [report]
 precision = 2
-fail_under = 92
+fail_under = 93
 exclude_lines =
     pragma: no cover
     def __repr__

--- a/bodhi/client/bindings.py
+++ b/bodhi/client/bindings.py
@@ -634,6 +634,6 @@ class BodhiClient(OpenIdBaseClient):
                 for build in koji.listTagged(release['candidate_tag'], latest=True):
                     if build['owner_name'] == self.username:
                         builds.append(build)
-            except:
+            except Exception:
                 log.exception('Unable to query candidate builds for %s' % release)
         return builds

--- a/bodhi/server/bugs.py
+++ b/bodhi/server/bugs.py
@@ -101,7 +101,7 @@ class Bugzilla(BugTracker):
         except InvalidComment:
             log.exception(
                 "Comment too long for bug #%d:  %s" % (bug_id, comment))
-        except:
+        except Exception:
             log.exception("Unable to add comment to bug #%d" % bug_id)
 
     def on_qa(self, bug_id, comment):
@@ -113,7 +113,7 @@ class Bugzilla(BugTracker):
         try:
             bug = self.bz.getbug(bug_id)
             bug.setstatus('ON_QA', comment=comment)
-        except:
+        except Exception:
             log.exception("Unable to alter bug #%d" % bug_id)
 
     def close(self, bug_id, versions, comment):
@@ -159,8 +159,9 @@ class Bugzilla(BugTracker):
                 bug_entity.title = 'Invalid bug number'
                 log.exception("Got fault from Bugzilla")
                 return
-            except:
+            except Exception:
                 log.exception("Unknown exception from Bugzilla")
+                return
         if bug.product == 'Security Response':
             bug_entity.parent = True
         bug_entity.title = to_unicode(bug.short_desc)
@@ -180,7 +181,7 @@ class Bugzilla(BugTracker):
             if bug.bug_status not in ('MODIFIED', 'VERIFIED', 'CLOSED'):
                 log.info('Setting bug #%d status to MODIFIED' % bug_id)
                 bug.setstatus('MODIFIED')
-        except:
+        except Exception:
             log.exception("Unable to alter bug #%d" % bug_id)
 
 

--- a/bodhi/server/consumers/masher.py
+++ b/bodhi/server/consumers/masher.py
@@ -336,7 +336,7 @@ class MasherThread(threading.Thread):
                 self.db = session
                 self.work()
                 self.db = None
-        except:
+        except Exception:
             self.log.exception('MasherThread failed. Transaction rolled back.')
 
     def results(self):
@@ -437,7 +437,7 @@ class MasherThread(threading.Thread):
             self.check_all_karma_thresholds()
             self.obsolete_older_updates()
 
-        except:
+        except Exception:
             self.log.exception('Exception in MasherThread(%s)' % self.id)
             self.save_state()
             raise
@@ -671,7 +671,7 @@ class MasherThread(threading.Thread):
                     if build.override:
                         try:
                             build.override.expire()
-                        except:
+                        except Exception:
                             log.exception('Problem expiring override')
 
     def remove_pending_tags(self):

--- a/bodhi/server/mail.py
+++ b/bodhi/server/mail.py
@@ -457,7 +457,7 @@ def _send_mail(from_addr, to_addr, body):
         smtp.sendmail(from_addr, [to_addr], body)
     except smtplib.SMTPRecipientsRefused as e:
         log.warn('"recipient refused" for %r, %r' % (to_addr, e))
-    except:
+    except Exception:
         log.exception('Unable to send mail')
     finally:
         if smtp:

--- a/bodhi/server/services/errors.py
+++ b/bodhi/server/services/errors.py
@@ -102,7 +102,7 @@ class html_handler(pyramid.httpexceptions.HTTPError):
                 request=errors.request,
                 summary=status2summary(errors.status),
             )
-        except:
+        except Exception:
             log.error(mako.exceptions.text_error_template().render())
             raise
 

--- a/bodhi/server/util.py
+++ b/bodhi/server/util.py
@@ -1093,7 +1093,7 @@ class TransactionalSessionMaker(object):
             # original Exception.
             try:
                 session.rollback()
-            except:
+            except Exception:
                 log.exception('An Exception was raised while rolling back a transaction.')
             raise e
         finally:

--- a/bodhi/server/views/generic.py
+++ b/bodhi/server/views/generic.py
@@ -331,7 +331,7 @@ def latest_builds(request):
             try:
                 for build in koji.getLatestBuilds(tag, package=package):
                     builds[tag] = build['nvr']
-            except:  # Things like EPEL don't have pending tags
+            except Exception:  # Things like EPEL don't have pending tags
                 pass
     return builds
 

--- a/bodhi/tests/server/base.py
+++ b/bodhi/tests/server/base.py
@@ -247,6 +247,6 @@ class TransactionalSessionMaker(object):
         try:
             yield session
             session.commit()
-        except:
+        except Exception:
             session.rollback()
             raise

--- a/bodhi/tests/server/functional/test_generic.py
+++ b/bodhi/tests/server/functional/test_generic.py
@@ -15,6 +15,7 @@
 from datetime import datetime
 import copy
 
+import mock
 from pyramid.testing import DummyRequest
 from webtest import TestApp
 
@@ -341,6 +342,22 @@ class TestGenericViews(base.BaseTestCase):
         self.assertIn('f17-updates-testing-pending', body)
         self.assertIn('f17-override', body)
         self.assertEquals(body['f17-updates'], 'TurboGears-1.0.2.2-2.fc17')
+
+    @mock.patch("bodhi.server.buildsys.DevBuildsys.getLatestBuilds", side_effect=Exception())
+    def test_latest_builds_exception(self, mock_getlatestbuilds):
+        """
+        Test that the latest_builds() just passes if it hits an exception
+        the result here is that there should be no builds returned
+        """
+        res = self.app.get('/latest_builds')
+        body = res.json_body
+
+        self.assertNotIn('f17-updates', body)
+        self.assertNotIn('f17-updates-pending', body)
+        self.assertNotIn('f17-updates-candidate', body)
+        self.assertNotIn('f17-updates-testing', body)
+        self.assertNotIn('f17-updates-testing-pending', body)
+        self.assertNotIn('f17-override', body)
 
     def test_candidate(self):
         res = self.app.get('/latest_candidates')

--- a/bodhi/tests/server/test_models.py
+++ b/bodhi/tests/server/test_models.py
@@ -58,7 +58,7 @@ class ModelTest(BaseTestCase):
                 self.db.add(self.obj)
                 self.db.flush()
                 return self.obj
-            except:
+            except Exception:
                 self.db.rollback()
                 raise
 

--- a/tools/fix-testing-updates.py
+++ b/tools/fix-testing-updates.py
@@ -52,7 +52,7 @@ for up in bad:
             db.flush()
 
             assert up.days_in_testing != 0, up
-    except:
+    except Exception:
         print('Cannot find koji build for %s' % build.nvr)
 
 # vim: ts=4 sw=4 ai expandtab

--- a/tox.ini
+++ b/tox.ini
@@ -69,7 +69,7 @@ add-ignore = D413
 show-source = True
 max-line-length = 100
 exclude = .git,.tox,dist,*egg,build
-ignore = E712,E722
+ignore = E712
 
 
 [pytest]


### PR DESCRIPTION
After re-provisioning my vagrant box today, i started getting failures on E722 complaining about blank except: lines.

So this PR Changes a bunch of bare excepts to except Exception: so the style tests pass where they were previously failing on E722

Signed-off-by: Ryan Lerch <rlerch@redhat.com>