### PR TITLE
Remove URLGrabber from the list of linked system libraries

### DIFF
--- a/bootstrap.py
+++ b/bootstrap.py
@@ -107,12 +107,11 @@ def _link_system_lib(lib):
 
 
 def link_system_libs():
-    for mod in ('koji', 'rpm', 'OpenSSL', 'urlgrabber', 'pycurl',
-                'rpmUtils', 'sqlitecachec', '_sqlitecache', 'psycopg2',
-                'krbVmodule', 'deltarpm', '_deltarpmmodule',
-                'fedora_cert', 'libxml2', 'libxml2mod', 'librepo', 'createrepo_c',
-                'dnf', 'gpg', 'gpgme', 'lzma', 'iniparse', 'hawkey',
-                'yum'):
+    for mod in ('koji', 'rpm', 'OpenSSL', 'pycurl', 'rpmUtils', 'sqlitecachec',
+                '_sqlitecache', 'psycopg2', 'krbVmodule', 'deltarpm',
+                '_deltarpmmodule', 'fedora_cert', 'libxml2', 'libxml2mod',
+                'librepo', 'createrepo_c', 'dnf', 'gpg', 'gpgme', 'lzma',
+                'iniparse', 'hawkey', 'yum'):
         _link_system_lib(mod)
 
 


### PR DESCRIPTION
SSIA

This is the last occurrence of urlgrabber in Bodhi codebase. It can be also removed from specfile. Package python-urlgrabber will be still installed in the testing environment because yum depends on it.