### PR TITLE
Fix the path to the lock files in push.py

### DIFF
--- a/bodhi/server/push.py
+++ b/bodhi/server/push.py
@@ -39,20 +39,15 @@ import bodhi.server.notifications
               help='Push updates with a specific request (default: testing,stable)')
 @click.option('--resume', help='Resume one or more previously failed pushes',
               is_flag=True, default=False)
-@click.option('--staging', help='Use the staging bodhi instance',
-              is_flag=True, default=False)
 @click.option('--username', prompt=True)
 @click.version_option(message='%(version)s')
 def push(username, cert_prefix, **kwargs):
-    staging = kwargs.pop('staging')
+    """Push builds out to the repositories."""
     resume = kwargs.pop('resume')
 
     lockfiles = defaultdict(list)
     locked_updates = []
-    if staging:
-        locks = '/var/cache/bodhi/mashing/MASHING-*'
-    else:
-        locks = '/mnt/koji/mash/updates/MASHING-*'
+    locks = '%s/MASHING-*' % config.get('mash_dir')
     for lockfile in glob.glob(locks):
         with file(lockfile) as lock:
             state = json.load(lock)

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -20,6 +20,11 @@ Backwards incompatible changes
     * ``comps_url``
     * ``mash_conf``
 
+* ``bodhi-push`` no longer has a ``--staging`` flag as it was not needed. It was used to determine
+  the mashing directory to look for lock files, but the directories it looked in were hardcoded
+  instead of using the ``mash_dir`` setting. With 3.0.0, ``mash_dir`` is used and the ``--staging``
+  flag is no longer needed.
+
 
 Dependency changes
 ^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
This pull request cherry picks the commit made in #1931 back to the 3.0 branch.