### PR TITLE
Use plain ASCII for alembic template

### DIFF
--- a/bodhi/server/migrations/script.py.mako
+++ b/bodhi/server/migrations/script.py.mako
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright © YEAR AUTHOR
+# Copyright (c) YEAR AUTHOR
 #
 # This file is part of Bodhi.
 #


### PR DESCRIPTION
For unknown reasons alembic strips the first line of the template when
creating a migration script. Then the utf-8 characters leads to an
encoding error.