### PR TITLE
Add support for Cornice 2, dropping support for Cornice 1.

### DIFF
--- a/bodhi/server/services/builds.py
+++ b/bodhi/server/services/builds.py
@@ -25,7 +25,8 @@ from sqlalchemy import func, distinct
 from sqlalchemy.sql import or_
 
 from bodhi.server.models import Update, Build, Package, Release
-from bodhi.server.validators import validate_updates, validate_packages, validate_releases
+from bodhi.server.validators import (colander_querystring_validator, validate_updates,
+                                     validate_packages, validate_releases)
 import bodhi.server.schemas
 import bodhi.server.security
 import bodhi.server.services.errors
@@ -61,7 +62,7 @@ def get_build(request):
 
 @builds.get(schema=bodhi.server.schemas.ListBuildSchema, renderer='json',
             error_handler=bodhi.server.services.errors.json_handler,
-            validators=(validate_releases, validate_updates,
+            validators=(colander_querystring_validator, validate_releases, validate_updates,
                         validate_packages))
 def query_builds(request):
     """

--- a/bodhi/server/services/comments.py
+++ b/bodhi/server/services/comments.py
@@ -21,6 +21,7 @@
 import math
 
 from cornice import Service
+from cornice.validators import colander_body_validator
 from pyramid.httpexceptions import HTTPBadRequest
 from sqlalchemy import func, distinct
 from sqlalchemy.sql import or_
@@ -28,6 +29,7 @@ from sqlalchemy.sql import or_
 from bodhi.server import log
 from bodhi.server.models import Comment, Build, Update
 from bodhi.server.validators import (
+    colander_querystring_validator,
     validate_packages,
     validate_update,
     validate_updates,
@@ -80,6 +82,7 @@ def get_comment(request):
 
 
 validators = (
+    colander_querystring_validator,
     validate_username,
     validate_update_owner,
     validate_ignore_user,
@@ -191,6 +194,7 @@ def query_comments(request):
                renderer='json',
                error_handler=bodhi.server.services.errors.json_handler,
                validators=(
+                   colander_body_validator,
                    validate_update,
                    validate_bug_feedback,
                    validate_testcase_feedback,

--- a/bodhi/server/services/errors.py
+++ b/bodhi/server/services/errors.py
@@ -73,7 +73,7 @@ def status2summary(status):
 class html_handler(pyramid.httpexceptions.HTTPError):
     """An HTML formatting handler for all our errors."""
 
-    def __init__(self, errors):
+    def __init__(self, errors, request):
         """
         Initialize the HTML error handler to render an error messgae for human readers.
 
@@ -82,6 +82,7 @@ class html_handler(pyramid.httpexceptions.HTTPError):
 
         Args:
             errors (cornice.errors.Errors): The errors to be rendered as HTML for users.
+            request (pyramid.util.Request): The current Request.
         """
         location = config.get('mako.directories')
         module, final = location.split(':')
@@ -99,7 +100,7 @@ class html_handler(pyramid.httpexceptions.HTTPError):
             body = template.render(
                 errors=errors,
                 status=errors.status,
-                request=errors.request,
+                request=request,
                 summary=status2summary(errors.status),
             )
         except Exception:

--- a/bodhi/server/services/overrides.py
+++ b/bodhi/server/services/overrides.py
@@ -21,6 +21,7 @@
 import math
 
 from cornice import Service
+from cornice.validators import colander_body_validator
 from pyramid.exceptions import HTTPNotFound
 
 from sqlalchemy import func, distinct
@@ -31,6 +32,7 @@ from bodhi.server.models import Build, BuildrootOverride, Package, Release, User
 import bodhi.server.schemas
 import bodhi.server.services.errors
 from bodhi.server.validators import (
+    colander_querystring_validator,
     validate_override_builds,
     validate_expiration_date,
     validate_packages,
@@ -91,6 +93,7 @@ def get_override(request):
 
 
 validators = (
+    colander_querystring_validator,
     validate_packages,
     validate_releases,
     validate_username,
@@ -212,6 +215,7 @@ def query_overrides(request):
                 accept=("application/json", "text/json"), renderer='json',
                 error_handler=bodhi.server.services.errors.json_handler,
                 validators=(
+                    colander_body_validator,
                     validate_override_builds,
                     validate_expiration_date,
                 ))
@@ -220,6 +224,7 @@ def query_overrides(request):
                 accept=("application/javascript"), renderer="jsonp",
                 error_handler=bodhi.server.services.errors.jsonp_handler,
                 validators=(
+                    colander_body_validator,
                     validate_override_builds,
                     validate_expiration_date,
                 ))

--- a/bodhi/server/services/packages.py
+++ b/bodhi/server/services/packages.py
@@ -23,6 +23,7 @@ from cornice import Service
 from sqlalchemy import func, distinct
 from sqlalchemy.sql.expression import case
 
+from bodhi.server import validators
 from bodhi.server.models import Package
 import bodhi.server.schemas
 import bodhi.server.security
@@ -34,11 +35,10 @@ packages = Service(name='packages', path='/packages/',
                    cors_origins=bodhi.server.security.cors_origins_ro)
 
 
-@packages.get(schema=bodhi.server.schemas.ListPackageSchema, renderer='json',
-              error_handler=bodhi.server.services.errors.json_handler,
-              validators=(
-                  # None yet...
-              ))
+@packages.get(
+    schema=bodhi.server.schemas.ListPackageSchema, renderer='json',
+    error_handler=bodhi.server.services.errors.json_handler,
+    validators=(validators.colander_querystring_validator,))
 def query_packages(request):
     """
     Search for packages via query string parameters.

--- a/bodhi/server/services/stacks.py
+++ b/bodhi/server/services/stacks.py
@@ -21,6 +21,7 @@
 import math
 
 from cornice import Service
+from cornice.validators import colander_body_validator
 from pyramid.exceptions import HTTPForbidden
 from pyramid.view import view_config
 from sqlalchemy import func, distinct
@@ -30,7 +31,8 @@ from bodhi.server import log, notifications
 from bodhi.server.config import config
 from bodhi.server.models import Package, Stack, Group, User
 from bodhi.server.util import tokenize
-from bodhi.server.validators import validate_packages, validate_stack, validate_requirements
+from bodhi.server.validators import (colander_querystring_validator, validate_packages,
+                                     validate_stack, validate_requirements)
 import bodhi.server.schemas
 import bodhi.server.security
 import bodhi.server.services.errors
@@ -70,11 +72,11 @@ def get_stack(request):
 @stacks.get(accept="text/html", renderer='stacks.html',
             error_handler=bodhi.server.services.errors.html_handler,
             schema=bodhi.server.schemas.ListStackSchema,
-            validators=(validate_packages,))
+            validators=(colander_querystring_validator, validate_packages,))
 @stacks.get(accept=('application/json', 'text/json'),
             error_handler=bodhi.server.services.errors.json_handler,
             schema=bodhi.server.schemas.ListStackSchema,
-            validators=(validate_packages,), renderer='json')
+            validators=(colander_querystring_validator, validate_packages,), renderer='json')
 def query_stacks(request):
     """
     Return a paginated list of filtered stacks.
@@ -126,7 +128,7 @@ def query_stacks(request):
 
 @stacks.post(schema=bodhi.server.schemas.SaveStackSchema,
              permission='edit',
-             validators=(validate_requirements,), renderer='json',
+             validators=(colander_body_validator, validate_requirements,), renderer='json',
              error_handler=bodhi.server.services.errors.json_handler)
 def save_stack(request):
     """

--- a/bodhi/server/services/updates.py
+++ b/bodhi/server/services/updates.py
@@ -22,6 +22,7 @@ import copy
 import math
 
 from cornice import Service
+from cornice.validators import colander_body_validator
 from sqlalchemy import func, distinct
 from sqlalchemy.sql import or_
 
@@ -42,6 +43,7 @@ import bodhi.server.security
 import bodhi.server.services.errors
 import bodhi.server.util
 from bodhi.server.validators import (
+    colander_querystring_validator,
     validate_nvrs,
     validate_uniqueness,
     validate_build_tags,
@@ -139,6 +141,7 @@ def get_update_for_editing(request):
 
 @update_request.post(schema=bodhi.server.schemas.UpdateRequestSchema,
                      validators=(
+                         colander_body_validator,
                          validate_enums,
                          validate_update_id,
                          validate_build_tags,
@@ -190,6 +193,7 @@ def set_request(request):
 
 
 validators = (
+    colander_querystring_validator,
     validate_release,
     validate_releases,
     validate_enums,
@@ -392,6 +396,7 @@ def query_updates(request):
               permission='create', renderer='json',
               error_handler=bodhi.server.services.errors.json_handler,
               validators=(
+                  colander_body_validator,
                   validate_nvrs,
                   validate_builds,
                   validate_uniqueness,

--- a/bodhi/server/services/user.py
+++ b/bodhi/server/services/user.py
@@ -25,7 +25,8 @@ from sqlalchemy import func, distinct
 from sqlalchemy.sql import or_
 
 from bodhi.server.models import Group, Package, Update, User
-from bodhi.server.validators import validate_updates, validate_packages, validate_groups
+from bodhi.server.validators import (colander_querystring_validator, validate_updates,
+                                     validate_packages, validate_groups)
 import bodhi.server.schemas
 import bodhi.server.security
 import bodhi.server.services.errors
@@ -90,6 +91,7 @@ def get_user(request):
 
 
 validators = (
+    colander_querystring_validator,
     validate_groups,
     validate_updates,
     validate_packages,

--- a/bodhi/server/views/generic.py
+++ b/bodhi/server/views/generic.py
@@ -437,7 +437,7 @@ def exception_view(exc, request):
     Return an error response upon generic errors (404s, 403s, 500s, etc..).
 
     This is here to catch everything that isn't caught by our cornice error
-    handlers.  When we do catch something, we transform it intpu a cornice
+    handlers.  When we do catch something, we transform it into a cornice
     Errors object and pass it to our nice cornice error handler.  That way, all
     the exception presentation and rendering we can keep in one place.
 
@@ -459,7 +459,7 @@ def exception_view(exc, request):
     if not len(errors):
         description = getattr(exc, 'explanation', None) or str(exc)
 
-        errors = cornice.errors.Errors(request, status=status)
-        errors.add('unknown', description=description)
+        errors = cornice.errors.Errors(status=status)
+        errors.add('body', description=description)
 
-    return bodhi.server.services.errors.html_handler(errors)
+    return bodhi.server.services.errors.html_handler(errors, request)

--- a/bodhi/tests/server/base.py
+++ b/bodhi/tests/server/base.py
@@ -183,8 +183,10 @@ class BaseTestCase(unittest.TestCase):
             _app = TestApp(main({}, testing=u'guest', **self.app_settings))
         self.app = _app
 
-    def get_csrf_token(self):
-        return self.app.get('/csrf').json_body['csrf_token']
+    def get_csrf_token(self, app=None):
+        if not app:
+            app = self.app
+        return app.get('/csrf').json_body['csrf_token']
 
     def get_update(self, builds='bodhi-2.0-1.fc17', stable_karma=3, unstable_karma=-3):
         if isinstance(builds, list):

--- a/devel/Vagrantfile.example
+++ b/devel/Vagrantfile.example
@@ -10,8 +10,8 @@
 VAGRANTFILE_API_VERSION = "2"
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
- config.vm.box_url = "https://download.fedoraproject.org/pub/fedora/linux/releases/25/CloudImages/x86_64/images/Fedora-Cloud-Base-Vagrant-25-1.3.x86_64.vagrant-libvirt.box"
- config.vm.box = "f25-cloud-libvirt"
+ config.vm.box_url = "https://download.fedoraproject.org/pub/fedora/linux/releases/26/CloudImages/x86_64/images/Fedora-Cloud-Base-Vagrant-26-1.5.x86_64.vagrant-libvirt.box"
+ config.vm.box = "f26-cloud-libvirt"
 
  # Forward traffic on the host to the development server on the guest.
  # You can change the host port that is forwarded to 5000 on the guest

--- a/devel/ansible/roles/core/tasks/main.yml
+++ b/devel/ansible/roles/core/tasks/main.yml
@@ -6,7 +6,6 @@
   with_items:
       - bash-completion
       - dstat
-      - fedora-easy-karma
       - htop
       - screen
       - tmux

--- a/devel/ansible/roles/dev/tasks/main.yml
+++ b/devel/ansible/roles/dev/tasks/main.yml
@@ -25,63 +25,70 @@
       - pungi
       - python
       - python-alembic
-      - python-arrow
-      - python-bleach
       - python-bugzilla
-      - python-click
-      - python-cornice
-      - python-cornice-sphinx
-      - python-devel
-      - python3-diff-cover
-      - python-dogpile-cache
-      - python-fedora
-      - python-ipdb
-      - python-kitchen
-      - python-librepo
-      - python-mock
       - python-openid
-      - python-pillow
       - python-progressbar
-      - python-psycopg2
       - python-pydns
       - python-pylibravatar
-      - python-pyramid
-      - python-pyramid-mako
       - python-pyramid-fas-openid
-      - python-pyramid-tm
-      - python-rpdb
       - python-simplemediawiki
-      - python-sqlalchemy
       - python-webtest
-      - python-zmq
+      - python2-arrow
+      - python2-bleach
+      - python2-click
       - python2-colander
       - python2-createrepo_c
       - python2-cryptography
+      - python2-devel
       - python2-dnf
+      - python2-dogpile-cache
       - python2-fedmsg-commands
       - python2-fedmsg-consumers
+      - python2-fedora
       - python2-flake8
+      - python2-ipdb
       - python2-jinja2
+      - python2-kitchen
+      - python2-librepo
       - python2-markdown
+      - python2-mock
+      - python2-pillow
+      - python2-psycopg2
+      - python2-pyramid
+      - python2-pyramid-mako
+      - python2-pyramid-tm
       - python2-pytest-cov
+      - python2-rpdb
       - python2-sphinx
+      - python2-sqlalchemy
       - python2-sqlalchemy_schemadisplay
       - python2-waitress
       - python2-yaml
+      - python3-pydocstyle
       - python3-tox
       - redhat-rpm-config
       - vim-enhanced
       - zlib-devel
+
+# cornice > 1 won't be available until Fedora 28 is released.
+- name: pip install cornice
+  pip:
+      name: cornice~=2.0
+
+# cornice_sphinx is not packaged in Fedora yet, but won't be available until Fedora 28 is released.
+- name: pip install cornice_sphinx
+  pip:
+      name: -e git+https://github.com/bowlofeggs/cornice.ext.sphinx.git@copy_child_nodes#egg=cornice_sphinx
 
 # This isn't packaged in Fedora yet, but it's only a development tool (we should still add it)
 - name: pip install debugtoolbar
   pip:
       name: pyramid_debugtoolbar
 
-# This isn't packaged in Fedora yet, but there is a package review open https://bugzilla.redhat.com/show_bug.cgi?id=1409654
-- name: pip install pydocstyle
+# This has been retired in Fedora and needs to be unretired. We'll pip install for now.
+- name: pip install diff_cover
   pip:
-      name: pydocstyle
+      name: diff_cover
 
 # This isn't packaged in Fedora yet, but there is a package review open https://bugzilla.redhat.com/show_bug.cgi?id=1505993
 - name: pip install feedgen
@@ -114,7 +121,7 @@
     replace: "sqlalchemy.url = postgresql://postgres:anypasswordworkslocally@localhost/bodhi2"
 
 - name: Apply database migrations
-  command: alembic upgrade head
+  shell: PYTHONPATH=. alembic upgrade head
   args:
       chdir: /home/vagrant/bodhi
 

--- a/devel/ci/Dockerfile-header
+++ b/devel/ci/Dockerfile-header
@@ -9,7 +9,6 @@ RUN dnf install -y \
     liberation-mono-fonts \
     packagedb-cli \
     pungi \
-    python2-cornice-sphinx \
     python2-createrepo_c \
     python2-jinja2 \
     python2-koji \

--- a/devel/ci/f25-packages
+++ b/devel/ci/f25-packages
@@ -16,3 +16,6 @@
     python2-fedmsg-consumers \
     python2-fedmsg-core \
     python3-diff-cover
+
+RUN pip install cornice~=2.0 pyramid~=1.7
+RUN pip install -e git+https://github.com/bowlofeggs/cornice.ext.sphinx.git@copy_child_nodes#egg=cornice_sphinx

--- a/devel/ci/f26-packages
+++ b/devel/ci/f26-packages
@@ -14,4 +14,5 @@
     python2-pyramid-tm \
     python2-sqlalchemy
 
-RUN pip install diff_cover
+RUN pip-2 install cornice~=2.0 diff_cover
+RUN pip-2 install -e git+https://github.com/bowlofeggs/cornice.ext.sphinx.git@copy_child_nodes#egg=cornice_sphinx

--- a/devel/ci/f27-packages
+++ b/devel/ci/f27-packages
@@ -14,4 +14,5 @@
     python2-pyramid-tm \
     python2-sqlalchemy
 
-RUN pip install diff_cover
+RUN pip-2 install cornice~=2.0 diff_cover
+RUN pip-2 install -e git+https://github.com/bowlofeggs/cornice.ext.sphinx.git@copy_child_nodes#egg=cornice_sphinx

--- a/devel/ci/pip-packages
+++ b/devel/ci/pip-packages
@@ -10,8 +10,10 @@ COPY requirements.txt /bodhi/requirements.txt
 RUN pip-2 install -r /bodhi/requirements.txt
 RUN pip-2 install \
     diff-cover \
+    mock \
     pytest \
     pytest-cov \
     sqlalchemy_schemadisplay \
     tox \
     webtest
+RUN pip-2 install -e git+https://github.com/bowlofeggs/cornice.ext.sphinx.git@copy_child_nodes#egg=cornice_sphinx

--- a/devel/ci/rawhide-packages
+++ b/devel/ci/rawhide-packages
@@ -13,4 +13,5 @@
     python2-sqlalchemy \
     python2-webtest
 
-RUN pip install diff_cover
+RUN pip-2 install cornice~=2.0 diff_cover
+RUN pip-2 install -e git+https://github.com/bowlofeggs/cornice.ext.sphinx.git@copy_child_nodes#egg=cornice_sphinx

--- a/devel/ci/rpm-packages
+++ b/devel/ci/rpm-packages
@@ -1,6 +1,5 @@
     python2-arrow \
     python2-bleach \
-    python2-cornice \
     python2-dogpile-cache \
     python2-flake8 \
     python2-iniparse \

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -27,7 +27,7 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../'
 
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
-extensions = ['cornice.ext.sphinxext', 'sphinx.ext.autodoc', 'sphinx.ext.extlinks',
+extensions = ['cornice_sphinx', 'sphinx.ext.autodoc', 'sphinx.ext.extlinks',
               'sphinx.ext.todo', 'sphinx.ext.coverage', 'sphinx.ext.viewcode']
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -2,6 +2,15 @@
 Release notes
 =============
 
+develop
+-------
+
+Dependency changes
+^^^^^^^^^^^^^^^^^^
+
+* Bodhi now requires ``cornice~=2``.
+
+
 v3.1.0
 ------
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ arrow
 bleach
 click
 colander
-cornice<2
+cornice~=2.0
 cryptography
 dogpile.cache
 fedmsg[consumers]
@@ -17,7 +17,7 @@ Pillow
 progressbar
 pyDNS
 pylibravatar
-pyramid
+pyramid~=1.7
 pyramid_fas_openid
 pyramid_mako
 pyramid_tm


### PR DESCRIPTION
Cornice 2 requires pyramid >= 1.7 and Fedora 25 only has
pyramid-1.5, so this commit also adjusts the Vagrantfile.example
to use Fedora 26 by default instead of 25.

re #1922

Signed-off-by: Randy Barlow <randy@electronsweatshop.com>