### PR TITLE
Remove python-pydns from dependencies

### DIFF
--- a/devel/ansible/roles/dev/tasks/main.yml
+++ b/devel/ansible/roles/dev/tasks/main.yml
@@ -28,7 +28,6 @@
       - python-bugzilla
       - python-openid
       - python-progressbar
-      - python-pydns
       - python-pylibravatar
       - python-pyramid-fas-openid
       - python-simplemediawiki

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ packagedb-cli
 # for captchas
 Pillow
 progressbar
-pyDNS
+pyDNS  # Should be required by pyLibravatar https://bugs.launchpad.net/pylibravatar/+bug/1661218
 pylibravatar
 pyramid~=1.7
 pyramid_fas_openid


### PR DESCRIPTION
Python-pydns package can be removed from the list of dependencies and also from specfile. It is not used in Bodhi codebase.

It'll be still available in the testing environment because some other packages depend on it.
```
$ dnf repoquery --whatrequires python-pydns
python-fmn-web-0:0.8.1-2.fc25.noarch
python-pylibravatar-0:1.6-9.fc25.noarch
python-pymilter-0:1.0-4.fc25.x86_64
python-pyspf-0:2.0.11-5.fc25.noarch
python2-pyspf-0:2.0.12-1.fc25.noarch
```