### PR TITLE
Do not dnf upgrade when building the CI containers.

### DIFF
--- a/devel/ci/Dockerfile-header
+++ b/devel/ci/Dockerfile-header
@@ -1,9 +1,6 @@
 FROM registry.fedoraproject.org/fedora:FEDORA_RELEASE
 MAINTAINER "Randy Barlow" <bowlofeggs@fedoraproject.org>
 
-# The echo works around https://bugzilla.redhat.com/show_bug.cgi?id=1483553 and any other future dnf
-# upgrade bugs.
-RUN dnf upgrade -y || echo "We are not trying to test dnf upgrade, so ignoring dnf failure."
 RUN dnf install -y \
     git \
     liberation-mono-fonts \


### PR DESCRIPTION
This commit has one pro, one speculative pro, and one con:

Pro: Bodhi's CI tests will run faster.

Speculative pro: Sometimes we get what seem like race conditions
in the Docker storage system. This *may* be due to how we have two
f26 containers trying to write the same layer (the pip container is
f26) at the same time due to the dnf upgrade.

Con: If Fedora updates to the base layer packages break Bodhi in
some way, we won't know until the next container base layer
rebuild, which happens every two weeks in Fedora.

Signed-off-by: Randy Barlow <randy@electronsweatshop.com>