### PR TITLE
Remove a guard against koji multicall returning dictionaries.

### DIFF
--- a/bodhi/server/views/generic.py
+++ b/bodhi/server/views/generic.py
@@ -286,8 +286,6 @@ def latest_candidates(request):
         response = koji.multiCall() or []  # Protect against None
 
         for taglist in response:
-            if isinstance(taglist, dict):
-                continue
             for build in taglist[0]:
                 item = {
                     'nvr': build['nvr'],


### PR DESCRIPTION
While writing tests for uncovered code today, I found this unusual
if statement that was guarding against koji multiCall() returning
dictionaries in its response. multiCall() as used here returns a
list of lists of dictionaries, so this if statement is not
triggered.

I attempted to research why this if statement was written in the
first place, but was unable to find a solid explanation. It was
added in 2286962e77162a1e7b0ca0c945235838507d1e16 and the original
commit message does not explain it. However, when it was added the
surrounding code did not use multicall and may have had different
return values.

In any case, I do not believe this code serves a purpose any
longer.

Signed-off-by: Randy Barlow <randy@electronsweatshop.com>