### PR TITLE
The popup_toggle view no longer asserts that the user exists.

### DIFF
--- a/bodhi/server/views/generic.py
+++ b/bodhi/server/views/generic.py
@@ -22,7 +22,7 @@ import datetime
 
 from pyramid.settings import asbool
 from pyramid.view import view_config, notfound_view_config
-from pyramid.exceptions import HTTPForbidden, HTTPBadRequest
+from pyramid.exceptions import HTTPForbidden
 from pyramid.httpexceptions import HTTPFound
 import cornice.errors
 import sqlalchemy as sa
@@ -380,16 +380,12 @@ def popup_toggle(request):
             page if "next" is not defined.
     Raises:
         pyramid.exceptions.HTTPForbidden: If the user is not logged in.
-        pyramid.httpexceptions.HTTPBadRequest: If the user is not found. It is unknown under which
-            circumstances this could happen.
     """
     # Get the user
     userid = request.authenticated_userid
     if userid is None:
         raise HTTPForbidden("You must be logged in.")
     user = request.db.query(models.User).filter_by(name=unicode(userid)).first()
-    if user is None:
-        raise HTTPBadRequest("For some reason, user does not exist.")
 
     # Toggle the value.
     user.show_popups = not user.show_popups


### PR DESCRIPTION
Since the popup_toggle() view asserts that the user is logged in,
it is redundant to also check that the user exists as the act of
logging in ensures that the user exists.

Signed-off-by: Randy Barlow <randy@electronsweatshop.com>