### PR TITLE
Remove an unreachable RSS type check.

### DIFF
--- a/bodhi/server/renderers.py
+++ b/bodhi/server/renderers.py
@@ -2,7 +2,6 @@ import io
 import operator
 
 from pytz import utc
-from pyramid.exceptions import HTTPNotFound
 from feedgen.feed import FeedGenerator
 
 
@@ -23,8 +22,6 @@ def rss(info):
             key = 'comments'
         elif 'overrides' in data:
             key = 'overrides'
-        else:
-            raise HTTPNotFound("RSS not implemented for this service")
 
         feed = FeedGenerator()
         feed.title(key)


### PR DESCRIPTION
The RSS handler has a series of if statements to check which type
of thing is being rendered. If none of the things match, it raised
a 404 error stating that the item cannot be rendered. This check
was not reachable by end users, since the decorator must be present
on views that support RSS for the code to be hit, and no views have
the decorator that aren't supported. It would be an error (and not
a 404) if a view had the RSS decorator without support in this
function, so it would truly be better to blow up than to hand back
a false 404. Thus, this commit removes that unreachable check.

Signed-off-by: Randy Barlow <randy@electronsweatshop.com>