### PR TITLE
Update libsolv before updating other packages in CI.

### DIFF
--- a/devel/ci/Dockerfile-header
+++ b/devel/ci/Dockerfile-header
@@ -1,6 +1,9 @@
 FROM registry.fedoraproject.org/fedora:FEDORA_RELEASE
 MAINTAINER "Randy Barlow" <bowlofeggs@fedoraproject.org>
 
+# Work around a severe dnf/libsolv/glibc issue: https://pagure.io/releng/issue/7125
+# This was suggested in a BZ comment: https://bugzilla.redhat.com/show_bug.cgi?id=1483553#c78
+RUN dnf upgrade -y libsolv || echo "We are not trying to test dnf upgrade, so ignoring dnf failure."
 # The echo works around https://bugzilla.redhat.com/show_bug.cgi?id=1483553 and any other future dnf
 # upgrade bugs.
 RUN dnf upgrade -y || echo "We are not trying to test dnf upgrade, so ignoring dnf failure."


### PR DESCRIPTION
This was suggested as a workaround to
https://pagure.io/releng/issue/7125 at
https://bugzilla.redhat.com/show_bug.cgi?id=1483553#c78

Signed-off-by: Randy Barlow <randy@electronsweatshop.com>