### PR TITLE
Delay 16 seconds between each CI container build.

### DIFF
--- a/devel/run_tests.sh
+++ b/devel/run_tests.sh
@@ -63,7 +63,7 @@ popd
 # tags.
 $PARALLEL sed -i "s/FEDORA_RELEASE/{= s:f:: =}/" devel/ci/Dockerfile-{} ::: $RELEASES
 # Build the containers.
-$PARALLEL "docker build --pull -t test/{} -f devel/ci/Dockerfile-{} . || (echo \"JENKIES FAIL\"; exit 1)" ::: $RELEASES || (echo -e "\n\n\033[0;31mFAILED TO BUILD IMAGE(S)\033[0m\n\n"; exit 1)
+$PARALLEL --delay 16 "docker build --pull -t test/{} -f devel/ci/Dockerfile-{} . || (echo \"JENKIES FAIL\"; exit 1)" ::: $RELEASES || (echo -e "\n\n\033[0;31mFAILED TO BUILD IMAGE(S)\033[0m\n\n"; exit 1)
 
 # Make individual folders for each release to drop its test results and docs.
 $PARALLEL mkdir -p $(pwd)/test_results/{} ::: $RELEASES


### PR DESCRIPTION
Bodhi's CI tests have been experiencing a high rate of what seem
like race conditions that lead to the parallel container test
builds failing. This commit is an experiment to see if staggering
the container builds by 8 seconds each will help us to win the race
more often.

Signed-off-by: Randy Barlow <randy@electronsweatshop.com>