### PR TITLE
Add issue #1989 to the 3.1.0 release notes.

### DIFF
--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -55,6 +55,7 @@ Bugs
 * The bindings will re-attempt authentication upon captcha failures (:issue:`1787`).
 * The formatting is fixed on mobile for the edit/create update form (:issue:`1791`).
 * The "Push to Stable" button is now rendered in the web UI on batched updates (:issue:`1907`).
+* Do not fail the mash if a changelog is malformed (:issue:`1989`).
 * Unreachable RSS Accept-header based redirects were fixed (:commit:`6f3db0c0`).
 * Fixed an unsafe default in ``bodhi.server.util.call_api()`` (:commit:`9461b3a4`).
 * Bodhi now distinguishes between testing and stable when asking Greenwave for gating decisions


### PR DESCRIPTION
This pull request is backporting the commit from #1994 to the 3.1 branch. It does not need review (it's already been reviewed there) - this is a convenient way to get Jenkies to test it before merging.

Signed-off-by: Randy Barlow <randy@electronsweatshop.com>