### PR TITLE
Do not allow pending updates to get request: batched.

### DIFF
--- a/bodhi/server/templates/update.html
+++ b/bodhi/server/templates/update.html
@@ -505,11 +505,6 @@ $(document).ready(function(){
               % if update.status.description != 'testing':
               <a id='testing' class="btn btn-sm btn-success"><span class="fa fa-fw fa-arrow-circle-right"></span> Push to Testing</a>
               % endif
-              % if update.status.description not in ['stable', 'obsolete']:
-                <a id='batched' class="btn btn-sm btn-success"><span class="fa fa-fw fa-arrow-circle-right"></span> Push to Batched</a>
-              % endif
-            % elif update.request.description in ['batched', 'stable']:
-                ${self.util.push_to_batched_or_stable_button(update) | n}
             % else:
               <a id='revoke' class="btn btn-sm btn-danger"><span class="fa fa-fw fa-arrow-circle-left"></span> Revoke</a>
             % endif
@@ -517,7 +512,7 @@ $(document).ready(function(){
             <a id='edit' class="btn btn-sm btn-primary"><span class="fa fa-fw fa-pencil"></span> Edit</a>
             % if update.critpath and update.critpath_approved:
               ${self.util.push_to_batched_or_stable_button(update) | n}
-	    % elif update.request and update.request.description == 'batched':
+            % elif update.request and update.request.description in ['batched', 'stable']:
               ${self.util.push_to_batched_or_stable_button(update) | n}
             % elif update.meets_testing_requirements:
               ${self.util.push_to_batched_or_stable_button(update) | n}

--- a/bodhi/tests/server/test_models.py
+++ b/bodhi/tests/server/test_models.py
@@ -1753,6 +1753,42 @@ class TestUpdate(ModelTest):
             link, (u"<a target='_blank' href='https://bugzilla.redhat.com/show_bug.cgi?id=1'>#1</a>"
                    u" foo\xe9bar"))
 
+    def test_set_request_pending_batched(self):
+        """
+        Ensure that we can't submit an update to batched if it is pending, even if it has met the
+        minimum testing requirements.
+        """
+        req = DummyRequest(user=DummyUser())
+        req.errors = cornice.Errors()
+        req.koji = buildsys.get_session()
+        self.assertEqual(self.obj.status, UpdateStatus.pending)
+        self.obj.stable_karma = 1
+        self.obj.comment(self.db, 'works', karma=1, author='bowlofeggs')
+
+        with self.assertRaises(BodhiException) as exc:
+            self.obj.set_request(self.db, UpdateRequest.batched, req.user.name)
+
+        self.assertEqual(self.obj.request, UpdateRequest.testing)
+        self.assertEqual(self.obj.status, UpdateStatus.pending)
+        self.assertEqual(
+            str(exc.exception),
+            ('This update is not in the testing repository yet. It cannot be requested for '
+             'batching until it is in testing.'))
+
+    def test_set_request_pending_stable(self):
+        """Ensure that we can submit an update to stable if it is pending and has enough karma."""
+        req = DummyRequest(user=DummyUser())
+        req.errors = cornice.Errors()
+        req.koji = buildsys.get_session()
+        self.assertEqual(self.obj.status, UpdateStatus.pending)
+        self.obj.stable_karma = 1
+        self.obj.comment(self.db, 'works', karma=1, author='bowlofeggs')
+
+        self.obj.set_request(self.db, UpdateRequest.stable, req.user.name)
+
+        self.assertEqual(self.obj.request, UpdateRequest.stable)
+        self.assertEqual(self.obj.status, UpdateStatus.pending)
+
     def test_set_request_untested_stable(self):
         """
         Ensure that we can't submit an update for stable if it hasn't met the


### PR DESCRIPTION
This PR is here to backport the fix to #1930 to the ```3.1``` branch. The patch has already been reviewed; this is a convenient way to run CI tests on the patch against the 3.1 branch before merging.

Previously, if pending updates received enough karma they would get
their request set to batched. This was bad because the update would
then not be mashed into the testing repository and would sit in
Koji only until the batched updates were set to stable, which means
that further testing oppotunities were missed.

Four different ideas were considered for fixing this bug:

1. We could make bodhi-push and the masher also select
   pending:batched updates when mashing testing updates. This
   seemed like the natural thing to do, but it might actually be
   the trickiest solution because so many if statements in the code
   need to be touched to say something like "or update.status is
   pending and update.request is batched".
2. The state:pending should always imply request:testing, and so we
   could adjust the code that looks to mash request:testing mash
   state:pending instead, which would pick up these updates too.
   However, this solution suffers from a similar problem to the
   first solution - a whole lot of places in the code would need to
   be touched and so it's not a simple fix. (The more places we
   have to touch to fix this, the higher chance we have of
   introducing new bugs ☺).
3. We could make it so pending updates don't get request:batched
   with karma, but stay at request:testing. Then after the mash
   runs, it checks the mashed updates to see if any of them are
   eligible to become batched and go ahead and do it. This seems
   simpler than #1 and #2, except for non-autokarma updates - we
   need to make sure that developers can't manually mark their
   updates to be batched when they are state:pending or those will
   end up in this same situation. That last caveat makes this
   solution a little less simple than it would otherwise be.
4. Refactor the state machine so that it is expressed in one place
   and is therefore much easier to modify and verify. This is a
   large undertaking.

After some deliberation solution #3 was chosen, though it was
tempting to go with #4.

fixes #1930

Signed-off-by: Randy Barlow <randy@electronsweatshop.com>