### PR TITLE
Remove an unneeded UTF-8 header from script.py.mako.

### DIFF
--- a/bodhi/server/migrations/script.py.mako
+++ b/bodhi/server/migrations/script.py.mako
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) YEAR AUTHOR
 #
 # This file is part of Bodhi.


### PR DESCRIPTION
re #1948

Signed-off-by: Randy Barlow <randy@electronsweatshop.com>