### PR TITLE
Run only one container build at a time in CI.

### DIFF
--- a/devel/run_tests.sh
+++ b/devel/run_tests.sh
@@ -63,7 +63,7 @@ popd
 # tags.
 $PARALLEL sed -i "s/FEDORA_RELEASE/{= s:f:: =}/" devel/ci/Dockerfile-{} ::: $RELEASES
 # Build the containers.
-$PARALLEL --delay 16 "docker build --pull -t test/{} -f devel/ci/Dockerfile-{} . || (echo \"JENKIES FAIL\"; exit 1)" ::: $RELEASES || (echo -e "\n\n\033[0;31mFAILED TO BUILD IMAGE(S)\033[0m\n\n"; exit 1)
+$PARALLEL -j 1 "docker build --pull -t test/{} -f devel/ci/Dockerfile-{} . || (echo \"JENKIES FAIL\"; exit 1)" ::: $RELEASES || (echo -e "\n\n\033[0;31mFAILED TO BUILD IMAGE(S)\033[0m\n\n"; exit 1)
 
 # Make individual folders for each release to drop its test results and docs.
 $PARALLEL mkdir -p $(pwd)/test_results/{} ::: $RELEASES


### PR DESCRIPTION
We've been trying to figure out a problem with the device mapper in
CentOS CI. We had previously tried to stagger the container builds
to see if it was a race condition and it did not work. This commit
instead tries to run only one docker build at a time.

Signed-off-by: Randy Barlow <randy@electronsweatshop.com>