### PR TITLE
introduce a new endpoint for waiving test results on an update

### DIFF
--- a/bodhi/server/config.py
+++ b/bodhi/server/config.py
@@ -412,7 +412,13 @@ class BodhiConfig(dict):
             'value': '%s has been submitted as an update to %s. %s',
             'validator': six.text_type},
         'greenwave_api_url': {
-            'value': 'https://greenwave.fedoraproject.org/api/v1.0',
+            'value': 'https://greenwave-web-greenwave.app.os.fedoraproject.org/api/v1.0',
+            'validator': six.text_type},
+        'waiverdb_api_url': {
+            'value': 'https://waiverdb-web-waiverdb.app.os.fedoraproject.org/api/v1.0',
+            'validator': six.text_type},
+        'waiverdb.access_token': {
+            'value': None,
             'validator': six.text_type},
         'koji_hub': {
             'value': 'https://koji.stg.fedoraproject.org/kojihub',

--- a/bodhi/server/schemas.py
+++ b/bodhi/server/schemas.py
@@ -790,3 +790,12 @@ class SaveOverrideSchema(CSRFProtectedSchema, colander.MappingSchema):
         colander.String(),
         missing=None,
     )
+
+
+class WaiveTestResultsSchema(CSRFProtectedSchema, colander.MappingSchema):
+    """An API schema for bodhi.server.services.updates.waive_test_results()."""
+
+    comment = colander.SchemaNode(
+        colander.String(),
+        missing=None,
+    )

--- a/bodhi/server/util.py
+++ b/bodhi/server/util.py
@@ -1145,7 +1145,7 @@ def get_critpath_components_from_pdc(branch, component_type='rpm'):
     return list(critpath_pkgs_set)
 
 
-def call_api(api_url, service_name, error_key=None, method='GET', data=None):
+def call_api(api_url, service_name, error_key=None, method='GET', data=None, headers=None):
     """
     Perform an HTTP request with response type and error handling.
 
@@ -1164,13 +1164,14 @@ def call_api(api_url, service_name, error_key=None, method='GET', data=None):
     """
     if data is None:
         data = dict()
-
     if method == 'POST':
+        if headers is None:
+            headers = {'Content-Type': 'application/json'}
         base_error_msg = (
             'Bodhi failed to send POST request to {0} at the following URL '
             '"{1}". The status code was "{2}".')
         rv = http_session.post(api_url,
-                               headers={'Content-Type': 'application/json'},
+                               headers=headers,
                                data=json.dumps(data),
                                timeout=60)
     else:
@@ -1248,3 +1249,24 @@ def greenwave_api_post(greenwave_api_url, data):
     # based on the error message
     return call_api(greenwave_api_url, service_name='Greenwave', method='POST',
                     data=data)
+
+
+def waiverdb_api_post(waiverdb_api_url, data):
+    """
+    Post a request to WaiverDB.
+
+    Args:
+        waiverdb_api_url (basestring): The URL to query.
+        data (dict): The parameters to send along with the request.
+    Returns:
+        dict: A dictionary response representing the API response's JSON.
+    Raises:
+        RuntimeError: If the server did not give us a 200 code.
+    """
+    # There is no error_key specified because the error key is not consistent
+    # based on the error message
+    return call_api(waiverdb_api_url, service_name='WaiverDB', method='POST',
+                    data=data, headers={
+                        'Content-Type': 'application/json',
+                        'Authorization': 'Bearer %s' % config.get('waiverdb.access_token')
+                    })

--- a/bodhi/tests/server/test_util.py
+++ b/bodhi/tests/server/test_util.py
@@ -586,6 +586,35 @@ class TestUtils(base.BaseTestCase):
             'The error was "".')
         assert actual_error == expected_error, actual_error
 
+    @mock.patch('bodhi.server.util.http_session')
+    def test_waiverdb_api_post(self, session):
+        """ Ensure that a POST request to WaiverDB works as expected.
+        """
+        session.post.return_value.status_code = 200
+        expected_json = {
+            'comment': 'this is not true!',
+            'id': 15,
+            'product_version': 'fedora-26',
+            'result_subject': {'productmd.compose.id': 'Fedora-9000-19700101.n.18'},
+            'result_testcase': 'compose.install_no_user',
+            'timestamp': '2017-11-28T17:42:04.209638',
+            'username': 'foo',
+            'waived': True,
+            'proxied_by': 'bodhi'
+        }
+        session.post.return_value.json.return_value = expected_json
+        data = {
+            'product_version': 'fedora-26',
+            'waived': True,
+            'proxy_user': 'foo',
+            'result_subject': {'productmd.compose.id': 'Fedora-9000-19700101.n.18'},
+            'result_testcase': 'compose.install_no_user',
+            'comment': 'this is not true!'
+        }
+        waiver = util.waiverdb_api_post('http://domain.local/api/v1.0/waivers/',
+                                        data)
+        assert waiver == expected_json, waiver
+
     def test_markup_escapes(self):
         """Ensure we correctly parse markdown & escape HTML"""
         text = (


### PR DESCRIPTION
A new endpoint `/updates/{id}/waive-test-results` for waiving test results. This is part of allowing packagers to be able to waive test results from the web UI. 