### PR TITLE
Define a Compose model to replace MASHER lockfiles.

### DIFF
--- a/bodhi/server/buildsys.py
+++ b/bodhi/server/buildsys.py
@@ -196,7 +196,7 @@ class DevBuildsys(Buildsystem):
 
             # Hardcoding for modules in the dev buildsys
             if token.startswith("2017"):
-                tag = "f17-updates-testing"
+                tag = "f27M-updates-testing"
                 data['extra'] = {
                     'typeinfo': {'module': {'more': 'mbs stuff goes here'}}
                 }
@@ -290,11 +290,11 @@ class DevBuildsys(Buildsystem):
             # Hardcoding for modules in the dev buildsys
             result = [
                 {'arches': 'x86_64', 'id': 15, 'locked': True,
-                 'name': 'f17-updates-candidate'},
+                 'name': 'f27M-updates-candidate'},
                 {'arches': 'x86_64', 'id': 16, 'locked': True,
-                 'name': 'f17-updates-testing'},
+                 'name': 'f27M-updates-testing'},
                 {'arches': 'x86_64', 'id': 17, 'locked': True,
-                 'name': 'f17'},
+                 'name': 'f27M'},
             ]
         else:
             release = build.split('.')[-1].replace('fc', 'f')

--- a/bodhi/server/mail.py
+++ b/bodhi/server/mail.py
@@ -409,7 +409,11 @@ def get_template(update, use_template='fedora_errata_template'):
             info['references'] += line
 
         # Find the most recent update for this package, other than this one
-        lastpkg = build.get_latest()
+        try:
+            lastpkg = build.get_latest()
+        except AttributeError:
+            # Not all build types have the get_latest() method, such as ModuleBuilds.
+            lastpkg = None
 
         # Grab the RPM header of the previous update, and generate a ChangeLog
         info['changelog'] = u""

--- a/bodhi/server/migrations/versions/4ed8554a4fc9_add_the_new_compose_model.py
+++ b/bodhi/server/migrations/versions/4ed8554a4fc9_add_the_new_compose_model.py
@@ -1,0 +1,68 @@
+# Copyright (c) 2017 Red Hat, Inc.
+#
+# This file is part of Bodhi.
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+"""
+Add the new Compose model.
+
+Revision ID: 4ed8554a4fc9
+Revises: 95ce24bed77a
+Create Date: 2017-11-21 20:10:08.977855
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+# revision identifiers, used by Alembic.
+revision = '4ed8554a4fc9'
+down_revision = '74cfbc6116ad'
+
+
+def upgrade():
+    """Create the composes table and drop updates.date_locked."""
+    op.create_table(
+        'composes',
+        sa.Column('checkpoints', sa.UnicodeText(), nullable=False),
+        sa.Column('error_message', sa.UnicodeText(), nullable=True),
+        sa.Column('date_created', sa.DateTime(), nullable=False),
+        sa.Column('state_date', sa.DateTime(), nullable=False),
+        sa.Column('release_id', sa.Integer(), nullable=False),
+        sa.Column(
+            'request',
+            postgresql.ENUM('unpush', 'testing', 'revoke', 'obsolete', 'stable', 'batched',
+                            name='ck_update_request', create_type=False),
+            nullable=False),
+        sa.Column(
+            'state',
+            postgresql.ENUM(
+                'requested', 'pending', 'initializing', 'updateinfo', 'punging', 'notifying',
+                'success', 'failed', name='ck_compose_state', create_type=True),
+            nullable=False),
+        sa.ForeignKeyConstraint(['release_id'], ['releases.id'], ),
+        sa.PrimaryKeyConstraint('release_id', 'request'))
+    op.drop_column(u'updates', 'date_locked')
+    # The new Compose object uses locked Updates to form a relationship. Let's ensure no Updates are
+    # locked when starting out.
+    op.execute("UPDATE updates SET locked = false WHERE locked = true")
+
+
+def downgrade():
+    """Drop the composes table and re-create updates.date_locked."""
+    op.add_column(u'updates', sa.Column('date_locked', postgresql.TIMESTAMP(), autoincrement=False,
+                                        nullable=True))
+    op.drop_table('composes')
+    op.execute("DROP TYPE ck_compose_state")

--- a/bodhi/server/scripts/monitor_composes.py
+++ b/bodhi/server/scripts/monitor_composes.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+# Copyright © 2017 Red Hat, Inc.
+#
+# This file is part of Bodhi.
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+"""Print a simple human-readable report about existing Compose objects."""
+import json
+
+import click
+
+from bodhi.server import buildsys, config, initialize_db, models
+
+
+@click.command()
+@click.version_option(message='%(version)s')
+def monitor():
+    """Print a simple human-readable report about existing Compose objects."""
+    initialize_db(config.config)
+    buildsys.setup_buildsystem(config.config)
+
+    click.echo('Locked updates: %s\n' % models.Update.query.filter_by(locked=True).count())
+
+    for c in sorted([c for c in models.Compose.query.all()]):
+        click.echo(c)
+        for attr in ('state', 'state_date', 'security', 'error_message'):
+            if getattr(c, attr) is not None:
+                click.echo('\t%s: %s' % (attr, getattr(c, attr)))
+        click.echo('\tcheckpoints: %s' % ', '.join(json.loads(c.checkpoints).keys()))
+        click.echo('\tlen(updates): %s\n' % len(c.updates))

--- a/bodhi/tests/server/__init__.py
+++ b/bodhi/tests/server/__init__.py
@@ -35,7 +35,7 @@ def create_update(session, build_nvrs, release_name=u'F17'):
             session.add(testcase)
             package.test_cases.append(testcase)
 
-        builds.append(RpmBuild(nvr=nvr, release=release, package=package,))
+        builds.append(RpmBuild(nvr=nvr, release=release, package=package, signed=True))
         session.add(builds[-1])
 
         # Add a buildroot override for this build
@@ -48,10 +48,11 @@ def create_update(session, build_nvrs, release_name=u'F17'):
 
     update = Update(
         title=', '.join(build_nvrs), builds=builds, user=user, request=UpdateRequest.testing,
-        notes=u'Useful details!', release=release, date_submitted=datetime(1984, 11, 2),
+        notes=u'Useful details!', type=UpdateType.bugfix, date_submitted=datetime(1984, 11, 2),
         requirements=u'rpmlint', stable_karma=3, unstable_karma=-3,
-        type=UpdateType.bugfix, test_gating_status=TestGatingStatus.passed)
+        test_gating_status=TestGatingStatus.passed)
     session.add(update)
+    update.release = release
 
     return update
 
@@ -101,7 +102,5 @@ def populate(db):
     with mock.patch(target='uuid.uuid4', return_value='wat'):
         update.assign_alias()
     db.add(update)
-
-    update.locked = True
 
     db.commit()

--- a/bodhi/tests/server/base.py
+++ b/bodhi/tests/server/base.py
@@ -231,6 +231,32 @@ class BaseTestCase(unittest.TestCase):
         """
         return create_update(self.db, build_nvrs, release_name)
 
+    def create_release(self, version):
+        """
+        Create and return a :class:`Release` with the given version.
+
+        Args:
+            version (basestring): A string of the version of the release, such as 27.
+        Returns:
+            bodhi.server.models.Release: A new release.
+        """
+        release = models.Release(
+            name=u'F{}'.format(version), long_name=u'Fedora {}'.format(version),
+            id_prefix=u'FEDORA', version=u'{}'.format(version.replace('M', '')),
+            dist_tag=u'f{}'.format(version), stable_tag=u'f{}-updates'.format(version),
+            testing_tag=u'f{}-updates-testing'.format(version),
+            candidate_tag=u'f{}-updates-candidate'.format(version),
+            pending_signing_tag=u'f{}-updates-testing-signing'.format(version),
+            pending_testing_tag=u'f{}-updates-testing-pending'.format(version),
+            pending_stable_tag=u'f{}-updates-pending'.format(version),
+            override_tag=u'f{}-override'.format(version),
+            branch=u'f{}'.format(version), state=models.ReleaseState.current)
+        self.db.add(release)
+        models.Release._all_releases = None
+        models.Release._tag_cache = None
+        self.db.flush()
+        return release
+
 
 class TransactionalSessionMaker(object):
     """

--- a/bodhi/tests/server/scripts/test_monitor_composes.py
+++ b/bodhi/tests/server/scripts/test_monitor_composes.py
@@ -1,0 +1,77 @@
+# -*- coding: utf-8 -*-
+# Copyright © 2017 Red Hat, Inc.
+#
+# This file is part of Bodhi.
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+"""
+This module contains tests for the bodhi.server.scripts.monitor_composes module.
+"""
+import json
+
+from click import testing
+import mock
+
+from bodhi.server import models
+from bodhi.server.scripts import monitor_composes
+from bodhi.tests.server.base import BaseTestCase
+
+
+@mock.patch('bodhi.server.scripts.monitor_composes.initialize_db', mock.MagicMock())
+@mock.patch('bodhi.server.scripts.monitor_composes.buildsys.setup_buildsystem', mock.MagicMock())
+class TestMonitor(BaseTestCase):
+    """This class contains tests for the monitor() function."""
+
+    def test_monitor_no_composes(self):
+        """Ensure correct output from the monitor function."""
+        runner = testing.CliRunner()
+
+        r = runner.invoke(monitor_composes.monitor)
+
+        self.assertEqual(r.exit_code, 0)
+        self.assertEqual(r.output, 'Locked updates: 0\n\n')
+
+    def test_monitor_with_composes(self):
+        """Ensure correct output from the monitor function."""
+        runner = testing.CliRunner()
+        update = models.Update.query.one()
+        update.locked = True
+        update.status = models.UpdateStatus.pending
+        update.request = models.UpdateRequest.testing
+        compose_1 = models.Compose(
+            release=update.release, request=update.request, state=models.ComposeState.notifying,
+            checkpoints=json.dumps({'check_1': True, 'check_2': True}))
+        ejabberd = self.create_update([u'ejabberd-16.09-4.fc17'])
+        ejabberd.locked = True
+        ejabberd.status = models.UpdateStatus.testing
+        ejabberd.request = models.UpdateRequest.stable
+        ejabberd.type = models.UpdateType.security
+        compose_2 = models.Compose(
+            release=ejabberd.release, request=ejabberd.request, state=models.ComposeState.failed,
+            error_message=u'y r u so mean nfs')
+        self.db.add(compose_1)
+        self.db.add(compose_2)
+        self.db.flush()
+
+        r = runner.invoke(monitor_composes.monitor)
+
+        self.assertEqual(r.exit_code, 0)
+        EXPECTED_OUTPUT = (
+            'Locked updates: 2\n\n<Compose: F17 stable>\n\tstate: <failed>\n\tstate_date: {}\n\t'
+            'security: True\n\terror_message: y r u so mean nfs\n\tcheckpoints: \n\t'
+            'len(updates): 1\n\n<Compose: F17 testing>\n\tstate: <notifying>\n\tstate_date: {}\n\t'
+            'security: False\n\tcheckpoints: check_2, check_1\n\tlen(updates): 1\n\n')
+        self.assertEqual(r.output,
+                         EXPECTED_OUTPUT.format(compose_2.state_date, compose_1.state_date))

--- a/bodhi/tests/server/test_push.py
+++ b/bodhi/tests/server/test_push.py
@@ -1,5 +1,8 @@
 # -*- coding: utf-8 -*-
-
+# Copyright © 2016-2017 Red Hat, Inc. and others.
+#
+# This file is part of Bodhi.
+#
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
 # as published by the Free Software Foundation; either version 2
@@ -165,50 +168,59 @@ class TestFilterReleases(base.BaseTestCase):
             self.assertEqual(str(ex.exception), 'Unknown release: RELEASE WITH NO NAME')
 
 
-TEST_ABORT_PUSH_EXPECTED_OUTPUT = """Warning: bodhi-2.0-1.fc17 is locked but not in a push
-Warning: bodhi-2.0-1.fc17 has unsigned builds and has been skipped
+TEST_ABORT_PUSH_EXPECTED_OUTPUT = """
+
+===== <Compose: F17 testing> =====
+
 python-nose-1.3.7-11.fc17
 python-paste-deploy-1.5.2-8.fc17
-Push these 2 updates? [y/N]: n
+bodhi-2.0-1.fc17
+
+
+Push these 3 updates? [y/N]: n
 Aborted!
 """
 
-TEST_BUILDS_FLAG_EXPECTED_OUTPUT = """ejabberd-16.09-4.fc17
-python-nose-1.3.7-11.fc17
-Push these 2 updates? [y/N]: y
+TEST_BUILDS_FLAG_EXPECTED_OUTPUT = """
 
-Locking updates...
+===== <Compose: F17 testing> =====
 
-Sending masher.start fedmsg
-"""
-
-TEST_CERT_PREFIX_FLAG_EXPECTED_OUTPUT = """Warning: bodhi-2.0-1.fc17 is locked but not in a push
-Warning: bodhi-2.0-1.fc17 has unsigned builds and has been skipped
-python-nose-1.3.7-11.fc17
-python-paste-deploy-1.5.2-8.fc17
-Push these 2 updates? [y/N]: y
-
-Locking updates...
-
-Sending masher.start fedmsg
-"""
-
-TEST_LOCKED_UPDATES_EXPECTED_OUTPUT = """Warning: bodhi-2.0-1.fc17 is locked but not in a push
-Warning: bodhi-2.0-1.fc17 has unsigned builds and has been skipped
-python-nose-1.3.7-11.fc17
-python-paste-deploy-1.5.2-8.fc17
-Push these 2 updates? [y/N]: y
-
-Locking updates...
-
-Sending masher.start fedmsg
-"""
-
-TEST_LOCKED_UPDATES_NOT_IN_A_PUSH_EXPECTED_OUTPUT = """Warning: ejabberd-16.09-4.fc17 is locked but not in a push
-python-nose-1.3.7-11.fc17
-python-paste-deploy-1.5.2-8.fc17
 ejabberd-16.09-4.fc17
+python-nose-1.3.7-11.fc17
+
+
+Push these 2 updates? [y/N]: y
+
+Locking updates...
+
+Sending masher.start fedmsg
+"""
+
+TEST_CERT_PREFIX_FLAG_EXPECTED_OUTPUT = """
+
+===== <Compose: F17 testing> =====
+
+python-nose-1.3.7-11.fc17
+python-paste-deploy-1.5.2-8.fc17
+bodhi-2.0-1.fc17
+
+
 Push these 3 updates? [y/N]: y
+
+Locking updates...
+
+Sending masher.start fedmsg
+"""
+
+TEST_LOCKED_UPDATES_EXPECTED_OUTPUT = """Existing composes detected: <Compose: F17 testing>. Do you wish to resume them all? [y/N]: y
+
+
+===== <Compose: F17 testing> =====
+
+ejabberd-16.09-4.fc17
+
+
+Push these 1 updates? [y/N]: y
 
 Locking updates...
 
@@ -217,14 +229,23 @@ Sending masher.start fedmsg
 
 TEST_NO_UPDATES_TO_PUSH_EXPECTED_OUTPUT = """Warning: python-nose-1.3.7-11.fc17 has unsigned builds and has been skipped
 Warning: python-paste-deploy-1.5.2-8.fc17 has unsigned builds and has been skipped
-Warning: bodhi-2.0-1.fc17 is locked but not in a push
 Warning: bodhi-2.0-1.fc17 has unsigned builds and has been skipped
 
 There are no updates to push.
 """
 
-TEST_RELEASES_FLAG_EXPECTED_OUTPUT = """python-nose-1.3.7-11.fc25
+TEST_RELEASES_FLAG_EXPECTED_OUTPUT = """
+
+===== <Compose: F25 testing> =====
+
+python-nose-1.3.7-11.fc25
+
+
+===== <Compose: F26 testing> =====
+
 python-paste-deploy-1.5.2-8.fc26
+
+
 Push these 2 updates? [y/N]: y
 
 Locking updates...
@@ -232,9 +253,29 @@ Locking updates...
 Sending masher.start fedmsg
 """
 
-TEST_REQUEST_FLAG_EXPECTED_OUTPUT = """Warning: bodhi-2.0-1.fc17 is locked but not in a push
-Warning: bodhi-2.0-1.fc17 has unsigned builds and has been skipped
+TEST_REQUEST_FLAG_EXPECTED_OUTPUT = """
+
+===== <Compose: F17 testing> =====
+
 python-paste-deploy-1.5.2-8.fc17
+bodhi-2.0-1.fc17
+
+
+Push these 2 updates? [y/N]: y
+
+Locking updates...
+
+Sending masher.start fedmsg
+"""
+
+TEST_RESUME_FLAG_EXPECTED_OUTPUT = """Resume <Compose: F17 testing>? [y/N]: y
+
+
+===== <Compose: F17 testing> =====
+
+ejabberd-16.09-4.fc17
+
+
 Push these 1 updates? [y/N]: y
 
 Locking updates...
@@ -242,8 +283,15 @@ Locking updates...
 Sending masher.start fedmsg
 """
 
-TEST_RESUME_FLAG_EXPECTED_OUTPUT = """Resume /mnt/koji/mash/updates/MASHING-f17-updates? [y/N]: y
+TEST_RESUME_EMPTY_COMPOSE = """Resume <Compose: F17 testing>? [y/N]: y
+<Compose: F17 stable> has no updates. It is being removed.
+
+
+===== <Compose: F17 testing> =====
+
 ejabberd-16.09-4.fc17
+
+
 Push these 1 updates? [y/N]: y
 
 Locking updates...
@@ -251,9 +299,15 @@ Locking updates...
 Sending masher.start fedmsg
 """
 
-TEST_RESUME_HUMAN_SAYS_NO_EXPECTED_OUTPUT = """Resume /mnt/koji/mash/updates/MASHING-f17-testing? [y/N]: n
-Resume /mnt/koji/mash/updates/MASHING-f17-updates? [y/N]: y
+TEST_RESUME_HUMAN_SAYS_NO_EXPECTED_OUTPUT = """Resume <Compose: F17 testing>? [y/N]: y
+Resume <Compose: F17 stable>? [y/N]: n
+
+
+===== <Compose: F17 testing> =====
+
 ejabberd-16.09-4.fc17
+
+
 Push these 1 updates? [y/N]: y
 
 Locking updates...
@@ -262,10 +316,15 @@ Sending masher.start fedmsg
 """
 
 TEST_UNSIGNED_UPDATES_SKIPPED_EXPECTED_OUTPUT = """Warning: python-nose-1.3.7-11.fc17 has unsigned builds and has been skipped
-Warning: bodhi-2.0-1.fc17 is locked but not in a push
-Warning: bodhi-2.0-1.fc17 has unsigned builds and has been skipped
+
+
+===== <Compose: F17 testing> =====
+
 python-paste-deploy-1.5.2-8.fc17
-Push these 1 updates? [y/N]: y
+bodhi-2.0-1.fc17
+
+
+Push these 2 updates? [y/N]: y
 
 Locking updates...
 
@@ -319,13 +378,10 @@ class TestPush(base.BaseTestCase):
             doctored_output = result.output
         self.assertEqual(doctored_output, TEST_ABORT_PUSH_EXPECTED_OUTPUT)
         self.assertEqual(publish.call_count, 0)
-
         # The updates should not be locked
-        python_nose = self.db.query(models.Update).filter_by(
-            title=u'python-nose-1.3.7-11.fc17').one()
-        python_paste_deploy = self.db.query(models.Update).filter_by(
-            title=u'python-paste-deploy-1.5.2-8.fc17').one()
-        for u in [python_nose, python_paste_deploy]:
+        for u in [u'bodhi-2.0-1.fc17', u'python-nose-1.3.7-11.fc17',
+                  u'python-paste-deploy-1.5.2-8.fc17']:
+            u = self.db.query(models.Update).filter_by(title=u).one()
             self.assertFalse(u.locked)
             self.assertIsNone(u.date_locked)
 
@@ -353,18 +409,18 @@ class TestPush(base.BaseTestCase):
         self.assertEqual(result.output, TEST_BUILDS_FLAG_EXPECTED_OUTPUT)
         publish.assert_called_once_with(
             topic='masher.start',
-            msg={'updates': [u'ejabberd-16.09-4.fc17', u'python-nose-1.3.7-11.fc17'],
-                 'resume': False, 'agent': 'bowlofeggs'},
+            msg={
+                'composes': [{'security': False, 'release_id': ejabberd.release.id,
+                              'request': u'testing', 'content_type': u'rpm'}],
+                'resume': False, 'agent': 'bowlofeggs', 'api_version': 2},
             force=True)
 
-        ejabberd = self.db.query(models.Update).filter_by(title=u'ejabberd-16.09-4.fc17').one()
-        python_nose = self.db.query(models.Update).filter_by(
-            title=u'python-nose-1.3.7-11.fc17').one()
-        python_paste_deploy = self.db.query(models.Update).filter_by(
-            title=u'python-paste-deploy-1.5.2-8.fc17').one()
-        for u in [ejabberd, python_nose]:
+        for u in [u'ejabberd-16.09-4.fc17', u'python-nose-1.3.7-11.fc17']:
+            u = self.db.query(models.Update).filter_by(title=u).one()
             self.assertTrue(u.locked)
             self.assertTrue(u.date_locked <= datetime.utcnow())
+        python_paste_deploy = self.db.query(models.Update).filter_by(
+            title=u'python-paste-deploy-1.5.2-8.fc17').one()
         self.assertFalse(python_paste_deploy.locked)
         self.assertIsNone(python_paste_deploy.date_locked)
 
@@ -387,105 +443,56 @@ class TestPush(base.BaseTestCase):
         init.assert_called_once_with(active=True, cert_prefix='some_prefix')
         publish.assert_called_once_with(
             topic='masher.start',
-            msg={'updates': ['python-nose-1.3.7-11.fc17', u'python-paste-deploy-1.5.2-8.fc17'],
-                 'resume': False, 'agent': 'bowlofeggs'},
+            msg={
+                'composes': [{'security': False, 'release_id': 1, 'request': u'testing',
+                              'content_type': u'rpm'}],
+                'resume': False, 'agent': 'bowlofeggs', 'api_version': 2},
             force=True)
 
     @mock.patch('bodhi.server.push.bodhi.server.notifications.init')
-    @mock.patch('bodhi.server.push.open', create=True)
     @mock.patch('bodhi.server.push.bodhi.server.notifications.publish')
-    @mock.patch('bodhi.server.push.glob.glob',
-                return_value=['/mnt/koji/mash/updates/MASHING-f17-updates'])
-    @mock.patch('bodhi.server.push.json.load', return_value={'updates': ['ejabberd-16.09-4.fc17']})
-    def test_locked_updates(self, load, glob, publish, mock_file, mock_init):
+    def test_locked_updates(self, publish, mock_init):
         """
         Test correct operation when there are some locked updates.
         """
         cli = CliRunner()
-        # Let's mark ejabberd as locked and already in a push. It should get silently ignored.
+        # Let's mark ejabberd as locked and already in a push. bodhi-push should prompt the user to
+        # resume this compose rather than starting a new one.
         ejabberd = self.create_update([u'ejabberd-16.09-4.fc17'])
         ejabberd.builds[0].signed = True
         ejabberd.locked = True
-        ejabberd.date_locked = datetime.utcnow()
+        compose = models.Compose(
+            release=ejabberd.release, request=ejabberd.request, state=models.ComposeState.failed,
+            error_message=u'y r u so mean nfs')
+        self.db.add(compose)
         self.db.commit()
 
         with mock.patch('bodhi.server.push.transactional_session_maker',
                         return_value=base.TransactionalSessionMaker(self.Session)):
-            result = cli.invoke(push.push, ['--username', 'bowlofeggs'], input='y')
+            result = cli.invoke(push.push, ['--username', 'bowlofeggs'], input='y\ny')
 
         self.assertEqual(result.exit_code, 0)
         mock_init.assert_called_once_with(active=True, cert_prefix=u'shell')
         self.assertEqual(result.output, TEST_LOCKED_UPDATES_EXPECTED_OUTPUT)
-        glob.assert_called_once_with('/mashdir//MASHING-*')
         publish.assert_called_once_with(
             topic='masher.start',
-            msg={'updates': ['python-nose-1.3.7-11.fc17', 'python-paste-deploy-1.5.2-8.fc17'],
-                 'resume': False, 'agent': 'bowlofeggs'},
+            msg={'composes': [ejabberd.compose.__json__()],
+                 'resume': True, 'agent': 'bowlofeggs', 'api_version': 2},
             force=True)
-        mock_file.assert_called_once_with('/mnt/koji/mash/updates/MASHING-f17-updates')
-
         ejabberd = self.db.query(models.Update).filter_by(title=u'ejabberd-16.09-4.fc17').one()
+        self.assertTrue(ejabberd.locked)
+        self.assertTrue(ejabberd.date_locked <= datetime.utcnow())
+        self.assertEqual(ejabberd.compose.release, ejabberd.release)
+        self.assertEqual(ejabberd.compose.request, ejabberd.request)
+        self.assertEqual(ejabberd.compose.state, models.ComposeState.requested)
+        self.assertEqual(ejabberd.compose.error_message, '')
         python_nose = self.db.query(models.Update).filter_by(
             title=u'python-nose-1.3.7-11.fc17').one()
         python_paste_deploy = self.db.query(models.Update).filter_by(
             title=u'python-paste-deploy-1.5.2-8.fc17').one()
-        for u in [ejabberd, python_nose, python_paste_deploy]:
-            self.assertTrue(u.locked)
-            self.assertTrue(u.date_locked <= datetime.utcnow())
-
-    @mock.patch('bodhi.server.push.bodhi.server.notifications.init')
-    @mock.patch('bodhi.server.push.open', create=True)
-    @mock.patch('bodhi.server.push.bodhi.server.notifications.publish')
-    @mock.patch('bodhi.server.push.glob.glob',
-                return_value=['/mnt/koji/mash/updates/MASHING-f17-updates'])
-    @mock.patch('bodhi.server.push.json.load', return_value={'updates': ['bodhi-2.0-1.fc17']})
-    def test_locked_updates_not_in_a_push(self, load, glob, publish, mock_file, mock_init):
-        """
-        Test correct operation when there are some locked updates that aren't in a push.
-        """
-        cli = CliRunner()
-        # Let's mark ejabberd as locked but not already in a push. It should print a warning but
-        # still get pushed.
-        ejabberd = self.create_update([u'ejabberd-16.09-4.fc17'])
-        ejabberd.builds[0].signed = True
-        ejabberd.locked = True
-        ejabberd.date_locked = datetime.utcnow()
-        self.db.commit()
-
-        with mock.patch('bodhi.server.push.transactional_session_maker',
-                        return_value=base.TransactionalSessionMaker(self.Session)):
-            result = cli.invoke(push.push, ['--username', 'bowlofeggs'], input='y')
-
-        self.assertEqual(result.exit_code, 0)
-        mock_init.assert_called_once_with(active=True, cert_prefix=u'shell')
-        # The packages might be printed in any order and the order isn't important. So let's compare
-        # the output with the package list removed to make sure that it is correct.
-        self.assertEqual(
-            '\n'.join([l for l in result.output.split('\n') if l[-4:] != 'fc17']),
-            '\n'.join([l for l in TEST_LOCKED_UPDATES_NOT_IN_A_PUSH_EXPECTED_OUTPUT.split('\n')
-                       if l[-4:] != 'fc17']))
-        # Now let's assert that the package list is correct
-        self.assertEqual(
-            set([l for l in result.output.split('\n') if l[-4:] == 'fc17']),
-            set([l for l in TEST_LOCKED_UPDATES_NOT_IN_A_PUSH_EXPECTED_OUTPUT.split('\n')
-                 if l[-4:] == 'fc17']))
-        glob.assert_called_once_with('/mashdir//MASHING-*')
-        publish.assert_called_once_with(
-            topic='masher.start',
-            msg={'updates': ['ejabberd-16.09-4.fc17', 'python-nose-1.3.7-11.fc17',
-                             'python-paste-deploy-1.5.2-8.fc17'],
-                 'resume': False, 'agent': 'bowlofeggs'},
-            force=True)
-        mock_file.assert_called_once_with('/mnt/koji/mash/updates/MASHING-f17-updates')
-
-        ejabberd = self.db.query(models.Update).filter_by(title=u'ejabberd-16.09-4.fc17').one()
-        python_nose = self.db.query(models.Update).filter_by(
-            title=u'python-nose-1.3.7-11.fc17').one()
-        python_paste_deploy = self.db.query(models.Update).filter_by(
-            title=u'python-paste-deploy-1.5.2-8.fc17').one()
-        for u in [ejabberd, python_nose, python_paste_deploy]:
-            self.assertTrue(u.locked)
-            self.assertTrue(u.date_locked <= datetime.utcnow())
+        for u in [python_nose, python_paste_deploy]:
+            self.assertFalse(u.locked)
+            self.assertIsNone(u.date_locked)
 
     @mock.patch('bodhi.server.push.bodhi.server.notifications.publish')
     def test_no_updates_to_push(self, publish):
@@ -493,10 +500,13 @@ class TestPush(base.BaseTestCase):
         If there are no updates to push, no push message should get sent.
         """
         cli = CliRunner()
+        bodhi = self.db.query(models.Update).filter_by(
+            title=u'bodhi-2.0-1.fc17').one()
         python_nose = self.db.query(models.Update).filter_by(
             title=u'python-nose-1.3.7-11.fc17').one()
         python_paste_deploy = self.db.query(models.Update).filter_by(
             title=u'python-paste-deploy-1.5.2-8.fc17').one()
+        bodhi.builds[0].signed = False
         python_nose.builds[0].signed = False
         python_paste_deploy.builds[0].signed = False
         self.db.commit()
@@ -510,6 +520,8 @@ class TestPush(base.BaseTestCase):
         self.assertEqual(publish.call_count, 0)
 
         # The updates should not be locked
+        bodhi = self.db.query(models.Update).filter_by(
+            title=u'bodhi-2.0-1.fc17').one()
         python_nose = self.db.query(models.Update).filter_by(
             title=u'python-nose-1.3.7-11.fc17').one()
         python_paste_deploy = self.db.query(models.Update).filter_by(
@@ -551,6 +563,8 @@ class TestPush(base.BaseTestCase):
         self.db.commit()
         # Let's make an update for each release
         python_nose = self.create_update([u'python-nose-1.3.7-11.fc25'], u'F25')
+        # Let's make nose a security update to test that its compose gets sorted first.
+        python_nose.type = models.UpdateType.security
         python_paste_deploy = self.create_update([u'python-paste-deploy-1.5.2-8.fc26'], u'F26')
         python_nose.builds[0].signed = True
         python_paste_deploy.builds[0].signed = True
@@ -568,10 +582,16 @@ class TestPush(base.BaseTestCase):
         self.assertEqual(result.exit_code, 0)
         mock_init.assert_called_once_with(active=True, cert_prefix=u'shell')
         self.assertEqual(result.output, TEST_RELEASES_FLAG_EXPECTED_OUTPUT)
+        f25_python_nose = self.db.query(models.Update).filter_by(
+            title=u'python-nose-1.3.7-11.fc25').one()
+        f26_python_paste_deploy = self.db.query(models.Update).filter_by(
+            title=u'python-paste-deploy-1.5.2-8.fc26').one()
         publish.assert_called_once_with(
             topic='masher.start',
-            msg={'updates': ['python-nose-1.3.7-11.fc25', 'python-paste-deploy-1.5.2-8.fc26'],
-                 'resume': False, 'agent': 'bowlofeggs'},
+            msg={
+                'composes': [f25_python_nose.compose.__json__(),
+                             f26_python_paste_deploy.compose.__json__()],
+                'resume': False, 'agent': 'bowlofeggs', 'api_version': 2},
             force=True)
 
         # The Fedora 17 updates should not have been locked.
@@ -581,17 +601,20 @@ class TestPush(base.BaseTestCase):
             title=u'python-paste-deploy-1.5.2-8.fc17').one()
         self.assertFalse(f17_python_nose.locked)
         self.assertIsNone(f17_python_nose.date_locked)
+        self.assertIsNone(f17_python_nose.compose)
         self.assertFalse(f17_python_paste_deploy.locked)
         self.assertIsNone(f17_python_paste_deploy.date_locked)
+        self.assertIsNone(f17_python_paste_deploy.compose)
         # The new updates should both be locked.
-        f25_python_nose = self.db.query(models.Update).filter_by(
-            title=u'python-nose-1.3.7-11.fc25').one()
-        f26_python_paste_deploy = self.db.query(models.Update).filter_by(
-            title=u'python-paste-deploy-1.5.2-8.fc26').one()
         self.assertTrue(f25_python_nose.locked)
         self.assertTrue(f25_python_nose.date_locked <= datetime.utcnow())
         self.assertTrue(f26_python_paste_deploy.locked)
         self.assertTrue(f26_python_paste_deploy.date_locked <= datetime.utcnow())
+        # The new updates should also be associated with the new Composes.
+        self.assertEqual(f25_python_nose.compose.release.id, f25.id)
+        self.assertEqual(f25_python_nose.compose.request, models.UpdateRequest.testing)
+        self.assertEqual(f26_python_paste_deploy.compose.release.id, f26.id)
+        self.assertEqual(f26_python_paste_deploy.compose.request, models.UpdateRequest.testing)
 
     @mock.patch('bodhi.server.push.bodhi.server.notifications.init')
     @mock.patch('bodhi.server.push.bodhi.server.notifications.publish')
@@ -614,28 +637,30 @@ class TestPush(base.BaseTestCase):
         self.assertEqual(result.exit_code, 0)
         mock_init.assert_called_once_with(active=True, cert_prefix=u'shell')
         self.assertEqual(result.output, TEST_REQUEST_FLAG_EXPECTED_OUTPUT)
-        publish.assert_called_once_with(
-            topic='masher.start',
-            msg={'updates': ['python-paste-deploy-1.5.2-8.fc17'],
-                 'resume': False, 'agent': 'bowlofeggs'},
-            force=True)
-
+        bodhi = self.db.query(models.Update).filter_by(
+            title=u'bodhi-2.0-1.fc17').one()
         python_nose = self.db.query(models.Update).filter_by(
             title=u'python-nose-1.3.7-11.fc17').one()
         python_paste_deploy = self.db.query(models.Update).filter_by(
             title=u'python-paste-deploy-1.5.2-8.fc17').one()
+        publish.assert_called_once_with(
+            topic='masher.start',
+            msg={'composes': [python_paste_deploy.compose.__json__()],
+                 'resume': False, 'agent': 'bowlofeggs', 'api_version': 2},
+            force=True)
         self.assertFalse(python_nose.locked)
         self.assertIsNone(python_nose.date_locked)
-        self.assertTrue(python_paste_deploy.locked)
-        self.assertTrue(python_paste_deploy.date_locked <= datetime.utcnow())
+        self.assertIsNone(python_nose.compose)
+        for u in [bodhi, python_paste_deploy]:
+            self.assertTrue(u.locked)
+            self.assertTrue(u.date_locked <= datetime.utcnow())
+            self.assertEqual(u.compose.release.id, python_paste_deploy.release.id)
+            self.assertEqual(u.compose.request, models.UpdateRequest.testing)
+            self.assertEqual(u.compose.content_type, models.ContentType.rpm)
 
     @mock.patch('bodhi.server.push.bodhi.server.notifications.init')
-    @mock.patch('bodhi.server.push.open', create=True)
     @mock.patch('bodhi.server.push.bodhi.server.notifications.publish')
-    @mock.patch('bodhi.server.push.glob.glob',
-                return_value=['/mnt/koji/mash/updates/MASHING-f17-updates'])
-    @mock.patch('bodhi.server.push.json.load', return_value={'updates': [u'ejabberd-16.09-4.fc17']})
-    def test_resume_flag(self, load, glob, publish, mock_file, mock_init):
+    def test_resume_flag(self, publish, mock_init):
         """
         Test correct operation when the --resume flag is given.
         """
@@ -645,7 +670,8 @@ class TestPush(base.BaseTestCase):
         ejabberd = self.create_update([u'ejabberd-16.09-4.fc17'])
         ejabberd.builds[0].signed = True
         ejabberd.locked = True
-        ejabberd.date_locked = datetime.utcnow()
+        compose = models.Compose(release=ejabberd.release, request=ejabberd.request)
+        self.db.add(compose)
         self.db.commit()
 
         with mock.patch('bodhi.server.push.transactional_session_maker',
@@ -655,37 +681,84 @@ class TestPush(base.BaseTestCase):
         self.assertEqual(result.exit_code, 0)
         mock_init.assert_called_once_with(active=True, cert_prefix=u'shell')
         self.assertEqual(result.output, TEST_RESUME_FLAG_EXPECTED_OUTPUT)
-        glob.assert_called_once_with('/mashdir//MASHING-*')
-        publish.assert_called_once_with(
-            topic='masher.start',
-            msg={'updates': ['ejabberd-16.09-4.fc17'],
-                 'resume': True, 'agent': 'bowlofeggs'},
-            force=True)
-        mock_file.assert_called_once_with('/mnt/koji/mash/updates/MASHING-f17-updates')
-
         ejabberd = self.db.query(models.Update).filter_by(title=u'ejabberd-16.09-4.fc17').one()
         python_nose = self.db.query(models.Update).filter_by(
             title=u'python-nose-1.3.7-11.fc17').one()
         python_paste_deploy = self.db.query(models.Update).filter_by(
             title=u'python-paste-deploy-1.5.2-8.fc17').one()
+        publish.assert_called_once_with(
+            topic='masher.start',
+            msg={'composes': [ejabberd.compose.__json__()],
+                 'resume': True, 'agent': 'bowlofeggs', 'api_version': 2},
+            force=True)
         # ejabberd should be locked still
         self.assertTrue(ejabberd.locked)
         self.assertTrue(ejabberd.date_locked <= datetime.utcnow())
+        self.assertEqual(ejabberd.compose.release, ejabberd.release)
+        self.assertEqual(ejabberd.compose.request, ejabberd.request)
         # The other packages should have been left alone
         for u in [python_nose, python_paste_deploy]:
             self.assertFalse(u.locked)
             self.assertIsNone(u.date_locked)
+            self.assertIsNone(u.compose)
 
     @mock.patch('bodhi.server.push.bodhi.server.notifications.init', mock.Mock())
-    @mock.patch('bodhi.server.push.open', create=True)
     @mock.patch('bodhi.server.push.bodhi.server.notifications.publish')
-    @mock.patch('bodhi.server.push.glob.glob',
-                return_value=['/mnt/koji/mash/updates/MASHING-f17-testing',
-                              '/mnt/koji/mash/updates/MASHING-f17-updates'])
-    @mock.patch('bodhi.server.push.json.load',
-                side_effect=[{'updates': [u'python-nose-1.3.7-11.fc17']},
-                             {'updates': [u'ejabberd-16.09-4.fc17']}])
-    def test_resume_human_says_no(self, load, glob, publish, mock_file):
+    def test_resume_empty_compose(self, publish):
+        """
+        Test correct operation when the --resume flag is given but one of the Composes has no
+        updates.
+        """
+        cli = CliRunner()
+        # Let's mark ejabberd as locked and already in a push. Since we are resuming and since we
+        # will decline pushing the first time we are asked, it should be the only package that gets
+        # included.
+        ejabberd = self.create_update([u'ejabberd-16.09-4.fc17'])
+        ejabberd.builds[0].signed = True
+        ejabberd.locked = True
+        compose = models.Compose(release=ejabberd.release, request=ejabberd.request)
+        self.db.add(compose)
+        # This compose has no updates, so bodhi-push should delete it.
+        compose = models.Compose(release=ejabberd.release, request=models.UpdateRequest.stable)
+        self.db.add(compose)
+        self.db.commit()
+
+        with mock.patch('bodhi.server.push.transactional_session_maker',
+                        return_value=base.TransactionalSessionMaker(self.Session)):
+            result = cli.invoke(push.push, ['--username', 'bowlofeggs', '--resume'],
+                                input='y\ny')
+
+        self.assertEqual(result.exit_code, 0)
+        self.assertEqual(result.output, TEST_RESUME_EMPTY_COMPOSE)
+        ejabberd = self.db.query(models.Update).filter_by(title=u'ejabberd-16.09-4.fc17').one()
+        python_nose = self.db.query(models.Update).filter_by(
+            title=u'python-nose-1.3.7-11.fc17').one()
+        python_paste_deploy = self.db.query(models.Update).filter_by(
+            title=u'python-paste-deploy-1.5.2-8.fc17').one()
+        publish.assert_called_once_with(
+            topic='masher.start',
+            msg={'composes': [ejabberd.compose.__json__()],
+                 'resume': True, 'agent': 'bowlofeggs', 'api_version': 2},
+            force=True)
+        # ejabberd should still be locked.
+        self.assertTrue(ejabberd.locked)
+        self.assertTrue(ejabberd.date_locked <= datetime.utcnow())
+        self.assertEqual(ejabberd.compose.release, ejabberd.release)
+        self.assertEqual(ejabberd.compose.request, ejabberd.request)
+        # These should be left alone.
+        for u in [python_nose, python_paste_deploy]:
+            self.assertFalse(u.locked)
+            self.assertIsNone(u.date_locked)
+            self.assertIsNone(u.compose)
+        # The empty compose should have been deleted.
+        self.assertEqual(
+            self.db.query(models.Compose).filter_by(
+                release_id=ejabberd.release.id, request=models.UpdateRequest.stable).count(),
+            0)
+
+    @mock.patch('bodhi.server.push.bodhi.server.notifications.init', mock.Mock())
+    @mock.patch('bodhi.server.push.bodhi.server.notifications.publish')
+    def test_resume_human_says_no(self, publish):
         """
         Test correct operation when the --resume flag is given but the human says they don't want to
         resume one of the lockfiles.
@@ -697,37 +770,43 @@ class TestPush(base.BaseTestCase):
         ejabberd = self.create_update([u'ejabberd-16.09-4.fc17'])
         ejabberd.builds[0].signed = True
         ejabberd.locked = True
-        ejabberd.date_locked = datetime.utcnow()
+        compose = models.Compose(release=ejabberd.release, request=ejabberd.request)
+        self.db.add(compose)
+        python_nose = self.db.query(models.Update).filter_by(
+            title=u'python-nose-1.3.7-11.fc17').one()
+        python_nose.locked = True
+        python_nose.request = models.UpdateRequest.stable
+        compose = models.Compose(release=python_nose.release, request=python_nose.request)
+        self.db.add(compose)
         self.db.commit()
 
         with mock.patch('bodhi.server.push.transactional_session_maker',
                         return_value=base.TransactionalSessionMaker(self.Session)):
             result = cli.invoke(push.push, ['--username', 'bowlofeggs', '--resume'],
-                                input='n\ny\ny')
+                                input='y\nn\ny')
 
         self.assertEqual(result.exit_code, 0)
         self.assertEqual(result.output, TEST_RESUME_HUMAN_SAYS_NO_EXPECTED_OUTPUT)
-        glob.assert_called_once_with('/mashdir//MASHING-*')
-        publish.assert_called_once_with(
-            topic='masher.start',
-            msg={'updates': ['ejabberd-16.09-4.fc17'],
-                 'resume': True, 'agent': 'bowlofeggs'},
-            force=True)
-        mock_file.assert_any_call('/mnt/koji/mash/updates/MASHING-f17-testing')
-        mock_file.assert_any_call('/mnt/koji/mash/updates/MASHING-f17-updates')
-
         ejabberd = self.db.query(models.Update).filter_by(title=u'ejabberd-16.09-4.fc17').one()
         python_nose = self.db.query(models.Update).filter_by(
             title=u'python-nose-1.3.7-11.fc17').one()
         python_paste_deploy = self.db.query(models.Update).filter_by(
             title=u'python-paste-deploy-1.5.2-8.fc17').one()
-        # ejabberd should be locked still
-        self.assertTrue(ejabberd.locked)
-        self.assertTrue(ejabberd.date_locked <= datetime.utcnow())
-        # The other packages should have been left alone
-        for u in [python_nose, python_paste_deploy]:
-            self.assertFalse(u.locked)
-            self.assertIsNone(u.date_locked)
+        publish.assert_called_once_with(
+            topic='masher.start',
+            msg={'composes': [ejabberd.compose.__json__()],
+                 'resume': True, 'agent': 'bowlofeggs', 'api_version': 2},
+            force=True)
+        # These should still be locked.
+        for u in [ejabberd, python_nose]:
+            self.assertTrue(u.locked)
+            self.assertTrue(u.date_locked <= datetime.utcnow())
+            self.assertEqual(u.compose.release, u.release)
+            self.assertEqual(u.compose.request, u.request)
+        # paste_deploy should have been left alone
+        self.assertFalse(python_paste_deploy.locked)
+        self.assertIsNone(python_paste_deploy.date_locked)
+        self.assertIsNone(python_paste_deploy.compose)
 
     @mock.patch('bodhi.server.push.bodhi.server.notifications.init')
     @mock.patch('bodhi.server.push.bodhi.server.notifications.publish')
@@ -749,17 +828,18 @@ class TestPush(base.BaseTestCase):
         mock_init.assert_called_once_with(active=True, cert_prefix=u'shell')
         self.assertEqual(result.exit_code, 0)
         self.assertEqual(result.output, TEST_UNSIGNED_UPDATES_SKIPPED_EXPECTED_OUTPUT)
-        publish.assert_called_once_with(
-            topic='masher.start',
-            msg={'updates': ['python-paste-deploy-1.5.2-8.fc17'],
-                 'resume': False, 'agent': 'bowlofeggs'},
-            force=True)
-
         python_nose = self.db.query(models.Update).filter_by(
             title=u'python-nose-1.3.7-11.fc17').one()
         python_paste_deploy = self.db.query(models.Update).filter_by(
             title=u'python-paste-deploy-1.5.2-8.fc17').one()
+        publish.assert_called_once_with(
+            topic='masher.start',
+            msg={'composes': [python_paste_deploy.compose.__json__()],
+                 'resume': False, 'agent': 'bowlofeggs', 'api_version': 2},
+            force=True)
         self.assertFalse(python_nose.locked)
         self.assertIsNone(python_nose.date_locked)
         self.assertTrue(python_paste_deploy.locked)
         self.assertTrue(python_paste_deploy.date_locked <= datetime.utcnow())
+        self.assertEqual(python_paste_deploy.compose.release, python_paste_deploy.release)
+        self.assertEqual(python_paste_deploy.compose.request, python_paste_deploy.request)

--- a/docs/administration.rst
+++ b/docs/administration.rst
@@ -6,7 +6,7 @@ Administration
 System Requirements
 ===================
 
-Bodhi is currently only supported on active Fedora releases.
+Bodhi is currently only supported on active Fedora releases. It requires PostgreSQL >= 9.2.0.
 
 
 Configuration

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -243,6 +243,8 @@ man_pages = [
      ['Randy Barlow'], 1),
     ('man_pages/bodhi-dequeue-stable', 'bodhi-dequeue-stable', u'move batched updates to stable',
      ['Randy Barlow'], 1),
+    ('man_pages/bodhi-monitor-composes', 'bodhi-monitor-composes', u'display a compose report',
+     ['Randy Barlow'], 1),
     ('man_pages/bodhi-push', 'bodhi-push', u'push Fedora updates', ['Randy Barlow'], 1),
     ('man_pages/initialize_bodhi_db', 'initialize_bodhi_db', u'intialize bodhi\'s database',
      ['Randy Barlow'], 1),

--- a/docs/man_pages/bodhi-monitor-composes.rst
+++ b/docs/man_pages/bodhi-monitor-composes.rst
@@ -1,0 +1,37 @@
+======================
+bodhi-monitor-composes
+======================
+
+Synopsis
+========
+
+``bodhi-monitor-composes``
+
+
+Description
+===========
+
+``bodhi-monitor-composes`` prints a human-readable report about the running Composes.
+
+
+Options
+=======
+
+``--help``
+
+    Display help text.
+
+``--version``
+
+    Report the Bodhi version and exit.
+
+
+Help
+====
+
+If you find bugs in bodhi (or in the man page), please feel free to file a bug report or a pull
+request:
+
+    https://github.com/fedora-infra/bodhi
+
+Bodhi's documentation is available online: https://bodhi.fedoraproject.org/docs

--- a/docs/man_pages/index.rst
+++ b/docs/man_pages/index.rst
@@ -10,5 +10,6 @@ Man pages
    bodhi-check-policies
    bodhi-clean-old-mashes
    bodhi-dequeue-stable
+   bodhi-monitor-composes
    bodhi-push
    initialize_bodhi_db

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -9,6 +9,7 @@ Dependency changes
 ^^^^^^^^^^^^^^^^^^
 
 * Bodhi now requires ``cornice>=3``.
+* Bodhi now formally documents that it requires PostgreSQL >= 9.2.0 in :doc:`administration`.
 
 
 v3.1.0

--- a/production.ini
+++ b/production.ini
@@ -476,8 +476,10 @@ debugtoolbar.hosts = 127.0.0.1 ::1
 ##
 ## Database
 ##
-# XXX - you should really change this to postgres
-sqlalchemy.url = sqlite:////var/cache/bodhi.db
+# This must be a PostgreSQL database. It is weirdly defaulted to sqlite, but that would not be
+# suitable for a production environment. You can encode a username and password in the URL. For
+# example, postgresql://username:password@hostname/database_name
+# sqlalchemy.url = sqlite:////var/cache/bodhi.db
 
 ##
 ## Templates

--- a/setup.py
+++ b/setup.py
@@ -157,6 +157,7 @@ setup(
     bodhi-dequeue-stable = bodhi.server.scripts.dequeue_stable:dequeue_stable
     bodhi-push = bodhi.server.push:push
     bodhi-expire-overrides = bodhi.server.scripts.expire_overrides:main
+    bodhi-monitor-composes = bodhi.server.scripts.monitor_composes:monitor
     bodhi-untag-branched = bodhi.server.scripts.untag_branched:main
     bodhi-approve-testing = bodhi.server.scripts.approve_testing:main
     bodhi-manage-releases = bodhi.server.scripts.manage_releases:main


### PR DESCRIPTION
Due to
[alembic #122](https://bitbucket.org/zzzeek/alembic/issues/122/),
it was not simple to write the included database migration in
a database backend agnostic fashion. Thus, this commit also
documents that Bodhi formally requires PostgreSQL.

This commit also happens to fix an issue (#717) where users could
not comment on Updates while they were mashing. This was due to
the extremely long transactions that Bodhi used to hold open prior
to this commit, and due to Bodhi modifying the state of the Update
early on during the process. The masher now commits whenever the
Compose's state changes and no longer modifies the Updates until
the end of the process. This means that the Update does not get
locked for hours in the database any longer.

This commit also addresses an RFE (#1245) to get bodhi-push to
collate the updates by release. It goes further by also collating
them by content type and stable/testing.

fixes #717
fixes #1245
fixes #2014

Signed-off-by: Randy Barlow <randy@electronsweatshop.com>