### PR TITLE
Remove an unreachable error handler around cache_nvrs().

### DIFF
--- a/bodhi/server/validators.py
+++ b/bodhi/server/validators.py
@@ -395,13 +395,7 @@ def validate_acls(request, **kwargs):
         # previously associated with an update, we can just look it up no prob.
         if 'builds' in request.validated:
             # Split out NVR data unless its already done.
-            try:
-                cache_nvrs(request, build)
-            except ValueError:
-                error = 'Problem caching NVRs when validating ACLs.'
-                log.exception(error)
-                request.errors.add('body', 'builds', error)
-                return
+            cache_nvrs(request, build)
 
             buildinfo = request.buildinfo[build]
 


### PR DESCRIPTION
While writing tests for bodhi.server.validators, I found a
try/except block that was very difficult to hit an exception in.
This particular validator is usually preceeded by other validators
that also call cache_nvrs(). This means that if cache_nvrs() raised
an Exception, we wouldn't get into validate_acls(), which means it
couldn't raise an Exception again. The views that don't work that
way pass through validate_acls() via a different path and do not
hit cache_nvrs() at all.

Furthermore, the error condition only gives the user an error
message that isn't particularly useful if they can somehow manage
to hit it.

Given both of these conditions, I've decided to remove the
try/except block.

Signed-off-by: Randy Barlow <randy@electronsweatshop.com>