### PR TITLE
Make builds.package_id non-nullable.

### DIFF
--- a/bodhi/server/migrations/versions/865d9432fa7d_build_package_id_is_now_required.py
+++ b/bodhi/server/migrations/versions/865d9432fa7d_build_package_id_is_now_required.py
@@ -1,0 +1,40 @@
+# Copyright (c) 2017 Red Hat, Inc.
+#
+# This file is part of Bodhi.
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+"""
+build.package_id is now required.
+
+Revision ID: 865d9432fa7d
+Revises: 74cfbc6116ad
+Create Date: 2017-12-07 22:17:59.312908
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = '865d9432fa7d'
+down_revision = '74cfbc6116ad'
+
+
+def upgrade():
+    """Mark builds.package_id as non-nullable."""
+    op.alter_column('builds', 'package_id', existing_type=sa.INTEGER(), nullable=False)
+
+
+def downgrade():
+    """Mark builds.package_id as nullable."""
+    op.alter_column('builds', 'package_id', existing_type=sa.INTEGER(), nullable=True)

--- a/bodhi/server/models.py
+++ b/bodhi/server/models.py
@@ -1164,7 +1164,7 @@ class Build(Base):
     __get_by__ = ('nvr',)
 
     nvr = Column(Unicode(100), unique=True, nullable=False)
-    package_id = Column(Integer, ForeignKey('packages.id'))
+    package_id = Column(Integer, ForeignKey('packages.id'), nullable=False)
     release_id = Column(Integer, ForeignKey('releases.id'))
     signed = Column(Boolean, default=False, nullable=False)
     update_id = Column(Integer, ForeignKey('updates.id'))

--- a/bodhi/server/validators.py
+++ b/bodhi/server/validators.py
@@ -453,13 +453,6 @@ def validate_acls(request, **kwargs):
             package = build.package
             release = build.update.release
 
-            # Some sanity checking..
-            if not package:
-                msg = build.nvr + ' has no package associated with it in ' + \
-                    'our DB, so we cannot verify that you\'re in the ACL.'
-                log.error(msg)
-                request.errors.add('body', 'builds', msg)
-                return
             if not release:
                 msg = build.nvr + ' has no release associated with it in ' + \
                     'our DB, so we cannot verify that you\'re in the ACL.'

--- a/bodhi/tests/server/services/test_builds.py
+++ b/bodhi/tests/server/services/test_builds.py
@@ -1,3 +1,8 @@
+# # -*- coding: utf-8 -*-
+# Copyright © 2014-2017 Red Hat Inc. and others.
+#
+# This file is part of Bodhi.
+#
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
 # as published by the Free Software Foundation; either version 2
@@ -12,7 +17,7 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
-from bodhi.server.models import RpmBuild
+from bodhi.server.models import RpmBuild, RpmPackage
 from bodhi.tests.server import base
 
 
@@ -37,7 +42,8 @@ class TestBuildsService(base.BaseTestCase):
 
         # First, stuff a second build in there
         session = self.db
-        build = RpmBuild(nvr=u'bodhi-3.0-1.fc21')
+        build = RpmBuild(nvr=u'bodhi-3.0-1.fc21',
+                         package=RpmPackage.query.filter_by(name=u'bodhi').one())
         session.add(build)
         session.flush()
 

--- a/bodhi/tests/server/services/test_overrides.py
+++ b/bodhi/tests/server/services/test_overrides.py
@@ -408,7 +408,8 @@ class TestOverridesService(base.BaseTestCase):
         expiration_date = o['expiration_date']
         old_build_id = o['build_id']
 
-        build = RpmBuild(nvr=u'bodhi-2.0-2.fc17', release=release)
+        build = RpmBuild(nvr=u'bodhi-2.0-2.fc17', release=release,
+                         package=RpmPackage.query.filter_by(name='bodhi').one())
         self.db.add(build)
         self.db.flush()
 
@@ -455,7 +456,8 @@ class TestOverridesService(base.BaseTestCase):
     def test_edit_unexisting_override(self):
         release = Release.get(u'F17', self.db)
 
-        build = RpmBuild(nvr=u'bodhi-2.0-2.fc17', release=release)
+        build = RpmBuild(nvr=u'bodhi-2.0-2.fc17', release=release,
+                         package=RpmPackage.query.filter_by(name='bodhi').one())
         self.db.add(build)
         self.db.flush()
 

--- a/bodhi/tests/server/test_models.py
+++ b/bodhi/tests/server/test_models.py
@@ -742,6 +742,15 @@ class TestBuild(ModelTest):
     klass = model.Build
     attrs = dict(nvr=u"TurboGears-1.0.8-3.fc11")
 
+    def do_get_dependencies(self):
+        """
+        A Build needs a package to be associated with.
+
+        Returns:
+            dict: A dictionary specifying a package to associate with this Build.
+        """
+        return {'package': model.Package(name='TurboGears')}
+
 
 class TestRpmBuild(ModelTest):
     """Unit test case for the ``RpmBuild`` model."""


### PR DESCRIPTION
While writing tests for the validators, I came across some untested
code that was checking to make sure that Builds had Pacages
associated with them. Since it would be an error for a Build to be
unassociated with a Package, I opted to delete that check and
instead make the foreign key non-nullable in the database.

Signed-off-by: Randy Barlow <randy@electronsweatshop.com>