### PR TITLE
Make updates.release_id non-nullable.

### DIFF
--- a/bodhi/server/migrations/versions/4ed8554a4fc9_add_the_new_compose_model.py
+++ b/bodhi/server/migrations/versions/4ed8554a4fc9_add_the_new_compose_model.py
@@ -29,7 +29,7 @@ from sqlalchemy.dialects import postgresql
 
 # revision identifiers, used by Alembic.
 revision = '4ed8554a4fc9'
-down_revision = '74cfbc6116ad'
+down_revision = '865d9432fa7d'
 
 
 def upgrade():

--- a/bodhi/server/migrations/versions/630acb5218a4_make_updates_release_id_non_nullable.py
+++ b/bodhi/server/migrations/versions/630acb5218a4_make_updates_release_id_non_nullable.py
@@ -1,0 +1,40 @@
+# Copyright (c) 2017 Red Hat, Inc.
+#
+# This file is part of Bodhi.
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+"""
+Make updates.release_id non-nullable.
+
+Revision ID: 630acb5218a4
+Revises: 74cfbc6116ad
+Create Date: 2017-12-08 13:12:59.837033
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = '630acb5218a4'
+down_revision = '4ed8554a4fc9'
+
+
+def upgrade():
+    """Make updates.release_id non-nullable."""
+    op.alter_column('updates', 'release_id', existing_type=sa.INTEGER(), nullable=False)
+
+
+def downgrade():
+    """Make updates.release_id nullable."""
+    op.alter_column('updates', 'release_id', existing_type=sa.INTEGER(), nullable=True)

--- a/bodhi/server/models.py
+++ b/bodhi/server/models.py
@@ -1518,7 +1518,7 @@ class Update(Base):
     old_updateid = Column(Unicode(32), default=None)
 
     # One-to-one relationships
-    release_id = Column(Integer, ForeignKey('releases.id'))
+    release_id = Column(Integer, ForeignKey('releases.id'), nullable=False)
     release = relationship('Release', lazy='joined', backref='updates')
 
     # One-to-many relationships

--- a/bodhi/server/validators.py
+++ b/bodhi/server/validators.py
@@ -448,13 +448,6 @@ def validate_acls(request, **kwargs):
             # with a pre-stored Build obj.
             package = build.package
             release = build.update.release
-
-            if not release:
-                msg = build.nvr + ' has no release associated with it in ' + \
-                    'our DB, so we cannot verify that you\'re in the ACL.'
-                log.error(msg)
-                request.errors.add('body', 'builds', msg)
-                return
         else:
             raise NotImplementedError()  # Should never get here.
 

--- a/bodhi/tests/server/services/test_comments.py
+++ b/bodhi/tests/server/services/test_comments.py
@@ -1,3 +1,8 @@
+# -*- coding: utf-8 -*-
+# Copyright © 2014-2017 Red Hat, Inc. and others.
+#
+# This file is part of Bodhi.
+#
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
 # as published by the Free Software Foundation; either version 2
@@ -419,6 +424,7 @@ class TestCommentsService(base.BaseTestCase):
             stable_karma=3,
             unstable_karma=-3,
         )
+        update.release = Release.query.one()
         self.db.add(update)
         self.db.flush()
 

--- a/bodhi/tests/server/test_models.py
+++ b/bodhi/tests/server/test_models.py
@@ -2558,7 +2558,6 @@ class TestUpdate(ModelTest):
         """Test validate_release() with the release set to None."""
         # This should not raise an Exception.
         self.obj.release = None
-        self.db.flush()
 
         self.assertIsNone(self.obj.release)
 


### PR DESCRIPTION
While writing tests for the validators, I came across an untested
block of code that was raising an error if the release on an update
was null. Rather than writing a test for that code, I decided to
make it impossible for updates to be unassociated with releases, as
much of the codebase assumes that updates have releases as is (and
it doesn't make sense to have updates floating around out there
without releases).

Signed-off-by: Randy Barlow <randy@electronsweatshop.com>