### PR TITLE
Remove an impossible validation check and its failing test.

### DIFF
--- a/bodhi/server/validators.py
+++ b/bodhi/server/validators.py
@@ -260,17 +260,6 @@ def validate_build_tags(request, **kwargs):
             return
 
         release = update.release
-        if not release:
-            # If the edited update has no release, something went wrong a while
-            # ago.  We're already in a corrupt state.  We can't perform the
-            # check further down as to whether or not the user is submitting
-            # builds that do or do not match the release of this update...
-            # because we don't know the release of this update.
-            request.errors.add('body', 'edited',
-                               'Pre-existing update %s has no associated '
-                               '"release" object.  Please submit a ticket to '
-                               'resolve this.' % edited)
-            return
     else:
         valid_tags = tag_types['candidate']
 

--- a/bodhi/tests/server/services/test_updates.py
+++ b/bodhi/tests/server/services/test_updates.py
@@ -718,30 +718,6 @@ class TestUpdatesService(base.BaseTestCase):
         self.assertEqual(res.json, expected_json)
         listTags.assert_called_once_with(update.title)
 
-    def test_edit_missing_release(self):
-        """Editing an update that is missing a release should report an error."""
-        update = self.db.query(Update).one()
-        update.release = None
-        update_json = self.get_update(update.title)
-        update_json['csrf_token'] = self.get_csrf_token()
-        update_json['notes'] = u'testing!!!'
-        update_json['edited'] = update.title
-        # This will cause an extra error in the output that we aren't testing here, so delete it.
-        del update_json['requirements']
-
-        res = self.app.post_json('/updates/', update_json, status=400)
-
-        expected_json = {
-            u'status': u'error',
-            u'errors': [
-                {u'description': (u'Pre-existing update bodhi-2.0-1.fc17 has no associated '
-                                  u'"release" object.  Please submit a ticket to resolve this.'),
-                 u'location': u'body', u'name': u'edited'},
-                {u'description': (u'Cannot find release associated with build: bodhi-2.0-1.fc17, '
-                                  u'tags: []'),
-                 u'location': u'body', u'name': u'builds'}]}
-        self.assertEqual(res.json, expected_json)
-
     def test_edit_untagged_build(self):
         """Editing an update that references untagged builds should raise an error."""
         update = self.db.query(Update).one()


### PR DESCRIPTION
Two commits conspired together to create a failing test, as they
were submitted in separate pull requests and each passed tests
individually. The first added a test condition for an existing
validator that tried to make sure that edited updates have releases
associated with them. The second made it impossible for updates to
be unassociated with a release. The combination caused a test to
fail because the test tried to create an update that was not
associated with a release to test the validator.

This commit removes the test and the validator it tests, since it
is no longer needed due to the database enforcing the relationship
now.

fixes #2062

Signed-off-by: Randy Barlow <randy@electronsweatshop.com>