### PR TITLE
UI for waiving test results on an update

### DIFF
--- a/bodhi/server/templates/update.html
+++ b/bodhi/server/templates/update.html
@@ -397,6 +397,43 @@ $(document).ready(function() {
       });
     });
 
+% if self.util.can_waive_test_results(update):
+    // handle for waiving test restuls.
+    // set focus on the comment textarea when opening the modal.
+    $("#waive_test_results").on('shown.bs.modal', function () {
+        $('#waive_comment').trigger('focus')
+    })
+    $("#waive_test_results").submit(function(evt) {
+      evt.preventDefault();
+      var comment = $('#waive_test_results [name=waive_comment]').val();
+      var url = '${request.route_url("update_waive_test_results", id=update.alias)}';
+      var $this = $(this);
+      $.ajax({
+          url: url,
+          data: {
+            comment: comment,
+            csrf_token: "${request.session.get_csrf_token()}",
+          },
+          method: 'POST',
+          dataType: 'json',
+          success: function(response) {
+            // Just reload the page to refresh the test gating status.
+            location.reload();
+          },
+          error: function(response) {
+            $this.modal('hide');
+            $.each(response.responseJSON.errors, function(i, error) {
+                msg = messenger.post({
+                  message: error.description,
+                  type: "error",
+                  hideAfter: false,
+                  showCloseButton: true,
+                });
+            });
+          },
+      });
+    })
+% endif
 });
 </script>
 
@@ -497,7 +534,6 @@ $(document).ready(function(){
       % if update.critpath:
       <span data-toggle="tooltip" title="This update is in the critical path" class="label label-danger"> <i class="fa fa-fw fa-fire"></i></span>
       % endif
-
       % if can_edit:
         % if not update.locked:
           <div id='updatebuttons' class="btn-group pull-right" role="group" aria-label="...">
@@ -522,6 +558,9 @@ $(document).ready(function(){
               ${self.util.push_to_batched_or_stable_button(update) | n}
             % endif
             <a id='unpush' class="btn btn-sm btn-danger"><span class="fa fa-fw fa-arrow-circle-left"></span> Unpush</a>
+          % endif
+          % if self.util.can_waive_test_results(update):
+            <a id='waive' class="btn btn-sm btn-primary" data-toggle="modal" data-target="#waive_test_results">Waive Test Results</a>
           % endif
           </div>
         % else:
@@ -1040,4 +1079,30 @@ $(document).ready(function(){
 <div class="row">
 
 </div>
+
+% if self.util.can_waive_test_results(update):
+<div class="modal fade" id="waive_test_results" tabindex="-1" role="dialog" aria-labelledby="waiveModalLabel" aria-hidden="true">
+  <form>
+  <div class="modal-dialog" role="document">
+    <div class="modal-content">
+      <div class="modal-header">
+        <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+        <h3 class="modal-title" id="waiveModalLabel">Waive Test Results</h3>
+        </button>
+      </div>
+      <div class="modal-body">
+          <div class="form-group">
+            <textarea class="form-control" id="waive_comment" name="waive_comment"></textarea>
+          </div>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-secondary" data-dismiss="modal">Cancel</button>
+        <button type="submit" class="btn btn-primary">Waive Test Results</button>
+      </div>
+    </div>
+    </form>
+  </div>
+</div>
+% endif
+
 </div> <!-- end container -->

--- a/bodhi/server/util.py
+++ b/bodhi/server/util.py
@@ -936,6 +936,21 @@ def testcase_link(context, test, short=False):
     return link
 
 
+def can_waive_test_results(context, update):
+    """
+    Return True or False if the test results can be waived on an update.
+
+    Args:
+        context (mako.runtime.Context): The current template rendering context. Unused.
+        update (bodhi.server.models.Update): The Update on which we are going to waive test results.
+    Returns:
+        bool: Indicating if the test results can be waived on the given update.
+    """
+    return (config.get('test_gating.required') and
+            not update.test_gating_passed and
+            update.status.description != 'stable')
+
+
 def sorted_builds(builds):
     """
     Sort the given builds by their NVRs.


### PR DESCRIPTION
This introduces a UI change for waving the test results on an update, built upon #2047 
I will add some screenshots to show how the change looks like.