### PR TITLE
Correct the documented default for the greenwave_api_url setting.

### DIFF
--- a/docs/user/release_notes.rst
+++ b/docs/user/release_notes.rst
@@ -5,6 +5,15 @@ Release notes
 develop
 -------
 
+Config change
+^^^^^^^^^^^^^
+
+The default value for ``greenwave_api_url`` was changed from
+``https://greenwave.fedoraproject.org/api/v1.0`` to
+``https://greenwave-web-greenwave.app.os.fedoraproject.org/api/v1.0`` as the old value was a
+non-extant domain.
+
+
 Dependency changes
 ^^^^^^^^^^^^^^^^^^
 

--- a/production.ini
+++ b/production.ini
@@ -94,7 +94,7 @@ use = egg:bodhi-server
 # test_gating.url =
 
 # The API url of Greenwave.
-# greenwave_api_url = https://greenwave.fedoraproject.org/api/v1.0
+# greenwave_api_url = https://greenwave-web-greenwave.app.os.fedoraproject.org/api/v1.0
 
 # Email domain to prepend usernames to
 # default_email_domain = fedoraproject.org


### PR DESCRIPTION
Signed-off-by: Randy Barlow <randy@electronsweatshop.com>