### PR TITLE
Python 3 tests

### DIFF
--- a/bodhi/client/bindings.py
+++ b/bodhi/client/bindings.py
@@ -474,7 +474,7 @@ class BodhiClient(OpenIdBaseClient):
             raise ValueError("No such file or directory: %s" % input_file)
 
         defaults = dict(severity='unspecified', suggest='unspecified')
-        config = configparser.SafeConfigParser(defaults=defaults)
+        config = configparser.ConfigParser(defaults=defaults)
         read = config.read(input_file)
 
         if len(read) != 1 or read[0] != input_file:

--- a/bodhi/client/bindings.py
+++ b/bodhi/client/bindings.py
@@ -80,6 +80,9 @@ class UpdateNotFound(BodhiClientException):
         """
         return u'Update not found: {}'.format(self.update)
 
+    # Use __unicode__ method under __str__ name for Python 3
+    __str__ = __unicode__
+
 
 def errorhandled(method):
     """Raise exceptions on failure. Used as a decorator for BodhiClient methods."""

--- a/bodhi/server/captcha.py
+++ b/bodhi/server/captcha.py
@@ -25,6 +25,7 @@ from __future__ import division
 import base64
 import math
 import random
+import binascii
 
 from PIL import Image, ImageDraw, ImageFont
 from pyramid.httpexceptions import HTTPGone, HTTPNotFound
@@ -259,8 +260,8 @@ def decrypt(ciphertext, settings):
 
     try:
         ciphertext = base64.urlsafe_b64decode(ciphertext)
-    except TypeError:
-        raise HTTPNotFound("%s is garbage" % ciphertext)
+    except (TypeError, binascii.Error):
+        raise HTTPNotFound("%s is garbage" % ciphertext.decode('utf-8'))
 
     try:
         plaintext = engine.decrypt(ciphertext, ttl=ttl)

--- a/bodhi/server/config.py
+++ b/bodhi/server/config.py
@@ -20,6 +20,7 @@
 from datetime import datetime
 import os
 import logging
+import binascii
 
 from pyramid import settings
 from pyramid.paster import get_appsettings
@@ -175,8 +176,8 @@ def _validate_fernet_key(value):
     try:
         engine = cryptography.fernet.Fernet(value)
         # This will raise a ValueError if value is not suitable as a Fernet key.
-        engine.encrypt('a secret test string')
-    except TypeError:
+        engine.encrypt(b'a secret test string')
+    except (TypeError, binascii.Error):
         raise ValueError('Fernet key must be 32 url-safe base64-encoded bytes.')
 
     return value

--- a/bodhi/server/consumers/masher.py
+++ b/bodhi/server/consumers/masher.py
@@ -33,12 +33,13 @@ import subprocess
 import tempfile
 import threading
 import time
-import urllib2
 from datetime import datetime
 
 import fedmsg.consumers
 import jinja2
 from six.moves import zip
+from six.moves.urllib import request as urllib2
+from six.moves.urllib.error import HTTPError, URLError
 import six
 
 from bodhi.server import bugs, initialize_db, log, buildsys, notifications, mail
@@ -363,7 +364,7 @@ class ComposerThread(threading.Thread):
             with self.db_factory() as session:
                 self.db = session
                 self.compose = Compose.from_dict(session, self._compose)
-                self.compose.error_message = unicode(e)
+                self.compose.error_message = str(e)
                 self.save_state(ComposeState.failed)
 
             self.log.exception('ComposerThread failed. Transaction rolled back.')
@@ -1234,7 +1235,7 @@ class PungiComposerThread(ComposerThread):
             try:
                 self.log.info('Polling %s' % master_repomd_url)
                 masterrepomd = urllib2.urlopen(master_repomd_url)
-            except (urllib2.URLError, urllib2.HTTPError):
+            except (URLError, HTTPError):
                 self.log.exception('Error fetching repomd.xml')
                 time.sleep(200)
                 continue

--- a/bodhi/server/consumers/masher.py
+++ b/bodhi/server/consumers/masher.py
@@ -533,7 +533,7 @@ class ComposerThread(threading.Thread):
             state (bodhi.server.models.ComposeState): If not ``None``, set the Compose's state
                 attribute to the given state. Defaults to ``None``.
         """
-        self.compose.checkpoints = json.dumps(self._checkpoints).decode('utf-8')
+        self.compose.checkpoints = json.dumps(self._checkpoints)
         if state is not None:
             self.compose.state = state
         self.db.commit()

--- a/bodhi/server/consumers/masher.py
+++ b/bodhi/server/consumers/masher.py
@@ -364,7 +364,7 @@ class ComposerThread(threading.Thread):
             with self.db_factory() as session:
                 self.db = session
                 self.compose = Compose.from_dict(session, self._compose)
-                self.compose.error_message = str(e)
+                self.compose.error_message = six.text_type(e)
                 self.save_state(ComposeState.failed)
 
             self.log.exception('ComposerThread failed. Transaction rolled back.')

--- a/bodhi/server/mail.py
+++ b/bodhi/server/mail.py
@@ -494,13 +494,13 @@ def send_mail(from_addr, to_addr, subject, body_text, headers=None):
     subject = to_bytes(subject)
     body_text = to_bytes(body_text)
 
-    msg = ['From: %s' % from_addr, 'To: %s' % to_addr]
+    msg = [b'From: %s' % from_addr, b'To: %s' % to_addr]
     if headers:
         for key, value in headers.items():
-            msg.append('%s: %s' % (key, to_bytes(value)))
-    msg.append('X-Bodhi: %s' % to_bytes(config.get('default_email_domain')))
-    msg += ['Subject: %s' % subject, '', body_text]
-    body = to_bytes('\r\n'.join(msg))
+            msg.append(b'%s: %s' % (to_bytes(key), to_bytes(value)))
+    msg.append(b'X-Bodhi: %s' % to_bytes(config.get('default_email_domain')))
+    msg += [b'Subject: %s' % subject, b'', body_text]
+    body = b'\r\n'.join(msg)
 
     log.info('Sending mail to %s: %s', to_addr, subject)
     _send_mail(from_addr, to_addr, body)

--- a/bodhi/server/models.py
+++ b/bodhi/server/models.py
@@ -3370,7 +3370,7 @@ class Update(Base):
                 if test.name not in test_names:
                     test_names.add(test.name)
                     tests.add(test)
-        return sorted(list(tests))
+        return sorted(list(tests), key=lambda testcase: testcase.name)
 
     @property
     def requested_tag(self):

--- a/bodhi/server/models.py
+++ b/bodhi/server/models.py
@@ -112,6 +112,8 @@ class EnumSymbol(object):
         """
         return six.text_type(self.value)
 
+    __str__ = __unicode__
+
     def __json__(self, request=None):
         """
         Return a JSON representation of this EnumSymbol.

--- a/bodhi/server/models.py
+++ b/bodhi/server/models.py
@@ -2247,11 +2247,11 @@ class Update(Base):
         If the "nvr" parameter is specified it will include name, version and
         release information in package labels.
         """
-        def build_label():
+        def build_label(build):
             return build.nvr if nvr else packagename_from_nvr(self, build.nvr)
 
         if len(self.builds) > 2:
-            title = ", ".join([build_label() for build in self.builds[:2]])
+            title = ", ".join([build_label(build) for build in self.builds[:2]])
 
             if amp:
                 title += ", &amp; "
@@ -2261,7 +2261,7 @@ class Update(Base):
             title += " more"
             return title
         else:
-            return " and ".join([build_label() for build in self.builds])
+            return " and ".join([build_label(build) for build in self.builds])
 
     def assign_alias(self):
         """Return a randomly-suffixed update ID.

--- a/bodhi/server/models.py
+++ b/bodhi/server/models.py
@@ -30,7 +30,6 @@ import rpm
 import time
 import uuid
 
-from pkgdb2client import PkgDB
 from simplemediawiki import MediaWiki
 from six.moves.urllib.parse import quote
 from sqlalchemy import (and_, Boolean, Column, DateTime, event, ForeignKey,
@@ -51,6 +50,9 @@ from bodhi.server.util import (
     get_nvr, get_rpm_header, header, packagename_from_nvr, tokenize, pagure_api_get,
     greenwave_api_post, waiverdb_api_post)
 import bodhi.server.util
+
+if six.PY2:
+    from pkgdb2client import PkgDB
 
 
 # http://techspot.zzzeek.org/2011/01/14/the-enum-recipe

--- a/bodhi/server/models.py
+++ b/bodhi/server/models.py
@@ -2273,7 +2273,7 @@ class Update(Base):
         """
         prefix = self.release.id_prefix
         year = time.localtime()[0]
-        id = hashlib.sha1(str(uuid.uuid4())).hexdigest()[:10]
+        id = hashlib.sha1(str(uuid.uuid4()).encode('utf-8')).hexdigest()[:10]
         alias = u'%s-%s-%s' % (prefix, year, id)
         log.debug('Setting alias for %s to %s' % (self.title, alias))
         self.alias = alias

--- a/bodhi/server/notifications.py
+++ b/bodhi/server/notifications.py
@@ -92,8 +92,9 @@ def send_fedmsgs_after_commit(session):
                 _log.debug('Emitted a fedmsg, %r, on the "%s" topic, queued by %r',
                            msg, topic, session)
             # Tidy up after ourselves so a second call to commit on this session won't
-            # send the same messages again.
-            del session.info['fedmsg'][topic]
+            # send the same messages again. We cannot delete topic from fedmsg dict
+            # because we cannot change dictionary size during iteration
+            session.info['fedmsg'][topic] = []
 
 
 def publish(topic, msg, force=False):

--- a/bodhi/server/scripts/monitor_composes.py
+++ b/bodhi/server/scripts/monitor_composes.py
@@ -38,5 +38,5 @@ def monitor():
         for attr in ('state', 'state_date', 'security', 'error_message'):
             if getattr(c, attr) is not None:
                 click.echo('\t%s: %s' % (attr, getattr(c, attr)))
-        click.echo('\tcheckpoints: %s' % ', '.join(json.loads(c.checkpoints).keys()))
+        click.echo('\tcheckpoints: %s' % ', '.join(sorted(json.loads(c.checkpoints).keys())))
         click.echo('\tlen(updates): %s\n' % len(c.updates))

--- a/bodhi/server/util.py
+++ b/bodhi/server/util.py
@@ -379,7 +379,7 @@ def avatar(context, username, size):
                 )
             else:
                 query = urlencode({'s': size, 'd': 'retro'})
-                hash = hashlib.sha256(openid).hexdigest()
+                hash = hashlib.sha256(openid.encode('utf-8')).hexdigest()
                 template = "https://seccdn.libravatar.org/avatar/%s?%s"
                 return template % (hash, query)
 

--- a/bodhi/server/util.py
+++ b/bodhi/server/util.py
@@ -18,7 +18,7 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 """Random functions that don't fit elsewhere."""
 
-from collections import defaultdict
+from collections import defaultdict, OrderedDict
 from contextlib import contextmanager
 import collections
 import functools
@@ -1209,6 +1209,8 @@ def get_critpath_components_from_pdc(branch, component_type='rpm', components=No
         'type': component_type,
         'fields': 'global_component'
     }
+    # Create ordered dictionary with sorted query args to be able to compare URLs
+    query_args = OrderedDict(sorted(query_args.items(), key=lambda x: x[0]))
 
     critpath_pkgs_set = set()
     if components and len(components) < PDC_CRITPATH_COMPONENTS_GETALL_LIMIT:

--- a/bodhi/server/util.py
+++ b/bodhi/server/util.py
@@ -961,8 +961,9 @@ def sorted_builds(builds):
     Returns:
         list: A list of Builds sorted by NVR.
     """
+    key_function = functools.cmp_to_key(rpm.labelCompare)
     return sorted(builds,
-                  cmp=lambda x, y: rpm.labelCompare(get_nvr(x), get_nvr(y)),
+                  key=lambda x: key_function(get_nvr(x)),
                   reverse=True)
 
 

--- a/bodhi/server/util.py
+++ b/bodhi/server/util.py
@@ -307,7 +307,7 @@ def sanity_check_repodata(myurl):
     try:
         h.perform()
     except librepo.LibrepoException as e:
-        rc, msg, general_msg = e
+        rc, msg, general_msg = e.args
         raise RepodataException(msg)
 
     updateinfo = os.path.join(myurl, 'updateinfo.xml.gz')

--- a/bodhi/server/util.py
+++ b/bodhi/server/util.py
@@ -30,7 +30,6 @@ import socket
 import subprocess
 import tempfile
 import time
-import urllib
 
 from kitchen.iterutils import iterate
 from pyramid.i18n import TranslationStringFactory
@@ -43,6 +42,7 @@ import markdown
 import requests
 import rpm
 from six.moves import map
+from six.moves.urllib.parse import urlencode
 import six
 
 from bodhi.server import log, buildsys, Session
@@ -378,7 +378,7 @@ def avatar(context, username, size):
                     default='retro',
                 )
             else:
-                query = urllib.urlencode({'s': size, 'd': 'retro'})
+                query = urlencode({'s': size, 'd': 'retro'})
                 hash = hashlib.sha256(openid).hexdigest()
                 template = "https://seccdn.libravatar.org/avatar/%s?%s"
                 return template % (hash, query)
@@ -864,7 +864,7 @@ def page_url(context, page):
     request = context.get('request')
     params = dict(request.params)
     params['page'] = page
-    return request.path_url + "?" + urllib.urlencode(params)
+    return request.path_url + "?" + urlencode(params)
 
 
 def bug_link(context, bug, short=False):
@@ -1079,7 +1079,7 @@ def taskotron_results(settings, entity='results/latest', max_queries=10, **kwarg
     max_queries = max_queries or 0
     url = settings['resultsdb_api_url'] + "/api/v2.0/" + entity
     if kwargs:
-        url = url + "?" + urllib.urlencode(kwargs)
+        url = url + "?" + urlencode(kwargs)
     data = True
     queries = 0
 
@@ -1214,14 +1214,14 @@ def get_critpath_components_from_pdc(branch, component_type='rpm', components=No
         # Do a query for every single component
         for component in components:
             query_args['global_component'] = component
-            pdc_api_url_with_args = '{0}?{1}'.format(pdc_api_url, urllib.urlencode(query_args))
+            pdc_api_url_with_args = '{0}?{1}'.format(pdc_api_url, urlencode(query_args))
             pdc_request_json = pdc_api_get(pdc_api_url_with_args)
             for branch_rv in pdc_request_json['results']:
                 critpath_pkgs_set.add(branch_rv['global_component'])
             if pdc_request_json['next']:
                 raise Exception('We got paging when requesting a single component?!')
     else:
-        pdc_api_url_with_args = '{0}?{1}'.format(pdc_api_url, urllib.urlencode(query_args))
+        pdc_api_url_with_args = '{0}?{1}'.format(pdc_api_url, urlencode(query_args))
         while True:
             pdc_request_json = pdc_api_get(pdc_api_url_with_args)
 

--- a/bodhi/tests/client/test___init__.py
+++ b/bodhi/tests/client/test___init__.py
@@ -32,6 +32,7 @@ import six
 from bodhi import client
 from bodhi.client import bindings, AuthError
 from bodhi.tests import client as client_test_data
+from bodhi.tests.utils import compare_output
 
 builtin_module_name = 'builtins' if six.PY3 else '__builtin__'
 
@@ -277,7 +278,7 @@ class TestNew(unittest.TestCase):
         self.assertEqual(result.exit_code, 0)
         expected_output = client_test_data.EXPECTED_UPDATE_OUTPUT.replace('example.com/tests',
                                                                           'localhost:6543')
-        self.assertEqual(result.output, expected_output + '\n')
+        self.assertTrue(compare_output(result.output, expected_output))
         bindings_client = send_request.mock_calls[0][1][0]
         send_request.assert_called_once_with(
             bindings_client, 'updates/', auth=True, verb='POST',
@@ -646,7 +647,7 @@ class TestRequest(unittest.TestCase):
                                                 'some_user', '--password', 's3kr3t'])
 
         self.assertEqual(result.exit_code, 0)
-        self.assertEqual(result.output, client_test_data.EXPECTED_UPDATE_OUTPUT + '\n')
+        self.assertTrue(compare_output(result.output, client_test_data.EXPECTED_UPDATE_OUTPUT))
         send_request.assert_called_once_with(
             'updates/bodhi-2.2.4-1.el7/request', verb='POST', auth=True,
             data={'csrf_token': 'a_csrf_token', 'request': u'revoke',
@@ -672,10 +673,10 @@ class TestRequest(unittest.TestCase):
                                                 'some_user', '--password', 's3kr3t'])
 
         self.assertEqual(result.exit_code, 2)
-        self.assertEqual(
+        self.assertTrue(compare_output(
             result.output,
             (u'Usage: request [OPTIONS] UPDATE STATE\n\nError: Invalid value for UPDATE: Update not'
-             u' found: bodhi-2.2.4-99.el7\n'))
+             u' found: bodhi-2.2.4-99.el7\n')))
         send_request.assert_called_once_with(
             'updates/bodhi-2.2.4-99.el7/request', verb='POST', auth=True,
             data={'csrf_token': 'a_csrf_token', 'request': u'revoke',
@@ -701,7 +702,7 @@ class TestRequest(unittest.TestCase):
         self.assertEqual(result.exit_code, 0)
         expected_output = client_test_data.EXPECTED_UPDATE_OUTPUT.replace('example.com/tests',
                                                                           'localhost:6543')
-        self.assertEqual(result.output, expected_output + '\n')
+        self.assertTrue(compare_output(result.output, expected_output))
         bindings_client = send_request.mock_calls[0][1][0]
         send_request.assert_called_once_with(
             bindings_client, 'updates/bodhi-2.2.4-99.el7/request', verb='POST', auth=True,
@@ -1168,7 +1169,7 @@ class TestPrintResp(unittest.TestCase):
 
         expected_output = client_test_data.EXPECTED_UPDATE_OUTPUT.replace('example.com/tests',
                                                                           'localhost:6543')
-        self.assertEqual(result.output, expected_output + '\n')
+        self.assertTrue(compare_output(result.output, expected_output))
 
     @mock.patch('bodhi.client.bindings.BodhiClient.csrf',
                 mock.MagicMock(return_value='a_csrf_token'))

--- a/bodhi/tests/client/test___init__.py
+++ b/bodhi/tests/client/test___init__.py
@@ -363,7 +363,7 @@ class TestNew(unittest.TestCase):
         self.assertEqual(result.exit_code, 0)
         expected_output = client_test_data.EXPECTED_UPDATE_OUTPUT.replace('example.com/tests',
                                                                           'localhost:6543')
-        self.assertEqual(result.output, expected_output + '\n')
+        self.assertTrue(compare_output(result.output, expected_output + '\n'))
         bindings_client = send_request.mock_calls[0][1][0]
         send_request.assert_called_once_with(
             bindings_client, 'updates/', auth=True, verb='POST',

--- a/bodhi/tests/client/test___init__.py
+++ b/bodhi/tests/client/test___init__.py
@@ -249,7 +249,7 @@ class TestNew(unittest.TestCase):
 
         self.assertEqual(result.exit_code, 0)
         expected_output = client_test_data.EXPECTED_UPDATE_OUTPUT.replace('unspecified', 'urgent')
-        self.assertEqual(result.output, expected_output + '\n')
+        self.assertTrue(compare_output(result.output, expected_output))
         bindings_client = send_request.mock_calls[0][1][0]
         send_request.assert_called_once_with(
             bindings_client, 'updates/', auth=True, verb='POST',

--- a/bodhi/tests/client/test___init__.py
+++ b/bodhi/tests/client/test___init__.py
@@ -27,11 +27,13 @@ from click import testing
 import fedora.client
 import mock
 import munch
+import six
 
 from bodhi import client
 from bodhi.client import bindings, AuthError
 from bodhi.tests import client as client_test_data
 
+builtin_module_name = 'builtins' if six.PY3 else '__builtin__'
 
 EXPECTED_DEFAULT_BASE_URL = os.environ.get('BODHI_URL', bindings.BASE_URL)
 
@@ -522,7 +524,7 @@ class TestQuery(unittest.TestCase):
         mock_input.return_value = 'dudemcpants'
 
         with mock.patch.dict('os.environ'):
-            with mock.patch('__builtin__.open', create=True) as mock_open:
+            with mock.patch('{}.open'.format(builtin_module_name), create=True) as mock_open:
                 mock_open.side_effect = fake_open_no_session_cache
                 runner = testing.CliRunner()
                 res = runner.invoke(client.query, ['--mine'])
@@ -578,7 +580,7 @@ class TestQueryBuildrootOverrides(unittest.TestCase):
         mock_input.return_value = 'dudemcpants'
 
         with mock.patch.dict('os.environ'):
-            with mock.patch('__builtin__.open', create=True) as mock_open:
+            with mock.patch('{}.open'.format(builtin_module_name), create=True) as mock_open:
                 mock_open.side_effect = fake_open_no_session_cache
                 runner = testing.CliRunner()
                 res = runner.invoke(client.query_buildroot_overrides, ['--mine'])

--- a/bodhi/tests/client/test_bindings.py
+++ b/bodhi/tests/client/test_bindings.py
@@ -1327,7 +1327,7 @@ class TestBodhiClient_parse_file(unittest.TestCase):
 
         self.assertEqual(six.text_type(exc.exception), 'Invalid input file: sad')
 
-    @mock.patch('{}.open'.format(builtin_module_name), create=True)
+    @mock.patch('{}.open'.format(builtin_module_name), new_callable=mock.mock_open)
     @mock.patch('bodhi.client.bindings.BodhiClient._load_cookies')
     @mock.patch('bodhi.client.bindings.os.path.exists')
     def test_parsing_valid_file(self, exists, _load_cookies, mock_open):
@@ -1361,6 +1361,8 @@ class TestBodhiClient_parse_file(unittest.TestCase):
             ""]
         exists.return_value = True
         mock_open.return_value.readline.side_effect = s
+        # Workaround for Python bug https://bugs.python.org/issue21258
+        mock_open.return_value.__iter__ = lambda self: iter(self.readline, '')
 
         client = bindings.BodhiClient()
         updates = client.parse_file("sad")

--- a/bodhi/tests/client/test_bindings.py
+++ b/bodhi/tests/client/test_bindings.py
@@ -27,6 +27,7 @@ import six
 
 from bodhi.client import bindings
 from bodhi.tests import client as client_test_data
+from bodhi.tests.utils import compare_output
 
 builtin_module_name = 'builtins' if six.PY3 else '__builtin__'
 
@@ -918,10 +919,10 @@ class TestBodhiClient_update_str(unittest.TestCase):
 
         text = client.update_str(client_test_data.EXAMPLE_UPDATE_MUNCH)
 
-        self.assertEqual(
+        self.assertTrue(compare_output(
             text,
             client_test_data.EXPECTED_UPDATE_OUTPUT.replace(
-                '[-3, 3]', '[-3, 3]\n        Bugs: 1234 - it broke\n            : 1235 - halp'))
+                '[-3, 3]', '[-3, 3]\n        Bugs: 1234 - it broke\n            : 1235 - halp')))
 
     def test_minimal(self):
         """Ensure correct output when minimal is True."""
@@ -955,10 +956,10 @@ class TestBodhiClient_update_str(unittest.TestCase):
 
         text = client.update_str(client_test_data.EXAMPLE_UPDATE_MUNCH)
 
-        self.assertEqual(
+        self.assertTrue(compare_output(
             text,
             client_test_data.EXPECTED_UPDATE_OUTPUT.replace(
-                '[-3, 3]', '[-3, 3]\n     Request: stable'))
+                '[-3, 3]', '[-3, 3]\n     Request: stable')))
 
     def test_severity(self):
         """Test that severity is rendered."""
@@ -978,7 +979,7 @@ class TestBodhiClient_update_str(unittest.TestCase):
 
         text = client.update_str(client_test_data.EXAMPLE_UPDATE_MUNCH)
 
-        self.assertEqual(text, client_test_data.EXPECTED_UPDATE_OUTPUT)
+        self.assertTrue(compare_output(text, client_test_data.EXPECTED_UPDATE_OUTPUT))
 
     def test_with_autokarma_unset(self):
         """
@@ -996,7 +997,7 @@ class TestBodhiClient_update_str(unittest.TestCase):
 
         expected_output = client_test_data.EXPECTED_UPDATE_OUTPUT.replace(
             'Autokarma: True  [-3, 3]', 'Autokarma: False  [None, None]')
-        self.assertEqual(text, expected_output)
+        self.assertTrue(compare_output(text, expected_output))
 
     def test_update_as_string(self):
         """Ensure we return a string if update is a string"""
@@ -1018,9 +1019,11 @@ class TestBodhiClient_update_str(unittest.TestCase):
                 client_test_data.EXAMPLE_UPDATE_MUNCH.comments[0], {u'anonymous': True}):
             text = client.update_str(client_test_data.EXAMPLE_UPDATE_MUNCH)
 
-        self.assertEqual(text, client_test_data.EXPECTED_UPDATE_OUTPUT.replace(
-            "Comments: bodhi ",
-            "Comments: bodhi (unauthenticated) "))
+        self.assertTrue(compare_output(
+            text,
+            client_test_data.EXPECTED_UPDATE_OUTPUT.replace(
+                "Comments: bodhi ",
+                "Comments: bodhi (unauthenticated) ")))
 
     @mock.patch.dict(
         client_test_data.EXAMPLE_UPDATE_MUNCH, {u'alias': None})
@@ -1037,7 +1040,7 @@ class TestBodhiClient_update_str(unittest.TestCase):
         expected_output = expected_output.replace(
             "   Update ID: FEDORA-EPEL-2016-3081a94111\n",
             "")
-        self.assertEqual(text, expected_output)
+        self.assertTrue(compare_output(text, expected_output))
 
 
 class TestErrorhandled(unittest.TestCase):

--- a/bodhi/tests/client/test_bindings.py
+++ b/bodhi/tests/client/test_bindings.py
@@ -28,6 +28,8 @@ import six
 from bodhi.client import bindings
 from bodhi.tests import client as client_test_data
 
+builtin_module_name = 'builtins' if six.PY3 else '__builtin__'
+
 
 class TestBodhiClient___init__(unittest.TestCase):
     """
@@ -99,7 +101,7 @@ class TestBodhiClient_init_username(unittest.TestCase):
     TEST_HOT_SESSION_CACHE = '{"https://bodhi.fedoraproject.org/:bowlofeggs": [["stuff", "login"]]}'
     TEST_OTHER_SESSION_CACHE = '{"https://other_domain/:bowlofeggs": [["stuff", "login"]]}'
 
-    @mock.patch('__builtin__.open', create=True)
+    @mock.patch('{}.open'.format(builtin_module_name), create=True)
     @mock.patch('bodhi.client.bindings.input', create=True)
     @mock.patch('bodhi.client.bindings.BodhiClient._load_cookies')
     @mock.patch('bodhi.client.bindings.os.path.exists')
@@ -121,7 +123,7 @@ class TestBodhiClient_init_username(unittest.TestCase):
         mock_open.assert_called_once_with(fedora.client.openidbaseclient.b_SESSION_FILE)
         self.assertEqual(client.username, 'pongou')
 
-    @mock.patch('__builtin__.open', create=True)
+    @mock.patch('{}.open'.format(builtin_module_name), create=True)
     @mock.patch('bodhi.client.bindings.input', create=True)
     @mock.patch('bodhi.client.bindings.BodhiClient._load_cookies')
     @mock.patch('bodhi.client.bindings.os.path.exists')
@@ -143,7 +145,7 @@ class TestBodhiClient_init_username(unittest.TestCase):
         mock_open.assert_called_once_with(fedora.client.openidbaseclient.b_SESSION_FILE)
         self.assertEqual(client.username, 'pongou')
 
-    @mock.patch('__builtin__.open', create=True)
+    @mock.patch('{}.open'.format(builtin_module_name), create=True)
     @mock.patch('bodhi.client.bindings.input', create=True)
     @mock.patch('bodhi.client.bindings.BodhiClient._load_cookies')
     @mock.patch('bodhi.client.bindings.os.path.exists')
@@ -165,7 +167,7 @@ class TestBodhiClient_init_username(unittest.TestCase):
         mock_open.assert_called_once_with(fedora.client.openidbaseclient.b_SESSION_FILE)
         self.assertEqual(client.username, 'pongou')
 
-    @mock.patch('__builtin__.open', create=True)
+    @mock.patch('{}.open'.format(builtin_module_name), create=True)
     @mock.patch('bodhi.client.bindings.input', create=True)
     @mock.patch('bodhi.client.bindings.BodhiClient._load_cookies')
     @mock.patch('bodhi.client.bindings.os.path.exists')
@@ -186,7 +188,7 @@ class TestBodhiClient_init_username(unittest.TestCase):
         mock_open.assert_called_once_with(fedora.client.openidbaseclient.b_SESSION_FILE)
         self.assertEqual(client.username, 'bowlofeggs')
 
-    @mock.patch('__builtin__.open', create=True)
+    @mock.patch('{}.open'.format(builtin_module_name), create=True)
     @mock.patch('bodhi.client.bindings.input', create=True)
     @mock.patch('bodhi.client.bindings.BodhiClient._load_cookies')
     @mock.patch('bodhi.client.bindings.json.loads')
@@ -216,7 +218,7 @@ class TestBodhiClient_init_username(unittest.TestCase):
         mock_open.assert_called_once_with(fedora.client.openidbaseclient.b_SESSION_FILE)
         self.assertEqual(client.username, 'correct')
 
-    @mock.patch('__builtin__.open', create=True)
+    @mock.patch('{}.open'.format(builtin_module_name), create=True)
     @mock.patch('bodhi.client.bindings.input', create=True)
     @mock.patch('bodhi.client.bindings.BodhiClient._load_cookies')
     @mock.patch('bodhi.client.bindings.os.path.exists')
@@ -236,7 +238,7 @@ class TestBodhiClient_init_username(unittest.TestCase):
         self.assertEqual(mock_open.call_count, 0)
         self.assertEqual(client.username, 'pongou')
 
-    @mock.patch('__builtin__.open', create=True)
+    @mock.patch('{}.open'.format(builtin_module_name), create=True)
     @mock.patch('bodhi.client.bindings.input', create=True)
     @mock.patch('bodhi.client.bindings.BodhiClient._load_cookies')
     @mock.patch('bodhi.client.bindings.os.path.exists')
@@ -258,7 +260,7 @@ class TestBodhiClient_init_username(unittest.TestCase):
         mock_open.assert_called_once_with(fedora.client.openidbaseclient.b_SESSION_FILE)
         self.assertEqual(client.username, 'pongou')
 
-    @mock.patch('__builtin__.open', create=True)
+    @mock.patch('{}.open'.format(builtin_module_name), create=True)
     @mock.patch('bodhi.client.bindings.input', create=True)
     @mock.patch('bodhi.client.bindings.BodhiClient._load_cookies')
     @mock.patch('bodhi.client.bindings.os.path.exists')
@@ -297,7 +299,7 @@ class TestBodhiClient_csrf(unittest.TestCase):
         # No need to init the username since we already have a token.
         self.assertEqual(init_username.call_count, 0)
 
-    @mock.patch('__builtin__.open', create=True)
+    @mock.patch('{}.open'.format(builtin_module_name), create=True)
     @mock.patch('bodhi.client.bindings.input', create=True)
     @mock.patch('bodhi.client.bindings.BodhiClient._load_cookies')
     @mock.patch('bodhi.client.bindings.os.path.exists')
@@ -328,7 +330,7 @@ class TestBodhiClient_csrf(unittest.TestCase):
         mock_open.assert_called_once_with(fedora.client.openidbaseclient.b_SESSION_FILE)
         self.assertEqual(client.username, 'bowlofeggs')
 
-    @mock.patch('__builtin__.open', create=True)
+    @mock.patch('{}.open'.format(builtin_module_name), create=True)
     @mock.patch('bodhi.client.bindings.input', create=True)
     @mock.patch('bodhi.client.bindings.BodhiClient._load_cookies')
     @mock.patch('bodhi.client.bindings.os.path.exists')
@@ -1322,7 +1324,7 @@ class TestBodhiClient_parse_file(unittest.TestCase):
 
         self.assertEqual(six.text_type(exc.exception), 'Invalid input file: sad')
 
-    @mock.patch('__builtin__.open', create=True)
+    @mock.patch('{}.open'.format(builtin_module_name), create=True)
     @mock.patch('bodhi.client.bindings.BodhiClient._load_cookies')
     @mock.patch('bodhi.client.bindings.os.path.exists')
     def test_parsing_valid_file(self, exists, _load_cookies, mock_open):
@@ -1392,7 +1394,7 @@ class TestBodhiClient_testable(unittest.TestCase):
     """
     Test the BodhiClient.testable() method.
     """
-    @mock.patch('__builtin__.open', create=True)
+    @mock.patch('{}.open'.format(builtin_module_name), create=True)
     @mock.patch('bodhi.client.bindings.BodhiClient._load_cookies', mock.MagicMock())
     @mock.patch('bodhi.client.bindings.BodhiClient.get_koji_session')
     @mock.patch('bodhi.client.bindings.dnf')
@@ -1440,7 +1442,7 @@ class TestGetKojiSession(unittest.TestCase):
     """
     This class tests the get_koji_session method.
     """
-    @mock.patch('__builtin__.open', create=True)
+    @mock.patch('{}.open'.format(builtin_module_name), create=True)
     @mock.patch('bodhi.client.bindings.ConfigParser.readfp')
     @mock.patch("os.path.exists")
     @mock.patch("os.path.expanduser", return_value="/home/dudemcpants/")
@@ -1458,7 +1460,7 @@ class TestGetKojiSession(unittest.TestCase):
         exists.assert_called_once_with("/home/dudemcpants/.koji/config")
         mock_open.assert_called_once_with("/home/dudemcpants/.koji/config")
 
-    @mock.patch('__builtin__.open', create=True)
+    @mock.patch('{}.open'.format(builtin_module_name), create=True)
     @mock.patch('bodhi.client.bindings.ConfigParser.readfp')
     @mock.patch("os.path.exists")
     @mock.patch("os.path.expanduser", return_value="/home/dudemcpants/")

--- a/bodhi/tests/server/consumers/test_masher.py
+++ b/bodhi/tests/server/consumers/test_masher.py
@@ -16,7 +16,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
-from cStringIO import StringIO
 import datetime
 import dummy_threading
 import errno
@@ -26,12 +25,13 @@ import shutil
 import tempfile
 import time
 import unittest
-import urllib2
-import urlparse
 
 from click import testing
 import mock
 import six
+import six.moves.urllib.parse as urlparse
+from six.moves.urllib.error import HTTPError, URLError
+from six import StringIO
 
 from bodhi.server import buildsys, exceptions, log, push
 from bodhi.server.config import config
@@ -2247,7 +2247,7 @@ class TestPungiComposerThread__wait_for_sync(ComposerThreadBaseTestCase):
     @mock.patch('bodhi.server.consumers.masher.time.sleep')
     @mock.patch(
         'bodhi.server.consumers.masher.urllib2.urlopen',
-        side_effect=[urllib2.HTTPError('url', 404, 'Not found', {}, None),
+        side_effect=[HTTPError('url', 404, 'Not found', {}, None),
                      StringIO('---\nyaml: rules')])
     def test_httperror(self, urlopen, sleep, publish):
         """
@@ -2350,7 +2350,7 @@ class TestPungiComposerThread__wait_for_sync(ComposerThreadBaseTestCase):
     @mock.patch('bodhi.server.consumers.masher.time.sleep')
     @mock.patch(
         'bodhi.server.consumers.masher.urllib2.urlopen',
-        side_effect=[urllib2.URLError('it broke'),
+        side_effect=[URLError('it broke'),
                      StringIO('---\nyaml: rules')])
     def test_urlerror(self, urlopen, sleep, publish):
         """

--- a/bodhi/tests/server/consumers/test_masher.py
+++ b/bodhi/tests/server/consumers/test_masher.py
@@ -1107,7 +1107,7 @@ That was the actual one'''
 
         with self.db_factory() as session:
             with tempfile.NamedTemporaryFile(delete=False) as script:
-                script.write('#!/bin/bash\nsleep 5\nexit 1\n')
+                script.write(b'#!/bin/bash\nsleep 5\nexit 1\n')
                 script.close()
                 os.chmod(script.name, 0o755)
 

--- a/bodhi/tests/server/consumers/test_masher.py
+++ b/bodhi/tests/server/consumers/test_masher.py
@@ -528,6 +528,7 @@ That was the actual one''' % mash_dir
         self.assertEquals(self.koji.__moved__[1],
                           (u'f17-updates-candidate', u'f17-updates-testing', u'bodhi-2.0-2.fc17'))
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_taskotron_results)
     @mock.patch('bodhi.server.consumers.masher.PungiComposerThread._wait_for_pungi')
     @mock.patch('bodhi.server.consumers.masher.PungiComposerThread._sanity_check_repo')
@@ -964,6 +965,7 @@ That was the actual one'''
             force=True,
             topic='mashtask.complete'))
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_taskotron_results)
     @mock.patch('bodhi.server.consumers.masher.PungiComposerThread._wait_for_pungi')
     @mock.patch('bodhi.server.consumers.masher.PungiComposerThread._sanity_check_repo')
@@ -1173,6 +1175,7 @@ That was the actual one'''
              'status_comments': True})
         self.assertTrue(os.path.exists(mash_dir))
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_taskotron_results)
     @mock.patch('bodhi.server.consumers.masher.PungiComposerThread._sanity_check_repo')
     @mock.patch('bodhi.server.consumers.masher.PungiComposerThread._stage_repo')
@@ -2123,6 +2126,7 @@ class TestComposerThread_save_state(ComposerThreadBaseTestCase):
 
 class TestPungiComposerThread__wait_for_sync(ComposerThreadBaseTestCase):
     """This test class contains tests for the PungiComposerThread._wait_for_sync() method."""
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch.dict(
         'bodhi.server.consumers.masher.config',
         {'fedora_testing_master_repomd':
@@ -2196,6 +2200,7 @@ class TestPungiComposerThread__wait_for_sync(ComposerThreadBaseTestCase):
         except Exception as ex:
             assert str(ex) == "Not found an arch to _wait_for_sync with"
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch.dict(
         'bodhi.server.consumers.masher.config',
         {'fedora_testing_master_repomd':
@@ -2239,6 +2244,7 @@ class TestPungiComposerThread__wait_for_sync(ComposerThreadBaseTestCase):
         urlopen.assert_has_calls(expected_calls)
         sleep.assert_has_calls([mock.call(200), mock.call(200)])
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch.dict(
         'bodhi.server.consumers.masher.config',
         {'fedora_testing_master_repomd':
@@ -2342,6 +2348,7 @@ class TestPungiComposerThread__wait_for_sync(ComposerThreadBaseTestCase):
         t.log.error.assert_called_once_with(
             'Cannot find local repomd: %s', os.path.join(repodata, 'repomd.xml'))
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch.dict(
         'bodhi.server.consumers.masher.config',
         {'fedora_testing_master_repomd':
@@ -2456,6 +2463,7 @@ class TestComposerThread_send_notifications(ComposerThreadBaseTestCase):
 class TestComposerThread_send_testing_digest(ComposerThreadBaseTestCase):
     """Test ComposerThread.send_testing_digest()."""
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch('bodhi.server.mail.smtplib.SMTP')
     def test_security_updates(self, SMTP):
         """If there are security updates, the maildata should mention it."""

--- a/bodhi/tests/server/consumers/test_updates.py
+++ b/bodhi/tests/server/consumers/test_updates.py
@@ -23,6 +23,7 @@ import unittest
 
 import mock
 import sqlalchemy
+import six
 
 from bodhi.server import config, exceptions, models, util
 from bodhi.server.consumers import updates
@@ -204,6 +205,7 @@ class TestUpdatesHandlerConsume(base.BaseTestCase):
         self.assertEqual(work_on_bugs.call_count, 0)
         self.assertEqual(fetch_test_cases.call_count, 0)
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch('bodhi.server.consumers.updates.UpdatesHandler.fetch_test_cases')
     @mock.patch('bodhi.server.consumers.updates.UpdatesHandler.work_on_bugs')
     def test_update_not_found(self, work_on_bugs, fetch_test_cases):

--- a/bodhi/tests/server/functional/test_packages.py
+++ b/bodhi/tests/server/functional/test_packages.py
@@ -14,6 +14,10 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
+import unittest
+
+import six
+
 from bodhi.server.models import (
     RpmPackage,
 )
@@ -21,6 +25,7 @@ from bodhi.tests.server import base
 
 
 class TestRpmPackagesService(base.BaseTestCase):
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_basic_json(self):
         """ Test querying with no arguments... """
         self.db.add(RpmPackage(name=u'a_second_package'))
@@ -29,6 +34,7 @@ class TestRpmPackagesService(base.BaseTestCase):
         body = resp.json_body
         self.assertEquals(len(body['packages']), 2)
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_filter_by_name(self):
         """ Test that filtering by name returns one package and not the other.
         """
@@ -38,6 +44,7 @@ class TestRpmPackagesService(base.BaseTestCase):
         body = resp.json_body
         self.assertEquals(len(body['packages']), 1)
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_filter_by_like(self):
         """ Test that filtering by like returns one package and not the other.
         """
@@ -47,6 +54,7 @@ class TestRpmPackagesService(base.BaseTestCase):
         body = resp.json_body
         self.assertEquals(len(body['packages']), 1)
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_filter_by_search(self):
         """ Test filtering by search
         """

--- a/bodhi/tests/server/functional/test_stacks.py
+++ b/bodhi/tests/server/functional/test_stacks.py
@@ -13,9 +13,11 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 import copy
+import unittest
 
 import mock
 from webtest import TestApp
+import six
 
 from bodhi.server import main
 from bodhi.server.models import Group, RpmPackage, Stack, User
@@ -47,6 +49,7 @@ class TestStacksService(base.BaseTestCase):
         self.assertEquals(res.json_body['stack']['name'], u'GNOME')
         self.assertEquals(res.json_body['stack']['packages'][0]['name'], u'gnome-shell')
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_stacks(self):
         res = self.app.get('/stacks/')
         body = res.json_body
@@ -54,6 +57,7 @@ class TestStacksService(base.BaseTestCase):
         self.assertEquals(body['stacks'][0]['name'], u'GNOME')
         self.assertEquals(body['stacks'][0]['packages'][0]['name'], u'gnome-shell')
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_stacks_with_pagination(self):
         # Create a second stack
         pkg1 = RpmPackage(name=u'firefox')
@@ -76,35 +80,41 @@ class TestStacksService(base.BaseTestCase):
         self.assertEquals(body['stacks'][0]['name'], 'Firefox')
         self.assertEquals(body['stacks'][0]['packages'][0]['name'], 'firefox')
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_stacks_by_name(self):
         res = self.app.get('/stacks/', {'name': 'GNOME'})
         body = res.json_body
         self.assertEquals(len(body['stacks']), 1)
         self.assertEquals(body['stacks'][0]['name'], 'GNOME')
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_stacks_by_name_mismatch(self):
         res = self.app.get('/stacks/', {'like': u'%KDE%'})
         body = res.json_body
         self.assertEquals(len(body['stacks']), 0)
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_stacks_by_name_match(self):
         res = self.app.get('/stacks/', {'like': '%GN%'})
         body = res.json_body
         self.assertEquals(len(body['stacks']), 1)
         self.assertEquals(body['stacks'][0]['name'], 'GNOME')
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_stacks_by_package_name(self):
         res = self.app.get('/stacks/', {"packages": 'gnome-shell'})
         body = res.json_body
         self.assertEquals(len(body['stacks']), 1)
         self.assertEquals(body['stacks'][0]['name'], 'GNOME')
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_stacks_by_nonexistant_package(self):
         res = self.app.get('/stacks/', {"packages": 'carbunkle'}, status=400)
         self.assertEquals(res.json_body['errors'][0]['name'], 'packages')
         self.assertEquals(res.json_body['errors'][0]['description'],
                           'Invalid packages specified: carbunkle')
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_valid_requirements)
     def test_new_stack(self, *args):
         self.db.add(RpmPackage(name=u'kde-filesystem'))
@@ -121,12 +131,14 @@ class TestStacksService(base.BaseTestCase):
         self.assertEquals(r.packages[0].name, 'kde-filesystem')
         self.assertEquals(r.requirements, u'rpmlint')
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_valid_requirements)
     def test_new_stack_invalid_name(self, *args):
         attrs = {"name": "", 'csrf_token': self.get_csrf_token()}
         res = self.app.post("/stacks/", attrs, status=400)
         self.assertEquals(res.json_body['status'], 'error')
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_valid_requirements)
     def test_new_stack_invalid_requirement(self, *args):
         attrs = {"name": u"Hackey", "packages": "nethack",
@@ -137,6 +149,7 @@ class TestStacksService(base.BaseTestCase):
         c = self.db.query(Stack).filter(Stack.name == attrs["name"]).count()
         self.assertEquals(c, 0)
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_valid_requirements)
     def test_new_stack_valid_requirement(self, *args):
         self.db.add(RpmPackage(name=u'nethack'))
@@ -152,6 +165,7 @@ class TestStacksService(base.BaseTestCase):
         self.assertEquals(len(r.packages), 1)
         self.assertEquals(r.requirements, attrs['requirements'])
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_valid_requirements)
     def test_edit_stack(self, *args):
         self.db.add(RpmPackage(name=u'gnome-music'))
@@ -180,6 +194,7 @@ class TestStacksService(base.BaseTestCase):
         self.assertEquals(res.json_body['status'], 'success')
         self.assertEquals(self.db.query(Stack).count(), 0)
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_valid_requirements)
     def test_edit_stack_remove_package(self, *args):
         self.db.add(RpmPackage(name=u'gnome-music'))
@@ -192,6 +207,7 @@ class TestStacksService(base.BaseTestCase):
         self.assertEquals(len(body['packages']), 1)
         self.assertEquals(body['packages'][0]['name'], 'gnome-music')
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_valid_requirements)
     def test_edit_stack_with_no_group_privs(self, *args):
         self.stack.users = []
@@ -208,6 +224,7 @@ class TestStacksService(base.BaseTestCase):
         self.assertEquals(body['errors'][0]['description'],
                           'guest does not have privileges to modify the GNOME stack')
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_valid_requirements)
     def test_edit_stack_with_no_user_privs(self, *args):
         user = User(name=u'bob')
@@ -224,6 +241,7 @@ class TestStacksService(base.BaseTestCase):
         self.assertEquals(body['errors'][0]['description'],
                           'guest does not have privileges to modify the GNOME stack')
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_valid_requirements)
     def test_edit_stack_with_user_privs(self, *args):
         user = self.db.query(User).filter_by(name=u'guest').one()
@@ -238,6 +256,7 @@ class TestStacksService(base.BaseTestCase):
         self.assertEquals(len(body['packages']), 2)
         self.assertEquals(body['packages'][-1]['name'], 'gnome-music')
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_valid_requirements)
     def test_edit_stack_with_group_privs(self, *args):
         self.stack.users = []

--- a/bodhi/tests/server/functional/test_stacks.py
+++ b/bodhi/tests/server/functional/test_stacks.py
@@ -45,7 +45,7 @@ class TestStacksService(base.BaseTestCase):
         self.app.get('/stacks/watwatwat', status=404)
 
     def test_get_single_stack(self):
-        res = self.app.get('/stacks/GNOME')
+        res = self.app.get('/stacks/GNOME', headers={'Accept': 'application/json'})
         self.assertEquals(res.json_body['stack']['name'], u'GNOME')
         self.assertEquals(res.json_body['stack']['packages'][0]['name'], u'gnome-shell')
 

--- a/bodhi/tests/server/functional/test_users.py
+++ b/bodhi/tests/server/functional/test_users.py
@@ -12,7 +12,10 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
+import unittest
+
 import mock
+import six
 
 from bodhi.server.config import config
 from bodhi.server.models import Update, User
@@ -71,6 +74,7 @@ class TestUsersService(base.BaseTestCase):
                      headers=dict(accept='application/atom+xml'),
                      status=406)
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_users(self):
         res = self.app.get('/users/')
         self.assertIn('application/json', res.headers['Content-Type'])
@@ -82,6 +86,7 @@ class TestUsersService(base.BaseTestCase):
         self.assertIn(u'anonymous', users)
         self.assertIn(u'bodhi', users)
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_users_jsonp(self):
         res = self.app.get('/users/',
                            {'callback': 'callback'},
@@ -91,6 +96,7 @@ class TestUsersService(base.BaseTestCase):
         self.assertIn('bodhi', res)
         self.assertIn('guest', res)
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_users_rss(self):
         res = self.app.get('/rss/users/',
                            headers=dict(accept='application/atom+xml'))
@@ -98,6 +104,7 @@ class TestUsersService(base.BaseTestCase):
         self.assertIn('bodhi', res)
         self.assertIn('guest', res)
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_like_users(self):
         res = self.app.get('/users/', {'like': 'odh'})
         body = res.json_body
@@ -110,6 +117,7 @@ class TestUsersService(base.BaseTestCase):
         body = res.json_body
         self.assertEquals(len(body['users']), 0)
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_search_users(self):
         """
         Test that the overrides/?search= endpoint works as expected
@@ -134,6 +142,7 @@ class TestUsersService(base.BaseTestCase):
         body = res.json_body
         self.assertEquals(len(body['users']), 0)
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_users_with_pagination(self):
         res = self.app.get('/users/')
         body = res.json_body
@@ -156,26 +165,31 @@ class TestUsersService(base.BaseTestCase):
         self.assertEquals(len(body['users']), 1)
         self.assertIn(body['users'][0]['name'], users)
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_users_by_name(self):
         res = self.app.get('/users/', {"name": 'guest'})
         body = res.json_body
         self.assertEquals(len(body['users']), 1)
         self.assertEquals(body['users'][0]['name'], 'guest')
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_users_by_name_match(self):
         res = self.app.get('/users/', {"name": 'gue%'})
         body = res.json_body
         self.assertEquals(len(body['users']), 1)
         self.assertEquals(body['users'][0]['name'], 'guest')
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_users_by_name_match_miss(self):
         res = self.app.get('/users/', {"name": '%wat%'})
         self.assertEquals(len(res.json_body['users']), 0)
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_users_by_groups(self):
         res = self.app.get('/users/', {"groups": 'packager'})
         self.assertEquals(len(res.json_body['users']), 1)
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_users_by_nonexistant_group(self):
         res = self.app.get('/users/', {"groups": 'carbunkle'}, status=400)
         body = res.json_body
@@ -183,6 +197,7 @@ class TestUsersService(base.BaseTestCase):
         self.assertEquals(body['errors'][0]['description'],
                           'Invalid groups specified: carbunkle')
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_users_by_mixed_nonexistant_group(self):
         res = self.app.get('/users/', {"groups": ['carbunkle', 'packager']}, status=400)
         body = res.json_body
@@ -190,18 +205,21 @@ class TestUsersService(base.BaseTestCase):
         self.assertEquals(body['errors'][0]['description'],
                           'Invalid groups specified: carbunkle')
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_users_by_group_miss(self):
         res = self.app.get('/users/', {"groups": 'provenpackager'})
         body = res.json_body
         self.assertEquals(len(body['users']), 0)
         assert 'errors' not in res.json_body
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_users_by_update_title(self):
         res = self.app.get('/users/', {"updates": 'bodhi-2.0-1.fc17'})
         body = res.json_body
         self.assertEquals(len(body['users']), 1)
         self.assertEquals(body['users'][0]['name'], 'guest')
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_users_by_update_alias(self):
         update = self.db.query(Update).first()
         update.alias = u'some_alias'
@@ -212,6 +230,7 @@ class TestUsersService(base.BaseTestCase):
         self.assertEquals(len(body['users']), 1)
         self.assertEquals(body['users'][0]['name'], 'guest')
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_users_by_nonexistant_update(self):
         res = self.app.get('/users/', {"updates": 'carbunkle'}, status=400)
         body = res.json_body
@@ -219,12 +238,14 @@ class TestUsersService(base.BaseTestCase):
         self.assertEquals(body['errors'][0]['description'],
                           'Invalid updates specified: carbunkle')
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_users_by_package_name(self):
         res = self.app.get('/users/', {"packages": 'bodhi'})
         body = res.json_body
         self.assertEquals(len(body['users']), 1)
         self.assertEquals(body['users'][0]['name'], 'guest')
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_users_by_nonexistant_package(self):
         res = self.app.get('/users/', {"packages": 'carbunkle'}, status=400)
         body = res.json_body

--- a/bodhi/tests/server/functional/test_users.py
+++ b/bodhi/tests/server/functional/test_users.py
@@ -35,18 +35,18 @@ class TestUsersService(base.BaseTestCase):
         self.app.get('/users/watwatwat', status=404)
 
     def test_get_single_user(self):
-        res = self.app.get('/users/bodhi')
+        res = self.app.get('/users/bodhi', headers={'Accept': 'application/json'})
         self.assertEquals(res.json_body['user']['name'], 'bodhi')
 
     def test_get_hardcoded_avatar(self):
-        res = self.app.get('/users/bodhi')
+        res = self.app.get('/users/bodhi', headers={'Accept': 'application/json'})
         self.assertEquals(res.json_body['user']['name'], 'bodhi')
         url = 'https://apps.fedoraproject.org/img/icons/bodhi-24.png'
         self.assertEquals(res.json_body['user']['avatar'], url)
 
     @mock.patch.dict(config, {'libravatar_enabled': True})
     def test_get_single_avatar(self):
-        res = self.app.get('/users/guest')
+        res = self.app.get('/users/guest', headers={'Accept': 'application/json'})
         self.assertEquals(res.json_body['user']['name'], 'guest')
 
         base = 'https://seccdn.libravatar.org/avatar/'

--- a/bodhi/tests/server/scripts/test_approve_testing.py
+++ b/bodhi/tests/server/scripts/test_approve_testing.py
@@ -20,9 +20,9 @@
 This module contains tests for the bodhi.server.scripts.approve_testing module.
 """
 from datetime import datetime, timedelta
-from cStringIO import StringIO
 
 from mock import patch
+from six import StringIO
 
 from bodhi.server.config import config
 from bodhi.server import models

--- a/bodhi/tests/server/scripts/test_expire_overrides.py
+++ b/bodhi/tests/server/scripts/test_expire_overrides.py
@@ -15,10 +15,10 @@
 This module contains tests for the bodhi.server.scripts.expire_overrides module.
 """
 import unittest
-from cStringIO import StringIO
 from datetime import timedelta
 
 import mock
+from six import StringIO
 
 from bodhi.server import models
 from bodhi.server.scripts import expire_overrides

--- a/bodhi/tests/server/scripts/test_initializedb.py
+++ b/bodhi/tests/server/scripts/test_initializedb.py
@@ -17,10 +17,10 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 """Contains tests for the bodhi.server.scripts.initializedb module."""
-from cStringIO import StringIO
 import unittest
 
 import mock
+from six import StringIO
 
 from bodhi.server.scripts import initializedb
 

--- a/bodhi/tests/server/scripts/test_monitor_composes.py
+++ b/bodhi/tests/server/scripts/test_monitor_composes.py
@@ -27,6 +27,7 @@ import mock
 from bodhi.server import models
 from bodhi.server.scripts import monitor_composes
 from bodhi.tests.server.base import BaseTestCase
+from bodhi.tests.utils import compare_output
 
 
 @mock.patch('bodhi.server.scripts.monitor_composes.initialize_db', mock.MagicMock())
@@ -69,9 +70,11 @@ class TestMonitor(BaseTestCase):
 
         self.assertEqual(r.exit_code, 0)
         EXPECTED_OUTPUT = (
-            'Locked updates: 2\n\n<Compose: F17 stable>\n\tstate: <failed>\n\tstate_date: {}\n\t'
+            'Locked updates: 2\n\n<Compose: F17 stable>\n\tstate: failed\n\tstate_date: {}\n\t'
             'security: True\n\terror_message: y r u so mean nfs\n\tcheckpoints: \n\t'
-            'len(updates): 1\n\n<Compose: F17 testing>\n\tstate: <notifying>\n\tstate_date: {}\n\t'
-            'security: False\n\tcheckpoints: check_2, check_1\n\tlen(updates): 1\n\n')
-        self.assertEqual(r.output,
-                         EXPECTED_OUTPUT.format(compose_2.state_date, compose_1.state_date))
+            'len(updates): 1\n\n<Compose: F17 testing>\n\tstate: notifying\n\tstate_date: {}\n\t'
+            'security: False\n\tcheckpoints: check_1, check_2\n\tlen(updates): 1\n\n')
+        self.assertTrue(compare_output(
+                        r.output,
+                        EXPECTED_OUTPUT.format(compose_2.state_date, compose_1.state_date)
+                        ))

--- a/bodhi/tests/server/scripts/test_untag_branched.py
+++ b/bodhi/tests/server/scripts/test_untag_branched.py
@@ -19,10 +19,10 @@
 """
 This module contains tests for the bodhi.server.scripts.untag_branched module.
 """
-from cStringIO import StringIO
 from datetime import datetime, timedelta
 
 from mock import call, patch
+from six import StringIO
 
 from bodhi.server import models
 from bodhi.server.scripts import untag_branched

--- a/bodhi/tests/server/services/test_builds.py
+++ b/bodhi/tests/server/services/test_builds.py
@@ -17,6 +17,10 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
+import unittest
+
+import six
+
 from bodhi.server.models import RpmBuild, RpmPackage
 from bodhi.tests.server import base
 
@@ -30,6 +34,7 @@ class TestBuildsService(base.BaseTestCase):
         res = self.app.get('/builds/bodhi-2.0-1.fc17')
         self.assertEquals(res.json_body['nvr'], 'bodhi-2.0-1.fc17')
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_builds(self):
         res = self.app.get('/builds/')
         body = res.json_body
@@ -38,6 +43,7 @@ class TestBuildsService(base.BaseTestCase):
         up = body['builds'][0]
         self.assertEquals(up['nvr'], u'bodhi-2.0-1.fc17')
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_builds_pagination(self):
 
         # First, stuff a second build in there
@@ -60,6 +66,7 @@ class TestBuildsService(base.BaseTestCase):
 
         self.assertNotEquals(build1, build2)
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_builds_by_package(self):
         res = self.app.get('/builds/', {"packages": "bodhi"})
         body = res.json_body
@@ -68,12 +75,14 @@ class TestBuildsService(base.BaseTestCase):
         up = body['builds'][0]
         self.assertEquals(up['nvr'], u'bodhi-2.0-1.fc17')
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_builds_by_unexisting_package(self):
         res = self.app.get('/builds/', {"packages": "flash"}, status=400)
         self.assertEquals(res.json_body['errors'][0]['name'], 'packages')
         self.assertEquals(res.json_body['errors'][0]['description'],
                           'Invalid packages specified: flash')
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_builds_by_release_name(self):
         res = self.app.get('/builds/', {"releases": "F17"})
         body = res.json_body
@@ -82,6 +91,7 @@ class TestBuildsService(base.BaseTestCase):
         up = body['builds'][0]
         self.assertEquals(up['nvr'], u'bodhi-2.0-1.fc17')
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_builds_by_release_version(self):
         res = self.app.get('/builds/', {"releases": "17"})
         body = res.json_body
@@ -90,22 +100,26 @@ class TestBuildsService(base.BaseTestCase):
         up = body['builds'][0]
         self.assertEquals(up['nvr'], u'bodhi-2.0-1.fc17')
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_builds_by_unexisting_release(self):
         res = self.app.get('/builds/', {"releases": "WinXP"}, status=400)
         self.assertEquals(res.json_body['errors'][0]['name'], 'releases')
         self.assertEquals(res.json_body['errors'][0]['description'],
                           'Invalid releases specified: WinXP')
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_builds_by_nvr(self):
         res = self.app.get('/builds/', {"nvr": "bodhi-2.0-1.fc17"})
         up = res.json_body['builds'][0]
         self.assertEquals(up['nvr'], u'bodhi-2.0-1.fc17')
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_builds_by_update_title(self):
         res = self.app.get('/builds/', {"updates": ["bodhi-2.0-1.fc17"]})
         up = res.json_body['builds'][0]
         self.assertEquals(up['nvr'], u'bodhi-2.0-1.fc17')
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_builds_no_rows_per_page(self):
         res = self.app.get('/builds/', {"rows_per_page": None}, status=400)
         self.assertEquals(res.json_body['status'], 'error')

--- a/bodhi/tests/server/services/test_comments.py
+++ b/bodhi/tests/server/services/test_comments.py
@@ -19,9 +19,11 @@
 
 import copy
 from datetime import datetime, timedelta
+import unittest
 
 import mock
 from webtest import TestApp
+import six
 
 from bodhi.server import main
 from bodhi.server.models import (Comment, Release, Update, UpdateRequest, UpdateStatus, UpdateType,
@@ -71,6 +73,7 @@ class TestCommentsService(base.BaseTestCase):
         comment.update(kwargs)
         return comment
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_invalid_update(self):
         res = self.app.post_json('/comments/', self.make_comment(
             update='bodhi-1.0-2.fc17',
@@ -79,6 +82,7 @@ class TestCommentsService(base.BaseTestCase):
         self.assertEquals(res.json_body['errors'][0]['description'],
                           "Invalid update specified: bodhi-1.0-2.fc17")
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_invalid_karma(self):
         res = self.app.post_json('/comments/',
                                  self.make_comment(karma=-2),
@@ -89,6 +93,7 @@ class TestCommentsService(base.BaseTestCase):
                                  status=400)
         assert '2 is greater than maximum value 1' in res, res
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch('bodhi.server.notifications.publish')
     def test_commenting_with_critpath_feedback(self, publish):
         comment = self.make_comment()
@@ -102,6 +107,7 @@ class TestCommentsService(base.BaseTestCase):
         self.assertEquals(res.json_body['comment']['karma_critpath'], -1)
         publish.assert_called_once_with(topic='update.comment', msg=mock.ANY)
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch('bodhi.server.notifications.publish')
     def test_commenting_with_bug_feedback(self, publish):
         comment = self.make_comment()
@@ -117,6 +123,7 @@ class TestCommentsService(base.BaseTestCase):
         self.assertEquals(len(feedback), 1)
         publish.assert_called_once_with(topic='update.comment', msg=mock.ANY)
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch('bodhi.server.notifications.publish')
     def test_commenting_with_testcase_feedback(self, publish):
         comment = self.make_comment()
@@ -132,6 +139,7 @@ class TestCommentsService(base.BaseTestCase):
         self.assertEquals(len(feedback), 1)
         publish.assert_called_once_with(topic='update.comment', msg=mock.ANY)
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch('bodhi.server.notifications.publish')
     def test_commenting_with_login(self, publish):
         res = self.app.post_json('/comments/', self.make_comment())
@@ -142,6 +150,7 @@ class TestCommentsService(base.BaseTestCase):
         self.assertEquals(res.json_body['comment']['user_id'], 1)
         publish.assert_called_once_with(topic='update.comment', msg=mock.ANY)
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch('bodhi.server.notifications.publish')
     def test_commenting_twice_with_neutral_karma(self, publish):
         res = self.app.post_json('/comments/', self.make_comment())
@@ -160,6 +169,7 @@ class TestCommentsService(base.BaseTestCase):
         self.assertEquals(res.json_body['comment']['user_id'], 1)
         self.assertEquals(publish.call_count, 2)
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch('bodhi.server.notifications.publish')
     def test_commenting_twice_with_double_positive_karma(self, publish):
         res = self.app.post_json('/comments/', self.make_comment(up2, karma=1))
@@ -183,6 +193,7 @@ class TestCommentsService(base.BaseTestCase):
         # Mainly, ensure that the karma didn't increase *again*
         self.assertEquals(res.json_body['comment']['update']['karma'], 1)
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch('bodhi.server.notifications.publish')
     def test_commenting_twice_with_positive_then_negative_karma(self, publish):
         res = self.app.post_json('/comments/', self.make_comment(up2, karma=1))
@@ -207,6 +218,7 @@ class TestCommentsService(base.BaseTestCase):
         self.assertEquals(res.json_body['caveats'][0]['description'],
                           'Your karma standing was reversed.')
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch('bodhi.server.notifications.publish')
     def test_commenting_with_negative_karma(self, publish):
         res = self.app.post_json('/comments/', self.make_comment(up2, karma=-1))
@@ -218,6 +230,7 @@ class TestCommentsService(base.BaseTestCase):
         publish.assert_called_once_with(topic='update.comment', msg=mock.ANY)
         self.assertEquals(res.json_body['comment']['update']['karma'], -1)
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch('bodhi.server.notifications.publish')
     def test_anonymous_commenting_with_email(self, publish):
         res = self.app.post_json('/comments/',
@@ -229,6 +242,7 @@ class TestCommentsService(base.BaseTestCase):
         self.assertEquals(res.json_body['comment']['user_id'], 2)
         publish.assert_called_once_with(topic='update.comment', msg=mock.ANY)
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_anonymous_commenting_with_invalid_email(self):
         res = self.app.post_json('/comments/',
                                  self.make_comment(email='foo'),
@@ -237,6 +251,7 @@ class TestCommentsService(base.BaseTestCase):
         self.assertEquals(res.json_body['errors'][0]['description'],
                           "Invalid email address")
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_anonymous_commenting_with_no_author(self):
         anonymous_settings = copy.copy(self.app_settings)
         anonymous_settings.update({
@@ -258,6 +273,7 @@ class TestCommentsService(base.BaseTestCase):
         self.assertEquals(res.json_body['errors'][0]['description'],
                           "You must provide an author")
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch('bodhi.server.services.comments.Update.comment',
                 side_effect=IOError('IOError. oops!'))
     def test_unexpected_exception(self, exception):
@@ -269,6 +285,7 @@ class TestCommentsService(base.BaseTestCase):
         self.assertEquals(res.json_body['errors'][0]['description'],
                           u'Unable to create comment')
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_get_single_comment(self):
         res = self.app.get('/comments/1')
         self.assertEquals(res.json_body['comment']['update_id'], 1)
@@ -291,6 +308,7 @@ class TestCommentsService(base.BaseTestCase):
     def test_404(self):
         self.app.get('/comments/a', status=400)
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_comments(self):
         res = self.app.get('/comments/')
         body = res.json_body
@@ -300,6 +318,7 @@ class TestCommentsService(base.BaseTestCase):
         self.assertEquals(comment['text'], u'srsly.  pretty good.')
         self.assertEquals(comment['karma'], 0)
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_comments_jsonp(self):
         res = self.app.get('/comments/',
                            {'callback': 'callback'},
@@ -308,17 +327,20 @@ class TestCommentsService(base.BaseTestCase):
         self.assertIn('callback', res)
         self.assertIn('srsly.  pretty good', res)
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_comments_rss(self):
         res = self.app.get('/rss/comments/',
                            headers=dict(accept='application/atom+xml'))
         self.assertIn('application/rss+xml', res.headers['Content-Type'])
         self.assertIn('srsly.  pretty good', res)
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_comments_page(self):
         res = self.app.get('/comments/', headers=dict(accept='text/html'))
         self.assertIn('text/html', res.headers['Content-Type'])
         self.assertIn('libravatar.org', res)
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_search_comments(self):
         res = self.app.get('/comments/', {'like': 'srsly'})
         body = res.json_body
@@ -331,6 +353,7 @@ class TestCommentsService(base.BaseTestCase):
         body = res.json_body
         self.assertEquals(len(body['comments']), 0)
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_comments_pagination(self):
         # Then, test pagination
         res = self.app.get('/comments/',
@@ -347,6 +370,7 @@ class TestCommentsService(base.BaseTestCase):
 
         self.assertNotEquals(comment1, comment2)
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_comments_by_since(self):
         tomorrow = datetime.utcnow() + timedelta(days=1)
         fmt = "%Y-%m-%d %H:%M:%S"
@@ -370,6 +394,7 @@ class TestCommentsService(base.BaseTestCase):
         self.assertEquals(comment['karma'], 1)
         self.assertEquals(comment['user']['name'], u'guest')
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_comments_by_invalid_since(self):
         res = self.app.get('/comments/', {"since": "forever"}, status=400)
         body = res.json_body
@@ -378,6 +403,7 @@ class TestCommentsService(base.BaseTestCase):
         self.assertEquals(error['name'], 'since')
         self.assertEquals(error['description'], 'Invalid date')
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_comments_by_future_date(self):
         """test filtering by future date"""
         tomorrow = datetime.utcnow() + timedelta(days=1)
@@ -387,6 +413,7 @@ class TestCommentsService(base.BaseTestCase):
         body = res.json_body
         self.assertEquals(len(body['comments']), 0)
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_comments_by_anonymous(self):
         res = self.app.get('/comments/', {"anonymous": "false"})
         body = res.json_body
@@ -395,6 +422,7 @@ class TestCommentsService(base.BaseTestCase):
         comment = body['comments'][0]
         self.assertEquals(comment['text'], u'wow. amaze.')
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_comments_by_invalid_anonymous(self):
         res = self.app.get('/comments/', {"anonymous": "lalala"}, status=400)
         body = res.json_body
@@ -404,6 +432,7 @@ class TestCommentsService(base.BaseTestCase):
         proper = "is neither in ('false', '0') nor in ('true', '1')"
         self.assertEquals(error['description'], '"lalala" %s' % proper)
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_comments_by_update(self):
         res = self.app.get('/comments/', {"updates": "bodhi-2.0-1.fc17"})
         body = res.json_body
@@ -412,6 +441,7 @@ class TestCommentsService(base.BaseTestCase):
         comment = body['comments'][0]
         self.assertEquals(comment['text'], u'srsly.  pretty good.')
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_comments_by_update_no_comments(self):
         nvr = u'bodhi-2.0-201.fc17'
         update = Update(
@@ -432,6 +462,7 @@ class TestCommentsService(base.BaseTestCase):
         body = res.json_body
         self.assertEquals(len(body['comments']), 0)
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_comments_by_unexisting_update(self):
         res = self.app.get('/comments/', {"updates": "flash-player"},
                            status=400)
@@ -439,6 +470,7 @@ class TestCommentsService(base.BaseTestCase):
         self.assertEquals(res.json_body['errors'][0]['description'],
                           "Invalid updates specified: flash-player")
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_comments_by_package(self):
         res = self.app.get('/comments/', {"packages": "bodhi"})
         body = res.json_body
@@ -447,6 +479,7 @@ class TestCommentsService(base.BaseTestCase):
         comment = body['comments'][0]
         self.assertEquals(comment['text'], u'srsly.  pretty good.')
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_comments_by_unexisting_package(self):
         res = self.app.get('/comments/', {"packages": "flash-player"},
                            status=400)
@@ -454,6 +487,7 @@ class TestCommentsService(base.BaseTestCase):
         self.assertEquals(res.json_body['errors'][0]['description'],
                           "Invalid packages specified: flash-player")
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_comments_by_username(self):
         res = self.app.get('/comments/', {"user": "guest"})
         body = res.json_body
@@ -462,6 +496,7 @@ class TestCommentsService(base.BaseTestCase):
         comment = body['comments'][0]
         self.assertEquals(comment['text'], u'wow. amaze.')
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_comments_by_unexisting_username(self):
         res = self.app.get('/comments/', {"user": "santa"}, status=400)
         body = res.json_body
@@ -470,6 +505,7 @@ class TestCommentsService(base.BaseTestCase):
         self.assertEquals(res.json_body['errors'][0]['description'],
                           "Invalid user specified: santa")
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_comments_by_update_owner(self):
         res = self.app.get('/comments/', {"update_owner": "guest"})
         body = res.json_body
@@ -478,6 +514,7 @@ class TestCommentsService(base.BaseTestCase):
         comment = body['comments'][0]
         self.assertEquals(comment['text'], u'srsly.  pretty good.')
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_comments_by_update_owner_with_none(self):
         user = User(name=u'ralph')
         self.db.add(user)
@@ -487,6 +524,7 @@ class TestCommentsService(base.BaseTestCase):
         self.assertEquals(len(body['comments']), 0)
         self.assertNotIn('errors', body)
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_comments_by_unexisting_update_owner(self):
         res = self.app.get('/comments/', {"update_owner": "santa"}, status=400)
         body = res.json_body
@@ -495,6 +533,7 @@ class TestCommentsService(base.BaseTestCase):
         self.assertEquals(res.json_body['errors'][0]['description'],
                           "Invalid user specified: santa")
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_comments_with_ignore_user(self):
         res = self.app.get('/comments/', {"ignore_user": "guest"})
         body = res.json_body
@@ -503,6 +542,7 @@ class TestCommentsService(base.BaseTestCase):
         comment = body['comments'][0]
         self.assertEquals(comment['text'], u'srsly.  pretty good.')
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_comments_with_unexisting_ignore_user(self):
         res = self.app.get('/comments/', {"ignore_user": "santa"}, status=400)
         body = res.json_body
@@ -511,16 +551,19 @@ class TestCommentsService(base.BaseTestCase):
         self.assertEquals(res.json_body['errors'][0]['description'],
                           "Invalid user specified: santa")
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_put_json_comment(self):
         """ We only want to POST comments, not PUT. """
         self.app.put_json('/comments/', self.make_comment(), status=405)
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_post_json_comment(self):
         self.app.post_json('/comments/', self.make_comment(text='awesome'))
         up = self.db.query(Update).filter_by(title=u'bodhi-2.0-1.fc17').one()
         self.assertEquals(len(up.comments), 3)
         self.assertEquals(up.comments[-1]['text'], 'awesome')
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_new_comment(self):
         comment = self.make_comment('bodhi-2.0-1.fc17', text='superb')
         r = self.app.post_json('/comments/', comment)
@@ -532,6 +575,7 @@ class TestCommentsService(base.BaseTestCase):
         self.assertEquals(comment['update_title'], u'bodhi-2.0-1.fc17')
         self.assertEquals(comment['karma'], 0)
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_no_self_karma(self):
         " Make sure you can't give +1 karma to your own updates.. "
         comment = self.make_comment('bodhi-2.0-1.fc17', karma=1)
@@ -551,6 +595,7 @@ class TestCommentsService(base.BaseTestCase):
                           "You may not give karma to your own updates.")
         self.assertEquals(comment['karma'], 0)  # This is the real check
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_comment_on_locked_update(self):
         """ Make sure you can comment on locked updates. """
         # Lock it
@@ -569,6 +614,7 @@ class TestCommentsService(base.BaseTestCase):
         self.assertEquals(len(up.comments), 1)  # After
         self.assertEquals(up.karma, 1)          # After
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_comment_on_locked_update_no_threshhold_action(self):
         " Make sure you can't trigger threshold action on locked updates "
         # Lock it

--- a/bodhi/tests/server/services/test_composes.py
+++ b/bodhi/tests/server/services/test_composes.py
@@ -60,7 +60,7 @@ class TestComposeCollectionGet(base.BaseTestCase):
 
     def test_no_composes_json(self):
         """Assert correct behavior for json interface when there are no composes."""
-        response = self.app.get('/composes/', status=200)
+        response = self.app.get('/composes/', status=200, headers={'Accept': 'application/json'})
 
         self.assertEqual(response.json, {'composes': []})
 
@@ -86,7 +86,7 @@ class TestComposeCollectionGet(base.BaseTestCase):
         self.db.add(compose)
         self.db.flush()
 
-        response = self.app.get('/composes/', status=200)
+        response = self.app.get('/composes/', status=200, headers={'Accept': 'application/json'})
 
         self.assertEqual(response.json, {'composes': [compose.__json__()]})
 
@@ -137,6 +137,6 @@ class TestComposeGet(base.BaseTestCase):
 
         response = self.app.get(
             '/composes/{}/{}'.format(compose.release.name, compose.request.value),
-            status=200)
+            status=200, headers={'Accept': 'application/json'})
 
         self.assertEqual(response.json, {'compose': compose.__json__()})

--- a/bodhi/tests/server/services/test_csrf.py
+++ b/bodhi/tests/server/services/test_csrf.py
@@ -17,11 +17,16 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 """This module contains tests for bodhi.server.services.csrf.py"""
+import unittest
+
+import six
+
 from bodhi.tests.server import base
 
 
 class TestCSRFService(base.BaseTestCase):
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_csrf_html(self):
         """
         Assert that we return just the CSRF token when requesting HTML
@@ -30,6 +35,7 @@ class TestCSRFService(base.BaseTestCase):
 
         self.assertEquals(res.body, self.get_csrf_token())
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_csrf_json(self):
         """
         Assert that we return the CSRF token in JSON format when requesting JSON

--- a/bodhi/tests/server/services/test_errors.py
+++ b/bodhi/tests/server/services/test_errors.py
@@ -17,13 +17,17 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 """This module contains tests for bodhi.server.services.errors.py"""
+import unittest
+
 import mock
+import six
 
 from bodhi.tests.server import base
 
 
 class TestHTMLHandlerErrors(base.BaseTestCase):
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch('bodhi.server.services.errors.log.error')
     @mock.patch('bodhi.server.services.errors.status2summary',
                 side_effect=IOError('random error'))

--- a/bodhi/tests/server/services/test_overrides.py
+++ b/bodhi/tests/server/services/test_overrides.py
@@ -19,9 +19,11 @@
 
 from datetime import datetime, timedelta
 import copy
+import unittest
 
 import mock
 from webtest import TestApp
+import six
 
 from bodhi.server.models import BuildrootOverride, RpmBuild, RpmPackage, Release, User
 from bodhi.server import main
@@ -51,6 +53,7 @@ class TestOverridesService(base.BaseTestCase):
         self.assertEquals(override['submitter']['name'], 'guest')
         self.assertEquals(override['notes'], 'blah blah blah')
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_overrides(self):
         res = self.app.get('/overrides/')
 
@@ -62,18 +65,21 @@ class TestOverridesService(base.BaseTestCase):
         self.assertEquals(override['submitter']['name'], 'guest')
         self.assertEquals(override['notes'], 'blah blah blah')
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_overrides_rss(self):
         res = self.app.get('/rss/overrides/',
                            headers=dict(accept='application/atom+xml'))
         self.assertIn('application/rss+xml', res.headers['Content-Type'])
         self.assertIn('blah blah blah', res)
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_expired_overrides(self):
         res = self.app.get('/overrides/', {'expired': 'true'})
 
         body = res.json_body
         self.assertEquals(len(body['overrides']), 0)
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_notexpired_overrides(self):
         res = self.app.get('/overrides/', {'expired': 'false'})
 
@@ -85,6 +91,7 @@ class TestOverridesService(base.BaseTestCase):
         self.assertEquals(override['submitter']['name'], 'guest')
         self.assertEquals(override['notes'], 'blah blah blah')
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_overrides_by_invalid_expired(self):
         res = self.app.get('/overrides/', {"expired": "lalala"},
                            status=400)
@@ -95,6 +102,7 @@ class TestOverridesService(base.BaseTestCase):
         self.assertEquals(errors[0]['description'],
                           '"lalala" is neither in (\'false\', \'0\') nor in (\'true\', \'1\')')
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_overrides_by_packages(self):
         res = self.app.get('/overrides/', {'packages': 'bodhi'})
 
@@ -106,6 +114,7 @@ class TestOverridesService(base.BaseTestCase):
         self.assertEquals(override['submitter']['name'], 'guest')
         self.assertEquals(override['notes'], 'blah blah blah')
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_overrides_by_packages_without_override(self):
         self.db.add(RpmPackage(name=u'python'))
         self.db.flush()
@@ -115,6 +124,7 @@ class TestOverridesService(base.BaseTestCase):
         body = res.json_body
         self.assertEquals(len(body['overrides']), 0)
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_overrides_by_invalid_packages(self):
         res = self.app.get('/overrides/', {'packages': 'flash-player'},
                            status=400)
@@ -126,6 +136,7 @@ class TestOverridesService(base.BaseTestCase):
         self.assertEquals(errors[0]['description'],
                           'Invalid packages specified: flash-player')
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_overrides_by_releases(self):
         res = self.app.get('/overrides/', {'releases': 'F17'})
 
@@ -137,6 +148,7 @@ class TestOverridesService(base.BaseTestCase):
         self.assertEquals(override['submitter']['name'], 'guest')
         self.assertEquals(override['notes'], 'blah blah blah')
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_overrides_by_builds(self):
         res = self.app.get('/overrides/', {'builds': 'bodhi-2.0-1.fc17'})
 
@@ -148,6 +160,7 @@ class TestOverridesService(base.BaseTestCase):
         self.assertEquals(override['submitter']['name'], 'guest')
         self.assertEquals(override['notes'], 'blah blah blah')
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_overrides_by_releases_without_override(self):
         self.db.add(Release(name=u'F42', long_name=u'Fedora 42',
                             id_prefix=u'FEDORA', version=u'42',
@@ -166,6 +179,7 @@ class TestOverridesService(base.BaseTestCase):
         body = res.json_body
         self.assertEquals(len(body['overrides']), 0)
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_overrides_by_invalid_releases(self):
         res = self.app.get('/overrides/', {'releases': 'F42'},
                            status=400)
@@ -177,6 +191,7 @@ class TestOverridesService(base.BaseTestCase):
         self.assertEquals(errors[0]['description'],
                           'Invalid releases specified: F42')
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_overrides_by_username(self):
         res = self.app.get('/overrides/', {"user": "guest"})
         body = res.json_body
@@ -187,6 +202,7 @@ class TestOverridesService(base.BaseTestCase):
         self.assertEquals(override['submitter']['name'], 'guest')
         self.assertEquals(override['notes'], 'blah blah blah')
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_overrides_by_username_without_override(self):
         self.db.add(User(name=u'bochecha'))
         self.db.flush()
@@ -196,6 +212,7 @@ class TestOverridesService(base.BaseTestCase):
         body = res.json_body
         self.assertEquals(len(body['overrides']), 0)
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_overrides_by_unexisting_username(self):
         res = self.app.get('/overrides/', {"user": "santa"}, status=400)
 
@@ -206,6 +223,7 @@ class TestOverridesService(base.BaseTestCase):
         self.assertEquals(errors[0]['description'],
                           "Invalid user specified: santa")
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_overrides_by_like(self):
         """
         Test that the overrides/?like= endpoint works as expected
@@ -223,6 +241,7 @@ class TestOverridesService(base.BaseTestCase):
         body = res.json_body
         self.assertEquals(len(body['overrides']), 0)
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_overrides_by_search(self):
         """
         Test that the overrides/?search= endpoint works as expected
@@ -246,6 +265,7 @@ class TestOverridesService(base.BaseTestCase):
         body = res.json_body
         self.assertEquals(len(body['overrides']), 0)
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch('bodhi.server.notifications.publish')
     def test_create_override(self, publish):
         release = Release.get(u'F17', self.db)
@@ -274,6 +294,7 @@ class TestOverridesService(base.BaseTestCase):
                           expiration_date.strftime("%Y-%m-%d %H:%M:%S"))
         self.assertEquals(o['expired_date'], None)
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch('bodhi.server.notifications.publish')
     def test_create_duplicate_override(self, publish):
         release = Release.get(u'F17', self.db)
@@ -306,6 +327,7 @@ class TestOverridesService(base.BaseTestCase):
         self.assertEquals(res.json_body['errors'][0]['description'],
                           'Buildroot override for %s already exists' % build.nvr)
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch('bodhi.server.notifications.publish')
     def test_create_override_multiple_nvr(self, publish):
         release = Release.get(u'F17', self.db)
@@ -349,6 +371,7 @@ class TestOverridesService(base.BaseTestCase):
                           expiration_date.strftime("%Y-%m-%d %H:%M:%S"))
         self.assertEquals(o2['expired_date'], None)
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch('bodhi.server.notifications.publish')
     def test_create_override_too_long(self, publish):
         release = Release.get(u'F17', self.db)
@@ -366,6 +389,7 @@ class TestOverridesService(base.BaseTestCase):
                 'csrf_token': self.get_csrf_token()}
         self.app.post('/overrides/', data, status=400)
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch('bodhi.server.notifications.publish')
     def test_create_override_for_newer_build(self, publish):
         old_build = RpmBuild.get(u'bodhi-2.0-1.fc17', self.db)
@@ -397,6 +421,7 @@ class TestOverridesService(base.BaseTestCase):
 
         self.assertNotEquals(old_build.override['expired_date'], None)
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch('bodhi.server.notifications.publish')
     def test_cannot_edit_override_build(self, publish):
         release = Release.get(u'F17', self.db)
@@ -427,6 +452,7 @@ class TestOverridesService(base.BaseTestCase):
         self.assertEquals(override['expired_date'], None)
         self.assertEquals(len(publish.call_args_list), 0)
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_edit_nonexisting_build(self):
         """
         Validate the handler for an override that exists with an edit on a build that doesn't.
@@ -453,6 +479,7 @@ class TestOverridesService(base.BaseTestCase):
         self.assertEquals(errors[0]['description'],
                           'No such build')
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_edit_unexisting_override(self):
         release = Release.get(u'F17', self.db)
 
@@ -478,6 +505,7 @@ class TestOverridesService(base.BaseTestCase):
         self.assertEquals(errors[0]['description'],
                           'No buildroot override for this build')
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch('bodhi.server.services.overrides.BuildrootOverride.edit',
                 mock.MagicMock(side_effect=IOError('no db for you!')))
     def test_edit_unexpected_error(self):
@@ -500,6 +528,7 @@ class TestOverridesService(base.BaseTestCase):
         self.assertEquals(errors[0]['description'],
                           'Unable to save buildroot override: no db for you!')
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_edit_notes(self):
         old_nvr = u'bodhi-2.0-1.fc17'
 
@@ -518,6 +547,7 @@ class TestOverridesService(base.BaseTestCase):
         self.assertEquals(override['expiration_date'], expiration_date)
         self.assertEquals(override['expired_date'], None)
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_edit_expiration_date(self):
         old_nvr = u'bodhi-2.0-1.fc17'
 
@@ -537,6 +567,7 @@ class TestOverridesService(base.BaseTestCase):
                           expiration_date.strftime("%Y-%m-%d %H:%M:%S"))
         self.assertEquals(override['expired_date'], None)
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_edit_fail_on_multiple(self):
         old_nvr = u'bodhi-2.0-1.fc17'
 
@@ -551,6 +582,7 @@ class TestOverridesService(base.BaseTestCase):
             'Cannot combine multiple NVRs with editing a buildroot override.',
         )
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch('bodhi.server.notifications.publish')
     def test_expire_override(self, publish):
         old_nvr = u'bodhi-2.0-1.fc17'
@@ -570,6 +602,7 @@ class TestOverridesService(base.BaseTestCase):
         publish.assert_called_once_with(
             topic='buildroot_override.untag', msg=mock.ANY)
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch('bodhi.server.notifications.publish')
     def test_unexpire_override(self, publish):
         # First expire a buildroot override
@@ -603,6 +636,7 @@ class TestOverridesService(base.BaseTestCase):
         publish.assert_called_once_with(
             topic='buildroot_override.tag', msg=mock.ANY)
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch('bodhi.server.notifications.publish')
     def test_create_override_with_missing_pkg(self, publish):
         nvr = u'not-bodhi-2.0-2.fc17'
@@ -674,6 +708,7 @@ class TestOverridesWebViews(base.BaseTestCase):
                             status=200, headers={'Accept': 'text/html'})
         self.assertIn('<h2 class="pull-left m-t-3">New Override</h2>', resp)
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_overrides_list(self):
         """
         Test that the overrides list page shows, and contains the one overrides

--- a/bodhi/tests/server/services/test_overrides.py
+++ b/bodhi/tests/server/services/test_overrides.py
@@ -45,7 +45,7 @@ class TestOverridesService(base.BaseTestCase):
         self.app.get('/overrides/{}'.format(b.nvr), status=404)
 
     def test_get_single_override(self):
-        res = self.app.get('/overrides/bodhi-2.0-1.fc17')
+        res = self.app.get('/overrides/bodhi-2.0-1.fc17', headers={'Accept': 'application/json'})
 
         override = res.json_body['override']
 

--- a/bodhi/tests/server/services/test_releases.py
+++ b/bodhi/tests/server/services/test_releases.py
@@ -18,6 +18,9 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 import mock
 import webtest
+import unittest
+
+import six
 
 from bodhi import server
 from bodhi.server.models import Release, ReleaseState, Update
@@ -47,6 +50,7 @@ class TestReleasesService(base.BaseTestCase):
     def test_404(self):
         self.app.get('/releases/watwatwat', status=404)
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_anonymous_cant_edit_release(self):
         """Ensure that an unauthenticated user cannot edit a release, since only an admin should."""
         name = u"F22"
@@ -76,6 +80,7 @@ class TestReleasesService(base.BaseTestCase):
         res = self.app.get('/releases/Fedora%2022')
         self.assertEquals(res.json_body['name'], 'F22')
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_releases(self):
         res = self.app.get('/releases/')
         body = res.json_body
@@ -84,6 +89,7 @@ class TestReleasesService(base.BaseTestCase):
         self.assertEquals(body['releases'][0]['name'], u'F17')
         self.assertEquals(body['releases'][1]['name'], u'F22')
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_releases_with_pagination(self):
         res = self.app.get('/releases/')
         body = res.json_body
@@ -99,11 +105,13 @@ class TestReleasesService(base.BaseTestCase):
         self.assertEquals(len(body['releases']), 1)
         self.assertEquals(body['releases'][0]['name'], 'F22')
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_releases_by_ids_unknown(self):
         res = self.app.get('/releases/', {"ids": [9234872348923467]})
 
         self.assertEquals(len(res.json_body['releases']), 0)
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_releases_by_ids_plural(self):
         releases = Release.query.all()
 
@@ -113,6 +121,7 @@ class TestReleasesService(base.BaseTestCase):
         self.assertEquals(set([r['name'] for r in res.json_body['releases']]),
                           set([release.name for release in releases]))
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_releases_by_ids_singular(self):
         release = Release.query.all()[0]
 
@@ -121,28 +130,33 @@ class TestReleasesService(base.BaseTestCase):
         self.assertEquals(len(res.json_body['releases']), 1)
         self.assertEquals(res.json_body['releases'][0]['name'], release.name)
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_releases_by_name(self):
         res = self.app.get('/releases/', {"name": 'F22'})
         body = res.json_body
         self.assertEquals(len(body['releases']), 1)
         self.assertEquals(body['releases'][0]['name'], 'F22')
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_releases_by_name_match(self):
         res = self.app.get('/releases/', {"name": '%1%'})
         body = res.json_body
         self.assertEquals(len(body['releases']), 1)
         self.assertEquals(body['releases'][0]['name'], 'F17')
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_releases_by_name_match_miss(self):
         res = self.app.get('/releases/', {"name": '%wat%'})
         self.assertEquals(len(res.json_body['releases']), 0)
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_releases_by_update_title(self):
         res = self.app.get('/releases/', {"updates": 'bodhi-2.0-1.fc17'})
         body = res.json_body
         self.assertEquals(len(body['releases']), 1)
         self.assertEquals(body['releases'][0]['name'], 'F17')
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_releases_by_update_alias(self):
         update = self.db.query(Update).first()
         update.alias = u'some_alias'
@@ -153,24 +167,28 @@ class TestReleasesService(base.BaseTestCase):
         self.assertEquals(len(body['releases']), 1)
         self.assertEquals(body['releases'][0]['name'], 'F17')
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_releases_by_nonexistant_update(self):
         res = self.app.get('/releases/', {"updates": 'carbunkle'}, status=400)
         self.assertEquals(res.json_body['errors'][0]['name'], 'updates')
         self.assertEquals(res.json_body['errors'][0]['description'],
                           'Invalid updates specified: carbunkle')
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_releases_by_package_name(self):
         res = self.app.get('/releases/', {"packages": 'bodhi'})
         body = res.json_body
         self.assertEquals(len(body['releases']), 1)
         self.assertEquals(body['releases'][0]['name'], 'F17')
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_releases_by_nonexistant_package(self):
         res = self.app.get('/releases/', {"packages": 'carbunkle'}, status=400)
         self.assertEquals(res.json_body['errors'][0]['name'], 'packages')
         self.assertEquals(res.json_body['errors'][0]['description'],
                           'Invalid packages specified: carbunkle')
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_new_release(self):
         attrs = {"name": u"F42", "long_name": "Fedora 42", "version": "42",
                  "id_prefix": "FEDORA", "branch": "f42", "dist_tag": "f42",
@@ -194,6 +212,7 @@ class TestReleasesService(base.BaseTestCase):
 
         self.assertEquals(r.state, ReleaseState.disabled)
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch('bodhi.server.services.releases.log.info', side_effect=IOError('BOOM!'))
     def test_save_release_exception_handler(self, info):
         """Test the exception handler in save_release()."""
@@ -220,6 +239,7 @@ class TestReleasesService(base.BaseTestCase):
         self.assertEqual(self.db.query(Release).filter(Release.name == attrs["name"]).count(), 0)
         info.assert_called_once_with('Creating a new release: F42')
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_new_release_invalid_tags(self):
         attrs = {"name": "EL42", "long_name": "EPEL 42", "version": "42",
                  "id_prefix": "FEDORA EPEL", "branch": "f42",
@@ -235,6 +255,7 @@ class TestReleasesService(base.BaseTestCase):
         for error in res.json_body['errors']:
             self.assertEquals(error["description"], "Invalid tag: %s" % attrs[error["name"]])
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_edit_release(self):
         name = u"F22"
 
@@ -278,6 +299,7 @@ class TestReleasesService(base.BaseTestCase):
         self.assertEquals(res.content_type, 'text/html')
         self.assertIn('Fedora 22', res)
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_query_releases_html_two_releases_same_state(self):
         """Test query_releases_html() with two releases in the same state."""
         attrs = {

--- a/bodhi/tests/server/services/test_releases.py
+++ b/bodhi/tests/server/services/test_releases.py
@@ -69,15 +69,15 @@ class TestReleasesService(base.BaseTestCase):
         self.assertEquals(r.state, ReleaseState.disabled)
 
     def test_get_single_release_by_lower(self):
-        res = self.app.get('/releases/f22')
+        res = self.app.get('/releases/f22', headers={'Accept': 'application/json'})
         self.assertEquals(res.json_body['name'], 'F22')
 
     def test_get_single_release_by_upper(self):
-        res = self.app.get('/releases/F22')
+        res = self.app.get('/releases/F22', headers={'Accept': 'application/json'})
         self.assertEquals(res.json_body['name'], 'F22')
 
     def test_get_single_release_by_long(self):
-        res = self.app.get('/releases/Fedora%2022')
+        res = self.app.get('/releases/Fedora%2022', headers={'Accept': 'application/json'})
         self.assertEquals(res.json_body['name'], 'F22')
 
     @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')

--- a/bodhi/tests/server/services/test_updates.py
+++ b/bodhi/tests/server/services/test_updates.py
@@ -1200,7 +1200,7 @@ class TestUpdatesService(base.BaseTestCase):
         self.app.get('/a', status=404)
 
     def test_get_single_update(self):
-        res = self.app.get('/updates/bodhi-2.0-1.fc17')
+        res = self.app.get('/updates/bodhi-2.0-1.fc17', headers={'Accept': 'application/json'})
         self.assertEquals(res.json_body['update']['title'], 'bodhi-2.0-1.fc17')
         self.assertIn('application/json', res.headers['Content-Type'])
 
@@ -3566,7 +3566,7 @@ class TestUpdatesService(base.BaseTestCase):
 
     def test_update_meeting_requirements_present(self):
         """ Check that the requirements boolean is present in our JSON """
-        res = self.app.get('/updates/bodhi-2.0-1.fc17')
+        res = self.app.get('/updates/bodhi-2.0-1.fc17', headers={'Accept': 'application/json'})
         actual = res.json_body['update']['meets_testing_requirements']
         expected = False
         self.assertEquals(actual, expected)

--- a/bodhi/tests/server/services/test_updates.py
+++ b/bodhi/tests/server/services/test_updates.py
@@ -21,6 +21,7 @@ from datetime import datetime, timedelta
 import copy
 import textwrap
 import time
+import unittest
 
 from mock import ANY
 from webtest import TestApp
@@ -82,18 +83,21 @@ class TestNewUpdate(base.BaseTestCase):
     """
     This class contains tests for the new_update() function.
     """
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_valid_requirements)
     def test_invalid_build_name(self, *args):
         res = self.app.post_json('/updates/', self.get_update(u'bodhi-2.0-1.fc17,invalidbuild-1.0'),
                                  status=400)
         assert 'Build not in name-version-release format' in res, res
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_valid_requirements)
     def test_empty_build_name(self, *args):
         res = self.app.post_json('/updates/', self.get_update([u'']), status=400)
         self.assertEquals(res.json_body['errors'][0]['name'], 'builds.0')
         self.assertEquals(res.json_body['errors'][0]['description'], 'Required')
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_valid_requirements)
     def test_fail_on_edit_with_empty_build_list(self, *args):
         update = self.get_update()
@@ -110,6 +114,7 @@ class TestNewUpdate(base.BaseTestCase):
             res.json_body['errors'][1]['description'],
             'ACL validation mechanism was unable to determine ACLs.')
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_taskotron_results)
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
@@ -126,12 +131,14 @@ class TestNewUpdate(base.BaseTestCase):
         publish.assert_called_once_with(
             topic='update.request.testing', msg=mock.ANY)
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_valid_requirements)
     def test_duplicate_build(self, *args):
         res = self.app.post_json(
             '/updates/', self.get_update([u'bodhi-2.0-2.fc17', u'bodhi-2.0-2.fc17']), status=400)
         assert 'Duplicate builds' in res, res
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_valid_requirements)
     def test_multiple_builds_of_same_package(self, *args):
         res = self.app.post_json('/updates/', self.get_update([u'bodhi-2.0-2.fc17',
@@ -139,6 +146,7 @@ class TestNewUpdate(base.BaseTestCase):
                                  status=400)
         assert 'Multiple bodhi builds specified' in res, res
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_valid_requirements)
     def test_invalid_autokarma(self, *args):
         res = self.app.post_json('/updates/', self.get_update(stable_karma=-1),
@@ -148,12 +156,14 @@ class TestNewUpdate(base.BaseTestCase):
                                  status=400)
         assert '1 is greater than maximum value -1' in res, res
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_valid_requirements)
     def test_duplicate_update(self, *args):
         res = self.app.post_json('/updates/', self.get_update(u'bodhi-2.0-1.fc17'),
                                  status=400)
         assert 'Update for bodhi-2.0-1.fc17 already exists' in res, res
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_valid_requirements)
     def test_invalid_requirements(self, *args):
         update = self.get_update()
@@ -161,6 +171,7 @@ class TestNewUpdate(base.BaseTestCase):
         res = self.app.post_json('/updates/', update, status=400)
         assert "Required check doesn't exist" in res, res
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
     def test_no_privs(self, publish, *args):
@@ -183,6 +194,7 @@ class TestNewUpdate(base.BaseTestCase):
             res.json_body['errors']
         self.assertEquals(publish.call_args_list, [])
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_taskotron_results)
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
@@ -204,6 +216,7 @@ class TestNewUpdate(base.BaseTestCase):
         publish.assert_called_once_with(
             topic='update.request.testing', msg=mock.ANY)
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_valid_requirements)
     def test_pkgdb_outage(self, *args):
         "Test the case where our call to the pkgdb throws an exception"
@@ -216,6 +229,7 @@ class TestNewUpdate(base.BaseTestCase):
         res = app.post_json('/updates/', update, status=400)
         assert "Unable to access the Package Database" in res, res
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_valid_requirements)
     def test_invalid_acl_system(self, *args):
         with mock.patch.dict(config, {'acl_system': 'null'}):
@@ -224,9 +238,11 @@ class TestNewUpdate(base.BaseTestCase):
 
         assert "guest does not have commit access to bodhi" in res, res
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_put_json_update(self):
         self.app.put_json('/updates/', self.get_update(), status=405)
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch.dict('bodhi.server.validators.config', {'acl_system': u'dummy'})
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
@@ -235,6 +251,7 @@ class TestNewUpdate(base.BaseTestCase):
         publish.assert_called_once_with(
             topic='update.request.testing', msg=mock.ANY)
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch.dict('bodhi.server.validators.config', {'acl_system': u'dummy'})
     @mock.patch(**mock_uuid4_version1)
     @mock.patch(**mock_valid_requirements)
@@ -265,6 +282,7 @@ class TestNewUpdate(base.BaseTestCase):
         publish.assert_called_once_with(
             topic='update.request.testing', msg=mock.ANY)
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch.dict('bodhi.server.validators.config', {'acl_system': u'dummy'})
     @mock.patch(**mock_uuid4_version1)
     @mock.patch(**mock_valid_requirements)
@@ -304,6 +322,7 @@ class TestNewUpdate(base.BaseTestCase):
         # At the end, ensure that the right kind of package was created.
         self.assertEquals(self.db.query(ModulePackage).count(), 1)
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_uuid4_version1)
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
@@ -336,6 +355,7 @@ class TestNewUpdate(base.BaseTestCase):
         publish.assert_called_once_with(
             topic='update.request.testing', msg=mock.ANY)
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch.dict('bodhi.server.validators.config', {'acl_system': u'dummy'})
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
@@ -350,6 +370,7 @@ class TestNewUpdate(base.BaseTestCase):
         self.assertEquals(up['bugs'][1]['bug_id'], 5678)
         self.assertEquals(up['bugs'][2]['bug_id'], 12345)
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch.dict('bodhi.server.validators.config', {'acl_system': u'dummy'})
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
@@ -364,6 +385,7 @@ class TestNewUpdate(base.BaseTestCase):
         self.assertEquals(up['bugs'][1]['bug_id'], 5678)
         self.assertEquals(up['bugs'][2]['bug_id'], 12345)
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch.dict('bodhi.server.validators.config', {'acl_system': u'dummy'})
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
@@ -376,6 +398,7 @@ class TestNewUpdate(base.BaseTestCase):
         self.assertEquals(up['errors'][0]['description'],
                           "Invalid bug ID specified: [u'1234', u'blargh']")
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch.dict('bodhi.server.validators.config', {'acl_system': u'dummy'})
     @mock.patch(**mock_valid_requirements)
     def test_new_update_with_existing_build(self, *args):
@@ -389,6 +412,7 @@ class TestNewUpdate(base.BaseTestCase):
 
         self.assertEqual(resp.json['title'], 'bodhi-2.0.0-3.fc17')
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch.dict('bodhi.server.validators.config', {'acl_system': u'dummy'})
     @mock.patch(**mock_valid_requirements)
     def test_new_update_with_existing_package(self, *args):
@@ -404,6 +428,7 @@ class TestNewUpdate(base.BaseTestCase):
         package = self.db.query(RpmPackage).filter_by(name=u'existing-package').one()
         self.assertEqual(package.name, 'existing-package')
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch.dict('bodhi.server.validators.config', {'acl_system': u'dummy'})
     @mock.patch(**mock_valid_requirements)
     def test_new_update_with_missing_package(self, *args):
@@ -416,6 +441,7 @@ class TestNewUpdate(base.BaseTestCase):
         package = self.db.query(RpmPackage).filter_by(name=u'missing-package').one()
         self.assertEqual(package.name, 'missing-package')
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
     def test_cascade_package_requirements_to_update(self, publish, *args):
@@ -434,6 +460,7 @@ class TestNewUpdate(base.BaseTestCase):
         publish.assert_called_once_with(
             topic='update.request.testing', msg=mock.ANY)
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
     def test_push_untested_critpath_to_release(self, publish, *args):
@@ -449,6 +476,7 @@ class TestNewUpdate(base.BaseTestCase):
         publish.assert_called_once_with(
             topic='update.request.testing', msg=mock.ANY)
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
     def test_obsoletion(self, publish, *args):
@@ -494,6 +522,7 @@ class TestNewUpdate(base.BaseTestCase):
                              '/updates/FEDORA-{}-53345602d5'.format(datetime.now().year)))
         self.assertEquals(up.comments[-1].text, expected_comment)
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
     @mock.patch('bodhi.server.services.updates.Update.new', side_effect=IOError('oops!'))
@@ -510,6 +539,7 @@ class TestNewUpdate(base.BaseTestCase):
         build = self.db.query(RpmBuild).filter(RpmBuild.nvr == u'bodhi-2.3.2-1.fc17').one()
         self.assertEqual(build.package.name, 'bodhi')
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.services.updates.Update.obsolete_older_updates',
                 side_effect=RuntimeError("bet you didn't see this coming!"))
@@ -551,6 +581,7 @@ class TestSetRequest(base.BaseTestCase):
     """
     This class contains tests for the set_request() function.
     """
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_valid_requirements)
     def test_set_request_locked_update(self, *args):
         """Ensure that we get an error if trying to set request of a locked update"""
@@ -567,6 +598,7 @@ class TestSetRequest(base.BaseTestCase):
         self.assertEquals(res.json_body[u'errors'][0][u'description'],
                           "Can't change request on a locked update")
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_valid_requirements)
     def test_set_request_archived_release(self, *args):
         """Ensure that we get an error if trying to setrequest of a update in an archived release"""
@@ -584,6 +616,7 @@ class TestSetRequest(base.BaseTestCase):
         self.assertEquals(res.json_body[u'errors'][0][u'description'],
                           "Can't change request for an archived release")
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.services.updates.Update.set_request',
                 side_effect=IOError('IOError. oops!'))
@@ -666,6 +699,7 @@ class TestUpdatesService(base.BaseTestCase):
         self.assertIn('Fedora Updates System', resp)
         self.assertIn('&copy;', resp)
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_edit_add_build_from_different_release(self):
         """Editing an update that references builds from other releases should raise an error."""
         update = self.db.query(Update).one()
@@ -690,6 +724,7 @@ class TestUpdatesService(base.BaseTestCase):
                  u'location': u'body', u'name': u'builds'}]}
         self.assertEqual(res.json, expected_json)
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_edit_invalidly_tagged_build(self):
         """Editing an update that references invalidly tagged builds should raise an error."""
         update = self.db.query(Update).one()
@@ -714,6 +749,7 @@ class TestUpdatesService(base.BaseTestCase):
         self.assertEqual(res.json, expected_json)
         listTags.assert_called_once_with('bodhi-2.0-1.fc17')
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_edit_koji_error(self):
         """Editing an update that references missing builds should raise an error."""
         update = self.db.query(Update).one()
@@ -739,6 +775,7 @@ class TestUpdatesService(base.BaseTestCase):
         self.assertEqual(res.json, expected_json)
         listTags.assert_called_once_with(update.title)
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_edit_untagged_build(self):
         """Editing an update that references untagged builds should raise an error."""
         update = self.db.query(Update).one()
@@ -765,6 +802,7 @@ class TestUpdatesService(base.BaseTestCase):
         self.assertEqual(res.json, expected_json)
         listTags.assert_called_once_with('bodhi-2.0-1.fc17')
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_taskotron_results)
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
@@ -801,6 +839,7 @@ class TestUpdatesService(base.BaseTestCase):
         assert build.update is not None
         self.assertEquals(build.update.notes, u'testing!!!')
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_taskotron_results)
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
@@ -919,6 +958,7 @@ class TestUpdatesService(base.BaseTestCase):
         res = app.get('/updates/%s' % str(nvr), status=200)
         self.assertEqual(res.json_body['can_edit'], False)
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_taskotron_results)
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
@@ -954,6 +994,7 @@ class TestUpdatesService(base.BaseTestCase):
             res.json_body['errors'][0]['description'],
             'Requirement not met Required tests did not pass on this update')
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_taskotron_results)
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
@@ -989,6 +1030,7 @@ class TestUpdatesService(base.BaseTestCase):
             res.json_body['errors'][0]['description'],
             'Requirement not met Required tests did not pass on this update')
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_taskotron_results)
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
@@ -1024,6 +1066,7 @@ class TestUpdatesService(base.BaseTestCase):
             res.json_body['errors'][0]['description'],
             'Requirement not met Required tests did not pass on this update')
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_taskotron_results)
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
@@ -1060,6 +1103,7 @@ class TestUpdatesService(base.BaseTestCase):
             res.json_body['errors'][0]['description'],
             config.get('not_yet_tested_msg'))
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_taskotron_results)
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
@@ -1095,6 +1139,7 @@ class TestUpdatesService(base.BaseTestCase):
             res.json_body['errors'][0]['description'],
             'Requirement not met Required tests did not pass on this update')
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_taskotron_results)
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
@@ -1130,6 +1175,7 @@ class TestUpdatesService(base.BaseTestCase):
             res.json_body['errors'][0]['description'],
             config.get('not_yet_tested_msg'))
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
     def test_old_bodhi1_redirect(self, publish, *args):
@@ -1179,6 +1225,7 @@ class TestUpdatesService(base.BaseTestCase):
         self.assertIn(id, resp)
         self.assertIn('&copy;', resp)
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_updates(self):
         res = self.app.get('/updates/')
         body = res.json_body
@@ -1208,6 +1255,7 @@ class TestUpdatesService(base.BaseTestCase):
         self.assertEquals(up['url'],
                           (urlparse.urljoin(config['base_address'], '/updates/%s' % alias)))
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_updates_jsonp(self):
         res = self.app.get('/updates/',
                            {'callback': 'callback'},
@@ -1216,12 +1264,14 @@ class TestUpdatesService(base.BaseTestCase):
         self.assertIn('callback', res)
         self.assertIn('bodhi-2.0-1.fc17', res)
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_updates_rss(self):
         res = self.app.get('/rss/updates/',
                            headers={'Accept': 'application/atom+xml'})
         self.assertIn('application/rss+xml', res.headers['Content-Type'])
         self.assertIn('bodhi-2.0-1.fc17', res)
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_updates_html(self):
         res = self.app.get('/updates/',
                            headers={'Accept': 'text/html'})
@@ -1229,6 +1279,7 @@ class TestUpdatesService(base.BaseTestCase):
         self.assertIn('bodhi-2.0-1.fc17', res)
         self.assertIn('&copy;', res)
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_updates_like(self):
         res = self.app.get('/updates/', {'like': 'odh'})
         body = res.json_body
@@ -1241,6 +1292,7 @@ class TestUpdatesService(base.BaseTestCase):
         body = res.json_body
         self.assertEquals(len(body['updates']), 0)
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_updates_search(self):
         """
         Test that the updates/?search= endpoint works as expected
@@ -1273,6 +1325,7 @@ class TestUpdatesService(base.BaseTestCase):
         up = body['updates'][0]
         self.assertEquals(up['title'], u'bodhi-2.0-1.fc17')
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_valid_requirements)
     def test_list_updates_pagination(self, *args):
 
@@ -1294,6 +1347,7 @@ class TestUpdatesService(base.BaseTestCase):
 
         self.assertNotEquals(update1, update2)
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_updates_by_approved_since(self):
         now = datetime.utcnow()
 
@@ -1338,6 +1392,7 @@ class TestUpdatesService(base.BaseTestCase):
         self.assertEquals(len(up['test_cases']), 1)
         self.assertEquals(up['test_cases'][0]['name'], u'Wat')
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_updates_by_invalid_approved_since(self):
         res = self.app.get('/updates/', {"approved_since": "forever"},
                            status=400)
@@ -1347,6 +1402,7 @@ class TestUpdatesService(base.BaseTestCase):
         self.assertEquals(res.json_body['errors'][0]['description'],
                           'Invalid date')
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_updates_by_approved_before(self):
         # Approve an update
         now = datetime.utcnow()
@@ -1388,6 +1444,7 @@ class TestUpdatesService(base.BaseTestCase):
         self.assertEquals(len(up['bugs']), 1)
         self.assertEquals(up['bugs'][0]['bug_id'], 12345)
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_updates_by_invalid_approved_before(self):
         res = self.app.get('/updates/', {"approved_before": "forever"},
                            status=400)
@@ -1397,6 +1454,7 @@ class TestUpdatesService(base.BaseTestCase):
         self.assertEquals(res.json_body['errors'][0]['description'],
                           'Invalid date')
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_updates_by_bugs(self):
         res = self.app.get('/updates/', {"bugs": '12345'})
         body = res.json_body
@@ -1423,6 +1481,7 @@ class TestUpdatesService(base.BaseTestCase):
         self.assertEquals(len(up['bugs']), 1)
         self.assertEquals(up['bugs'][0]['bug_id'], 12345)
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_updates_by_invalid_bug(self):
         res = self.app.get('/updates/', {"bugs": "cockroaches"}, status=400)
         body = res.json_body
@@ -1431,11 +1490,13 @@ class TestUpdatesService(base.BaseTestCase):
         self.assertEquals(res.json_body['errors'][0]['description'],
                           "Invalid bug ID specified: [u'cockroaches']")
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_updates_by_unexisting_bug(self):
         res = self.app.get('/updates/', {"bugs": "19850110"})
         body = res.json_body
         self.assertEquals(len(body['updates']), 0)
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_updates_by_critpath(self):
         res = self.app.get('/updates/', {"critpath": "false"})
         body = res.json_body
@@ -1460,6 +1521,7 @@ class TestUpdatesService(base.BaseTestCase):
         self.assertEquals(up['alias'], u'FEDORA-%s-a3bbe1a8f2' % YEAR)
         self.assertEquals(up['karma'], 1)
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_updates_by_invalid_critpath(self):
         res = self.app.get('/updates/', {"critpath": "lalala"},
                            status=400)
@@ -1469,6 +1531,7 @@ class TestUpdatesService(base.BaseTestCase):
         self.assertEquals(res.json_body['errors'][0]['description'],
                           '"lalala" is neither in (\'false\', \'0\') nor in (\'true\', \'1\')')
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_updates_by_cves(self):
         res = self.app.get("/updates/", {"cves": "CVE-1985-0110"})
         body = res.json_body
@@ -1493,11 +1556,13 @@ class TestUpdatesService(base.BaseTestCase):
         self.assertEquals(up['alias'], u'FEDORA-%s-a3bbe1a8f2' % YEAR)
         self.assertEquals(up['karma'], 1)
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_updates_by_unexisting_cve(self):
         res = self.app.get('/updates/', {"cves": "CVE-2013-1015"})
         body = res.json_body
         self.assertEquals(len(body['updates']), 0)
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_updates_by_invalid_cve(self):
         res = self.app.get('/updates/', {"cves": "WTF-ZOMG-BBQ"},
                            status=400)
@@ -1507,6 +1572,7 @@ class TestUpdatesService(base.BaseTestCase):
         self.assertEquals(res.json_body['errors'][0]['description'],
                           '"WTF-ZOMG-BBQ" is not a valid CVE id')
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_updates_by_date_submitted_invalid_date(self):
         """test filtering by submitted date with an invalid date"""
         res = self.app.get('/updates/', {"submitted_since": "11-01-1984"}, status=400)
@@ -1516,6 +1582,7 @@ class TestUpdatesService(base.BaseTestCase):
         self.assertEquals(body['errors'][0]['description'],
                           'Invalid date')
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_updates_by_date_submitted_future_date(self):
         """test filtering by submitted date with future date"""
         tomorrow = datetime.utcnow() + timedelta(days=1)
@@ -1525,6 +1592,7 @@ class TestUpdatesService(base.BaseTestCase):
         body = res.json_body
         self.assertEquals(len(body['updates']), 0)
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_updates_by_date_submitted_valid(self):
         """test filtering by submitted date with valid data"""
         res = self.app.get('/updates/', {"submitted_since": "1984-11-01"})
@@ -1550,6 +1618,7 @@ class TestUpdatesService(base.BaseTestCase):
         self.assertEquals(up['alias'], u'FEDORA-%s-a3bbe1a8f2' % YEAR)
         self.assertEquals(up['karma'], 1)
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_updates_by_date_submitted_before_invalid_date(self):
         """test filtering by submitted before date with an invalid date"""
         res = self.app.get('/updates/', {"submitted_before": "11-01-1984"}, status=400)
@@ -1559,12 +1628,14 @@ class TestUpdatesService(base.BaseTestCase):
         self.assertEquals(body['errors'][0]['description'],
                           'Invalid date')
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_updates_by_date_submitted_before_old_date(self):
         """test filtering by submitted before date with old date"""
         res = self.app.get('/updates/', {"submitted_before": "1975-01-01"})
         body = res.json_body
         self.assertEquals(len(body['updates']), 0)
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_updates_by_date_submitted_before_valid(self):
         """test filtering by submitted before date with valid date"""
         today = datetime.utcnow().strftime("%Y-%m-%d")
@@ -1591,6 +1662,7 @@ class TestUpdatesService(base.BaseTestCase):
         self.assertEquals(up['alias'], u'FEDORA-%s-a3bbe1a8f2' % YEAR)
         self.assertEquals(up['karma'], 1)
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_updates_by_locked(self):
         Update.query.one().locked = True
         self.db.flush()
@@ -1617,6 +1689,7 @@ class TestUpdatesService(base.BaseTestCase):
         self.assertEquals(up['alias'], u'FEDORA-%s-a3bbe1a8f2' % YEAR)
         self.assertEquals(up['karma'], 1)
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_updates_by_content_type(self):
         res = self.app.get('/updates/', {"content_type": "module"})
         body = res.json_body
@@ -1626,6 +1699,7 @@ class TestUpdatesService(base.BaseTestCase):
         body = res.json_body
         self.assertEquals(len(body['updates']), 1)
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_updates_by_invalid_locked(self):
         res = self.app.get('/updates/', {"locked": "maybe"},
                            status=400)
@@ -1635,6 +1709,7 @@ class TestUpdatesService(base.BaseTestCase):
         self.assertEquals(res.json_body['errors'][0]['description'],
                           '"maybe" is neither in (\'false\', \'0\') nor in (\'true\', \'1\')')
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_updates_by_modified_since(self):
         now = datetime.utcnow()
 
@@ -1675,6 +1750,7 @@ class TestUpdatesService(base.BaseTestCase):
         self.assertEquals(len(up['bugs']), 1)
         self.assertEquals(up['bugs'][0]['bug_id'], 12345)
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_updates_by_invalid_modified_since(self):
         res = self.app.get('/updates/', {"modified_since": "the dawn of time"},
                            status=400)
@@ -1684,6 +1760,7 @@ class TestUpdatesService(base.BaseTestCase):
         self.assertEquals(res.json_body['errors'][0]['description'],
                           'Invalid date')
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_updates_by_modified_before(self):
         now = datetime.utcnow()
         tomorrow = now + timedelta(days=1)
@@ -1726,6 +1803,7 @@ class TestUpdatesService(base.BaseTestCase):
         self.assertEquals(len(up['bugs']), 1)
         self.assertEquals(up['bugs'][0]['bug_id'], 12345)
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_updates_by_invalid_modified_before(self):
         res = self.app.get('/updates/', {"modified_before": "the dawn of time"},
                            status=400)
@@ -1735,6 +1813,7 @@ class TestUpdatesService(base.BaseTestCase):
         self.assertEquals(res.json_body['errors'][0]['description'],
                           'Invalid date')
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_updates_by_package(self):
         res = self.app.get('/updates/', {"packages": "bodhi"})
         body = res.json_body
@@ -1759,6 +1838,7 @@ class TestUpdatesService(base.BaseTestCase):
         self.assertEquals(up['alias'], u'FEDORA-%s-a3bbe1a8f2' % YEAR)
         self.assertEquals(up['karma'], 1)
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_updates_by_builds(self):
         res = self.app.get('/updates/', {"builds": "bodhi-3.0-1.fc17"})
         body = res.json_body
@@ -1787,11 +1867,13 @@ class TestUpdatesService(base.BaseTestCase):
         self.assertEquals(up['alias'], u'FEDORA-%s-a3bbe1a8f2' % YEAR)
         self.assertEquals(up['karma'], 1)
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_updates_by_unexisting_package(self):
         res = self.app.get('/updates/', {"packages": "flash-player"})
         body = res.json_body
         self.assertEquals(len(body['updates']), 0)
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_updates_by_pushed(self):
         res = self.app.get('/updates/', {"pushed": "false"})
         body = res.json_body
@@ -1817,6 +1899,7 @@ class TestUpdatesService(base.BaseTestCase):
         self.assertEquals(up['karma'], 1)
         self.assertEquals(up['pushed'], False)
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_updates_by_invalid_pushed(self):
         res = self.app.get('/updates/', {"pushed": "who knows?"},
                            status=400)
@@ -1826,6 +1909,7 @@ class TestUpdatesService(base.BaseTestCase):
         self.assertEquals(res.json_body['errors'][0]['description'],
                           '"who knows?" is neither in (\'false\', \'0\') nor in (\'true\', \'1\')')
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_updates_by_pushed_since(self):
         now = datetime.utcnow()
 
@@ -1865,6 +1949,7 @@ class TestUpdatesService(base.BaseTestCase):
         self.assertEquals(len(up['bugs']), 1)
         self.assertEquals(up['bugs'][0]['bug_id'], 12345)
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_updates_by_invalid_pushed_since(self):
         res = self.app.get('/updates/', {"pushed_since": "a while ago"},
                            status=400)
@@ -1874,6 +1959,7 @@ class TestUpdatesService(base.BaseTestCase):
         self.assertEquals(res.json_body['errors'][0]['description'],
                           'Invalid date')
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_updates_by_pushed_before(self):
         now = datetime.utcnow()
         tomorrow = now + timedelta(days=1)
@@ -1915,6 +2001,7 @@ class TestUpdatesService(base.BaseTestCase):
         self.assertEquals(len(up['bugs']), 1)
         self.assertEquals(up['bugs'][0]['bug_id'], 12345)
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_updates_by_invalid_pushed_before(self):
         res = self.app.get('/updates/', {"pushed_before": "a while ago"},
                            status=400)
@@ -1924,6 +2011,7 @@ class TestUpdatesService(base.BaseTestCase):
         self.assertEquals(res.json_body['errors'][0]['description'],
                           'Invalid date')
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_updates_by_release_name(self):
         res = self.app.get('/updates/', {"releases": "F17"})
         body = res.json_body
@@ -1948,6 +2036,7 @@ class TestUpdatesService(base.BaseTestCase):
         self.assertEquals(up['alias'], u'FEDORA-%s-a3bbe1a8f2' % YEAR)
         self.assertEquals(up['karma'], 1)
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_updates_by_singular_release_param(self):
         """
         Test the singular parameter "release" rather than "releases".
@@ -1976,6 +2065,7 @@ class TestUpdatesService(base.BaseTestCase):
         self.assertEquals(up['alias'], u'FEDORA-%s-a3bbe1a8f2' % YEAR)
         self.assertEquals(up['karma'], 1)
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_updates_by_release_version(self):
         res = self.app.get('/updates/', {"releases": "17"})
         body = res.json_body
@@ -2000,6 +2090,7 @@ class TestUpdatesService(base.BaseTestCase):
         self.assertEquals(up['alias'], u'FEDORA-%s-a3bbe1a8f2' % YEAR)
         self.assertEquals(up['karma'], 1)
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_updates_by_unexisting_release(self):
         res = self.app.get('/updates/', {"releases": "WinXP"}, status=400)
         body = res.json_body
@@ -2008,6 +2099,7 @@ class TestUpdatesService(base.BaseTestCase):
         self.assertEquals(res.json_body['errors'][0]['description'],
                           'Invalid releases specified: WinXP')
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_updates_by_request(self):
         res = self.app.get('/updates/', {'request': "testing"})
         body = res.json_body
@@ -2032,6 +2124,7 @@ class TestUpdatesService(base.BaseTestCase):
         self.assertEquals(up['alias'], u'FEDORA-%s-a3bbe1a8f2' % YEAR)
         self.assertEquals(up['karma'], 1)
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_updates_by_unexisting_request(self):
         res = self.app.get('/updates/', {"request": "impossible"},
                            status=400)
@@ -2042,6 +2135,7 @@ class TestUpdatesService(base.BaseTestCase):
                           u'"impossible" is not one of revoke, testing,'
                           ' obsolete, batched, stable, unpush')
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_updates_by_severity(self):
         res = self.app.get('/updates/', {"severity": "medium"})
         body = res.json_body
@@ -2066,6 +2160,7 @@ class TestUpdatesService(base.BaseTestCase):
         self.assertEquals(up['alias'], u'FEDORA-%s-a3bbe1a8f2' % YEAR)
         self.assertEquals(up['karma'], 1)
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_updates_by_unexisting_severity(self):
         res = self.app.get('/updates/', {"severity": "schoolmaster"},
                            status=400)
@@ -2075,6 +2170,7 @@ class TestUpdatesService(base.BaseTestCase):
         self.assertEquals(res.json_body['errors'][0]['description'],
                           '"schoolmaster" is not one of high, urgent, medium, low, unspecified')
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_updates_by_status(self):
         res = self.app.get('/updates/', {"status": "pending"})
         body = res.json_body
@@ -2099,6 +2195,7 @@ class TestUpdatesService(base.BaseTestCase):
         self.assertEquals(up['alias'], u'FEDORA-%s-a3bbe1a8f2' % YEAR)
         self.assertEquals(up['karma'], 1)
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_updates_by_status_active_release(self):
         res = self.app.get(
             '/updates/', {"status": "pending", "active_releases": 'true'})
@@ -2124,6 +2221,7 @@ class TestUpdatesService(base.BaseTestCase):
         self.assertEquals(up['alias'], u'FEDORA-%s-a3bbe1a8f2' % YEAR)
         self.assertEquals(up['karma'], 1)
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_updates_by_status_inactive_release(self):
         rel = self.db.query(Release).filter_by(name='F17').one()
         rel.state = ReleaseState.archived
@@ -2134,6 +2232,7 @@ class TestUpdatesService(base.BaseTestCase):
         body = res.json_body
         self.assertEquals(len(body['updates']), 0)
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_updates_by_unexisting_status(self):
         res = self.app.get('/updates/', {"status": "single"},
                            status=400)
@@ -2144,6 +2243,7 @@ class TestUpdatesService(base.BaseTestCase):
             res.json_body['errors'][0]['description'],
             '"single" is not one of testing, processing, obsolete, stable, unpushed, pending')
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_updates_by_suggest(self):
         res = self.app.get('/updates/', {"suggest": "unspecified"})
         body = res.json_body
@@ -2168,6 +2268,7 @@ class TestUpdatesService(base.BaseTestCase):
         self.assertEquals(up['alias'], u'FEDORA-%s-a3bbe1a8f2' % YEAR)
         self.assertEquals(up['karma'], 1)
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_updates_by_unexisting_suggest(self):
         res = self.app.get('/updates/', {"suggest": "no idea"},
                            status=400)
@@ -2177,6 +2278,7 @@ class TestUpdatesService(base.BaseTestCase):
         self.assertEquals(res.json_body['errors'][0]['description'],
                           '"no idea" is not one of logout, reboot, unspecified')
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_updates_by_type(self):
         res = self.app.get('/updates/', {"type": "bugfix"})
         body = res.json_body
@@ -2201,6 +2303,7 @@ class TestUpdatesService(base.BaseTestCase):
         self.assertEquals(up['alias'], u'FEDORA-%s-a3bbe1a8f2' % YEAR)
         self.assertEquals(up['karma'], 1)
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_updates_by_unexisting_type(self):
         res = self.app.get('/updates/', {"type": "not_my"},
                            status=400)
@@ -2210,6 +2313,7 @@ class TestUpdatesService(base.BaseTestCase):
         self.assertEquals(res.json_body['errors'][0]['description'],
                           '"not_my" is not one of newpackage, bugfix, security, enhancement')
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_updates_by_username(self):
         res = self.app.get('/updates/', {"user": "guest"})
         body = res.json_body
@@ -2234,6 +2338,7 @@ class TestUpdatesService(base.BaseTestCase):
         self.assertEquals(up['alias'], u'FEDORA-%s-a3bbe1a8f2' % YEAR)
         self.assertEquals(up['karma'], 1)
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_updates_by_unexisting_username(self):
         res = self.app.get('/updates/', {"user": "santa"},
                            status=400)
@@ -2243,6 +2348,7 @@ class TestUpdatesService(base.BaseTestCase):
         self.assertEquals(res.json_body['errors'][0]['description'],
                           "Invalid user specified: santa")
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_uuid4_version1)
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
@@ -2294,6 +2400,7 @@ class TestUpdatesService(base.BaseTestCase):
         self.assertEquals(len(publish.call_args_list), 2)
         publish.assert_called_with(topic='update.edit', msg=ANY)
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
     def test_edit_testing_update_with_new_builds(self, publish, *args):
@@ -2340,6 +2447,7 @@ class TestUpdatesService(base.BaseTestCase):
         self.assertEquals(len(publish.call_args_list), 3)
         publish.assert_called_with(topic='update.edit', msg=ANY)
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
     def test_edit_testing_update_with_new_builds_with_stable_request(self, publish, *args):
@@ -2386,6 +2494,7 @@ class TestUpdatesService(base.BaseTestCase):
         self.assertEquals(len(publish.call_args_list), 3)
         publish.assert_called_with(topic='update.edit', msg=ANY)
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
     def test_edit_update_with_different_release(self, publish, *args):
@@ -2422,6 +2531,7 @@ class TestUpdatesService(base.BaseTestCase):
         self.assertEquals(up['errors'][0]['description'],
                           'Cannot add a F18 build to an F17 update')
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
     def test_edit_stable_update(self, publish, *args):
@@ -2448,6 +2558,7 @@ class TestUpdatesService(base.BaseTestCase):
         self.assertEquals(up['errors'][0]['description'], "Cannot edit stable updates")
         self.assertEquals(len(publish.call_args_list), 1)
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
     def test_edit_locked_update(self, publish, *args):
@@ -2506,6 +2617,7 @@ class TestUpdatesService(base.BaseTestCase):
         self.assertEquals(len(publish.call_args_list), 2)
         publish.assert_called_with(topic='update.edit', msg=ANY)
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
     def test_pending_update_on_stable_karma_reached_autopush_enabled(self, publish, *args):
@@ -2531,6 +2643,7 @@ class TestUpdatesService(base.BaseTestCase):
         self.assertEquals(up.request, UpdateRequest.testing)
         self.assertEquals(up.status, UpdateStatus.pending)
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
     def test_pending_urgent_update_on_stable_karma_reached_autopush_enabled(self, publish, *args):
@@ -2560,6 +2673,7 @@ class TestUpdatesService(base.BaseTestCase):
         self.assertEquals(up.request, UpdateRequest.stable)
         self.assertEquals(up.status, UpdateStatus.pending)
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_valid_requirements)
     def test_pending_update_on_stable_karma_not_reached(self, publish, *args):
         """ Ensure that pending update does not directly request for stable
@@ -2582,6 +2696,7 @@ class TestUpdatesService(base.BaseTestCase):
         self.assertEquals(up.request, UpdateRequest.testing)
         self.assertEquals(up.status, UpdateStatus.pending)
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
     def test_pending_update_on_stable_karma_reached_autopush_disabled(self, publish, *args):
@@ -2612,6 +2727,7 @@ class TestUpdatesService(base.BaseTestCase):
         up.comment(self.db, text, author=u'bodhi')
         self.assertIn('pushed to stable now if the maintainer wishes', up.comments[-1]['text'])
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
     def test_obsoletion_locked_with_open_request(self, publish, *args):
@@ -2631,6 +2747,7 @@ class TestUpdatesService(base.BaseTestCase):
         self.assertEquals(up.status, UpdateStatus.pending)
         self.assertEquals(up.request, UpdateRequest.testing)
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
     def test_obsoletion_unlocked_with_open_request(self, publish, *args):
@@ -2646,6 +2763,7 @@ class TestUpdatesService(base.BaseTestCase):
         self.assertEquals(up.status, UpdateStatus.obsolete)
         self.assertEquals(up.request, None)
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
     def test_obsoletion_unlocked_with_open_stable_request(self, publish, *args):
@@ -2665,6 +2783,7 @@ class TestUpdatesService(base.BaseTestCase):
         self.assertEquals(up.status, UpdateStatus.pending)
         self.assertEquals(up.request, UpdateRequest.stable)
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
     def test_push_to_stable_for_obsolete_update(self, publish, *args):
@@ -2708,6 +2827,7 @@ class TestUpdatesService(base.BaseTestCase):
         self.assertIn(id, resp)
         self.assertNotIn('Push to Stable', resp)
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_valid_requirements)
     def test_enabled_button_for_autopush(self, *args):
         """Test Enabled button on Update page when autopush is True"""
@@ -2721,6 +2841,7 @@ class TestUpdatesService(base.BaseTestCase):
         self.assertIn(nvr, resp)
         self.assertIn('Enabled', resp)
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_valid_requirements)
     def test_disabled_button_for_autopush(self, *args):
         """Test Disabled button on Update page when autopush is False"""
@@ -2734,6 +2855,7 @@ class TestUpdatesService(base.BaseTestCase):
         self.assertIn(nvr, resp)
         self.assertIn('Disabled', resp)
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_taskotron_results)
     @mock.patch(**mock_valid_requirements)
     def test_invalid_request(self, *args):
@@ -2757,6 +2879,7 @@ class TestUpdatesService(base.BaseTestCase):
         self.assertEqual(resp['errors'][0]['name'], 'request')
         self.assertEqual(resp['errors'][0]['description'], 'Required')
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_taskotron_results)
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
@@ -2772,6 +2895,7 @@ class TestUpdatesService(base.BaseTestCase):
         self.assertEqual(resp.json['update']['request'], 'testing')
         self.assertEquals(publish.call_args_list, [])
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_taskotron_results)
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
@@ -2794,6 +2918,7 @@ class TestUpdatesService(base.BaseTestCase):
         self.assertEqual(resp.json['update']['status'], 'testing')
         publish.assert_called_with(topic='update.request.revoke', msg=mock.ANY)
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_taskotron_results)
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
@@ -2816,6 +2941,7 @@ class TestUpdatesService(base.BaseTestCase):
         self.assertEqual(resp.json['update']['status'], 'unpushed')
         publish.assert_called_with(topic='update.request.revoke', msg=mock.ANY)
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
     def test_obsolete_if_unstable_with_autopush_enabled_when_pending(self, publish, *args):
@@ -2842,6 +2968,7 @@ class TestUpdatesService(base.BaseTestCase):
         self.assertEquals(up.status, UpdateStatus.obsolete)
         self.assertEquals(up.request, None)
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
     def test_obsolete_if_unstable_with_autopush_disabled_when_pending(self, publish, *args):
@@ -2867,6 +2994,7 @@ class TestUpdatesService(base.BaseTestCase):
         self.assertEquals(up.status, UpdateStatus.pending)
         self.assertEquals(up.request, UpdateRequest.testing)
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
     def test_obsolete_if_unstable_karma_not_reached_with_autopush_enabled_when_pending(
@@ -2893,6 +3021,7 @@ class TestUpdatesService(base.BaseTestCase):
         self.assertEquals(up.status, UpdateStatus.pending)
         self.assertEquals(up.request, UpdateRequest.testing)
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
     def test_obsolete_if_unstable_with_autopush_enabled_when_testing(self, publish, *args):
@@ -2930,6 +3059,7 @@ class TestUpdatesService(base.BaseTestCase):
         self.assertEquals(up.status, UpdateStatus.obsolete)
         self.assertEquals(up.request, None)
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_taskotron_results)
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
@@ -2949,6 +3079,7 @@ class TestUpdatesService(base.BaseTestCase):
         self.assertEqual(resp.json['update']['status'], 'unpushed')
         publish.assert_called_with(topic='update.request.unpush', msg=mock.ANY)
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_taskotron_results)
     @mock.patch(**mock_valid_requirements)
     def test_invalid_stable_request(self, *args):
@@ -2967,6 +3098,7 @@ class TestUpdatesService(base.BaseTestCase):
             resp.json['errors'][0]['description'],
             config.get('not_yet_tested_msg'))
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_taskotron_results)
     @mock.patch(**mock_valid_requirements)
     def test_request_to_stable_based_on_stable_karma(self, *args):
@@ -3011,6 +3143,7 @@ class TestUpdatesService(base.BaseTestCase):
         self.assertEquals(up.request, UpdateRequest.stable)
         self.assertEquals(up.status, UpdateStatus.testing)
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_taskotron_results)
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
@@ -3038,6 +3171,7 @@ class TestUpdatesService(base.BaseTestCase):
         publish.assert_called_with(
             topic='update.request.stable', msg=mock.ANY)
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_taskotron_results)
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
@@ -3063,6 +3197,7 @@ class TestUpdatesService(base.BaseTestCase):
             resp.json['errors'][0]['description'],
             "Can't change request for an archived release")
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_failed_taskotron_results)
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
@@ -3087,6 +3222,7 @@ class TestUpdatesService(base.BaseTestCase):
         self.assertIn('errors', resp)
         self.assertIn('Required task', resp)
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_absent_taskotron_results)
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
@@ -3111,6 +3247,7 @@ class TestUpdatesService(base.BaseTestCase):
         self.assertIn('errors', resp)
         self.assertIn('No result found for', resp)
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_taskotron_results)
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
@@ -3142,6 +3279,7 @@ class TestUpdatesService(base.BaseTestCase):
         except AssertionError:
             pass
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_taskotron_results)
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
@@ -3172,6 +3310,7 @@ class TestUpdatesService(base.BaseTestCase):
         except AssertionError:
             pass
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_valid_requirements)
     def test_update_with_older_build_in_testing_from_diff_user(self, r):
         """
@@ -3207,12 +3346,14 @@ class TestUpdatesService(base.BaseTestCase):
         # Ensure the second update was created successfully
         self.db.query(Update).filter_by(title=newtitle).one()
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_valid_requirements)
     def test_updateid_alias(self, *args):
         res = self.app.post_json('/updates/', self.get_update(u'bodhi-2.0.0-3.fc17'))
         json = res.json_body
         self.assertEquals(json['alias'], json['updateid'])
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_updates_by_lowercase_release_name(self):
         res = self.app.get('/updates/', {"releases": "f17"})
         body = res.json_body
@@ -3230,6 +3371,7 @@ class TestUpdatesService(base.BaseTestCase):
         # But be sure that we don't redirect if the package doesn't exist
         res = self.app.get('/updates/non-existant', status=404)
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_updates_by_alias_and_updateid(self):
         upd = self.db.query(Update).filter(Update.alias.isnot(None)).first()
         res = self.app.get('/updates/', {"alias": upd.alias})
@@ -3253,6 +3395,7 @@ class TestUpdatesService(base.BaseTestCase):
         body = res.json_body
         self.assertEquals(len(body['updates']), 0)
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
     def test_submitting_multi_release_updates(self, publish, *args):
@@ -3295,6 +3438,7 @@ class TestUpdatesService(base.BaseTestCase):
         # Make sure two fedmsg messages were published
         self.assertEquals(len(publish.call_args_list), 2)
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
     def test_edit_update_bugs(self, publish, *args):
@@ -3339,6 +3483,7 @@ class TestUpdatesService(base.BaseTestCase):
         self.assertEquals(up['status'], u'pending')
         self.assertEquals(up['request'], u'testing')
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
     def test_edit_missing_update(self, publish, *args):
@@ -3351,6 +3496,7 @@ class TestUpdatesService(base.BaseTestCase):
         self.assertEquals(r['status'], 'error')
         self.assertEquals(r['errors'][0]['description'], 'Cannot find update to edit: %s' % edited)
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
     def test_edit_update_and_disable_features(self, publish, *args):
@@ -3390,6 +3536,7 @@ class TestUpdatesService(base.BaseTestCase):
         self.assertEquals(up['stable_karma'], 3)
         self.assertEquals(up['unstable_karma'], -3)
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
     def test_edit_update_change_type(self, publish, *args):
@@ -3424,6 +3571,7 @@ class TestUpdatesService(base.BaseTestCase):
         expected = False
         self.assertEquals(actual, expected)
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
     def test_edit_testing_update_reset_karma(self, publish, *args):
@@ -3450,6 +3598,7 @@ class TestUpdatesService(base.BaseTestCase):
         # This is what we really want to test here.
         self.assertEquals(up['karma'], 0)
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
     def test_edit_testing_update_reset_karma_with_same_tester(self, publish, *args):
@@ -3511,6 +3660,7 @@ class TestUpdatesService(base.BaseTestCase):
         # Bob should be able to give karma again since the reset
         self.assertEquals(upd.karma, 1)
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
     def test__composite_karma_with_one_negative(self, publish, *args):
@@ -3535,6 +3685,7 @@ class TestUpdatesService(base.BaseTestCase):
         up = self.db.query(Update).filter_by(title=nvr).one()
         self.assertEqual(up._composite_karma, (0, -1))
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
     def test__composite_karma_with_changed_karma(self, publish, *args):
@@ -3567,6 +3718,7 @@ class TestUpdatesService(base.BaseTestCase):
         self.assertEqual(up._composite_karma, (1, 0))
         self.assertEquals(up.karma, 1)
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
     def test__composite_karma_with_positive_karma_first(self, publish, *args):
@@ -3599,6 +3751,7 @@ class TestUpdatesService(base.BaseTestCase):
         self.assertEqual(up._composite_karma, (1, -1))
         self.assertEquals(up.karma, 0)
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
     def test__composite_karma_with_no_negative_karma(self, publish, *args):
@@ -3627,6 +3780,7 @@ class TestUpdatesService(base.BaseTestCase):
         self.assertEqual(up._composite_karma, (2, 0))
         self.assertEquals(up.karma, 2)
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
     def test__composite_karma_with_anonymous_comment(self, publish, *args):
@@ -3652,6 +3806,7 @@ class TestUpdatesService(base.BaseTestCase):
         up = self.db.query(Update).filter_by(title=nvr).one()
         self.assertEqual(up._composite_karma, (0, 0))
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
     def test__composite_karma_with_no_feedback(self, publish, *args):
@@ -3673,6 +3828,7 @@ class TestUpdatesService(base.BaseTestCase):
         up = self.db.query(Update).filter_by(title=nvr).one()
         self.assertEqual(up._composite_karma, (0, 0))
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
     def test_karma_threshold_with_disabled_autopush(self, publish, *args):
@@ -3712,6 +3868,7 @@ class TestUpdatesService(base.BaseTestCase):
         self.assertEquals(up['stable_karma'], 4)
         self.assertEquals(up['unstable_karma'], -4)
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
     def test_disable_autopush_for_critical_updates(self, publish, *args):
@@ -3748,6 +3905,7 @@ class TestUpdatesService(base.BaseTestCase):
         # Autopush gets disabled since there is a negative karma from ralph
         self.assertEquals(up.autokarma, False)
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
     def test_autopush_critical_update_with_no_negative_karma(self, publish, *args):
@@ -3784,6 +3942,7 @@ class TestUpdatesService(base.BaseTestCase):
         up = self.db.query(Update).filter_by(title=resp.json['title']).one()
         self.assertEquals(up.request, UpdateRequest.batched)
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
     def test_manually_push_critical_update_with_negative_karma(self, publish, *args):
@@ -3841,6 +4000,7 @@ class TestUpdatesService(base.BaseTestCase):
         self.assertIn('text/html', resp.headers['Content-Type'])
         self.assertIn(id, resp)
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
     def test_manually_push_critical_update_with_autopush_turned_off(self, publish, *args):
@@ -3890,6 +4050,7 @@ class TestUpdatesService(base.BaseTestCase):
         self.assertIn('text/html', resp.headers['Content-Type'])
         self.assertIn(id, resp)
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
     def test_disable_autopush_non_critical_update_with_negative_karma(self, publish, *args):
@@ -3935,6 +4096,7 @@ class TestUpdatesService(base.BaseTestCase):
         self.assertEquals(up.request, UpdateRequest.testing)
         self.assertEquals(up.status, UpdateStatus.testing)
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
     def test_autopush_non_critical_update_with_no_negative_karma(self, publish, *args):
@@ -3973,6 +4135,7 @@ class TestUpdatesService(base.BaseTestCase):
         up = self.db.query(Update).filter_by(title=resp.json['title']).one()
         self.assertEquals(up.request, UpdateRequest.batched)
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
     def test_edit_button_not_present_when_stable(self, publish, *args):
@@ -3997,6 +4160,7 @@ class TestUpdatesService(base.BaseTestCase):
         self.assertNotIn('Push to Stable', resp)
         self.assertNotIn('Edit', resp)
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
     def test_push_to_batched_button_present_when_karma_reached(self, publish, *args):
@@ -4025,6 +4189,7 @@ class TestUpdatesService(base.BaseTestCase):
         self.assertNotIn('Push to Stable', resp)
         self.assertIn('Edit', resp)
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
     def test_push_to_stable_button_present_when_karma_reached_urgent(self, publish, *args):
@@ -4054,6 +4219,7 @@ class TestUpdatesService(base.BaseTestCase):
         self.assertIn('Push to Stable', resp)
         self.assertIn('Edit', resp)
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
     def test_push_to_stable_button_present_when_karma_reached_and_batched(self, publish, *args):
@@ -4082,6 +4248,7 @@ class TestUpdatesService(base.BaseTestCase):
         self.assertIn('Push to Stable', resp)
         self.assertIn('Edit', resp)
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
     def test_push_to_stable_button_present_when_autokarma_and_batched(self, publish, *args):
@@ -4110,6 +4277,7 @@ class TestUpdatesService(base.BaseTestCase):
         self.assertIn('Push to Stable', resp)
         self.assertIn('Edit', resp)
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
     def test_push_to_batched_button_present_when_time_reached(self, publish, *args):
@@ -4137,6 +4305,7 @@ class TestUpdatesService(base.BaseTestCase):
         self.assertNotIn('Push to Stable', resp)
         self.assertIn('Edit', resp)
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
     def test_push_to_stable_button_present_when_time_reached_and_urgent(self, publish, *args):
@@ -4166,6 +4335,7 @@ class TestUpdatesService(base.BaseTestCase):
         self.assertIn('Push to Stable', resp)
         self.assertIn('Edit', resp)
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
     def test_push_to_stable_button_present_when_time_reached_and_batched(self, publish, *args):
@@ -4193,6 +4363,7 @@ class TestUpdatesService(base.BaseTestCase):
         self.assertIn('Push to Stable', resp)
         self.assertIn('Edit', resp)
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
     def test_push_to_batched_button_present_when_time_reached_critpath(self, publish, *args):
@@ -4220,6 +4391,7 @@ class TestUpdatesService(base.BaseTestCase):
         self.assertNotIn('Push to Stable', resp)
         self.assertIn('Edit', resp)
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
     def test_push_to_stable_button_present_when_time_reached_and_batched_critpath(self, publish,
@@ -4249,6 +4421,7 @@ class TestUpdatesService(base.BaseTestCase):
         self.assertIn('Push to Stable', resp)
         self.assertIn('Edit', resp)
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
     def test_manually_push_to_stable_based_on_karma(self, publish, *args):
@@ -4300,6 +4473,7 @@ class TestUpdatesService(base.BaseTestCase):
         self.assertIn(id, resp)
         self.assertIn('Push to Stable', resp)
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
     def test_manually_push_to_batched_based_on_karma(self, publish, *args):
@@ -4349,6 +4523,7 @@ class TestUpdatesService(base.BaseTestCase):
         self.assertIn('Push to Batched', resp)
         self.assertNotIn('Push to Stable', resp)
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
     def test_edit_update_with_expired_override(self, publish, *args):
@@ -4386,6 +4561,7 @@ class TestUpdatesService(base.BaseTestCase):
         up = r.json_body
         self.assertEquals(up['title'], nvr)
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_taskotron_results)
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
@@ -4424,6 +4600,7 @@ class TestUpdatesService(base.BaseTestCase):
             ("Cannot submit bodhi ('0', '1.0', '1.fc17') to stable since it is older than "
              "('0', '2.0', '1.fc17')"))
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
     def test_edit_testing_update_with_build_from_different_update(self, publish, *args):
@@ -4474,6 +4651,7 @@ class TestUpdatesService(base.BaseTestCase):
         self.assertEquals(len(up.builds), 1)
         self.assertEquals(up.builds[0].nvr, nvr1)
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
     def test_meets_testing_requirements_since_karma_reset_critpath(self, publish, *args):
@@ -4517,6 +4695,7 @@ class TestUpdatesService(base.BaseTestCase):
         self.assertEquals(update.days_to_stable, 0)
         self.assertEqual(update.meets_testing_requirements, True)
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_taskotron_results)
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
@@ -4543,6 +4722,7 @@ class TestUpdatesService(base.BaseTestCase):
         publish.assert_called_with(
             topic='update.request.batched', msg=mock.ANY)
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
     def test_newpackage_update_bypass_batched(self, publish, *args):
@@ -4573,6 +4753,7 @@ class TestUpdatesService(base.BaseTestCase):
         up = self.db.query(Update).filter_by(title=resp.json['title']).one()
         self.assertEquals(up.request, UpdateRequest.stable)
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
     def test_urgent_update_bypass_batched(self, publish, *args):
@@ -4603,6 +4784,7 @@ class TestUpdatesService(base.BaseTestCase):
         up = self.db.query(Update).filter_by(title=resp.json['title']).one()
         self.assertEquals(up.request, UpdateRequest.stable)
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_taskotron_results)
     @mock.patch(**mock_valid_requirements)
     def test_alert_not_displayed_if_no_summary_present(self, publish, *args):
@@ -4629,6 +4811,7 @@ class TestUpdatesService(base.BaseTestCase):
                 '<div class="alert alert-danger">The update can not be pushed:',
                 resp)
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_taskotron_results)
     @mock.patch(**mock_valid_requirements)
     def test_alert_notdisplayed_if_summary_present_but_gating_off(
@@ -4656,6 +4839,7 @@ class TestUpdatesService(base.BaseTestCase):
             self.assertNotIn(
                 '<div class="alert alert-danger">The update can not be pushed: \' + summary ', resp)
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_taskotron_results)
     @mock.patch(**mock_valid_requirements)
     def test_alert_displayed_if_summary_present(self, publish, *args):
@@ -4686,6 +4870,7 @@ class TestWaiveTestResults(base.BaseTestCase):
     """
     This class contains tests for the waive_test_results() function.
     """
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_cannot_waive_test_results_on_locked_update(self, *args):
         """Ensure that we get an error if trying to waive test results of a locked update"""
         nvr = u'bodhi-2.0-1.fc17'
@@ -4701,6 +4886,7 @@ class TestWaiveTestResults(base.BaseTestCase):
         self.assertEquals(res.json_body[u'errors'][0][u'description'],
                           "Can't waive test results on a locked update")
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_cannot_waive_test_results_when_test_gating_is_off(self, *args):
         """
         Ensure that we get an error if trying to waive test results of an update
@@ -4719,6 +4905,7 @@ class TestWaiveTestResults(base.BaseTestCase):
         self.assertEquals(res.json_body[u'errors'][0][u'description'],
                           "Test gating is not enabled")
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch('bodhi.server.services.updates.Update.waive_test_results',
                 side_effect=IOError('IOError. oops!'))
     @mock.patch('bodhi.server.services.updates.log.exception')

--- a/bodhi/tests/server/services/test_updates.py
+++ b/bodhi/tests/server/services/test_updates.py
@@ -21,13 +21,13 @@ from datetime import datetime, timedelta
 import copy
 import textwrap
 import time
-import urlparse
 
 from mock import ANY
 from webtest import TestApp
 import koji
 import mock
 import six
+from six.moves.urllib import parse as urlparse
 
 from bodhi.server import main
 from bodhi.server.config import config

--- a/bodhi/tests/server/test___init__.py
+++ b/bodhi/tests/server/test___init__.py
@@ -35,14 +35,14 @@ class TestExceptionFilter(unittest.TestCase):
     @mock.patch('bodhi.server.log.exception')
     def test_exception(self, exception):
         """An Exception should be logged and returned."""
-        request_response = IOError('Your money is gone.')
+        request_response = OSError('Your money is gone.')
 
         # The second argument is not used.
         response = server.exception_filter(request_response, None)
 
         self.assertIs(response, request_response)
         exception.assert_called_once_with(
-            "Unhandled exception raised:  IOError('Your money is gone.',)")
+            "Unhandled exception raised:  OSError('Your money is gone.',)")
 
     @mock.patch('bodhi.server.log.exception')
     def test_no_exception(self, exception):

--- a/bodhi/tests/server/test_alembic.py
+++ b/bodhi/tests/server/test_alembic.py
@@ -43,5 +43,5 @@ class TestAlembic(unittest.TestCase):
             stdin=proc1.stdout, stdout=subprocess.PIPE)
 
         stdout = proc2.communicate()[0]
-        stdout = stdout.strip().split('\n')
+        stdout = stdout.strip().split(b'\n')
         self.assertEqual(len(stdout), 1)

--- a/bodhi/tests/server/test_captcha.py
+++ b/bodhi/tests/server/test_captcha.py
@@ -20,6 +20,7 @@ import unittest
 import mock
 import PIL.Image
 from pyramid.httpexceptions import HTTPGone, HTTPNotFound
+import six
 
 from bodhi.server import captcha
 from bodhi.server.config import config
@@ -44,7 +45,7 @@ class TestDecrypt(unittest.TestCase):
         with self.assertRaises(HTTPNotFound) as exc:
             captcha.decrypt(base64_unsafe_message, config)
 
-        self.assertEqual(str(exc.exception), '$@#his3##d*f is garbage')
+        self.assertEqual(six.text_type(exc.exception), '$@#his3##d*f is garbage')
 
     @mock.patch.dict(config, {'captcha.secret': 'gFqE6rcBXVLssjLjffsQsAa-nlm5Bg06MTKrVT9hsMA='})
     def test_invalid_token(self):

--- a/bodhi/tests/server/test_config.py
+++ b/bodhi/tests/server/test_config.py
@@ -363,7 +363,7 @@ class ValidateFernetKey(unittest.TestCase):
 
     def test_valid_key(self):
         """A valid key should be a string, even if we pass it a unicode"""
-        key = six.text_type('gFqE6rcBXVLssjLjffsQsAa-nlm5Bg06MTKrVT9hsMA=')
+        key = b'gFqE6rcBXVLssjLjffsQsAa-nlm5Bg06MTKrVT9hsMA='
         result = config._validate_fernet_key(key)
 
         self.assertEqual(result, key)

--- a/bodhi/tests/server/test_mail.py
+++ b/bodhi/tests/server/test_mail.py
@@ -175,11 +175,11 @@ class TestSend(base.BaseTestCase):
         SMTP.assert_called_once_with('smtp.example.com')
         sendmail = SMTP.return_value.sendmail
         self.assertEqual(sendmail.call_count, 1)
-        self.assertEqual(sendmail.mock_calls[0][1][0], 'updates@fedoraproject.org')
-        self.assertEqual(sendmail.mock_calls[0][1][1], ['fake@news.com'])
-        self.assertTrue('X-Bodhi-Update-Title: bodhi-2.0-1.fc17' in sendmail.mock_calls[0][1][2])
+        self.assertEqual(sendmail.mock_calls[0][1][0], b'updates@fedoraproject.org')
+        self.assertEqual(sendmail.mock_calls[0][1][1], [b'fake@news.com'])
+        self.assertTrue(b'X-Bodhi-Update-Title: bodhi-2.0-1.fc17' in sendmail.mock_calls[0][1][2])
         self.assertTrue(
-            'Subject: [Fedora Update] [comment] bodhi-2.0-1.fc17' in sendmail.mock_calls[0][1][2])
+            b'Subject: [Fedora Update] [comment] bodhi-2.0-1.fc17' in sendmail.mock_calls[0][1][2])
 
     @mock.patch.dict('bodhi.server.mail.config', {'smtp_server': 'smtp.example.com'})
     @mock.patch('bodhi.server.mail.smtplib.SMTP', side_effect=Exception())

--- a/bodhi/tests/server/test_metadata.py
+++ b/bodhi/tests/server/test_metadata.py
@@ -273,7 +273,7 @@ class TestUpdateInfoMetadata(UpdateInfoMetadataTestCase):
         assert len(updateinfos) == 1, "We generated %d updateinfo metadata" % len(updateinfos)
         updateinfo = updateinfos[0]
         hash = basename(updateinfo).split("-", 1)[0]
-        hashed = sha256(open(updateinfo).read()).hexdigest()
+        hashed = sha256(open(updateinfo, 'rb').read()).hexdigest()
         assert hash == hashed, "File: %s\nHash: %s" % (basename(updateinfo), hashed)
         return updateinfo
 

--- a/bodhi/tests/server/test_models.py
+++ b/bodhi/tests/server/test_models.py
@@ -2140,10 +2140,9 @@ class TestUpdate(ModelTest):
             self.obj.set_request(self.db, UpdateRequest.stable, req.user.name)
             assert False
         except BodhiException as e:
-            pass
-        self.assertEqual(self.obj.request, UpdateRequest.testing)
-        self.assertEqual(self.obj.status, UpdateStatus.pending)
-        self.assertEqual(str(e), config.get('not_yet_tested_msg'))
+            self.assertEqual(self.obj.request, UpdateRequest.testing)
+            self.assertEqual(self.obj.status, UpdateStatus.pending)
+            self.assertEqual(str(e), config.get('not_yet_tested_msg'))
 
     @mock.patch('bodhi.server.notifications.publish')
     def test_set_request_stable_after_week_in_testing(self, publish):
@@ -2187,21 +2186,20 @@ class TestUpdate(ModelTest):
             self.obj.set_request(self.db, UpdateRequest.stable, req.user.name)
             assert False
         except BodhiException as e:
-            pass
-        expected_msg = (
-            'This critical path update has not yet been approved for pushing to the '
-            'stable repository.  It must first reach a karma of %s, consisting of %s '
-            'positive karma from proventesters, along with %d additional karma from '
-            'the community. Or, it must spend %s days in testing without any negative '
-            'feedback')
-        expected_msg = expected_msg % (
-            config.get('critpath.min_karma'),
-            config.get('critpath.num_admin_approvals'),
-            (config.get('critpath.min_karma') -
-                config.get('critpath.num_admin_approvals')),
-            config.get('critpath.stable_after_days_without_negative_karma'))
-        expected_msg += ' Additionally, it must pass automated tests.'
-        self.assertEqual(str(e), expected_msg)
+            expected_msg = (
+                'This critical path update has not yet been approved for pushing to the '
+                'stable repository.  It must first reach a karma of %s, consisting of %s '
+                'positive karma from proventesters, along with %d additional karma from '
+                'the community. Or, it must spend %s days in testing without any negative '
+                'feedback')
+            expected_msg = expected_msg % (
+                config.get('critpath.min_karma'),
+                config.get('critpath.num_admin_approvals'),
+                (config.get('critpath.min_karma') -
+                    config.get('critpath.num_admin_approvals')),
+                config.get('critpath.stable_after_days_without_negative_karma'))
+            expected_msg += ' Additionally, it must pass automated tests.'
+            self.assertEqual(str(e), expected_msg)
 
     @mock.patch('bodhi.server.notifications.publish')
     def test_met_testing_requirements_at_7_days_after_bodhi_comment(self, publish):

--- a/bodhi/tests/server/test_models.py
+++ b/bodhi/tests/server/test_models.py
@@ -340,7 +340,7 @@ class TestEnumMeta(unittest.TestCase):
         expected_values = ['testing', 'stable']
 
         for v in iter(m):
-            self.assertEqual(str(v), '<{}>'.format(expected_values.pop(0)))
+            self.assertEqual(repr(v), '<{}>'.format(expected_values.pop(0)))
             self.assertEqual(type(v), model.EnumSymbol)
 
         self.assertEqual(expected_values, [])

--- a/bodhi/tests/server/test_models.py
+++ b/bodhi/tests/server/test_models.py
@@ -897,10 +897,12 @@ class TestRpmPackage(ModelTest, unittest.TestCase):
 
         rv = self.package.get_pkg_committers_from_pagure()
 
-        self.assertEqual(
-            rv,
-            (['ignatenkobrain', 'releng', 'dmach', 'jsilhan', 'mluscon', 'jmracek', 'mhatina'],
-             ['rpm-software-management-sig']))
+        committers, groups = rv
+
+        self.assertEqual(sorted(committers),
+                         ['dmach', 'ignatenkobrain', 'jmracek', 'jsilhan',
+                          'mhatina', 'mluscon', 'releng'])
+        self.assertEqual(groups, ['rpm-software-management-sig'])
         session.get.assert_called_once_with(
             'https://src.fedoraproject.org/pagure/api/0/rpms/the-greatest-package?expand_group=1',
             timeout=60)

--- a/bodhi/tests/server/test_models.py
+++ b/bodhi/tests/server/test_models.py
@@ -2596,7 +2596,8 @@ class TestUpdate(ModelTest):
         expected_names = [u"Test 1", u"Test 2"]
 
         self.assertEqual(len(tests), len(expected))
-        self.assertEqual(sorted(tests), sorted(expected))
+        self.assertEqual(sorted(tests, key=lambda testcase: testcase.name),
+                         sorted(expected, key=lambda testcase: testcase.name))
 
         self.assertEqual(len(test_names), len(expected_names))
         self.assertEqual(sorted(test_names), sorted(expected_names))

--- a/bodhi/tests/server/test_models.py
+++ b/bodhi/tests/server/test_models.py
@@ -533,12 +533,11 @@ class TestCompose(BaseTestCase):
 
         j = compose.__json__(composer=True)
 
-        self.assertEqual(j.keys(), ['security', 'release_id', 'request', 'content_type'])
+        self.assertEqual(set(j.keys()), {'security', 'release_id', 'request', 'content_type'})
         # If we remove the extra keys from normal_json, the remaining dictionary should be the same
         # as j.
-        for k in normal_json.keys():
-            if k not in j.keys():
-                del(normal_json[k])
+        for k in set(normal_json.keys()) - set(j.keys()):
+            del(normal_json[k])
         self.assertEqual(j, normal_json)
 
     def test___lt___false_fallthrough(self):

--- a/bodhi/tests/server/test_models.py
+++ b/bodhi/tests/server/test_models.py
@@ -1074,7 +1074,7 @@ class TestRpmBuild(ModelTest):
             changelog,
             ('* Sat Aug  3 2013 Fedora Releng <rel-eng@lists.fedoraproject.org> - 2.1.0-1\n- Added '
              'a free money feature.\n* Tue Jun 11 2013 Randy <bowlofeggs@fpo> - 2.0.1-2\n- Make '
-             'users \xe2\x98\xba\n'))
+             'users ☺\n'))
         # No exception should have been logged.
         self.assertEqual(exception.call_count, 0)
         get_rpm_header.assert_called_once_with(self.obj.nvr)

--- a/bodhi/tests/server/test_renderers.py
+++ b/bodhi/tests/server/test_renderers.py
@@ -20,17 +20,19 @@
 import copy
 import datetime
 import re
+import unittest
 
 from webtest import TestApp
 import PIL.Image
 from six import StringIO
+import six
 
 from bodhi.server import main
 from bodhi.tests.server import base
 
 
 class TestRenderers(base.BaseTestCase):
-
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_renderer_jpeg(self):
         """
         Test that the renderer returns a jpeg. In this case, the CAPTCHA image.

--- a/bodhi/tests/server/test_renderers.py
+++ b/bodhi/tests/server/test_renderers.py
@@ -20,10 +20,10 @@
 import copy
 import datetime
 import re
-import StringIO
 
 from webtest import TestApp
 import PIL.Image
+from six import StringIO
 
 from bodhi.server import main
 from bodhi.tests.server import base
@@ -58,6 +58,6 @@ class TestRenderers(base.BaseTestCase):
         captcha_url = re.search(r'"http://localhost(/captcha/[^"]*)"', str(res)).groups()[0]
         resp = app.get(captcha_url, status=200)
         self.assertIn('image/jpeg', resp.headers['Content-Type'])
-        jpegdata = StringIO.StringIO(resp.body)
+        jpegdata = StringIO(resp.body)
         img = PIL.Image.open(jpegdata)
         self.assertEqual(img.size, (300, 80))

--- a/bodhi/tests/server/test_util.py
+++ b/bodhi/tests/server/test_util.py
@@ -439,9 +439,9 @@ class TestUtils(base.BaseTestCase):
         self.assertEqual(
             session.get.mock_calls,
             [mock.call(
-                ('http://domain.local/rest_api/v1/component-branches/?name=f26'
-                 '&fields=global_component&global_component=gcc&page_size=100&critical_path=true'
-                 '&active=true&type=rpm'),
+                ('http://domain.local/rest_api/v1/component-branches/?active=true'
+                 '&critical_path=true&fields=global_component&name=f26&page_size=100&type=rpm'
+                 '&global_component=gcc'),
                 timeout=60),
              mock.call().json()])
 
@@ -469,9 +469,9 @@ class TestUtils(base.BaseTestCase):
         self.assertEqual(
             session.get.mock_calls,
             [mock.call(
-                ('http://domain.local/rest_api/v1/component-branches/?name=f26'
-                 '&fields=global_component&global_component=gcc&page_size=100&critical_path=true'
-                 '&active=true&type=rpm'),
+                ('http://domain.local/rest_api/v1/component-branches/?active=true'
+                 '&critical_path=true&fields=global_component&name=f26&page_size=100&type=rpm'
+                 '&global_component=gcc'),
                 timeout=60),
              mock.call().json()])
 

--- a/bodhi/tests/server/test_util.py
+++ b/bodhi/tests/server/test_util.py
@@ -20,7 +20,6 @@ import subprocess
 import unittest
 
 import mock
-import pkgdb2client
 import six
 
 from bodhi.server import util, models
@@ -29,6 +28,9 @@ from bodhi.server.config import config
 from bodhi.server.models import (ComposeState, TestGatingStatus, Update, UpdateRequest,
                                  UpdateSeverity)
 from bodhi.tests.server import base
+
+if six.PY2:
+    import pkgdb2client
 
 
 class TestBugLink(base.BaseTestCase):

--- a/bodhi/tests/server/test_util.py
+++ b/bodhi/tests/server/test_util.py
@@ -351,28 +351,29 @@ class TestUtils(base.BaseTestCase):
         """
         self.assertEqual(util.get_critpath_components(), ['kernel', 'glibc'])
 
-    @mock.patch.object(pkgdb2client.PkgDB, 'get_critpath_packages')
-    @mock.patch.dict(util.config, {
-        'critpath.type': 'pkgdb',
-        'pkgdb_url': 'http://domain.local'
-    })
-    def test_get_critpath_components_pkgdb_success(self, mock_get_critpath):
-        """ Ensure that critpath packages can be found using PkgDB.
-        """
-        # A subset of critpath packages
-        critpath_pkgs = [
-            'pth',
-            'xorg-x11-server-utils',
-            'giflib',
-            'basesystem'
-        ]
-        mock_get_critpath.return_value = {
-            'pkgs': {
-                'f20': critpath_pkgs
+    if six.PY2:
+        @mock.patch.object(pkgdb2client.PkgDB, 'get_critpath_packages')
+        @mock.patch.dict(util.config, {
+            'critpath.type': 'pkgdb',
+            'pkgdb_url': 'http://domain.local'
+        })
+        def test_get_critpath_components_pkgdb_success(self, mock_get_critpath):
+            """ Ensure that critpath packages can be found using PkgDB.
+            """
+            # A subset of critpath packages
+            critpath_pkgs = [
+                'pth',
+                'xorg-x11-server-utils',
+                'giflib',
+                'basesystem'
+            ]
+            mock_get_critpath.return_value = {
+                'pkgs': {
+                    'f20': critpath_pkgs
+                }
             }
-        }
-        pkgs = util.get_critpath_components('f20')
-        assert critpath_pkgs == pkgs, pkgs
+            pkgs = util.get_critpath_components('f20')
+            assert critpath_pkgs == pkgs, pkgs
 
     @mock.patch('bodhi.server.util.http_session')
     @mock.patch.dict(util.config, {

--- a/bodhi/tests/server/test_validators.py
+++ b/bodhi/tests/server/test_validators.py
@@ -20,6 +20,7 @@ import unittest
 import mock
 from cornice.errors import Errors
 from pyramid import exceptions
+import six
 
 from bodhi.server import validators
 from bodhi.tests.server.base import BaseTestCase
@@ -50,6 +51,7 @@ class TestValidateCSRFToken(BaseTestCase):
                  u'name': u'update'}]}
         self.assertEqual(r.json, expected_reponse)
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_valid_token(self):
         """No exception should be raised with a valid token."""
         update = models.Update.query.one()

--- a/bodhi/tests/server/views/test_generic.py
+++ b/bodhi/tests/server/views/test_generic.py
@@ -19,9 +19,11 @@
 
 from datetime import datetime
 import copy
+import unittest
 
 import mock
 from webtest import TestApp
+import six
 
 from bodhi.server import main, util
 from bodhi.server.models import (
@@ -270,6 +272,7 @@ class TestGenericViews(base.BaseTestCase):
             "</div>"
         )
 
+    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_metrics(self):
         res = self.app.get('/metrics')
         self.assertIn('$.plot', res)

--- a/bodhi/tests/utils.py
+++ b/bodhi/tests/utils.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+# Copyright © 2018 Red Hat, Inc.
+#
+# This file is part of Bodhi.
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+"""This module contains useful functions that helps with testing."""
+
+import re
+
+
+def prepare_text_for_comparison(text):
+    """Transfer wrapped text output to one line."""
+    text = text.replace('\n', '')  # Remove newlines
+    text = re.sub(r' +:', '', text)  # Remove start of wrapped lines
+    text = "".join(text.split())  # Remove whitespaces
+    return text
+
+
+def compare_output(output, expected):
+    """Compare content of wrapped text outputs and show diff if enabled."""
+    output = prepare_text_for_comparison(output)
+    expected = prepare_text_for_comparison(expected)
+    return output == expected

--- a/bodhi/tests/utils.py
+++ b/bodhi/tests/utils.py
@@ -19,6 +19,7 @@
 """This module contains useful functions that helps with testing."""
 
 import re
+import difflib
 
 
 def prepare_text_for_comparison(text):
@@ -29,8 +30,16 @@ def prepare_text_for_comparison(text):
     return text
 
 
-def compare_output(output, expected):
+def compare_output(output, expected, debug_output=False):
     """Compare content of wrapped text outputs and show diff if enabled."""
-    output = prepare_text_for_comparison(output)
-    expected = prepare_text_for_comparison(expected)
-    return output == expected
+    prepared_output = prepare_text_for_comparison(output)
+    prepared_expected = prepare_text_for_comparison(expected)
+    if prepared_output == prepared_expected:
+        return True
+    else:
+        if debug_output:
+            differ = difflib.Differ()
+            diff = differ.compare(output.splitlines(True),
+                                  expected.splitlines(True))
+            print(''.join(list(diff)))
+        return False

--- a/devel/ansible/roles/dev/files/.bashrc
+++ b/devel/ansible/roles/dev/files/.bashrc
@@ -34,12 +34,7 @@ function bresetdb {
 
 function btest {
     find /home/vagrant/bodhi -name "*.pyc" -delete;
-    pushd /home/vagrant/bodhi && tox && py.test $@; popd
-}
-
-function btest3 {
-    find /home/vagrant/bodhi -name "__pycache__" -type d -exec rm -r {} \;
-    pushd /home/vagrant/bodhi && py.test-3 $@ && tox; popd
+    pushd /home/vagrant/bodhi && tox && py.test-2 $@ && py.test-3 $@; popd
 }
 
 export BODHI_URL="http://localhost:6543/"

--- a/devel/ansible/roles/dev/files/.bashrc
+++ b/devel/ansible/roles/dev/files/.bashrc
@@ -37,6 +37,11 @@ function btest {
     pushd /home/vagrant/bodhi && tox && py.test $@; popd
 }
 
+function btest3 {
+    find /home/vagrant/bodhi -name "__pycache__" -type d -exec rm -r {} \;
+    pushd /home/vagrant/bodhi && py.test-3 $@ && tox; popd
+}
+
 export BODHI_URL="http://localhost:6543/"
 export PYTHONWARNINGS="once"
 

--- a/devel/ansible/roles/dev/files/motd
+++ b/devel/ansible/roles/dev/files/motd
@@ -11,6 +11,7 @@ bshell:      Get a handy python shell initialized with Bodhi models.
 bstart:      Start the Bodhi service.
 bstop:       Stop the Bodhi service.
 btest:       Run Bodhi's test suite.
+btest3:      Run Bodhi's test suite with Python 3.
 bteststyle:  Run just the flake8 code style tests.
 
 

--- a/devel/ansible/roles/dev/files/motd
+++ b/devel/ansible/roles/dev/files/motd
@@ -11,7 +11,6 @@ bshell:      Get a handy python shell initialized with Bodhi models.
 bstart:      Start the Bodhi service.
 bstop:       Stop the Bodhi service.
 btest:       Run Bodhi's test suite.
-btest3:      Run Bodhi's test suite with Python 3.
 bteststyle:  Run just the flake8 code style tests.
 
 

--- a/devel/ansible/roles/dev/tasks/main.yml
+++ b/devel/ansible/roles/dev/tasks/main.yml
@@ -63,9 +63,28 @@
       - python2-sqlalchemy_schemadisplay
       - python2-waitress
       - python2-yaml
+      - python3-arrow
+      - python3-bleach
+      - python3-click
+      - python3-colander
+      - python3-createrepo_c
       - python3-diff-cover
+      - python3-dogpile-cache
+      - python3-fedmsg
+      - python3-fedora
+      - python3-kitchen
+      - python3-markdown
+      - python3-mock
+      - python3-munch
+      - python3-pillow
       - python3-pydocstyle
+      - python3-pylibravatar
+      - python3-pytest
+      - python3-pytest-cov
+      - python3-simplemediawiki
+      - python3-sqlalchemy
       - python3-tox
+      - python3-webtest
       - redhat-rpm-config
       - vim-enhanced
       - zlib-devel
@@ -74,6 +93,11 @@
 - name: pip install cornice
   pip:
       name: cornice
+
+- name: pip install cornice for Python 3
+  pip:
+      name: cornice
+      executable: pip3
 
 # cornice_sphinx is not packaged in Fedora yet, but won't be available until Fedora 28 is released.
 - name: pip install cornice_sphinx
@@ -84,6 +108,11 @@
 - name: pip install debugtoolbar
   pip:
       name: pyramid_debugtoolbar
+
+- name: pip install debugtoolbar
+  pip:
+      name: pyramid_debugtoolbar
+      executable: pip3
 
 - name: Install bodhi in developer mode
   command: python /home/vagrant/bodhi/setup.py develop

--- a/devel/ansible/roles/dev/tasks/main.yml
+++ b/devel/ansible/roles/dev/tasks/main.yml
@@ -22,7 +22,7 @@
       - pcaro-hermit-fonts
       - postgresql-devel
       - pungi
-      - python
+      - python2
       - python-alembic
       - python-bugzilla
       - python-openid

--- a/devel/ansible/roles/dev/tasks/main.yml
+++ b/devel/ansible/roles/dev/tasks/main.yml
@@ -120,6 +120,12 @@
       chdir: /home/vagrant/bodhi
       creates: /usr/lib/python2.7/site-packages/bodhi.egg-link
 
+- name: Install bodhi in developer mode for Python 3
+  command: python3 /home/vagrant/bodhi/setup.py develop
+  args:
+      chdir: /home/vagrant/bodhi
+      creates: /usr/lib/python3.6/site-packages/bodhi.egg-link
+
 - name: Retrieve database dump
   get_url:
       url: https://infrastructure.fedoraproject.org/infra/db-dumps/bodhi2.dump.xz

--- a/devel/ansible/roles/dev/tasks/main.yml
+++ b/devel/ansible/roles/dev/tasks/main.yml
@@ -120,11 +120,15 @@
       chdir: /home/vagrant/bodhi
       creates: /usr/lib/python2.7/site-packages/bodhi.egg-link
 
+- name: Get Python 3 version
+  command: python3 -c "import sys; print('%s.%s' % sys.version_info[0:2])"
+  register: python3_version
+
 - name: Install bodhi in developer mode for Python 3
   command: python3 /home/vagrant/bodhi/setup.py develop
   args:
       chdir: /home/vagrant/bodhi
-      creates: /usr/lib/python3.6/site-packages/bodhi.egg-link
+      creates: /usr/lib/python{{ python3_version.stdout }}/site-packages/bodhi.egg-link
 
 - name: Retrieve database dump
   get_url:

--- a/devel/ansible/roles/dev/tasks/main.yml
+++ b/devel/ansible/roles/dev/tasks/main.yml
@@ -77,6 +77,7 @@
       - python3-mock
       - python3-munch
       - python3-pillow
+      - python3-psycopg2
       - python3-pydocstyle
       - python3-pylibravatar
       - python3-pytest

--- a/devel/ansible/roles/dev/tasks/main.yml
+++ b/devel/ansible/roles/dev/tasks/main.yml
@@ -76,6 +76,7 @@
       - python3-markdown
       - python3-mock
       - python3-munch
+      - python3-openid
       - python3-pillow
       - python3-psycopg2
       - python3-pydocstyle

--- a/devel/ansible/roles/dev/tasks/main.yml
+++ b/devel/ansible/roles/dev/tasks/main.yml
@@ -81,6 +81,7 @@
       - python3-psycopg2
       - python3-pydocstyle
       - python3-pylibravatar
+      - python3-pyramid
       - python3-pytest
       - python3-pytest-cov
       - python3-simplemediawiki

--- a/devel/ansible/roles/dev/tasks/main.yml
+++ b/devel/ansible/roles/dev/tasks/main.yml
@@ -149,6 +149,12 @@
     regexp: "^sqlalchemy.url = sqlite.*$"
     replace: "sqlalchemy.url = postgresql://postgres:anypasswordworkslocally@localhost/bodhi2"
 
+# Bug in zope.interface filled here https://github.com/zopefoundation/zope.interface/issues/114
+- name: Fix namespace-package bug in zope.interface
+  copy:
+      content: "__import__('pkg_resources').declare_namespace(__name__)"
+      dest: "/usr/lib64/python{{ python3_version.stdout }}/site-packages/zope/__init__.py"
+
 - name: Apply database migrations
   shell: PYTHONPATH=. alembic upgrade head
   args:

--- a/devel/ansible/roles/dev/tasks/main.yml
+++ b/devel/ansible/roles/dev/tasks/main.yml
@@ -116,6 +116,12 @@
       name: pyramid_debugtoolbar
       executable: pip3
 
+# New version with Python 3 subpackage is available only in F28 and newer
+- name: pip install pyradim-fas-openid for Python3
+  pip:
+      name: pyramid_fas_openid
+      executable: pip3
+
 - name: Install bodhi in developer mode
   command: python /home/vagrant/bodhi/setup.py develop
   args:

--- a/devel/ci/Dockerfile-header
+++ b/devel/ci/Dockerfile-header
@@ -17,3 +17,5 @@ RUN dnf install -y \
     python2-koji \
     python2-librepo \
     python2-yaml \
+    python3-createrepo_c \
+    python3-yaml \

--- a/devel/ci/f26-packages
+++ b/devel/ci/f26-packages
@@ -10,3 +10,6 @@
 
 RUN pip-2 install cornice
 RUN pip-2 install -e git+https://github.com/Cornices/cornice.ext.sphinx.git@master#egg=cornice_sphinx
+RUN pip-3 install cornice
+RUN pip-3 install -e git+https://github.com/Cornices/cornice.ext.sphinx.git@master#egg=cornice_sphinx
+RUN pip-3 install pyramid-fas-openid

--- a/devel/ci/f27-packages
+++ b/devel/ci/f27-packages
@@ -10,3 +10,6 @@
 
 RUN pip-2 install cornice
 RUN pip-2 install -e git+https://github.com/Cornices/cornice.ext.sphinx.git@master#egg=cornice_sphinx
+RUN pip-3 install cornice
+RUN pip-3 install -e git+https://github.com/Cornices/cornice.ext.sphinx.git@master#egg=cornice_sphinx
+RUN pip-3 install pyramid-fas-openid

--- a/devel/ci/pip-packages
+++ b/devel/ci/pip-packages
@@ -3,11 +3,14 @@
     gcc-c++ \
     graphviz \
     python2-devel \
+    python3-devel \
+    python3-simplemediawiki \
     redhat-rpm-config
 
 COPY requirements.txt /bodhi/requirements.txt
 
 RUN pip-2 install -r /bodhi/requirements.txt
+RUN pip-3 install -r /bodhi/requirements.txt
 RUN pip-2 install \
     diff-cover \
     mock \
@@ -16,4 +19,13 @@ RUN pip-2 install \
     sqlalchemy_schemadisplay \
     tox \
     webtest
-RUN pip install -e git+https://github.com/Cornices/cornice.ext.sphinx.git@master#egg=cornice_sphinx
+RUN pip-3 install \
+    diff-cover \
+    mock \
+    pytest \
+    pytest-cov \
+    sqlalchemy_schemadisplay \
+    tox \
+    webtest
+RUN pip-2 install -e git+https://github.com/Cornices/cornice.ext.sphinx.git@master#egg=cornice_sphinx
+RUN pip-3 install -e git+https://github.com/Cornices/cornice.ext.sphinx.git@master#egg=cornice_sphinx

--- a/devel/ci/rawhide-packages
+++ b/devel/ci/rawhide-packages
@@ -7,4 +7,7 @@
     python2-pylibravatar \
     python2-pyramid-fas-openid \
     python2-simplemediawiki \
-    python2-webtest
+    python3-cornice \
+    python3-cornice-sphinx \
+    python2-webtest \
+    python3-pyramid-fas-openid

--- a/devel/ci/rpm-packages
+++ b/devel/ci/rpm-packages
@@ -17,8 +17,6 @@
     python3-alembic \
     python3-arrow \
     python3-bleach \
-    python3-cornice \
-    python3-createrepo_c \
     python3-diff-cover \
     python3-dogpile-cache \
     python3-fedmsg \
@@ -31,7 +29,6 @@
     python3-pillow \
     python3-pydocstyle \
     python3-pylibravatar \
-    python3-pyramid-fas-openid \
     python3-pyramid-mako \
     python3-pyramid-tm \
     python3-pytest \

--- a/devel/ci/rpm-packages
+++ b/devel/ci/rpm-packages
@@ -14,6 +14,29 @@
     python2-pytest-cov \
     python2-sqlalchemy \
     python2-sqlalchemy_schemadisplay \
+    python3-alembic \
+    python3-arrow \
+    python3-bleach \
+    python3-cornice \
+    python3-createrepo_c \
     python3-diff-cover \
+    python3-dogpile-cache \
+    python3-fedmsg \
+    python3-fedora \
+    python3-feedgen \
+    python3-kitchen \
+    python3-markdown \
+    python3-mock \
+    python3-munch \
+    python3-pillow \
     python3-pydocstyle \
+    python3-pylibravatar \
+    python3-pyramid-fas-openid \
+    python3-pyramid-mako \
+    python3-pyramid-tm \
+    python3-pytest \
+    python3-pytest-cov \
+    python3-simplemediawiki \
+    python3-sqlalchemy \
     python3-tox \
+    python3-webtest \

--- a/devel/run_tests.sh
+++ b/devel/run_tests.sh
@@ -78,6 +78,8 @@ for r in $RELEASES; do
     echo "RUN find /bodhi -name \"*__pycache__\" -delete" >> Dockerfile-$r
     echo "RUN rm -rf *.egg-info" >> Dockerfile-$r
     echo "RUN rm -rf .tox" >> Dockerfile-$r
+    echo "RUN rm -rf /bodhi/docs/_build" >> Dockerfile-$r
+    echo "RUN rm -rf /bodhi/docs/developer/docblocks" >> Dockerfile-$r
 done
 popd
 

--- a/devel/test_container.sh
+++ b/devel/test_container.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/bash -ex
-# Copyright (c) 2017 Red Hat, Inc.
+# Copyright (c) 2017-2018 Red Hat, Inc.
 #
 # This file is part of Bodhi.
 #
@@ -36,10 +36,16 @@ sed -i '/pyramid_debugtoolbar/d' devel/development.ini.example
 
 cp devel/development.ini.example development.ini
 
-/usr/bin/python setup.py develop || fail
+/usr/bin/python2 setup.py develop || fail
+py3_version=$(python3 -c "import sys ; print(sys.version[:3])")
+mkdir -p /usr/local/lib/python$py3_version/site-packages/
+/usr/bin/python3 setup.py develop || fail
 
 /usr/bin/tox || fail
+
 /usr/bin/py.test-2 $@ || (gather_results; fail)
+# Since we skip some tests in Python 3, we don't reach the usually required 96% coverage yet.
+sed -i "s/fail_under.*/fail_under = 78/" .coveragerc
 /usr/bin/py.test-3 $@ || (gather_results; fail)
 
 gather_results

--- a/devel/test_container.sh
+++ b/devel/test_container.sh
@@ -41,6 +41,8 @@ py3_version=$(python3 -c "import sys ; print(sys.version[:3])")
 mkdir -p /usr/local/lib/python$py3_version/site-packages/
 /usr/bin/python3 setup.py develop || fail
 
+/usr/bin/tox || fail
+
 # The pip container calls it py.test but the Fedora container calls it py.test-2.
 if ! rpm -q python3-fedmsg; then
     /usr/bin/py.test $@ || (gather_results; fail)
@@ -59,12 +61,5 @@ if ! rpm -q python3-fedmsg; then
 else
     /usr/bin/py.test-3 $@ || (gather_results; fail)
 fi
-
-# There is a problem where Sphinx won't build the docs because of pkgdb, which
-# isn't available for Python 3, even though we have imports guarded with if six.py3. Let's work
-# around it by sed'ing out the pkgdb imports when building the docs.
-sed -i "s/from pkgdb2client import PkgDB/PkgDB = None/" bodhi/server/models.py
-sed -i "s/from pkgdb2client import PkgDB/PkgDB = None/" bodhi/server/util.py
-/usr/bin/tox || fail
 
 gather_results

--- a/devel/test_container.sh
+++ b/devel/test_container.sh
@@ -39,7 +39,8 @@ cp devel/development.ini.example development.ini
 /usr/bin/python setup.py develop || fail
 
 /usr/bin/tox || fail
-/usr/bin/py.test $@ || (gather_results; fail)
+/usr/bin/py.test-2 $@ || (gather_results; fail)
+/usr/bin/py.test-3 $@ || (gather_results; fail)
 
 gather_results
 

--- a/docs/user/release_notes.rst
+++ b/docs/user/release_notes.rst
@@ -9,6 +9,7 @@ Dependency changes
 ^^^^^^^^^^^^^^^^^^
 
 * Pungi 4.1.20 or higher is now required.
+* ``six`` is now a required dependency.
 
 
 Bugs

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,5 +25,6 @@ pyramid_tm
 python-bugzilla
 python-fedora
 simplemediawiki
+six
 sqlalchemy
 waitress

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,7 +23,6 @@ pyramid_mako
 pyramid_tm
 python-bugzilla
 python-fedora
-python-openid
 simplemediawiki
 sqlalchemy
 waitress

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,10 +11,11 @@ feedgen
 kitchen
 jinja2
 markdown
-packagedb-cli
+packagedb-cli; python_version <= '2.7'
 # for captchas
 Pillow
-pyDNS  # Should be required by pyLibravatar https://bugs.launchpad.net/pylibravatar/+bug/1661218
+pyDNS; python_version <= '2.7'  # Should be required by pyLibravatar https://bugs.launchpad.net/pylibravatar/+bug/1661218
+py3dns; python_version >= '3.0'  # Should be required by pyLibravatar https://bugs.launchpad.net/pylibravatar/+bug/1661218
 pylibravatar
 pyramid~=1.7
 pyramid_fas_openid

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,8 +8,9 @@ cryptography
 dogpile.cache
 fedmsg[consumers]
 feedgen
-kitchen
+iniparse
 jinja2
+kitchen
 markdown
 packagedb-cli; python_version <= '2.7'
 # for captchas


### PR DESCRIPTION
Hello.

As I mentioned in https://github.com/fedora-infra/bodhi/issues/2059 I started with the final phase of Python 3 compatibility for Bodhi. The final phase is based on availability to run tests also with Python 3.

The changes proposed in this PR enables me to execute tests in VM provisioned by Ansible. There are a lot of failures and I'll fix it one by one but with these changes, you can at least try to run tests with Python 3.

After the first look, it seems that some errors are caused by a different wrapping of outputs in CLI.

Feel free to add feedback although it is still in progress.

See you soon :)

Lumír