### PR TITLE
Ensure there is a summary to display before displaying it

### DIFF
--- a/bodhi/server/templates/update.html
+++ b/bodhi/server/templates/update.html
@@ -81,9 +81,12 @@ ${update.type} update for ${update.beautify_title(amp=True) | n}
         });
     };
 
-    var test_gating_passed = '${update.test_gating_passed}';
-    var test_gating_required = '${request.registry.settings.get("test_gating.required")}';
-    if (test_gating_required == 'True' && test_gating_passed == 'False') {
+    // data
+    ${ request.registry.settings.get("test_gating.required") }
+    ${ update.test_gating_passed }
+    ${ update.greenwave_summary_string }
+    % if request.registry.settings.get("test_gating.required") is True and \
+            not update.test_gating_passed and update.greenwave_summary_string:
         var summary = '${update.greenwave_summary_string}';
         $('#resultsdb h3').after(
            '<div class="alert alert-danger">The update can not be pushed: ' + summary + '</div>');
@@ -92,7 +95,7 @@ ${update.type} update for ${update.beautify_title(amp=True) | n}
             'decision_context': 'bodhi_update_push_stable',
             'subject': ${ update.greenwave_subject_json | n }
         });
-    }
+    % endif
 
     var make_row = function(outcome, testcase, note, arch, time, url, flavor) {
       var icon = '<span data-toggle="tooltip" data-placement="top" ' +

--- a/bodhi/tests/server/services/test_updates.py
+++ b/bodhi/tests/server/services/test_updates.py
@@ -4548,6 +4548,84 @@ class TestUpdatesService(base.BaseTestCase):
         up = self.db.query(Update).filter_by(title=resp.json['title']).one()
         self.assertEquals(up.request, UpdateRequest.stable)
 
+    @mock.patch(**mock_taskotron_results)
+    @mock.patch(**mock_valid_requirements)
+    def test_alert_not_displayed_if_no_summary_present(self, publish, *args):
+        """ Ensure that the alert is not display if there are not summary
+        status (returned normaly by greenwave) set in the database for this
+        update.
+        """
+        nvr = u'bodhi-2.1-1.fc17'
+
+        up_data = self.get_update(nvr)
+        up_data['csrf_token'] = self.app.get('/csrf').json_body['csrf_token']
+        self.app.post_json('/updates/', up_data)
+
+        build = self.db.query(RpmBuild).filter_by(nvr=nvr).one()
+        build.update.test_gating_status = TestGatingStatus.failed
+        self.assertEqual(build.update.request, UpdateRequest.testing)
+
+        with mock.patch.dict(self.app.app.registry.settings, {'test_gating.required': True}):
+            resp = self.app.get('/updates/%s' % nvr,
+                                headers={'Accept': 'text/html'})
+            self.assertIn('text/html', resp.headers['Content-Type'])
+            self.assertIn(nvr, resp)
+            self.assertNotIn(
+                '<div class="alert alert-danger">The update can not be pushed:',
+                resp)
+
+    @mock.patch(**mock_taskotron_results)
+    @mock.patch(**mock_valid_requirements)
+    def test_alert_notdisplayed_if_summary_present_but_gating_off(
+            self, publish, *args):
+        """ Ensure that the alert is not being displayed even if there is a
+        summary status (returned normaly by greenwave) set in the database
+        for this update, because the configuration is set otherwise.
+        """
+        nvr = u'bodhi-2.1-1.fc17'
+
+        up_data = self.get_update(nvr)
+        up_data['csrf_token'] = self.app.get('/csrf').json_body['csrf_token']
+        self.app.post_json('/updates/', up_data)
+
+        build = self.db.query(RpmBuild).filter_by(nvr=nvr).one()
+        build.update.test_gating_status = TestGatingStatus.failed
+        build.update.greenwave_summary_string = 'Because Randy said so'
+        self.assertEqual(build.update.request, UpdateRequest.testing)
+
+        with mock.patch.dict(self.app.app.registry.settings, {'test_gating.required': False}):
+            resp = self.app.get('/updates/%s' % nvr,
+                                headers={'Accept': 'text/html'})
+            self.assertIn('text/html', resp.headers['Content-Type'])
+            self.assertIn(nvr, resp)
+            self.assertNotIn(
+                '<div class="alert alert-danger">The update can not be pushed: \' + summary ', resp)
+
+    @mock.patch(**mock_taskotron_results)
+    @mock.patch(**mock_valid_requirements)
+    def test_alert_displayed_if_summary_present(self, publish, *args):
+        """ Ensure that the alert is displayed if there is a summary status
+        (returned normaly by greenwave) set in the database for this update.
+        """
+        nvr = u'bodhi-2.1-1.fc17'
+
+        up_data = self.get_update(nvr)
+        up_data['csrf_token'] = self.app.get('/csrf').json_body['csrf_token']
+        self.app.post_json('/updates/', up_data)
+
+        build = self.db.query(RpmBuild).filter_by(nvr=nvr).one()
+        build.update.test_gating_status = TestGatingStatus.failed
+        build.update.greenwave_summary_string = 'Because Randy said so'
+        self.assertEqual(build.update.request, UpdateRequest.testing)
+
+        with mock.patch.dict(self.app.app.registry.settings, {'test_gating.required': True}):
+            resp = self.app.get('/updates/%s' % nvr,
+                                headers={'Accept': 'text/html'})
+            self.assertIn('text/html', resp.headers['Content-Type'])
+            self.assertIn(nvr, resp)
+            self.assertIn(
+                '<div class="alert alert-danger">The update can not be pushed: \' + summary ', resp)
+
 
 class TestWaiveTestResults(base.BaseTestCase):
     """


### PR DESCRIPTION
If an update is waiting for its information about whether it passed
gating or not, then its gating status is False, but there is no
greenwave summary since greenwave hasn't been queried yet.

So ensure there is a greenwave summary to display before displaying it

Signed-off-by: Pierre-Yves Chibon <pingou@pingoured.fr>