### PR TITLE
Insert utcnow for issued_date if not yet pushed

### DIFF
--- a/bodhi/server/metadata.py
+++ b/bodhi/server/metadata.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2017 Red Hat, Inc. and others.
+# Copyright 2007-2018 Red Hat, Inc. and others.
 #
 # This file is part of Bodhi.
 #
@@ -17,6 +17,7 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 """Create metadata files when mashing repositories."""
+from datetime import datetime
 import logging
 import os
 import shelve
@@ -194,8 +195,16 @@ class UpdateInfoMetadata(object):
 
         if update.date_pushed:
             rec.issued_date = update.date_pushed
+        else:
+            # Sometimes we only set the date_pushed after it's pushed out, however,
+            # it seems that Satellite does not like update entries without issued_date.
+            # Since we know that we are pushing it now, and the next push will get the data
+            # correctly, let's just insert utcnow().
+            rec.issued_date = datetime.utcnow()
         if update.date_modified:
             rec.updated_date = update.date_modified
+        else:
+            rec.updated_date = datetime.utcnow()
 
         col = cr.UpdateCollection()
         col.name = to_bytes(update.release.long_name)


### PR DESCRIPTION
This works around a silly bug in Satellite where it really wants
an issued date and will crash if not there.

Signed-off-by: Patrick Uiterwijk <patrick@puiterwijk.org>