### PR TITLE
Run 4 CI build jobs in parallel.

### DIFF
--- a/devel/ci/run_tests.sh
+++ b/devel/ci/run_tests.sh
@@ -26,4 +26,4 @@ sudo yum install -y bzip2 docker parallel
 
 sudo systemctl start docker
 
-BUILD_PARALLEL="-j 2" ./devel/run_tests.sh
+BUILD_PARALLEL="-j 4" ./devel/run_tests.sh


### PR DESCRIPTION
We had some issues in the past with too many concurrent CI builds
causing race conditions. We solved it by doing only one build at a
time, but of course this is quite slow. A while ago we switched to
two builds in parallel, and this has been stable. This commit is an
experiment to see if four builds is stable.

Signed-off-by: Randy Barlow <randy@electronsweatshop.com>