### PR TITLE
Loosen the restrictions on two test assertions.

### DIFF
--- a/bodhi/tests/server/test_metadata.py
+++ b/bodhi/tests/server/test_metadata.py
@@ -134,7 +134,7 @@ class TestAddUpdate(base.BaseTestCase):
 
         md.shelf.close()
         self.assertEqual(len(md.uinfo.updates), 1)
-        self.assertTrue(abs((datetime.utcnow() - md.uinfo.updates[0].updated_date).seconds) < 1)
+        self.assertTrue(abs((datetime.utcnow() - md.uinfo.updates[0].updated_date).seconds) < 2)
 
     def test_date_pushed_none(self):
         """The metadata should use utcnow() if an update's date_pushed is None."""
@@ -147,7 +147,7 @@ class TestAddUpdate(base.BaseTestCase):
 
         md.shelf.close()
         self.assertEqual(len(md.uinfo.updates), 1)
-        self.assertTrue(abs((datetime.utcnow() - md.uinfo.updates[0].issued_date).seconds) < 1)
+        self.assertTrue(abs((datetime.utcnow() - md.uinfo.updates[0].issued_date).seconds) < 2)
 
 
 class TestUpdateInfoMetadata(base.BaseTestCase):


### PR DESCRIPTION
I recently wrote some tests to assert that some dates were set
"recently" by asserting it was within 1 second. A CI build recently
failed this assertion, so this commit loosens it to check for 2
seconds.

Signed-off-by: Randy Barlow <randy@electronsweatshop.com>