### PR TITLE
Do not print traceback in updates-new command

### DIFF
--- a/bodhi/tests/client/test___init__.py
+++ b/bodhi/tests/client/test___init__.py
@@ -377,7 +377,7 @@ class TestNew(unittest.TestCase):
             client.new,
             ['--user', 'bowlofeggs', '--password', 's3kr3t', '--autokarma', 'bodhi-2.2.4-1.el7'])
 
-        self.assertEqual(result.exit_code, 0)
+        self.assertEqual(result.exit_code, 2)
         self.assertIn("This is a BodhiClientException message", result.output)
 
     @mock.patch('bodhi.client.bindings.BodhiClient.csrf',
@@ -395,9 +395,22 @@ class TestNew(unittest.TestCase):
             client.new,
             ['--user', 'bowlofeggs', '--password', 's3kr3t', '--autokarma', 'bodhi-2.2.4-1.el7'])
 
+        self.assertEqual(result.exit_code, 2)
+        self.assertIn("This is an Exception message", result.output)
+
+    @mock.patch('bodhi.client.bindings.getpass.getpass', side_effect=EOFError)
+    def test_keep_quiet_if_ctrld_ends_password_input(self, getpass):
+        """
+        Assert keeping quiet if user press Ctrl+D to end password input
+        """
+        runner = testing.CliRunner()
+
+        result = runner.invoke(
+            client.new,
+            ['--user', 'bowlofeggs', '--autokarma', 'bodhi-2.2.4-1.el7'])
+
         self.assertEqual(result.exit_code, 0)
-        self.assertIn("Traceback (most recent call last):", result.output)
-        self.assertIn("Exception: This is an Exception message", result.output)
+        self.assertEqual('', result.output.strip())
 
     @mock.patch('bodhi.client.bindings.BodhiClient.csrf',
                 mock.MagicMock(return_value='a_csrf_token'))
@@ -729,10 +742,7 @@ class TestRequest(unittest.TestCase):
                                                 'some_user', '--password', 's3kr3t'])
 
         self.assertEqual(result.exit_code, 2)
-        self.assertTrue(compare_output(
-            result.output,
-            (u'Usage: request [OPTIONS] UPDATE STATE\n\nError: Invalid value for UPDATE: Update not'
-             u' found: bodhi-2.2.4-99.el7\n')))
+        self.assertIn('Update not found: bodhi-2.2.4-99.el7', result.output)
         send_request.assert_called_once_with(
             'updates/bodhi-2.2.4-99.el7/request', verb='POST', auth=True,
             data={'csrf_token': 'a_csrf_token', 'request': u'revoke',


### PR DESCRIPTION
Just like other commands, do not catch and print traceback in method
new. Instead, let handle_errors decorator to handle exceptions raised.

The updated handle_errors ensure that 1 will be returned for AuthError,
and 2 will be returned for any other errors.

Major changes in this patch

* Exception handler of bindings.BodhiClientException is droppped.
  Handling Exception covers that.
* Handle EOFError that could be raised if user press Ctrl+D to
  stop entering password. bodhi just terminates and keeps quiet without
  any message output.
* Add __str__ to UpdateNotFound.
* Do not raise click.BadParameter from method request in order to ensure
  handle_errors is able to handle any type of errors raised from
  request. Meanwhile, "an update is not found" is not proper for a bad
  parameter error.
* Tests are updated.

Signed-off-by: Chenxiong Qi <cqi@redhat.com>