### PR TITLE
Link updates to package packages

### DIFF
--- a/bodhi/server/templates/update.html
+++ b/bodhi/server/templates/update.html
@@ -628,11 +628,9 @@ $(document).ready(function(){
     <h4 id='shortdesc'>
       ${update.type} update
       in ${update.release.long_name} for
-      <a href="${request.route_url('updates') + '?packages=' + build.package.name}">
-        ${update.beautify_title(amp=True) | n}
-      </a>
-      
-      
+      % for build in update.builds:
+        <a href="https://apps.fedoraproject.org/packages/{$build.package.name}">${build.package.name}</a>${'' if loop.last else ','}
+      % endfor
     </h4>
     <div>
       Status: ${self.util.status2html(update.status) | n}

--- a/bodhi/server/templates/update.html
+++ b/bodhi/server/templates/update.html
@@ -625,10 +625,14 @@ $(document).ready(function(){
       % endif
 
     </h1>
-    <h4>
+    <h4 id='shortdesc'>
       ${update.type} update
-      in ${update.release.long_name}
-      for ${update.beautify_title(amp=True) | n}
+      in ${update.release.long_name} for
+      <a href="${request.route_url('updates') + '?packages=' + build.package.name}">
+        ${update.beautify_title(amp=True) | n}
+      </a>
+      
+      
     </h4>
     <div>
       Status: ${self.util.status2html(update.status) | n}


### PR DESCRIPTION
This adds a link to https://bodhi.fedoraproject.org/updates/?packages=qesteidutil here.

![image](https://user-images.githubusercontent.com/8781107/36254125-e431e7c4-125a-11e8-88f9-e180030c216b.png)

Signed-off-by: Anatoli Babenia <anatoli@rainforce.org>