### PR TITLE
Upgrade the Vagrant environment to Fedora 27.

### DIFF
--- a/devel/Vagrantfile.example
+++ b/devel/Vagrantfile.example
@@ -10,8 +10,10 @@
 VAGRANTFILE_API_VERSION = "2"
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
- config.vm.box_url = "https://download.fedoraproject.org/pub/fedora/linux/releases/26/CloudImages/x86_64/images/Fedora-Cloud-Base-Vagrant-26-1.5.x86_64.vagrant-libvirt.box"
- config.vm.box = "f26-cloud-libvirt"
+ config.vm.box_url = "https://download.fedoraproject.org/pub/fedora/linux/releases/27/CloudImages/x86_64/images/Fedora-Cloud-Base-Vagrant-27-1.6.x86_64.vagrant-libvirt.box"
+ config.vm.box = "f27-cloud-libvirt"
+ config.vm.box_download_checksum = "905ae86af10113f34c2abb9124dd83f197b918e16ffdd0bba47852b9ba06198f"
+ config.vm.box_download_checksum_type = "sha256"
 
  # Forward traffic on the host to the development server on the guest.
  # You can change the host port that is forwarded to 5000 on the guest

--- a/devel/ansible/roles/dev/tasks/main.yml
+++ b/devel/ansible/roles/dev/tasks/main.yml
@@ -12,7 +12,6 @@
       - git
       - graphviz
       - httpie
-      - koji
       - liberation-mono-fonts
       - libffi-devel
       - libjpeg-devel
@@ -48,6 +47,7 @@
       - python2-ipdb
       - python2-jinja2
       - python2-kitchen
+      - python2-koji
       - python2-librepo
       - python2-markdown
       - python2-mock
@@ -63,6 +63,7 @@
       - python2-sqlalchemy_schemadisplay
       - python2-waitress
       - python2-yaml
+      - python3-diff-cover
       - python3-pydocstyle
       - python3-tox
       - redhat-rpm-config
@@ -83,11 +84,6 @@
 - name: pip install debugtoolbar
   pip:
       name: pyramid_debugtoolbar
-
-# This has been retired in Fedora and needs to be unretired. We'll pip install for now.
-- name: pip install diff_cover
-  pip:
-      name: diff_cover
 
 - name: Install bodhi in developer mode
   command: python /home/vagrant/bodhi/setup.py develop


### PR DESCRIPTION
Fedora's production Bodhi instance is deployed on Fedora 27, so it
would be more ideal if the development environment matched.

Signed-off-by: Randy Barlow <randy@electronsweatshop.com>