### PR TITLE
Make sure fixedin field is lower than 256 chars

### DIFF
--- a/bodhi/server/bugs.py
+++ b/bodhi/server/bugs.py
@@ -201,15 +201,17 @@ class Bugzilla(BugTracker):
                 fixedin = [v.strip() for v in bug.fixed_in.split()]
                 # Strip out any empty strings (already stripped)
                 fixedin = [v for v in fixedin if v]
-                # And add our build if its not already there
-                if version not in fixedin:
-                    fixedin.append(version)
 
                 # There are Red Hat preferences to how this field should be
                 # structured.  We should use:
                 # - the full NVR as it appears in koji
                 # - space-separated if there's more than one.
-                args['fixedin'] = " ".join(fixedin)
+                fixedinString = " ".join(fixedin)
+                
+                # Add our build if its not already there
+                # but only if resultant string length is lower than 256 chars
+                if (version not in fixedin) and (len(fixedinString)+len(version) < 255):
+                    args['fixedin'] = fixedinString + " " + version
 
             bug.close('ERRATA', **args)
         except xmlrpc_client.Fault:

--- a/bodhi/server/bugs.py
+++ b/bodhi/server/bugs.py
@@ -211,8 +211,8 @@ class Bugzilla(BugTracker):
                 # Add our build if its not already there
                 # but only if resultant string length is lower than 256 chars
                 # See https://github.com/fedora-infra/bodhi/issues/1430
-                if (version not in fixedin) and (len(fixedin_str) + len(version) < 255):
-                    args['fixedin'] = " ".join([fixedin_str, version])
+                if (version not in fixedin) and ((len(fixedin_str) + len(version)) < 255):
+                    args['fixedin'] = " ".join([fixedin_str, version]).strip()
 
             bug.close('ERRATA', **args)
         except xmlrpc_client.Fault:

--- a/bodhi/server/bugs.py
+++ b/bodhi/server/bugs.py
@@ -206,12 +206,13 @@ class Bugzilla(BugTracker):
                 # structured.  We should use:
                 # - the full NVR as it appears in koji
                 # - space-separated if there's more than one.
-                fixedinString = " ".join(fixedin)
-                
+                fixedin_str = " ".join(fixedin)
+
                 # Add our build if its not already there
                 # but only if resultant string length is lower than 256 chars
-                if (version not in fixedin) and (len(fixedinString)+len(version) < 255):
-                    args['fixedin'] = fixedinString + " " + version
+                # See https://github.com/fedora-infra/bodhi/issues/1430
+                if (version not in fixedin) and (len(fixedin_str) + len(version) < 255):
+                    args['fixedin'] = " ".join([fixedin_str, version])
 
             bug.close('ERRATA', **args)
         except xmlrpc_client.Fault:


### PR DESCRIPTION
Make sure fixedin field is lower than 256 chars (fixes #1430 ).

Instead of adding the new version to the fixedin list and then check the length of the resultant string, check if the new version can be added to the string without going over the 255 chars limit.