### PR TITLE
Add an API for retrieving information about Composes.

### DIFF
--- a/bodhi/server/consumers/masher.py
+++ b/bodhi/server/consumers/masher.py
@@ -238,7 +238,7 @@ class Masher(fedmsg.consumers.FedmsgConsumer):
                 # Acknowledge that we've received the command to run these composes.
                 c.state = ComposeState.pending
 
-            return [c.__json__() for c in composes]
+            return [c.__json__(composer=True) for c in composes]
 
     def work(self, msg):
         """Begin the push process.

--- a/bodhi/server/push.py
+++ b/bodhi/server/push.py
@@ -154,7 +154,7 @@ def push(username, cert_prefix, **kwargs):
         else:
             click.echo('\nThere are no updates to push.')
 
-        composes = [c.__json__() for c in composes]
+        composes = [c.__json__(composer=True) for c in composes]
 
     if composes:
         click.echo('\nSending masher.start fedmsg')

--- a/bodhi/server/services/composes.py
+++ b/bodhi/server/services/composes.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright © 2017 Red Hat, Inc.
+# Copyright © 2017-2018 Red Hat, Inc.
 #
 # This file is part of Bodhi.
 #
@@ -28,9 +28,14 @@ from bodhi.server.services import errors
 
 
 @resource(collection_path='/composes/', path='/composes/{release_name}/{request}',
-          description='Compose service', error_handler=errors.html_handler)
+          description='Compose service')
 class Composes(object):
-    """Defines resources for interacting with Compose objects."""
+    """
+    Defines resources for interacting with Compose objects.
+
+    Operations acting on the collection are served at ``/composes/`` and operations acting on a
+    single compose are served at ``/composes/<release_name>/<request>``.
+    """
 
     def __init__(self, request, context=None):
         """
@@ -51,22 +56,33 @@ class Composes(object):
         """
         return [(Allow, Everyone, 'view_composes')]
 
+    @view(
+        accept=('application/json', 'text/json'), renderer='json',
+        cors_origins=security.cors_origins_ro, error_handler=errors.json_handler,
+        permission='view_composes')
     @view(accept=('text/html',), renderer='composes.html', cors_origins=security.cors_origins_ro,
-          permission='view_composes')
+          permission='view_composes', error_handler=errors.html_handler)
     def collection_get(self):
         """
         List composes.
+
+        This method responds to the ``/composes/`` endpoint.
 
         Returns:
             dict: A dictionary mapping the key 'composes' to an iterable of all Compose objects.
         """
         return {'composes': sorted(models.Compose.query.all())}
 
-    @view(accept=('text/html',), renderer='compose.html', cors_origins=security.cors_origins_ro,
+    @view(accept=('application/json', 'text/json'), renderer='json',
+          cors_origins=security.cors_origins_ro, error_handler=errors.json_handler,
           permission='view_composes')
+    @view(accept=('text/html',), renderer='compose.html', cors_origins=security.cors_origins_ro,
+          permission='view_composes', error_handler=errors.html_handler)
     def get(self):
         """
         Retrieve and render a single compose.
+
+        This API responses to the ``/composes/<release_name>/<request>`` endpoint.
 
         Returns:
             dict: A dictionary mapping the key 'compose' to a single Compose object.

--- a/bodhi/tests/server/test_push.py
+++ b/bodhi/tests/server/test_push.py
@@ -453,7 +453,7 @@ class TestPush(base.BaseTestCase):
         self.assertEqual(result.output, TEST_LOCKED_UPDATES_EXPECTED_OUTPUT)
         publish.assert_called_once_with(
             topic='masher.start',
-            msg={'composes': [ejabberd.compose.__json__()],
+            msg={'composes': [ejabberd.compose.__json__(composer=True)],
                  'resume': True, 'agent': 'bowlofeggs', 'api_version': 2},
             force=True)
         ejabberd = self.db.query(models.Update).filter_by(title=u'ejabberd-16.09-4.fc17').one()
@@ -568,8 +568,8 @@ class TestPush(base.BaseTestCase):
         publish.assert_called_once_with(
             topic='masher.start',
             msg={
-                'composes': [f25_python_nose.compose.__json__(),
-                             f26_python_paste_deploy.compose.__json__()],
+                'composes': [f25_python_nose.compose.__json__(composer=True),
+                             f26_python_paste_deploy.compose.__json__(composer=True)],
                 'resume': False, 'agent': 'bowlofeggs', 'api_version': 2},
             force=True)
 
@@ -624,7 +624,7 @@ class TestPush(base.BaseTestCase):
             title=u'python-paste-deploy-1.5.2-8.fc17').one()
         publish.assert_called_once_with(
             topic='masher.start',
-            msg={'composes': [python_paste_deploy.compose.__json__()],
+            msg={'composes': [python_paste_deploy.compose.__json__(composer=True)],
                  'resume': False, 'agent': 'bowlofeggs', 'api_version': 2},
             force=True)
         self.assertFalse(python_nose.locked)
@@ -667,7 +667,7 @@ class TestPush(base.BaseTestCase):
             title=u'python-paste-deploy-1.5.2-8.fc17').one()
         publish.assert_called_once_with(
             topic='masher.start',
-            msg={'composes': [ejabberd.compose.__json__()],
+            msg={'composes': [ejabberd.compose.__json__(composer=True)],
                  'resume': True, 'agent': 'bowlofeggs', 'api_version': 2},
             force=True)
         # ejabberd should be locked still
@@ -716,7 +716,7 @@ class TestPush(base.BaseTestCase):
             title=u'python-paste-deploy-1.5.2-8.fc17').one()
         publish.assert_called_once_with(
             topic='masher.start',
-            msg={'composes': [ejabberd.compose.__json__()],
+            msg={'composes': [ejabberd.compose.__json__(composer=True)],
                  'resume': True, 'agent': 'bowlofeggs', 'api_version': 2},
             force=True)
         # ejabberd should still be locked.
@@ -773,7 +773,7 @@ class TestPush(base.BaseTestCase):
             title=u'python-paste-deploy-1.5.2-8.fc17').one()
         publish.assert_called_once_with(
             topic='masher.start',
-            msg={'composes': [ejabberd.compose.__json__()],
+            msg={'composes': [ejabberd.compose.__json__(composer=True)],
                  'resume': True, 'agent': 'bowlofeggs', 'api_version': 2},
             force=True)
         # These should still be locked.
@@ -817,7 +817,7 @@ class TestPush(base.BaseTestCase):
             title=u'python-paste-deploy-1.5.2-8.fc17').one()
         publish.assert_called_once_with(
             topic='masher.start',
-            msg={'composes': [python_paste_deploy.compose.__json__()],
+            msg={'composes': [python_paste_deploy.compose.__json__(composer=True)],
                  'resume': False, 'agent': 'bowlofeggs', 'api_version': 2},
             force=True)
         self.assertFalse(python_nose.locked)
@@ -857,7 +857,7 @@ class TestPush(base.BaseTestCase):
             title=u'python-paste-deploy-1.5.2-8.fc17').one()
         publish.assert_called_once_with(
             topic='masher.start',
-            msg={'composes': [python_paste_deploy.compose.__json__()],
+            msg={'composes': [python_paste_deploy.compose.__json__(composer=True)],
                  'resume': False, 'agent': 'bowlofeggs', 'api_version': 2},
             force=True)
         self.assertTrue(python_nose.locked)

--- a/docs/server_api/composes.rst
+++ b/docs/server_api/composes.rst
@@ -1,0 +1,9 @@
+Composes
+========
+
+``cornice_sphinx`` does `not <https://github.com/Cornices/cornice.ext.sphinx/issues/15>`_ yet have
+the ability to render documentation for the ``/composes/`` API, so we will include docblock
+documentation for that service here instead.
+
+
+.. autoclass:: bodhi.server.services.composes.Composes

--- a/docs/server_api/index.rst
+++ b/docs/server_api/index.rst
@@ -22,6 +22,7 @@ sections of the API by following the links below:
    admin
    builds
    comments
+   composes
    csrf
    markdown
    overrides


### PR DESCRIPTION
re #2015

Signed-off-by: Randy Barlow <randy@electronsweatshop.com>

The docs won't build for this PR until #2173 is merged, because the docs are upset that there are two classes named ```Compose```. I could make all docblock use the fully qualified name, but it's easier to just resolve the conflict in #2173, and the name there made more sense to be plural anyway.