### PR TITLE
Use ':' as separator for name:stream:version in pungi variants.xml when mashing modules.

### DIFF
--- a/bodhi/server/consumers/masher.py
+++ b/bodhi/server/consumers/masher.py
@@ -1308,6 +1308,25 @@ class ModuleComposerThread(PungiComposerThread):
         """
         pass
 
+    def _raise_on_get_build_multicall_error(self, result, build):
+        """
+        Raise an Exception if multicall result contains an error element.
+
+        Args:
+            result (list): Child list from the koji.multiCall() result.
+            build (bodhi.server.models.Build): build for which the koji.multiCall() returned
+                this result.
+        """
+        if type(result) == list and not result:
+            err = 'Empty list returned for getBuild("%s").' % build.nvr
+            self.log.error(err)
+            raise Exception(err)
+        elif type(result) != list:
+            err = 'Unexpected data returned for getBuild("%s"): %r.' \
+                % (build.nvr, result)
+            self.log.error(err)
+            raise Exception(err)
+
     def _generate_module_list(self):
         """
         Generate a list of NSVs which should be used for pungi modular compose.
@@ -1315,13 +1334,25 @@ class ModuleComposerThread(PungiComposerThread):
         Returns:
             list: list of NSV string which should be composed.
         """
-        newest_builds = {}
+        # For modules, both name and version can contain dashes. This makes it
+        # impossible to distinguish between name and version from "nvr". We
+        # therefore have to ask for Koji build here and get that information
+        # from there.
+        koji = buildsys.get_session()
+        koji.multicall = True
+        for build in self.compose.release.builds:
+            koji.getBuild(build.nvr)
+        results = koji.multiCall()
+
         # we loop through builds so we get rid of older builds and get only
         # a dict with the newest builds
-        for build in self.compose.release.builds:
-            nsv = build.nvr.rsplit('-', 1)
-            ns = nsv[0]
-            version = nsv[1]
+        newest_builds = {}
+        for result, build in zip(results, self.compose.release.builds):
+            self._raise_on_get_build_multicall_error(result, build)
+            koji_build = result[0]
+            # name:stream:version maps to Koji's name-version-release.
+            ns = "%s:%s" % (koji_build["name"], koji_build["version"])
+            version = koji_build["release"]
 
             if ns in newest_builds:
                 curr_version = newest_builds[ns]
@@ -1332,10 +1363,18 @@ class ModuleComposerThread(PungiComposerThread):
 
         # make sure that the modules we want to update get their correct versions
         for update in self.compose.updates:
-            for build in update.builds:
-                nsv = build.nvr.rsplit('-', 1)
-                ns = nsv[0]
-                version = nsv[1]
+            # We need to get the Koji builds also for the updates.
+            koji.multicall = True
+            for update in self.compose.updates:
+                for build in update.builds:
+                    koji.getBuild(build.nvr)
+            results = koji.multiCall()
+            for result, build in zip(results, update.builds):
+                self._raise_on_get_build_multicall_error(result, build)
+                koji_build = result[0]
+                # name:stream:version maps to Koji's name-version-release.
+                ns = "%s:%s" % (koji_build["name"], koji_build["version"])
+                version = koji_build["release"]
                 newest_builds[ns] = version
 
-        return ["%s-%s" % (nstream, v) for nstream, v in six.iteritems(newest_builds)]
+        return ["%s:%s" % (nstream, v) for nstream, v in six.iteritems(newest_builds)]

--- a/bodhi/tests/server/consumers/pungi.basepath/variants.module.xml.j2
+++ b/bodhi/tests/server/consumers/pungi.basepath/variants.module.xml.j2
@@ -1,1 +1,9 @@
-This file doesn't need to have a real Pungi config, it just needs to exist.
+Raw NSVs:
+[%- for module in modules %]
+[[ module ]]
+[%- endfor %]
+
+Calculated NSVCs:
+[%- for module in moduledefs %]
+[[ module.name ]]:[[ module.stream ]]:[[ module.version ]]:[[ module.context ]]
+[% endfor %]

--- a/bodhi/tests/server/consumers/test_masher.py
+++ b/bodhi/tests/server/consumers/test_masher.py
@@ -1185,16 +1185,16 @@ That was the actual one'''
             package = Package(name=u'testmodule',
                               type=ContentType.module)
             db.add(package)
-            build1 = ModuleBuild(nvr=u'testmodule-master-20171',
+            build1 = ModuleBuild(nvr=u'testmodule-master-20171.1',
                                  release=release, signed=True,
                                  package=package)
             db.add(build1)
-            build2 = ModuleBuild(nvr=u'testmodule-master-20172',
+            build2 = ModuleBuild(nvr=u'testmodule-master-20172.2',
                                  release=release, signed=True,
                                  package=package)
             db.add(build2)
             update = Update(
-                title=u'testmodule-master-20172',
+                title=u'testmodule-master-20172.2',
                 builds=[build2], user=user,
                 status=UpdateStatus.testing,
                 request=UpdateRequest.stable,
@@ -1227,6 +1227,20 @@ That was the actual one'''
                                 force=True,
                                 msg=mock.ANY)
 
+        self.assertEqual(t._module_defs, [{'context': '2',
+                                           'version': '20172',
+                                           'name': 'testmodule',
+                                           'stream': 'master'}])
+        self.assertEqual(t._module_list, ['testmodule:master:20172'])
+
+        EXPECTED_VARIANTS = '''Raw NSVs:
+testmodule:master:20172
+
+Calculated NSVCs:
+testmodule:master:20172:2
+'''
+        self.assertEqual(t._variants_file, EXPECTED_VARIANTS)
+
         self.assertEqual(
             Popen.mock_calls,
             [mock.call(
@@ -1255,8 +1269,8 @@ That was the actual one'''
         build = ModuleBuild(nvr=u'testmodule-master-20171',
                             release=release, signed=True,
                             package=package)
-        t = ModuleMasherThread({}, 'puiterwijk', log, self.db_factory,
-                               self.tempdir)
+        t = ModuleComposerThread(self.semmock, {}, 'puiterwijk', log, self.db_factory,
+                                 self.tempdir)
         with self.assertRaises(Exception) as exc:
             t._raise_on_get_build_multicall_error([], build)
 
@@ -1271,8 +1285,8 @@ That was the actual one'''
         build = ModuleBuild(nvr=u'testmodule-master-20171',
                             release=release, signed=True,
                             package=package)
-        t = ModuleMasherThread({}, 'puiterwijk', log, self.db_factory,
-                               self.tempdir)
+        t = ModuleComposerThread(self.semmock, {}, 'puiterwijk', log, self.db_factory,
+                                 self.tempdir)
         with self.assertRaises(Exception) as exc:
             t._raise_on_get_build_multicall_error({}, build)
 

--- a/bodhi/tests/server/consumers/test_masher.py
+++ b/bodhi/tests/server/consumers/test_masher.py
@@ -1185,16 +1185,16 @@ That was the actual one'''
             package = Package(name=u'testmodule',
                               type=ContentType.module)
             db.add(package)
-            build1 = ModuleBuild(nvr=u'testmodule-master-1',
+            build1 = ModuleBuild(nvr=u'testmodule-master-20171',
                                  release=release, signed=True,
                                  package=package)
             db.add(build1)
-            build2 = ModuleBuild(nvr=u'testmodule-master-2',
+            build2 = ModuleBuild(nvr=u'testmodule-master-20172',
                                  release=release, signed=True,
                                  package=package)
             db.add(build2)
             update = Update(
-                title=u'testmodule-master-2',
+                title=u'testmodule-master-20172',
                 builds=[build2], user=user,
                 status=UpdateStatus.testing,
                 request=UpdateRequest.stable,
@@ -1247,6 +1247,38 @@ That was the actual one'''
              'send_stable_announcements': True,
              'send_testing_digest': True,
              'status_comments': True})
+
+    def test_mash_module_koji_multicall_result_empty_list(self):
+        release = self.create_release('27M')
+        package = Package(name=u'testmodule',
+                          type=ContentType.module)
+        build = ModuleBuild(nvr=u'testmodule-master-20171',
+                            release=release, signed=True,
+                            package=package)
+        t = ModuleMasherThread({}, 'puiterwijk', log, self.db_factory,
+                               self.tempdir)
+        with self.assertRaises(Exception) as exc:
+            t._raise_on_get_build_multicall_error([], build)
+
+        self.assertEqual(
+            six.text_type(exc.exception),
+            'Empty list returned for getBuild("%s").' % (build.nvr))
+
+    def test_mash_module_koji_multicall_result_dict(self):
+        release = self.create_release('27M')
+        package = Package(name=u'testmodule',
+                          type=ContentType.module)
+        build = ModuleBuild(nvr=u'testmodule-master-20171',
+                            release=release, signed=True,
+                            package=package)
+        t = ModuleMasherThread({}, 'puiterwijk', log, self.db_factory,
+                               self.tempdir)
+        with self.assertRaises(Exception) as exc:
+            t._raise_on_get_build_multicall_error({}, build)
+
+        self.assertEqual(
+            six.text_type(exc.exception),
+            'Unexpected data returned for getBuild("%s"): {}.' % (build.nvr))
 
     @mock.patch(**mock_failed_taskotron_results)
     @mock.patch('bodhi.server.consumers.masher.PungiComposerThread._sanity_check_repo')


### PR DESCRIPTION

Signed-off-by: Jan Kaluza <jkaluza@redhat.com>