### PR TITLE
Don't downgrade bug status from VERIFIED or CLOSED to ON_QA

### DIFF
--- a/bodhi/server/bugs.py
+++ b/bodhi/server/bugs.py
@@ -165,7 +165,7 @@ class Bugzilla(BugTracker):
 
     def on_qa(self, bug_id, comment):
         """
-        Change the status of this bug to ON_QA.
+        Change the status of this bug to ON_QA if it is not already ON_QA, VERIFIED, or CLOSED.
 
         This will also comment on the bug with some details on how to test and provide feedback for
         this update.
@@ -174,10 +174,13 @@ class Bugzilla(BugTracker):
             bug_id (int): The bug id you wish to set to ON_QA.
             comment (basestring): The comment to be included with the state change.
         """
-        log.debug("Setting Bug #%d to ON_QA" % bug_id)
         try:
             bug = self.bz.getbug(bug_id)
-            bug.setstatus('ON_QA', comment=comment)
+            if bug.bug_status not in ('ON_QA', 'VERIFIED', 'CLOSED'):
+                log.debug("Setting Bug #%d to ON_QA" % bug_id)
+                bug.setstatus('ON_QA', comment=comment)
+            else
+                bug.addcomment(comment)
         except Exception:
             log.exception("Unable to alter bug #%d" % bug_id)
 

--- a/bodhi/server/bugs.py
+++ b/bodhi/server/bugs.py
@@ -179,7 +179,7 @@ class Bugzilla(BugTracker):
             if bug.bug_status not in ('ON_QA', 'VERIFIED', 'CLOSED'):
                 log.debug("Setting Bug #%d to ON_QA" % bug_id)
                 bug.setstatus('ON_QA', comment=comment)
-            else
+            else:
                 bug.addcomment(comment)
         except Exception:
             log.exception("Unable to alter bug #%d" % bug_id)

--- a/bodhi/tests/server/test_bugs.py
+++ b/bodhi/tests/server/test_bugs.py
@@ -282,6 +282,22 @@ class TestBugzilla(unittest.TestCase):
         bz._bz.getbug.return_value.setstatus.assert_called_once_with('ON_QA', comment='A message.')
         self.assertEqual(exception.call_count, 0)
 
+    @mock.patch('bodhi.server.bugs.log.exception')
+    def test_on_qa_skipped(self, exception):
+        """
+        Test the on_qa() method when the bug is already closed - it must not change bug state.
+        """
+        bz = bugs.Bugzilla()
+        bz._bz = mock.MagicMock()
+        bz._bz.getbug.return_value.bug_status = 'CLOSED'
+
+        bz.on_qa(1411188, 'A message.')
+
+        bz._bz.getbug.assert_called_once_with(1411188)
+        bz._bz.getbug.return_value.addcomment.assert_called_once_with('A message.')
+        bz._bz.getbug.return_value.setstatus.assert_not_called()
+        self.assertEqual(exception.call_count, 0)
+
 
 class TestFakeBugTracker(unittest.TestCase):
     """This test class contains tests for the FakeBugTracker class."""

--- a/bodhi/tests/server/test_bugs.py
+++ b/bodhi/tests/server/test_bugs.py
@@ -283,13 +283,48 @@ class TestBugzilla(unittest.TestCase):
         self.assertEqual(exception.call_count, 0)
 
     @mock.patch('bodhi.server.bugs.log.exception')
-    def test_on_qa_skipped(self, exception):
+    def test_on_qa_skipped_because_closed(self, exception):
         """
-        Test the on_qa() method when the bug is already closed - it must not change bug state.
+        Test the on_qa() method when the bug is already CLOSED.
+        It must not change bug state, only post the comment.
         """
         bz = bugs.Bugzilla()
         bz._bz = mock.MagicMock()
         bz._bz.getbug.return_value.bug_status = 'CLOSED'
+
+        bz.on_qa(1411188, 'A message.')
+
+        bz._bz.getbug.assert_called_once_with(1411188)
+        bz._bz.getbug.return_value.addcomment.assert_called_once_with('A message.')
+        bz._bz.getbug.return_value.setstatus.assert_not_called()
+        self.assertEqual(exception.call_count, 0)
+
+    @mock.patch('bodhi.server.bugs.log.exception')
+    def test_on_qa_skipped_because_verified(self, exception):
+        """
+        Test the on_qa() method when the bug is already VERIFIED.
+        It must not change bug state, only post the comment.
+        """
+        bz = bugs.Bugzilla()
+        bz._bz = mock.MagicMock()
+        bz._bz.getbug.return_value.bug_status = 'VERIFIED'
+
+        bz.on_qa(1411188, 'A message.')
+
+        bz._bz.getbug.assert_called_once_with(1411188)
+        bz._bz.getbug.return_value.addcomment.assert_called_once_with('A message.')
+        bz._bz.getbug.return_value.setstatus.assert_not_called()
+        self.assertEqual(exception.call_count, 0)
+
+    @mock.patch('bodhi.server.bugs.log.exception')
+    def test_on_qa_skipped_because_already_set(self, exception):
+        """
+        Test the on_qa() method when the bug is already ON_QA.
+        It must not be set again ON_QA, only post the comment.
+        """
+        bz = bugs.Bugzilla()
+        bz._bz = mock.MagicMock()
+        bz._bz.getbug.return_value.bug_status = 'ON_QA'
 
         bz.on_qa(1411188, 'A message.')
 


### PR DESCRIPTION
Signed-off-by: Mattia Verga <mattia.verga@tiscali.it>
Fixes #1091 #1349 

This patch checks if a bug is already in VERIFIED or CLOSED status and avoids to downgrade it to ON_QA.
Also, if the bug is already in ON_QA it just add a new comment without set again the ON_QA state (for example when an update on multiple Fedora branches is linked to a bug)