### PR TITLE
 Require comments to have text in them

### DIFF
--- a/bodhi/server/models.py
+++ b/bodhi/server/models.py
@@ -2748,6 +2748,9 @@ class Update(Base):
         """
         if not author:
             raise ValueError('You must provide a comment author')
+            
+        if not text:
+            raise ValueError('You must provide text in comment')
 
         caveats = []
 


### PR DESCRIPTION
In response to https://github.com/fedora-infra/bodhi/issues/2009