### PR TITLE
Rename the Compose resource to Composes.

### DIFF
--- a/bodhi/server/services/composes.py
+++ b/bodhi/server/services/composes.py
@@ -29,7 +29,7 @@ from bodhi.server.services import errors
 
 @resource(collection_path='/composes/', path='/composes/{release_name}/{request}',
           description='Compose service', error_handler=errors.html_handler)
-class Compose(object):
+class Composes(object):
     """Defines resources for interacting with Compose objects."""
 
     def __init__(self, request, context=None):

--- a/bodhi/server/templates/composes.html
+++ b/bodhi/server/templates/composes.html
@@ -11,7 +11,7 @@
         <div class="compose-box">
         <div class="compose">
             <h4>
-                <a class="notblue" href="${request.route_url('compose', release_name=compose.release.name, request=compose.request.value)}">${ compose.release.name } ${ compose.request.description }</a>
+                <a class="notblue" href="${request.route_url('composes', release_name=compose.release.name, request=compose.request.value)}">${ compose.release.name } ${ compose.request.description }</a>
                 % if compose.security:
                     <span class="fa fa-shield text-danger" title="This compose contains security updates." data-toggle="tooltip"></span>
                 % endif

--- a/bodhi/server/templates/master.html
+++ b/bodhi/server/templates/master.html
@@ -107,7 +107,7 @@
                             <a class="dropdown-item" href="${request.route_url('masher_status')}">
                               Masher Status
                             </a>
-                            <a class="dropdown-item" href="${request.route_url('collection_compose')}">
+                            <a class="dropdown-item" href="${request.route_url('collection_composes')}">
                               Composes
                             </a>
                             % for state in request.releases:

--- a/bodhi/tests/server/services/test_composes.py
+++ b/bodhi/tests/server/services/test_composes.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017 Red Hat, Inc.
+# Copyright 2017-2018 Red Hat, Inc.
 #
 # This file is part of Bodhi.
 #
@@ -32,9 +32,9 @@ class TestCompose__init__(base.BaseTestCase):
         """Assert the request is stored properly."""
         request = testing.DummyRequest()
 
-        compose = composes.Compose(request)
+        composes_resource = composes.Composes(request)
 
-        self.assertIs(compose.request, request)
+        self.assertIs(composes_resource.request, request)
 
 
 class TestCompose__acl__(base.BaseTestCase):
@@ -42,9 +42,9 @@ class TestCompose__acl__(base.BaseTestCase):
     def test___acl__(self):
         """Assert the permissions are correct."""
         request = testing.DummyRequest()
-        compose = composes.Compose(request)
+        composes_resource = composes.Composes(request)
 
-        acls = compose.__acl__()
+        acls = composes_resource.__acl__()
 
         self.assertEqual(acls, [(security.Allow, security.Everyone, 'view_composes')])
 


### PR DESCRIPTION
It bugged me a bit that the resource was singular rather than
plural, so this commit adjusts it. This should not be noticeable
to users.

Signed-off-by: Randy Barlow <randy@electronsweatshop.com>