### PR TITLE
2169

### DIFF
--- a/bodhi/server/config.py
+++ b/bodhi/server/config.py
@@ -432,7 +432,7 @@ class BodhiConfig(dict):
             'validator': _validate_rstripped_str},
         'waiverdb.access_token': {
             'value': None,
-            'validator': six.text_type},
+            'validator': _validate_none_or(six.text_type)},
         'koji_hub': {
             'value': 'https://koji.stg.fedoraproject.org/kojihub',
             'validator': str},

--- a/bodhi/server/util.py
+++ b/bodhi/server/util.py
@@ -948,6 +948,7 @@ def can_waive_test_results(context, update):
     """
     return (config.get('test_gating.required') and
             not update.test_gating_passed and
+            config.get('waiverdb.access_token') and
             update.status.description != 'stable')
 
 

--- a/bodhi/tests/server/test_util.py
+++ b/bodhi/tests/server/test_util.py
@@ -274,14 +274,27 @@ class TestComposeState2HTML(unittest.TestCase):
 
 class TestCanWaiveTestResults(base.BaseTestCase):
     """Test the can_waive_test_results() function."""
-    @mock.patch.dict('bodhi.server.util.config', {'test_gating.required': True})
+
+    @mock.patch.dict('bodhi.server.util.config',
+                     {'test_gating.required': True, 'waiverdb.access_token': None})
+    def test_access_token_undefined(self):
+        """If Bodhi is not configured with an access token, the result should be False."""
+        u = Update.query.all()[0]
+        u.test_gating_status = TestGatingStatus.failed
+        u.status = models.UpdateStatus.testing
+
+        self.assertFalse(util.can_waive_test_results(None, u))
+
+    @mock.patch.dict('bodhi.server.util.config',
+                     {'test_gating.required': True, 'waiverdb.access_token': 'secret'})
     def test_can_waive_test_results(self):
         u = Update.query.all()[0]
         u.test_gating_status = TestGatingStatus.failed
         u.status = models.UpdateStatus.testing
         self.assertTrue(util.can_waive_test_results(None, u))
 
-    @mock.patch.dict('bodhi.server.util.config', {'test_gating.required': False})
+    @mock.patch.dict('bodhi.server.util.config',
+                     {'test_gating.required': False, 'waiverdb.access_token': 'secret'})
     def test_gating_required_false(self):
         """
         Assert that it should return false if test_gating is not enabled, even if
@@ -292,7 +305,8 @@ class TestCanWaiveTestResults(base.BaseTestCase):
         u.status = models.UpdateStatus.testing
         self.assertFalse(util.can_waive_test_results(None, u))
 
-    @mock.patch.dict('bodhi.server.util.config', {'test_gating.required': True})
+    @mock.patch.dict('bodhi.server.util.config',
+                     {'test_gating.required': True, 'waiverdb.access_token': 'secret'})
     def test_all_tests_passed(self):
         """
         Assert that it should return false if all tests passed, even if
@@ -303,7 +317,8 @@ class TestCanWaiveTestResults(base.BaseTestCase):
         u.status = models.UpdateStatus.testing
         self.assertFalse(util.can_waive_test_results(None, u))
 
-    @mock.patch.dict('bodhi.server.util.config', {'test_gating.required': True})
+    @mock.patch.dict('bodhi.server.util.config',
+                     {'test_gating.required': True, 'waiverdb.access_token': 'secret'})
     def test_update_is_stable(self):
         """
         Assert that it should return false if the update is stable, even if


### PR DESCRIPTION
This PR has two commits because the second depends on the first.

* Fix the default of ```waiverdb.access_token``` to be ```None``` instead of ```"None"```.
* Do not show to waive button if ```waiverdb.access_token``` is undefined.