### PR TITLE
Enable Bodhi to identify containers in Koji.

### DIFF
--- a/bodhi/server/buildsys.py
+++ b/bodhi/server/buildsys.py
@@ -350,6 +350,15 @@ class DevBuildsys(Buildsystem):
                 {'arches': 'x86_64', 'id': 17, 'locked': True,
                  'name': 'f27M'},
             ]
+        elif 'container' in build:
+            result = [
+                {'arches': 'x86_64', 'id': 15, 'locked': True,
+                 'name': 'f28C-updates-candidate'},
+                {'arches': 'x86_64', 'id': 16, 'locked': True,
+                 'name': 'f28C-updates-testing'},
+                {'arches': 'x86_64', 'id': 17, 'locked': True,
+                 'name': 'f28C'},
+            ]
         else:
             release = build.split('.')[-1].replace('fc', 'f')
             result = [

--- a/bodhi/server/models.py
+++ b/bodhi/server/models.py
@@ -556,8 +556,7 @@ class ContentType(DeclEnum):
         if 'module' in extra.get('typeinfo', {}):
             identity = cls.module
         elif 'container_koji_task_id' in extra:
-            # TODO - implement containers as yet another content type someday.
-            raise NotImplementedError("Inferred type 'container' is unhandled.")
+            identity = cls.container
 
         return base.find_polymorphic_child(identity)
 

--- a/bodhi/tests/server/services/test_updates.py
+++ b/bodhi/tests/server/services/test_updates.py
@@ -308,13 +308,33 @@ class TestNewUpdate(base.BaseTestCase):
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
     def test_new_container_update(self, publish, *args):
-        data = self.get_update('mariadb-10.1-10.f25container')
-        r = self.app.post_json('/updates/', data, status=501)
+        self.create_release(u'28C')
+        data = self.get_update('mariadb-10.1-10.f28container')
+
+        r = self.app.post_json('/updates/', data, status=200)
+
         up = r.json_body
-        self.assertEquals(up['status'], 'error')
-        self.assertEquals(up['errors'][1]['description'],
-                          'Unable to infer content_type.  '
-                          '"Inferred type \'container\' is unhandled."')
+        self.assertEquals(up['title'], u'mariadb-10.1-10.f28container')
+        self.assertEquals(up['status'], u'pending')
+        self.assertEquals(up['request'], u'testing')
+        self.assertEquals(up['user']['name'], u'guest')
+        self.assertEquals(up['release']['name'], u'F28C')
+        self.assertEquals(up['type'], u'bugfix')
+        self.assertEquals(up['content_type'], u'container')
+        self.assertEquals(up['severity'], u'unspecified')
+        self.assertEquals(up['suggest'], u'unspecified')
+        self.assertEquals(up['close_bugs'], True)
+        self.assertEquals(up['notes'], u'this is a test update')
+        self.assertIsNotNone(up['date_submitted'])
+        self.assertEquals(up['date_modified'], None)
+        self.assertEquals(up['date_approved'], None)
+        self.assertEquals(up['date_pushed'], None)
+        self.assertEquals(up['locked'], False)
+        self.assertEquals(up['alias'], u'FEDORA-%s-033713b73b' % YEAR)
+        self.assertEquals(up['karma'], 0)
+        self.assertEquals(up['requirements'], 'rpmlint')
+        publish.assert_called_once_with(
+            topic='update.request.testing', msg=mock.ANY)
 
     @mock.patch.dict('bodhi.server.validators.config', {'acl_system': u'dummy'})
     @mock.patch(**mock_valid_requirements)


### PR DESCRIPTION
fixes #2027

Signed-off-by: Randy Barlow <randy@electronsweatshop.com>