### PR TITLE
bodhi-push no longer authenticates to Koji.

### DIFF
--- a/bodhi/server/buildsys.py
+++ b/bodhi/server/buildsys.py
@@ -473,12 +473,13 @@ class DevBuildsys(Buildsystem):
             }
 
 
-def koji_login(config):
+def koji_login(config, authenticate):
     """
     Login to Koji and return the session.
 
     Args:
         config (bodhi.server.config.BodhiConfig): Bodhi's configuration dictionary.
+        authenticate (bool): If True, establish an authenticated client session.
     Returns:
         koji.ClientSession: An authenticated Koji ClientSession that is ready to use.
     """
@@ -492,7 +493,7 @@ def koji_login(config):
     }
 
     koji_client = koji.ClientSession(_koji_hub, koji_options)
-    if not koji_client.krb_login(**get_krb_conf(config)):
+    if authenticate and not koji_client.krb_login(**get_krb_conf(config)):
         log.error('Koji krb_login failed')
     return koji_client
 
@@ -545,12 +546,13 @@ def teardown_buildsystem():
     DevBuildsys.clear()
 
 
-def setup_buildsystem(settings):
+def setup_buildsystem(settings, authenticate=True):
     """
     Initialize the buildsystem client.
 
     Args:
         settings (bodhi.server.config.BodhiConfig): Bodhi's config.
+        authenticate (bool): If True, establish an authenticated Koji session. Defaults to True.
     Raises:
         ValueError: If the buildsystem is configured to an invalid value.
     """
@@ -567,7 +569,7 @@ def setup_buildsystem(settings):
 
         def get_koji_login():
             """Call koji_login with settings and return the result."""
-            return koji_login(config=settings)
+            return koji_login(config=settings, authenticate=authenticate)
 
         _buildsystem = get_koji_login
     elif buildsys in ('dev', 'dummy', None):

--- a/bodhi/tests/server/test_push.py
+++ b/bodhi/tests/server/test_push.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright © 2016-2017 Red Hat, Inc. and others.
+# Copyright © 2016-2018 Red Hat, Inc. and others.
 #
 # This file is part of Bodhi.
 #
@@ -868,3 +868,23 @@ class TestPush(base.BaseTestCase):
         self.assertTrue(python_paste_deploy.date_locked <= datetime.utcnow())
         self.assertEqual(python_paste_deploy.compose.release, python_paste_deploy.release)
         self.assertEqual(python_paste_deploy.compose.request, python_paste_deploy.request)
+
+
+class TetUpdateSigStatus(base.BaseTestCase):
+    """Test the update_sig_status() function."""
+
+    @mock.patch.dict('bodhi.server.push.config',
+                     {'buildsystem': 'koji', 'koji_hub': 'https://example.com/koji'})
+    @mock.patch('bodhi.server.buildsys._buildsystem', None)
+    @mock.patch('bodhi.server.buildsys.koji.ClientSession.krb_login')
+    def test_sets_up_buildsys_without_auth(self, krb_login):
+        """
+        bodhi-push should not set up authentication for the build system.
+
+        https://github.com/fedora-infra/bodhi/issues/2190
+        """
+        u = self.db.query(models.Update).first()
+
+        push.update_sig_status(u)
+
+        self.assertEqual(krb_login.call_count, 0)


### PR DESCRIPTION
Sometimes users run bodhi-push as root. Typically, the backend
fedmsg-hub process is run as the apache user. When users ran
bodhi-push as root, this would cause the Kerberos ticket cache to
become root owned with permissions of 0600, which would prevent
the composer process from authenticating to Koji, causing the
composes to fail.

This commit adjusts the buildsys code to allow callers to request
whether they want an authenticated Koji session or not, and adjusts
bodhi-push to request an unauthenticated session.

fixes #2190

Signed-off-by: Randy Barlow <randy@electronsweatshop.com>