### PR TITLE
Do not archive CI results anymore.

### DIFF
--- a/devel/ci/githubprb-project.yml
+++ b/devel/ci/githubprb-project.yml
@@ -50,8 +50,6 @@
     triggers:
         - githubprb
     publishers:
-        - archive:
-            artifacts: 'test_results/test_results.tar.bz2'
         - junit:
             results: 'test_results/**/nosetests.xml'
     builders:


### PR DESCRIPTION
I originally archived these files because I thought it'd be useful,
but I've never even looked at them so they are a waste of
resources.

Signed-off-by: Randy Barlow <randy@electronsweatshop.com>