### PR TITLE
Remove docs that infer_content_class raises NotImplementedError.

### DIFF
--- a/bodhi/server/models.py
+++ b/bodhi/server/models.py
@@ -546,8 +546,6 @@ class ContentType(DeclEnum):
         Returns:
             BodhiBase: The type-specific child class of base that is appropriate to use with the
             given koji build.
-        Raises:
-            NotImplementedError: If the build is a container.
         """
         # Default value.  Overridden below if we find markers in the build info
         identity = cls.rpm


### PR DESCRIPTION
Bodhi recently gained the ability to identify containers, and when
it did so infer_content_class() no longer would raise
NotImplementedErrors when encountering containers, but at the time
I forgot to remove the statement from the docblock.

Signed-off-by: Randy Barlow <randy@electronsweatshop.com>