### PR TITLE
Clean up some dev artifacts before running CI tests.

### DIFF
--- a/devel/run_tests.sh
+++ b/devel/run_tests.sh
@@ -56,6 +56,10 @@ for r in $RELEASES; do
     fi
     cat $r-packages Dockerfile-footer >> Dockerfile-$r
     echo "COPY . /bodhi" >> Dockerfile-$r
+    echo "RUN find /bodhi -name \"*.pyc\" -delete" >> Dockerfile-$r
+    echo "RUN find /bodhi -name \"*__pycache__\" -delete" >> Dockerfile-$r
+    echo "RUN rm -rf *.egg-info" >> Dockerfile-$r
+    echo "RUN rm -rf .tox" >> Dockerfile-$r
 done
 popd
 


### PR DESCRIPTION
I noticed that if I run the container tests inside the Vagrant
environment, they often fail to build due to various dev artifacts
that get copied into the container. This commit removes some of
those artifacts, so the CI tests can run inside the Vagrant box.

Signed-off-by: Randy Barlow <randy@electronsweatshop.com>