### PR TITLE
Add a -a flag to the ci test runner, which will archive results.

### DIFF
--- a/devel/ci/run_tests.sh
+++ b/devel/ci/run_tests.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/bash -ex
-# Copyright (c) 2017 Red Hat, Inc.
+# Copyright (c) 2017-2018 Red Hat, Inc.
 #
 # This file is part of Bodhi.
 #
@@ -26,4 +26,4 @@ sudo yum install -y bzip2 docker parallel
 
 sudo systemctl start docker
 
-BUILD_PARALLEL="-j 4" ./devel/run_tests.sh
+BUILD_PARALLEL="-j 4" ./devel/run_tests.sh -a


### PR DESCRIPTION
With this patch it is now possible to run the CI tests inside of the Vagrant environment.

Signed-off-by: Randy Barlow <randy@electronsweatshop.com>