### PR TITLE
Use correct N, V, R splitting for module builds and add stream support

### DIFF
--- a/bodhi/server/buildsys.py
+++ b/bodhi/server/buildsys.py
@@ -340,7 +340,7 @@ class DevBuildsys(Buildsystem):
                  'perm': None, 'perm_id': None},
                 {'arches': 'i386 x86_64 ppc ppc64', 'id': 5, 'locked': True,
                  'name': '%s-testing' % release, 'perm': None, 'perm_id': None}]
-        elif '-master-' in build:
+        elif '-master-' in build or build.startswith(('nodejs-6-', 'nodejs-8-', 'nodejs-9-')):
             # Hardcoding for modules in the dev buildsys
             result = [
                 {'arches': 'x86_64', 'id': 15, 'locked': True,

--- a/bodhi/server/consumers/masher.py
+++ b/bodhi/server/consumers/masher.py
@@ -48,8 +48,7 @@ from bodhi.server.exceptions import BodhiException
 from bodhi.server.metadata import UpdateInfoMetadata
 from bodhi.server.models import (Compose, ComposeState, Update, UpdateRequest, UpdateType, Release,
                                  UpdateStatus, ReleaseState, ContentType)
-from bodhi.server.util import (get_nvr, sorted_updates, sanity_check_repodata,
-                               transactional_session_maker)
+from bodhi.server.util import sorted_updates, sanity_check_repodata, transactional_session_maker
 
 
 def checkpoint(method):
@@ -880,11 +879,10 @@ class ContainerComposerThread(ComposerThread):
 
             for build in update.builds:
                 image_name = '{}/{}'.format(build.release.branch, build.package.name)
-                name, version, release = get_nvr(build.nvr)
-                version_release = '{}-{}'.format(version, release)
+                version_release = '{}-{}'.format(build.nvr_version, build.nvr_release)
                 source_url = 'docker://{}/{}:{}'.format(source_registry, image_name,
                                                         version_release)
-                for dtag in [version_release, version, destination_tag]:
+                for dtag in [version_release, build.nvr_version, destination_tag]:
                     destination_url = 'docker://{}/{}:{}'.format(destination_registry, image_name,
                                                                  dtag)
                     skopeo_cmd = [

--- a/bodhi/server/services/updates.py
+++ b/bodhi/server/services/updates.py
@@ -416,8 +416,8 @@ def query_updates(request):
                   colander_body_validator,
                   validate_nvrs,
                   validate_builds,
-                  validate_uniqueness,
                   validate_build_tags,
+                  validate_uniqueness,
                   validate_acls,
                   validate_enums,
                   validate_requirements,
@@ -451,13 +451,7 @@ def new_update(request):
         for nvr in data['builds']:
             name, version, release = request.buildinfo[nvr]['nvr']
 
-            # Figure out what kind of package this should be.
-            # (Note, this can possibly raise a NotImplementedError, but the
-            # error should have been caught earlier in the validator when
-            # inferring the Package type and creating the Package in the validator.)
-            package_class = ContentType.infer_content_class(
-                base=Package, build=request.buildinfo[nvr]['info'])
-            package = request.db.query(package_class).filter_by(name=name).one()
+            package = Package.get_or_create(request.buildinfo[nvr])
 
             # Also figure out the build type and create the build if absent.
             build_class = ContentType.infer_content_class(


### PR DESCRIPTION
This patch adds nvr_name, nvr_version and nvr_release to Build models that will
represent the correct n, v and r components for different build types.
This will also allow multiple builds of different module streams without them
overriding eachother.

Signed-off-by: Patrick Uiterwijk <puiterwijk@redhat.com>