### PR TITLE
[BACKPORT] Use correct N, V, R splitting for module builds and add stream support

### DIFF
--- a/bodhi/server/buildsys.py
+++ b/bodhi/server/buildsys.py
@@ -340,7 +340,7 @@ class DevBuildsys(Buildsystem):
                  'perm': None, 'perm_id': None},
                 {'arches': 'i386 x86_64 ppc ppc64', 'id': 5, 'locked': True,
                  'name': '%s-testing' % release, 'perm': None, 'perm_id': None}]
-        elif '-master-' in build:
+        elif '-master-' in build or build.startswith(('nodejs-6-', 'nodejs-8-', 'nodejs-9-')):
             # Hardcoding for modules in the dev buildsys
             result = [
                 {'arches': 'x86_64', 'id': 15, 'locked': True,

--- a/bodhi/server/models.py
+++ b/bodhi/server/models.py
@@ -48,7 +48,7 @@ from bodhi.server.config import config
 from bodhi.server.exceptions import BodhiException, LockedUpdateException
 from bodhi.server.util import (
     avatar as get_avatar, build_evr, flash_log, get_critpath_components,
-    get_nvr, get_rpm_header, header, packagename_from_nvr, tokenize, pagure_api_get,
+    get_rpm_header, header, tokenize, pagure_api_get,
     greenwave_api_post, waiverdb_api_post)
 import bodhi.server.util
 
@@ -1146,6 +1146,44 @@ class Package(Base):
         del states
         return x
 
+    @staticmethod
+    def _get_name(build):
+        """
+        Determine the package name for a particular build.
+
+        For most builds, this will return the RPM name, unless overridden in a specific
+        subclass.
+
+        Args:
+            build (dict): Information about the build from the build system (koji).
+        Returns:
+            str: The Package object identifier for this build.
+        """
+        name, _, _ = build['nvr']
+        return name
+
+    @staticmethod
+    def get_or_create(build):
+        """
+        Identify and return the Package instance associated with the build.
+
+        For example, given a normal koji build, return a RpmPackage instance.
+        Or, given a container, return a ContainerBuild instance.
+
+        Args:
+            build (dict): Information about the build from the build system (koji).
+        Returns:
+            Package: A type-specific instance of Package for the specific build requested.
+        """
+        base = ContentType.infer_content_class(Package, build['info'])
+        name = base._get_name(build)
+        package = base.query.filter_by(name=name).one_or_none()
+        if not package:
+            package = base(name=name)
+            Session().add(package)
+            Session().flush()
+        return package
+
 
 class ContainerPackage(Package):
     """Represents a Container package."""
@@ -1161,6 +1199,19 @@ class ModulePackage(Package):
     __mapper_args__ = {
         'polymorphic_identity': ContentType.module,
     }
+
+    @staticmethod
+    def _get_name(build):
+        """
+        Determine the name:stream for a particular module build.
+
+        Args:
+            build (dict): Information about the build from the build system (koji).
+        Returns:
+            str: The name:stream of this module build.
+        """
+        name, stream, _ = build['nvr']
+        return '%s:%s' % (name, stream)
 
 
 class RpmPackage(Package):
@@ -1217,6 +1268,68 @@ class Build(Base):
         'polymorphic_on': type,
         'polymorphic_identity': ContentType.base,
     }
+
+    def _get_kojiinfo(self):
+        """
+        Return Koji build info about this build, from a cache if possible.
+
+        Returns:
+            dict: The response from Koji's getBuild() for this Build.
+        """
+        if not hasattr(self, '_kojiinfo'):
+            koji_session = buildsys.get_session()
+            self._kojiinfo = koji_session.getBuild(self.nvr)
+        return self._kojiinfo
+
+    def _get_n_v_r(self):
+        """
+        Return the N, V and R components for a traditionally dash-separated build.
+
+        Returns:
+            tuple: A 3-tuple of name, version, release.
+        """
+        return self.nvr.rsplit('-', 2)
+
+    @property
+    def nvr_name(self):
+        """
+        Return the RPM name.
+
+        Returns:
+            str: The name of the Build.
+        """
+        return self._get_n_v_r()[0]
+
+    @property
+    def nvr_version(self):
+        """
+        Return the RPM version.
+
+        Returns:
+            str: The version of the Build.
+        """
+        return self._get_n_v_r()[1]
+
+    @property
+    def nvr_release(self):
+        """
+        Return the RPM release.
+
+        Returns:
+            str: The release of the Build.
+        """
+        return self._get_n_v_r()[2]
+
+    def get_n_v_r(self):
+        """
+        Return the (name, version, release) of this build.
+
+        Note: This does not directly return the Build's nvr attribute, which is a str.
+
+        Returns:
+            tuple: A 3-tuple representing the name, version and release from the build.
+        """
+        return (self.nvr_name, self.nvr_version, self.nvr_release)
 
     def get_url(self):
         """
@@ -1309,6 +1422,36 @@ class ModuleBuild(Build):
         'polymorphic_identity': ContentType.module,
     }
 
+    @property
+    def nvr_name(self):
+        """
+        Return the ModuleBuild's name.
+
+        Returns:
+            str: The name of the module.
+        """
+        return self._get_kojiinfo()['name']
+
+    @property
+    def nvr_version(self):
+        """
+        Return the the ModuleBuild's stream.
+
+        Returns:
+            str: The stream of the ModuleBuild.
+        """
+        return self._get_kojiinfo()['version']
+
+    @property
+    def nvr_release(self):
+        """
+        Return the ModuleBuild's version and context.
+
+        Returns:
+            str: The version of the ModuleBuild.
+        """
+        return self._get_kojiinfo()['release']
+
 
 class RpmBuild(Build):
     """
@@ -1336,15 +1479,11 @@ class RpmBuild(Build):
         Return:
             tuple: (epoch, version, release)
         """
-        if self.epoch:
-            name, version, release = get_nvr(self.nvr)
-            return (str(self.epoch), version, release)
-        else:
-            koji_session = buildsys.get_session()
-            build = koji_session.getBuild(self.nvr)
-            evr = build_evr(build)
-            self.epoch = int(evr[0])
-            return evr
+        if not self.epoch:
+            self.epoch = self._get_kojiinfo()['epoch']
+            if not self.epoch:
+                self.epoch = 0
+        return (str(self.epoch), str(self.nvr_version), str(self.nvr_release))
 
     def get_latest(self):
         """
@@ -1882,11 +2021,7 @@ class Update(Base):
                                                 "locked update")
 
                 new_builds.append(build)
-                name, version, release = buildinfo[build]['nvr']
-                package = db.query(Package).filter_by(name=name).first()
-                if not package:
-                    package = Package(name=name)
-                    db.add(package)
+                Package.get_or_create(buildinfo[build])
                 b = db.query(Build).filter_by(nvr=build).first()
 
                 up.builds.append(b)
@@ -2045,8 +2180,8 @@ class Update(Base):
                          Update.status == UpdateStatus.pending))
             ).all():
                 obsoletable = False
-                nvr = get_nvr(build.nvr)
-                if rpm.labelCompare(get_nvr(oldBuild.nvr), nvr) < 0:
+                nvr = build.get_n_v_r()
+                if rpm.labelCompare(oldBuild.get_n_v_r(), nvr) < 0:
                     log.debug("%s is newer than %s" % (nvr, oldBuild.nvr))
                     obsoletable = True
 
@@ -2219,11 +2354,11 @@ class Update(Base):
         If the "nvr" parameter is specified it will include name, version and
         release information in package labels.
         """
-        def build_label():
-            return build.nvr if nvr else packagename_from_nvr(self, build.nvr)
+        def build_label(build):
+            return build.nvr if nvr else build.package.name
 
         if len(self.builds) > 2:
-            title = ", ".join([build_label() for build in self.builds[:2]])
+            title = ", ".join([build_label(build) for build in self.builds[:2]])
 
             if amp:
                 title += ", &amp; "
@@ -2233,7 +2368,7 @@ class Update(Base):
             title += " more"
             return title
         else:
-            return " and ".join([build_label() for build in self.builds])
+            return " and ".join([build_label(build) for build in self.builds])
 
     def assign_alias(self):
         """Return a randomly-suffixed update ID.
@@ -3904,7 +4039,7 @@ class Bug(Base):
         # Build a mapping of package names to build versions
         # so that .close() can figure out which build version fixes which bug.
         versions = dict([
-            (get_nvr(b.nvr)[0], b.nvr) for b in update.builds
+            (b.nvr_name, b.nvr) for b in update.builds
         ])
         bugs.bugtracker.close(self.bug_id, versions=versions, comment=self.default_message(update))
 

--- a/bodhi/server/services/updates.py
+++ b/bodhi/server/services/updates.py
@@ -407,8 +407,8 @@ def query_updates(request):
                   colander_body_validator,
                   validate_nvrs,
                   validate_builds,
-                  validate_uniqueness,
                   validate_build_tags,
+                  validate_uniqueness,
                   validate_acls,
                   validate_enums,
                   validate_requirements,
@@ -442,13 +442,7 @@ def new_update(request):
         for nvr in data['builds']:
             name, version, release = request.buildinfo[nvr]['nvr']
 
-            # Figure out what kind of package this should be.
-            # (Note, this can possibly raise a NotImplementedError, but the
-            # error should have been caught earlier in the validator when
-            # inferring the Package type and creating the Package in the validator.)
-            package_class = ContentType.infer_content_class(
-                base=Package, build=request.buildinfo[nvr]['info'])
-            package = request.db.query(package_class).filter_by(name=name).one()
+            package = Package.get_or_create(request.buildinfo[nvr])
 
             # Also figure out the build type and create the build if absent.
             build_class = ContentType.infer_content_class(

--- a/bodhi/server/util.py
+++ b/bodhi/server/util.py
@@ -96,33 +96,6 @@ def get_rpm_header(nvr, tries=0):
     raise ValueError("No rpm headers found in koji for %r" % nvr)
 
 
-def get_nvr(nvr):
-    """
-    Return the (name, version, release) from a given name-ver-rel string.
-
-    Args:
-        nvr (basestring): The name-version-release string that you wish to know the split nvr from.
-    Returns:
-        tuple: A 3-tuple representing the name, version, and release from the given nvr string.
-    """
-    x = list(map(six.text_type, nvr.split('-')))
-    return ('-'.join(x[:-2]), x[-2], x[-1])
-
-
-def packagename_from_nvr(context, nvr):
-    """
-    Extract and return the package name from the given nvr string.
-
-    Args:
-        context (mako.runtime.Context): The current template rendering context. Unused.
-        nvr (basestring): The name-version-release string that you wish to know the name from.
-    Returns:
-        basestring: The name from the nvr string.
-    """
-    x = list(map(six.text_type, nvr.split('-')))
-    return '-'.join(x[:-2])
-
-
 def mkmetadatadir(path):
     """
     Generate package metadata for a given directory.
@@ -962,7 +935,7 @@ def sorted_builds(builds):
         list: A list of Builds sorted by NVR.
     """
     return sorted(builds,
-                  cmp=lambda x, y: rpm.labelCompare(get_nvr(x), get_nvr(y)),
+                  cmp=lambda x, y: rpm.labelCompare(x.get_n_v_r(), y.get_n_v_r()),
                   reverse=True)
 
 
@@ -981,26 +954,22 @@ def sorted_updates(updates):
             with a multicall.
     """
     builds = defaultdict(set)
-    build_to_update = {}
     sync, async = [], []
     for update in updates:
         for build in update.builds:
-            n, v, r = get_nvr(build.nvr)
-            builds[n].add(build.nvr)
-            build_to_update[build.nvr] = update
-    for package in builds:
+            builds[build.nvr_name].add(build)
+    # The sorted here is so we actually have a way to test this
+    # Otherwise, we would be depending on the way Python orders dict keys
+    for package in sorted(builds.keys()):
         if len(builds[package]) > 1:
-            log.info('Found multiple %s packages' % package)
             log.debug(builds[package])
             for build in sorted_builds(builds[package])[::-1]:
-                update = build_to_update[build]
-                if update not in sync:
-                    sync.append(update)
-                if update in async:
-                    async.remove(update)
+                if build.update not in sync:
+                    sync.append(build.update)
+                if build.update in async:
+                    async.remove(build.update)
         else:
-            update = build_to_update[builds[package].pop()]
-            if update not in async and update not in sync:
+            if build.update not in async and build.update not in sync:
                 async.append(update)
     log.info('sync = %s' % ([up.title for up in sync],))
     log.info('async = %s' % ([up.title for up in async],))

--- a/bodhi/server/validators.py
+++ b/bodhi/server/validators.py
@@ -54,7 +54,6 @@ from .models import (
     User,
 )
 from .util import (
-    get_nvr,
     splitter,
     tokenize,
     taskotron_results,
@@ -149,6 +148,67 @@ def validate_csrf_token(node, value):
         raise colander.Invalid(node, csrf_error_message)
 
 
+def cache_tags(request, build):
+    """
+    Cache the tags for a koji build.
+
+    Args:
+        request (pyramid.util.Request): The current request.
+        build (basestring): The NVR of the build to cache.
+    Returns:
+        list or None: The list of tags, or None if there was a failure communicating with koji.
+    """
+    if build in request.buildinfo and 'tags' in request.buildinfo[build]:
+        return request.buildinfo[build]['tags']
+    tags = None
+    try:
+        tags = [tag['name'] for tag in request.koji.listTags(build)]
+        if len(tags) == 0:
+            request.errors.add('body', 'builds',
+                               'Cannot find any tags associated with build: %s' % build)
+    except koji.GenericError:
+        request.errors.add('body', 'builds',
+                           'Invalid koji build: %s' % build)
+    # This might end up setting tags to None. That is expected, and indicates it failed.
+    request.buildinfo[build]['tags'] = tags
+    return tags
+
+
+def cache_release(request, build):
+    """
+    Cache the builds release from the request.
+
+    Args:
+        request (pyramid.util.Request): The current request.
+        build (basestring): The NVR of the build to cache.
+    Returns:
+        Release or None: The release object, or None if no release can be matched to the tags
+            associated with the build.
+    """
+    if build in request.buildinfo and 'release' in request.buildinfo[build]:
+        return request.buildinfo[build]['release']
+    tags = cache_tags(request, build)
+    if tags is None:
+        return None
+    build_rel = None
+    try:
+        build_rel = Release.from_tags(tags, request.db)
+    except KeyError:
+        log.warn('Unable to determine release from '
+                 'tags: %r build: %r' % (tags, build))
+        request.errors.add('body', 'builds',
+                           'Unable to determine release ' +
+                           'from build: %s' % build)
+    if not build_rel:
+        msg = 'Cannot find release associated with ' + \
+            'build: {}, tags: {}'.format(build, tags)
+        log.warn(msg)
+        request.errors.add('body', 'builds', msg)
+    # This might end up setting build_rel to None. That is expected, and indicates it failed.
+    request.buildinfo[build]['release'] = build_rel
+    return build_rel
+
+
 def cache_nvrs(request, build):
     """
     Cache the NVR from the given build on the request, and the koji getBuild() response.
@@ -163,14 +223,13 @@ def cache_nvrs(request, build):
         return
     if build not in request.buildinfo:
         request.buildinfo[build] = {}
-    name, version, release = get_nvr(build)
 
-    if '' in (name, version, release):
-        raise ValueError
-
-    request.buildinfo[build]['nvr'] = name, version, release
-    # Cram some extra information in there, used later to infer type.
-    request.buildinfo[build]['info'] = request.koji.getBuild(build)
+    # Request info from koji, used to split NVR and determine type
+    # We use Koji's information to get the NVR split, because modules can have dashes in their
+    # stream.
+    kbinfo = request.koji.getBuild(build)
+    request.buildinfo[build]['info'] = kbinfo
+    request.buildinfo[build]['nvr'] = kbinfo['name'], kbinfo['version'], kbinfo['release']
 
 
 def validate_nvrs(request, **kwargs):
@@ -265,32 +324,15 @@ def validate_build_tags(request, **kwargs):
 
     for build in request.validated.get('builds', []):
         valid = False
-        try:
-            tags = request.buildinfo[build]['tags'] = [
-                tag['name'] for tag in request.koji.listTags(build)
-            ]
-        except koji.GenericError:
-            request.errors.add('body', 'builds',
-                               'Invalid koji build: %s' % build)
+        tags = cache_tags(request, build)
+        if tags is None:
+            return
+        build_rel = cache_release(request, build)
+        if build_rel is None:
             return
 
         # Disallow adding builds for a different release
         if edited:
-            try:
-                build_rel = Release.from_tags(tags, request.db)
-                if not build_rel:
-                    raise KeyError("Couldn't find release from build tags")
-            except KeyError:
-                if tags:
-                    msg = 'Cannot find release associated with build: ' + \
-                        '{}, tags: {}'.format(build, tags)
-                else:
-                    msg = 'Cannot find any tags associated with build: ' + \
-                        '{}'.format(build)
-                log.warn(msg)
-                request.errors.add('body', 'builds', msg)
-                return
-
             if build_rel is not release:
                 request.errors.add('body', 'builds', 'Cannot add a %s build to an %s update' % (
                     build_rel.name, release.name))
@@ -344,7 +386,6 @@ def validate_acls(request, **kwargs):
         # If you're not logged in, obviously you don't have ACLs.
         request.errors.add('cookies', 'user', 'No ACLs for anonymous user')
         return
-    db = request.db
     user = User.get(request.user.name, request.db)
     committers = []
     watchers = []
@@ -392,7 +433,7 @@ def validate_acls(request, **kwargs):
 
             # Figure out what kind of package this should be
             try:
-                package_class = ContentType.infer_content_class(
+                ContentType.infer_content_class(
                     base=Package, build=buildinfo['info'])
             except Exception as e:
                 error = 'Unable to infer content_type.  %r' % str(e)
@@ -402,33 +443,10 @@ def validate_acls(request, **kwargs):
                     request.errors.status = HTTPNotImplemented.code
                 return
 
-            # Get the Package object
-            package_name = buildinfo['nvr'][0]
-            package = package_class.query.filter_by(name=package_name).first()
-            if not package:
-                log.debug("Adding package %s, type %r",
-                          package_name, package_class)
-                package = package_class(name=package_name)
-                db.add(package)
-                db.flush()
-
-            # Determine the release associated with this build
-            tags = buildinfo.get('tags', [])
-            try:
-                release = Release.from_tags(tags, db)
-            except KeyError:
-                log.warn('Unable to determine release from '
-                         'tags: %r build: %r' % (tags, build))
-                request.errors.add('body', 'builds',
-                                   'Unable to determine release ' +
-                                   'from build: %s' % build)
-                return
-            buildinfo['release'] = release
-            if not release:
-                msg = 'Cannot find release associated with ' + \
-                    'build: {}, tags: {}'.format(build, tags)
-                log.warn(msg)
-                request.errors.add('body', 'builds', msg)
+            # Get the Package and Release objects
+            package = Package.get_or_create(buildinfo)
+            release = cache_release(request, build)
+            if release is None:
                 return
         elif 'update' in request.validated:
             buildinfo = request.buildinfo[build.nvr]
@@ -537,10 +555,14 @@ def validate_uniqueness(request, **kwargs):
     if not builds:  # validate_nvr failed
         return
     for build1 in builds:
-        nvr1 = request.buildinfo[build1]['nvr']
+        rel1 = cache_release(request, build1)
+        if not rel1:
+            return
         seen_build = 0
         for build2 in builds:
-            nvr2 = request.buildinfo[build2]['nvr']
+            rel2 = cache_release(request, build2)
+            if not rel2:
+                return
             if build1 == build2:
                 seen_build += 1
                 if seen_build > 1:
@@ -549,13 +571,13 @@ def validate_uniqueness(request, **kwargs):
                     return
                 continue
 
-            release1 = nvr1[-1].split('.')[-1]
-            release2 = nvr2[-1].split('.')[-1]
+            pkg1 = Package.get_or_create(request.buildinfo[build1])
+            pkg2 = Package.get_or_create(request.buildinfo[build2])
 
-            if nvr1[0] == nvr2[0] and release1 == release2:
+            if pkg1.name == pkg2.name and rel1 == rel2:
                 request.errors.add(
                     'body', 'builds', "Multiple {} builds specified: {} & {}".format(
-                        nvr1[0], build1, build2))
+                        pkg1.name, build1, build2))
                 return
 
 
@@ -1082,15 +1104,11 @@ def _validate_override_build(request, nvr, db):
             request.errors.add('body', 'nvr', 'Invalid build')
             return
 
-        pkgname, version, rel = get_nvr(nvr)
         build_info = request.koji.getBuild(nvr)
-        package_class = ContentType.infer_content_class(
-            base=Package, build=build_info)
-        package = package_class.get(pkgname, db)
-        if not package:
-            package = package_class(name=pkgname)
-            db.add(package)
-            db.flush()
+        package = Package.get_or_create({'nvr': (build_info['name'],
+                                                 build_info['version'],
+                                                 build_info['release']),
+                                         'info': build_info})
 
         build_class = ContentType.infer_content_class(
             base=Build, build=build_info)

--- a/bodhi/tests/server/services/test_updates.py
+++ b/bodhi/tests/server/services/test_updates.py
@@ -304,6 +304,60 @@ class TestNewUpdate(base.BaseTestCase):
         # At the end, ensure that the right kind of package was created.
         self.assertEquals(self.db.query(ModulePackage).count(), 1)
 
+    @mock.patch(**mock_valid_requirements)
+    def test_multiple_builds_of_same_module_stream(self, *args):
+        self.create_release(u'27M')
+
+        res = self.app.post_json('/updates/', self.get_update([u'nodejs-6-20170101',
+                                                               u'nodejs-6-20170202']),
+                                 status=400)
+        assert 'Multiple nodejs:6 builds specified' in res, res
+
+    @mock.patch(**mock_valid_requirements)
+    def test_multiple_builds_of_different_module_stream(self, *args):
+        self.create_release(u'27M')
+
+        res = self.app.post_json('/updates/', self.get_update([u'nodejs-6-20170101',
+                                                               u'nodejs-8-20170202']))
+        res = res.json
+        assert res['request'] == 'testing'
+        assert len(res['builds']) == 2
+        assert res['builds'][0]['type'] == 'module'
+        assert res['builds'][1]['type'] == 'module'
+        assert res['builds'][0]['nvr'] == 'nodejs-6-20170101'
+        assert res['builds'][1]['nvr'] == 'nodejs-8-20170202'
+        assert res['title'] == 'nodejs-6-20170101 nodejs-8-20170202'
+
+        # At the end, ensure that the right kind of packages were created.
+        self.assertEquals(self.db.query(ModulePackage).count(), 2)
+
+    @mock.patch(**mock_valid_requirements)
+    def test_multiple_updates_single_module_steam(self, *args):
+        # Ensure there are no module packages in the DB to begin with.
+        self.assertEquals(self.db.query(ModulePackage).count(), 0)
+        self.create_release(u'27M')
+
+        # First create an update for nodejs:6
+        self.app.post_json('/updates/', self.get_update(u'nodejs-6-20170101'))
+
+        # Next create a second update for nodejs:6
+        self.app.post_json('/updates/', self.get_update(u'nodejs-6-20170202'))
+
+        # At the end, ensure that the right kind of package was created.
+        self.assertEquals(self.db.query(ModulePackage).count(), 1)
+        pkg = self.db.query(ModulePackage).one()
+        assert pkg.name == 'nodejs:6'
+
+        # Assert that one update obsoleted the other
+        updates = self.db.query(Update).all()
+        assert updates[1].title == 'nodejs-6-20170101'
+        assert updates[1].status.name == 'obsolete'
+        assert updates[1].request is None
+
+        assert updates[2].title == 'nodejs-6-20170202'
+        assert updates[2].status.name == 'pending'
+        assert updates[2].request.name == 'testing'
+
     @mock.patch(**mock_uuid4_version1)
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
@@ -312,9 +366,11 @@ class TestNewUpdate(base.BaseTestCase):
         r = self.app.post_json('/updates/', data, status=501)
         up = r.json_body
         self.assertEquals(up['status'], 'error')
-        self.assertEquals(up['errors'][1]['description'],
-                          'Unable to infer content_type.  '
-                          '"Inferred type \'container\' is unhandled."')
+        self.assertEquals(
+            up['errors'][1]['description'],
+            ("Cannot find release associated with build: mariadb-10.1-10.f25container, tags: "
+             "[u'f25container-updates-candidate', u'f25container', "
+             "u'f25container-updates-testing']"))
 
     @mock.patch.dict('bodhi.server.validators.config', {'acl_system': u'dummy'})
     @mock.patch(**mock_valid_requirements)
@@ -662,11 +718,11 @@ class TestUpdatesService(base.BaseTestCase):
         expected_json = {
             u'status': u'error',
             u'errors': [
+                {u'description': u'Unable to determine release from build: bodhi-3.2.0-1.fc27',
+                 u'location': u'body', u'name': u'builds'},
                 {u'description': (
                     u"Cannot find release associated with build: bodhi-3.2.0-1.fc27, "
                     u"tags: [u'f27-updates-candidate', u'f27', u'f27-updates-testing']"),
-                 u'location': u'body', u'name': u'builds'},
-                {u'description': u'Unable to determine release from build: bodhi-3.2.0-1.fc27',
                  u'location': u'body', u'name': u'builds'}]}
         self.assertEqual(res.json, expected_json)
 
@@ -712,10 +768,7 @@ class TestUpdatesService(base.BaseTestCase):
             u'status': u'error',
             u'errors': [
                 {u'description': u'Invalid koji build: bodhi-2.0-1.fc17', u'location': u'body',
-                 u'name': u'builds'},
-                {u'description': (u'Cannot find release associated with build: bodhi-2.0-1.fc17, '
-                                  u'tags: []'),
-                 u'location': u'body', u'name': u'builds'}]}
+                 u'name': u'builds'}]}
         self.assertEqual(res.json, expected_json)
         listTags.assert_called_once_with(update.title)
 

--- a/bodhi/tests/server/test_util.py
+++ b/bodhi/tests/server/test_util.py
@@ -24,7 +24,6 @@ import pkgdb2client
 import six
 
 from bodhi.server import util, models
-from bodhi.server.buildsys import setup_buildsystem, teardown_buildsystem
 from bodhi.server.config import config
 from bodhi.server.models import (ComposeState, TestGatingStatus, Update, UpdateRequest,
                                  UpdateSeverity)
@@ -331,12 +330,6 @@ class TestCanWaiveTestResults(base.BaseTestCase):
 
 
 class TestUtils(base.BaseTestCase):
-
-    def setUp(self):
-        setup_buildsystem({'buildsystem': 'dev'})
-
-    def tearDown(self):
-        teardown_buildsystem()
 
     def test_config(self):
         assert config.get('sqlalchemy.url'), config
@@ -721,14 +714,6 @@ class TestUtils(base.BaseTestCase):
             'status code was "404". The error was "".')
         assert actual_error == expected_error, actual_error
 
-    def test_get_nvr(self):
-        """Assert the correct return value and type from get_nvr()."""
-        result = util.get_nvr(u'ejabberd-16.12-3.fc26')
-
-        assert result == ('ejabberd', '16.12', '3.fc26')
-        for element in result:
-            assert isinstance(element, six.text_type)
-
     @mock.patch('bodhi.server.util.http_session')
     def test_greenwave_api_post(self, session):
         """ Ensure that a POST request to Greenwave works as expected.
@@ -933,12 +918,17 @@ class TestUtils(base.BaseTestCase):
         except Exception:
             pass
 
-    def test_sorted_builds(self):
-        new = 'bodhi-2.0-1.fc24'
-        old = 'bodhi-1.5-4.fc24'
-        b1, b2 = util.sorted_builds([new, old])
-        assert b1 == new, b1
-        assert b2 == old, b2
+    def test_sorted_updates_async_removal(self):
+        u1 = self.create_update(['bodhi-1.0-1.fc24', 'somepkg-2.0-3.fc24'])
+        u2 = self.create_update(['somepkg-1.0-3.fc24'])
+
+        us = [u1, u2]
+        sync, async = util.sorted_updates(us)
+
+        assert len(sync) == 2
+        assert len(async) == 0
+        assert sync[0] == u2
+        assert sync[1] == u1
 
     def test_splitter(self):
         splitlist = util.splitter(["build-0.1", "build-0.2"])


### PR DESCRIPTION
This pull request is a backport of @puiterwijk patch from #2226. It's already been reviewed. I'm using this pull request as a way to run CentOS CI on the backport before merging. Thus, no need for re-review.

This patch adds nvr_name, nvr_version and nvr_release to Build models that will
represent the correct n, v and r components for different build types.
This will also allow multiple builds of different module streams without them
overriding eachother.

Signed-off-by: Patrick Uiterwijk <puiterwijk@redhat.com>