### PR TITLE
[BACKPORT] Fixed Release.version_int for modular releases

### DIFF
--- a/bodhi/server/models.py
+++ b/bodhi/server/models.py
@@ -809,7 +809,7 @@ class Release(Base):
         Returns:
             int: The version of the release.
         """
-        regex = re.compile('\D+(\d+)$')
+        regex = re.compile('\D+(\d+)[M]?$')
         return int(regex.match(self.name).groups()[0])
 
     @property

--- a/bodhi/tests/server/test_models.py
+++ b/bodhi/tests/server/test_models.py
@@ -550,6 +550,36 @@ class TestRelease(ModelTest):
         assert releases is model.Release.all_releases(self.db)
 
 
+class TestReleaseModular(ModelTest):
+    """Unit test case for the ``Release`` model for modular releases."""
+    klass = model.Release
+    attrs = dict(
+        name=u"F11M",
+        long_name=u"Fedora 11 Modular",
+        id_prefix=u"FEDORA-MODULAR",
+        version=u'11',
+        branch=u'f11m',
+        dist_tag=u"dist-f11",
+        stable_tag=u"dist-f11-updates",
+        testing_tag=u"dist-f11-updates-testing",
+        candidate_tag=u"dist-f11-updates-candidate",
+        pending_signing_tag=u"dist-f11-updates-testing-signing",
+        pending_testing_tag=u"dist-f11-updates-testing-pending",
+        pending_stable_tag=u"dist-f11-updates-pending",
+        override_tag=u"dist-f11-override",
+        state=model.ReleaseState.current)
+
+    def test_version_int(self):
+        self.assertEqual(self.obj.version_int, 11)
+
+    def test_all_releases(self):
+        releases = model.Release.all_releases(self.db)
+        state = ReleaseState.from_string(list(releases.keys())[0])
+        assert 'long_name' in releases[state.value][0], releases
+        # Make sure it's the same cached object
+        assert releases is model.Release.all_releases(self.db)
+
+
 class MockWiki(object):
     """ Mocked simplemediawiki.MediaWiki class. """
     def __init__(self, response):


### PR DESCRIPTION
This pull request is a backport of @puiterwijk's patch from #2232. It's already been reviewed. I'm using this pull request as a way to run CentOS CI on the backport before merging. Thus, no need for re-review.

Signed-off-by: Patrick Uiterwijk <puiterwijk@redhat.com>