### PR TITLE
Tests bodhi.server.captcha

### DIFF
--- a/bodhi/server/captcha.py
+++ b/bodhi/server/captcha.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright © 2014-2017 Red Hat, Inc.
+# Copyright © 2014-2018 Red Hat, Inc.
 #
 # This file is part of Bodhi.
 #
@@ -193,10 +193,7 @@ def validate(request, cipherkey, value):
     """
     settings = request.registry.settings
 
-    try:
-        plainkey = decrypt(cipherkey, settings)
-    except cryptography.fernet.InvalidToken:
-        return False
+    plainkey = decrypt(cipherkey, settings)
 
     _, expected_value = math_generator(plainkey=plainkey, settings=settings)
     return value == expected_value

--- a/bodhi/tests/server/test_captcha.py
+++ b/bodhi/tests/server/test_captcha.py
@@ -1,5 +1,8 @@
 # -*- coding: utf-8 -*-
-
+# Copyright © 2016-2018 Red Hat, Inc.
+#
+# This file is part of Bodhi.
+#
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
 # as published by the Free Software Foundation; either version 2
@@ -24,6 +27,51 @@ import six
 
 from bodhi.server import captcha
 from bodhi.server.config import config
+
+
+class TestCaptchaImage(unittest.TestCase):
+    """Test the captcha_image() function."""
+
+    def test_return_type(self):
+        """Assert correct return type."""
+        request = mock.MagicMock()
+        request.registry.settings = {
+            'captcha.secret': 'gFqE6rcBXVLssjLjffsQsAa-nlm5Bg06MTKrVT9hsMA=', 'captcha.ttl': 600,
+            'captcha.image_width': 1920, 'captcha.image_height': 1080,
+            'captcha.font_path': '/usr/share/fonts/liberation/LiberationMono-Bold.ttf',
+            'captcha.font_size': 24, 'captch.font_color': '#012345', 'captcha.padding': 6}
+        # We need to put a captcha onto the request.
+        cipherkey, url = captcha.generate_captcha(None, request)
+        request.matchdict = {'cipherkey': cipherkey}
+
+        image = captcha.captcha_image(request)
+
+        self.assertTrue(isinstance(image, PIL.Image.Image))
+
+    @mock.patch('bodhi.server.captcha.jpeg_generator')
+    def test_jpeg_generator_called_correctly(self, jpeg_generator):
+        """
+        Make sure jpeg_generator() is called correctly.
+
+        We don't have an easy way to make sure the captcha looks right (if we did, it wouldn't be a
+        good captcha and also we shouldn't publish it in unit tests), so let's just make sure
+        jpeg_generator() is called correctly.
+        """
+        request = mock.MagicMock()
+        request.registry.settings = {
+            'captcha.secret': 'gFqE6rcBXVLssjLjffsQsAa-nlm5Bg06MTKrVT9hsMA=', 'captcha.ttl': 600,
+            'captcha.image_width': 1920, 'captcha.image_height': 1080,
+            'captcha.font_path': '/usr/share/fonts/liberation/LiberationMono-Bold.ttf',
+            'captcha.font_size': 24, 'captch.font_color': '#012345', 'captcha.padding': 6}
+        # We need to put a captcha onto the request.
+        cipherkey, url = captcha.generate_captcha(None, request)
+        request.matchdict = {'cipherkey': cipherkey}
+
+        image = captcha.captcha_image(request)
+
+        self.assertEqual(image, jpeg_generator.return_value)
+        plainkey = captcha.decrypt(cipherkey, request.registry.settings)
+        jpeg_generator.assert_called_once_with(plainkey, request.registry.settings)
 
 
 class TestDecrypt(unittest.TestCase):
@@ -55,6 +103,38 @@ class TestDecrypt(unittest.TestCase):
             captcha.decrypt(invalid_token, config)
 
         self.assertEqual(str(exc.exception), 'captcha token is no longer valid')
+
+    @mock.patch.dict(config, {'captcha.secret': 'gFqE6rcBXVLssjLjffsQsAa-nlm5Bg06MTKrVT9hsMA='})
+    def test_text_type_cipherkey(self):
+        """Ensure that decrypt can decrypt what encrypt generated, when it is a six.text_type."""
+        plaintext = "don't let eve see this!"
+        bobs_message = captcha.encrypt(plaintext, config).decode('utf-8')
+
+        result = captcha.decrypt(bobs_message, config)
+
+        self.assertEqual(result, plaintext)
+
+
+class TestGenerateCaptcha(unittest.TestCase):
+    """Test the generate_captcha() function."""
+
+    def test_captcha_can_be_solved(self):
+        """Assert that the generated catpcha can be solved."""
+        request = mock.MagicMock()
+        request.registry.settings = {
+            'captcha.secret': 'gFqE6rcBXVLssjLjffsQsAa-nlm5Bg06MTKrVT9hsMA=', 'captcha.ttl': 600}
+        request.session = {}
+
+        cipherkey, url = captcha.generate_captcha(None, request)
+
+        self.assertEqual(request.session['captcha'], cipherkey)
+        request.route_url.assert_called_once_with('captcha_image', cipherkey=cipherkey)
+        self.assertEqual(url, request.route_url.return_value)
+        # Let's cheat and find out what the correct value for this cipherkey is and make sure it is
+        # accepted by validate().
+        plainkey = captcha.decrypt(cipherkey, request.registry.settings)
+        value = captcha.math_generator(plainkey, request.registry.settings)[1]
+        self.assertTrue(captcha.validate(request, cipherkey, value))
 
 
 class TestJPEGGenerator(unittest.TestCase):
@@ -157,3 +237,25 @@ class TestMathGenerator(unittest.TestCase):
 
         self.assertEqual(puzzle, '42 + 7 =')
         self.assertEqual(value, '49')
+
+
+class TestValidate(unittest.TestCase):
+    """Test the validate() function."""
+
+    def test_match(self):
+        r = mock.MagicMock()
+        r.registry.settings = {'captcha.secret': 'gFqE6rcBXVLssjLjffsQsAa-nlm5Bg06MTKrVT9hsMA=',
+                               'captcha.ttl': 600}
+        plaintext = "41 + 1 ="
+        cipherkey = captcha.encrypt(plaintext, r.registry.settings)
+
+        self.assertIs(captcha.validate(r, cipherkey, '42'), True)
+
+    def test_no_match(self):
+        r = mock.MagicMock()
+        r.registry.settings = {'captcha.secret': 'gFqE6rcBXVLssjLjffsQsAa-nlm5Bg06MTKrVT9hsMA=',
+                               'captcha.ttl': 600}
+        plaintext = "41 + 1 ="
+        cipherkey = captcha.encrypt(plaintext, r.registry.settings)
+
+        self.assertIs(captcha.validate(r, cipherkey, '41'), False)


### PR DESCRIPTION
This pull request gets ```bodhi.server.captcha``` to 100% line test coverage in two commits. The first removes an unreachable error handler (the commit message explains in greater detail), and the second adds tests.