### PR TITLE
Fix loop variable leaking in sorted_updates

### DIFF
--- a/bodhi/server/util.py
+++ b/bodhi/server/util.py
@@ -970,10 +970,18 @@ def sorted_updates(updates):
                 if build.update in async:
                     async.remove(build.update)
         else:
+            build = list(builds[package])[0]
             if build.update not in async and build.update not in sync:
-                async.append(update)
+                async.append(build.update)
     log.info('sync = %s' % ([up.title for up in sync],))
     log.info('async = %s' % ([up.title for up in async],))
+    if not (len(set(sync) & set(async)) == 0 and
+            len(set(sync) | set(async)) == len(updates)):
+        # There should be absolutely no way to hit this code path, but let's be paranoid, and check
+        # every run, to make sure no update gets left behind.
+        # It makes sure that there is no update in sync AND async, and that the combination of
+        # sync OR async is the full set of updates.
+        raise Exception('ERROR! SYNC+ASYNC != UPDATES! sorted_updates failed')  # pragma: no cover
     return sync, async
 
 


### PR DESCRIPTION
The recent N,V,R code introduced a bug in this, where the build and updates variables
were still the build and updates values from the builds population loop.

Signed-off-by: Patrick Uiterwijk <puiterwijk@redhat.com>