### PR TITLE
Refactor the container compose to use a container copy function.

### DIFF
--- a/bodhi/tests/server/consumers/test_masher.py
+++ b/bodhi/tests/server/consumers/test_masher.py
@@ -1891,7 +1891,7 @@ class TestContainerComposerThread__compose_updates(ComposerThreadBaseTestCase):
                      'docker://{}/f28/{}'.format(config['container.source_registry'], source),
                      'docker://{}/f28/{}:{}'.format(config['container.destination_registry'],
                                                     source.split(':')[0], dtag)],
-                    shell=False, stderr=-1, stdout=-1)
+                    shell=False, stderr=-1, stdout=-1, cwd=None)
                 expected_mock_calls.append(mock_call)
                 expected_mock_calls.append(mock.call().communicate())
         self.assertEqual(Popen.mock_calls, expected_mock_calls)
@@ -1919,7 +1919,7 @@ class TestContainerComposerThread__compose_updates(ComposerThreadBaseTestCase):
                      'docker://{}/f28/{}'.format(config['container.source_registry'], source),
                      'docker://{}/f28/{}:{}'.format(config['container.destination_registry'],
                                                     source.split(':')[0], dtag)],
-                    shell=False, stderr=-1, stdout=-1)
+                    shell=False, stderr=-1, stdout=-1, cwd=None)
                 expected_mock_calls.append(mock_call)
                 expected_mock_calls.append(mock.call().communicate())
         self.assertEqual(Popen.mock_calls, expected_mock_calls)
@@ -1945,7 +1945,7 @@ class TestContainerComposerThread__compose_updates(ComposerThreadBaseTestCase):
                 config['container.source_registry']),
             'docker://{}/f28/testcontainer1:2.0.1-71.fc28'.format(
                 config['container.destination_registry'])]
-        Popen.assert_called_once_with(skopeo_cmd, shell=False, stderr=-1, stdout=-1)
+        Popen.assert_called_once_with(skopeo_cmd, shell=False, stderr=-1, stdout=-1, cwd=None)
         self.assertEqual(str(exc.exception),
                          '{} returned a non-0 exit code: 1'.format(' '.join(skopeo_cmd)))
 
@@ -1972,7 +1972,7 @@ class TestContainerComposerThread__compose_updates(ComposerThreadBaseTestCase):
                      'docker://{}/f28/{}'.format(config['container.source_registry'], source),
                      'docker://{}/f28/{}:{}'.format(config['container.destination_registry'],
                                                     source.split(':')[0], dtag)],
-                    shell=False, stderr=-1, stdout=-1)
+                    shell=False, stderr=-1, stdout=-1, cwd=None)
                 expected_mock_calls.append(mock_call)
                 expected_mock_calls.append(mock.call().communicate())
         self.assertEqual(Popen.mock_calls, expected_mock_calls)

--- a/bodhi/tests/server/test_util.py
+++ b/bodhi/tests/server/test_util.py
@@ -1273,10 +1273,14 @@ class TestCMDFunctions(base.BaseTestCase):
         mock_popen_obj.communicate.return_value = ('output', 'error')
         mock_popen_obj.returncode = 1
         util.cmd('/bin/echo', '"home/imgs/catpix"')
-        mock_popen.assert_called_once_with(['/bin/echo'], cwd='"home/imgs/catpix"',
-                                           stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-        mock_error.assert_any_call('error')
-        mock_debug.assert_called_once_with('output')
+        mock_popen.assert_called_once_with(
+            ['/bin/echo'], cwd='"home/imgs/catpix"', stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+            shell=False)
+
+        self.assertEqual(
+            mock_error.mock_calls,
+            [mock.call('/bin/echo returned a non-0 exit code: 1'), mock.call('output\nerror')])
+        mock_debug.assert_called_once_with('Running /bin/echo')
 
     @mock.patch('bodhi.server.log.debug')
     @mock.patch('bodhi.server.log.error')
@@ -1291,10 +1295,13 @@ class TestCMDFunctions(base.BaseTestCase):
         mock_popen_obj.communicate.return_value = ('output', None)
         mock_popen_obj.returncode = 0
         util.cmd('/bin/echo', '"home/imgs/catpix"')
-        mock_popen.assert_called_once_with(['/bin/echo'], cwd='"home/imgs/catpix"',
-                                           stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+
+        mock_popen.assert_called_once_with(
+            ['/bin/echo'], cwd='"home/imgs/catpix"', stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+            shell=False)
         mock_error.assert_not_called()
-        mock_debug.assert_called_once_with('output')
+        self.assertEqual(mock_debug.mock_calls,
+                         [mock.call('Running /bin/echo'), mock.call('output\nNone')])
 
     @mock.patch('bodhi.server.log.debug')
     @mock.patch('bodhi.server.log.error')
@@ -1309,10 +1316,12 @@ class TestCMDFunctions(base.BaseTestCase):
         mock_popen_obj.communicate.return_value = ('output', 'error')
         mock_popen_obj.returncode = 0
         util.cmd('/bin/echo', '"home/imgs/catpix"')
-        mock_popen.assert_called_once_with(['/bin/echo'], cwd='"home/imgs/catpix"',
-                                           stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+
+        mock_popen.assert_called_once_with(
+            ['/bin/echo'], cwd='"home/imgs/catpix"', stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+            shell=False)
         mock_error.assert_not_called()
-        mock_debug.assert_called_with('error')
+        mock_debug.assert_called_with('output\nerror')
 
 
 class TestTransactionalSessionMaker(base.BaseTestCase):

--- a/devel/development.ini.example
+++ b/devel/development.ini.example
@@ -47,7 +47,7 @@ cache.long_term.expire = 3600
 # If you want to test composing containers in development, it can be handy to run your own container
 # registry locally. To do that, you can run a container registry like this:
 # 
-#   $ sudo docker run -it -d -p 5000:5000 --restart=always --name registry registry:2
+#   $ sudo docker run -e REGISTRY_STORAGE_DELETE_ENABLED=true -it -d -p 5000:5000 --restart=always --name registry registry:2
 #
 # The following settings should work with a local container registry as described above:
 container.destination_registry = localhost:5000

--- a/production.ini
+++ b/production.ini
@@ -164,7 +164,7 @@ use = egg:bodhi-server
 # https://github.com/projectatomic/skopeo#private-registries-with-authentication
 # skopeo.cmd = /usr/bin/skopeo
 
-# Extra flags to pass to the skopeo copy command.
+# Comma separated list of extra flags to pass to the skopeo copy command.
 # skopeo.extra_copy_flags =
 
 # Container hostnames. You can specify a port as well, using the traditional syntax (i.e., localhost:5000).


### PR DESCRIPTION
In an effort to re-use the skopeo code between the Buildroot
Override container handler and the composer, this commit creates a
useful common function that can satisfy the needs of both use
cases.

re #2018

Signed-off-by: Randy Barlow <randy@electronsweatshop.com>