### PR TITLE
Add number of days an update is in current state to CLI output.

### DIFF
--- a/bodhi/client/__init__.py
+++ b/bodhi/client/__init__.py
@@ -726,7 +726,7 @@ def print_resp(resp, client, verbose=False):
             click.echo(client.update_str(resp.updates[0]))
         else:
             for update in resp.updates:
-                click.echo(client.update_str(update, minimal=True).strip())
+                click.echo(client.update_str(update, minimal=True))
         if 'total' in resp:
             click.echo('%s updates found (%d shown)' % (
                 resp.total, len(resp.updates)))

--- a/bodhi/client/__init__.py
+++ b/bodhi/client/__init__.py
@@ -379,7 +379,13 @@ def edit(user, password, url, **kwargs):
 @handle_errors
 def query(url, mine=False, **kwargs):
     # User Docs that show in the --help
-    """Query updates on Bodhi."""
+    """Query updates on Bodhi.
+
+    A leading '*' means that this is a 'security' update.
+
+    The number between brackets next to the date indicates the number of days
+    the update is in the current state.
+    """
     # Developer Docs
     """
     Query updates based on flags.

--- a/bodhi/client/bindings.py
+++ b/bodhi/client/bindings.py
@@ -679,7 +679,7 @@ class BodhiClient(OpenIdBaseClient):
                 security, update['builds'][0]['nvr'], update['content_type'],
                 update['status'], date, days_in_status)
             for build in update['builds'][1:]:
-                val += '\n %s' % build['nvr']
+                val += '\n  %s' % build['nvr']
             return val
 
         # Content will be formatted as wrapped lines, each line is in format

--- a/bodhi/client/bindings.py
+++ b/bodhi/client/bindings.py
@@ -653,9 +653,19 @@ class BodhiClient(OpenIdBaseClient):
             val = ""
             date = update['date_pushed'] and update['date_pushed'].split()[0] \
                 or update['date_submitted'].split()[0]
-            val += ' %-37s %-6s %-11s  %-8s  %10s' % (
-                update['builds'][0]['nvr'], update['content_type'], update['type'],
-                update['status'], date)
+            # Calculate number of days in current status
+            # https://github.com/fedora-infra/bodhi/issues/2176
+            # we need to convert string to datetime object to exactly calculate with hours
+            if update['date_pushed']:
+                update_time = datetime.datetime.strptime(update['date_pushed'],
+                                                         '%Y-%m-%d %H:%M:%S')
+            else:
+                update_time = datetime.datetime.strptime(update['date_submitted'],
+                                                         '%Y-%m-%d %H:%M:%S')
+            days_in_status = (datetime.datetime.utcnow() - update_time).days
+            val += ' %-40s %-6s %-3s  %-8s  %10s (%d)' % (
+                update['builds'][0]['nvr'], update['content_type'], update['type'][:3],
+                update['status'], date, days_in_status)
             for build in update['builds'][1:]:
                 val += '\n %s' % build['nvr']
             return val

--- a/bodhi/tests/client/__init__.py
+++ b/bodhi/tests/client/__init__.py
@@ -435,8 +435,8 @@ EXAMPLE_QUERY_MUNCH_MULTI = Munch({
                   u'show_popups': True}}]})
 
 EXAMPLE_QUERY_OUTPUT_MULTI = """\
-nodejs-grunt-wrap-0.3.0-2.fc25           rpm        testing   2017-02-13 (17)
-nodejs-grunt-wrap-0.3.0-2.fc25           rpm        testing   2017-02-13 (17)
+ nodejs-grunt-wrap-0.3.0-2.fc25           rpm        testing   2017-02-13 (17)
+ nodejs-grunt-wrap-0.3.0-2.fc25           rpm        testing   2017-02-13 (17)
 2 updates found (2 shown)
 """
 

--- a/bodhi/tests/client/__init__.py
+++ b/bodhi/tests/client/__init__.py
@@ -435,8 +435,8 @@ EXAMPLE_QUERY_MUNCH_MULTI = Munch({
                   u'show_popups': True}}]})
 
 EXAMPLE_QUERY_OUTPUT_MULTI = """\
-nodejs-grunt-wrap-0.3.0-2.fc25        rpm    newpackage   testing   2017-02-13
-nodejs-grunt-wrap-0.3.0-2.fc25        rpm    newpackage   testing   2017-02-13
+nodejs-grunt-wrap-0.3.0-2.fc25           rpm        testing   2017-02-13 (17)
+nodejs-grunt-wrap-0.3.0-2.fc25           rpm        testing   2017-02-13 (17)
 2 updates found (2 shown)
 """
 

--- a/bodhi/tests/client/test___init__.py
+++ b/bodhi/tests/client/test___init__.py
@@ -512,6 +512,8 @@ class TestQuery(unittest.TestCase):
 
     @mock.patch('bodhi.client.bindings.BodhiClient.csrf',
                 mock.MagicMock(return_value='a_csrf_token'))
+    @mock.patch('bodhi.client.bindings._days_since',
+                mock.MagicMock(return_value=17))
     @mock.patch('bodhi.client.bindings.BodhiClient.send_request',
                 return_value=client_test_data.EXAMPLE_QUERY_MUNCH_MULTI, autospec=True)
     def test_query_multiple_update(self, send_request):

--- a/bodhi/tests/client/test_bindings.py
+++ b/bodhi/tests/client/test_bindings.py
@@ -997,7 +997,41 @@ class TestBodhiClient_update_str(unittest.TestCase):
 
         text = client.update_str(client_test_data.EXAMPLE_UPDATE_MUNCH, minimal=True)
 
-        expected_output = (' bodhi-2.2.4-1.el7                        rpm    bug  stable    '
+        expected_output = (' bodhi-2.2.4-1.el7                        rpm        stable    '
+                           '2016-10-21 (2)')
+        self.assertEqual(text, expected_output)
+
+    @mock.patch.dict(
+        client_test_data.EXAMPLE_UPDATE_MUNCH,
+        {u'date_pushed': u'',
+         u'pushed': False,
+         u'status': u'pending'})
+    @mock.patch('bodhi.client.bindings.datetime.datetime')
+    def test_minimal_not_pushed(self, mock_datetime):
+        """Ensure correct output when minimal is True and not yet pushed."""
+        client = bindings.BodhiClient()
+        mock_datetime.utcnow = mock.Mock(return_value=datetime(2016, 10, 5, 23, 0, 0))
+        mock_datetime.strptime = datetime.strptime
+
+        text = client.update_str(client_test_data.EXAMPLE_UPDATE_MUNCH, minimal=True)
+
+        expected_output = (' bodhi-2.2.4-1.el7                        rpm        pending   '
+                           '2016-10-05 (0)')
+        self.assertEqual(text, expected_output)
+
+    @mock.patch.dict(
+        client_test_data.EXAMPLE_UPDATE_MUNCH,
+        {u'type': u'security'})
+    @mock.patch('bodhi.client.bindings.datetime.datetime')
+    def test_minimal_type_security(self, mock_datetime):
+        """Ensure correct output when minimal is True and type security"""
+        client = bindings.BodhiClient()
+        mock_datetime.utcnow = mock.Mock(return_value=datetime(2016, 10, 24, 12, 0, 0))
+        mock_datetime.strptime = datetime.strptime
+
+        text = client.update_str(client_test_data.EXAMPLE_UPDATE_MUNCH, minimal=True)
+
+        expected_output = ('*bodhi-2.2.4-1.el7                        rpm        stable    '
                            '2016-10-21 (2)')
         self.assertEqual(text, expected_output)
 
@@ -1014,7 +1048,7 @@ class TestBodhiClient_update_str(unittest.TestCase):
 
         text = client.update_str(client_test_data.EXAMPLE_UPDATE_MUNCH, minimal=True)
 
-        expected_output = (' bodhi-2.2.4-1.el7                        rpm    bug  stable    '
+        expected_output = (' bodhi-2.2.4-1.el7                        rpm        stable    '
                            '2016-10-21 (2)\n bodhi-pants-2.2.4-1.el7')
         self.assertEqual(text, expected_output)
 

--- a/bodhi/tests/client/test_bindings.py
+++ b/bodhi/tests/client/test_bindings.py
@@ -988,28 +988,34 @@ class TestBodhiClient_update_str(unittest.TestCase):
             client_test_data.EXPECTED_UPDATE_OUTPUT.replace(
                 '[-3, 3]', '[-3, 3]\n        Bugs: 1234 - it broke\n            : 1235 - halp')))
 
-    def test_minimal(self):
+    @mock.patch('bodhi.client.bindings.datetime.datetime')
+    def test_minimal(self, mock_datetime):
         """Ensure correct output when minimal is True."""
         client = bindings.BodhiClient()
+        mock_datetime.utcnow = mock.Mock(return_value=datetime(2016, 10, 24, 12, 0, 0))
+        mock_datetime.strptime = datetime.strptime
 
         text = client.update_str(client_test_data.EXAMPLE_UPDATE_MUNCH, minimal=True)
 
-        expected_output = (' bodhi-2.2.4-1.el7                     rpm    bugfix       stable    '
-                           '2016-10-21')
+        expected_output = (' bodhi-2.2.4-1.el7                        rpm    bug  stable    '
+                           '2016-10-21 (2)')
         self.assertEqual(text, expected_output)
 
     @mock.patch.dict(
         client_test_data.EXAMPLE_UPDATE_MUNCH,
         {u'builds': [{u'epoch': 0, u'nvr': u'bodhi-2.2.4-1.el7', u'signed': True},
                      {u'epoch': 0, u'nvr': u'bodhi-pants-2.2.4-1.el7', u'signed': True}]})
-    def test_minimal_with_multiple_builds(self):
+    @mock.patch('bodhi.client.bindings.datetime.datetime')
+    def test_minimal_with_multiple_builds(self, mock_datetime):
         """Ensure correct output when minimal is True, and multiple builds"""
         client = bindings.BodhiClient()
+        mock_datetime.utcnow = mock.Mock(return_value=datetime(2016, 10, 24, 12, 0, 0))
+        mock_datetime.strptime = datetime.strptime
 
         text = client.update_str(client_test_data.EXAMPLE_UPDATE_MUNCH, minimal=True)
 
-        expected_output = (u' bodhi-2.2.4-1.el7                     rpm    bugfix       stable    '
-                           '2016-10-21\n bodhi-pants-2.2.4-1.el7')
+        expected_output = (' bodhi-2.2.4-1.el7                        rpm    bug  stable    '
+                           '2016-10-21 (2)\n bodhi-pants-2.2.4-1.el7')
         self.assertEqual(text, expected_output)
 
     @mock.patch.dict(client_test_data.EXAMPLE_UPDATE_MUNCH, {u'request': u'stable'})

--- a/bodhi/tests/client/test_bindings.py
+++ b/bodhi/tests/client/test_bindings.py
@@ -1049,7 +1049,7 @@ class TestBodhiClient_update_str(unittest.TestCase):
         text = client.update_str(client_test_data.EXAMPLE_UPDATE_MUNCH, minimal=True)
 
         expected_output = (' bodhi-2.2.4-1.el7                        rpm        stable    '
-                           '2016-10-21 (2)\n bodhi-pants-2.2.4-1.el7')
+                           '2016-10-21 (2)\n  bodhi-pants-2.2.4-1.el7')
         self.assertEqual(text, expected_output)
 
     @mock.patch.dict(client_test_data.EXAMPLE_UPDATE_MUNCH, {u'request': u'stable'})

--- a/docs/user/man_pages/bodhi.rst
+++ b/docs/user/man_pages/bodhi.rst
@@ -271,7 +271,16 @@ The ``updates`` command allows users to interact with bodhi updates.
 
 ``bodhi updates query [options]``
 
-    Query the bodhi server for updates. The ``query`` subcommand supports the following options:
+    Query the bodhi server for updates.
+    
+    If the query returns only one update, a detailed view of the update will be displayed.
+    
+    If more than one update is returned, the command will display a list showing the packages
+    contained in the update, the update content-type (rpm / module / ...), the current status
+    of the update (pushed / testing / ...) and the date of the last status change with
+    the number of days passed since. A leading ``*`` marks security updates.
+    
+    The ``query`` subcommand supports the following options:
 
     ``--updateid <id>``
 


### PR DESCRIPTION
Fixes #2176

Signed-off-by: Mattia Verga mattia.verga@tiscali.it

To get the necessary space for the new column I've shortened the 'status' column to the first three letters (it now displays "bug", "new" or "sec"). The remaining chars were added to the 'update name' column (it was 37 chars, now it's 40).

Days calculation is done taking into account the time of the update, not just days. So if the update has been pushed to a state in day 1 at 12.00 and we're now in day 2 at 11.59, the CLI will show `(0)`.

To get consistent testing I had to mock `datetime.datetime` module to have `utcnow()` return a specific value. Unfortunately, this had also mocked `strptime()`, so I restored it with `mock_datetime.strptime = datetime.strptime`... it's not very elegant, but I found no other way to mock only `utcnow()`.