### PR TITLE
Include the missing tests in the summary about greenwave's decision

### DIFF
--- a/bodhi/server/models.py
+++ b/bodhi/server/models.py
@@ -1961,6 +1961,12 @@ class Update(Base):
                 self.test_gating_status = TestGatingStatus.passed
         else:
             self.test_gating_status = TestGatingStatus.failed
+            missing_reqs = [
+                req['testcase'] for req in
+                decision.get('unsatisfied_requirements', [])
+            ]
+            if missing_reqs:
+                decision['summary'] += '\n Missing: %s' % (', '.join(missing_reqs))
         self.greenwave_summary_string = decision['summary']
 
     @classmethod

--- a/bodhi/server/templates/update.html
+++ b/bodhi/server/templates/update.html
@@ -1044,6 +1044,12 @@ $(document).ready(function(){
     <div class="tab-pane" id="automatedtests" role="tabpanel">
       <div id="resultsdb">
       <h3>Automated Test Results</h3>
+      <p>
+        Test results and gating status may sometimes conflict as the gating status is retrieved
+        periodically by Bodhi's backend server, while the test results presented here are retrieved
+        upon page load. If your update is marked as gated while all the tests show green/passed, the
+        next check of gating status should open the gate.
+      </p>
       <img class='spinner' src='static/img/spinner.gif'>
       </div>
     </div>

--- a/bodhi/server/util.py
+++ b/bodhi/server/util.py
@@ -549,7 +549,8 @@ def test_gating_status2html(context, status, reason=None):
     html = u'<span class="label label-%s">Tests %s</span>' % (label_class, description)
     from bodhi.server.models import TestGatingStatus
     if status not in [None, TestGatingStatus.ignored, TestGatingStatus.passed] and reason:
-        html += u'<p><a class="gating-summary" href="#automatedtests">%s</a></p>' % reason
+        html += u'<p><a class="gating-summary" href="#automatedtests">%s</a></p>' % (
+                reason.split('\n', 1)[0])
     return html
 
 

--- a/bodhi/tests/server/consumers/test_updates.py
+++ b/bodhi/tests/server/consumers/test_updates.py
@@ -139,7 +139,7 @@ class TestUpdatesHandlerConsume(base.BaseTestCase):
                 'policies_satisfied': False,
                 'summary': u'what have you done‽',
                 'applicable_policies': ['taskotron_release_critical_tasks'],
-                'unsatisfied_requirements': ['some arbitrary test you disagree with']
+                'unsatisfied_requirements': [{'testcase': 'some arbitrary test you disagree with'}]
             }
             mock_greenwave.return_value = greenwave_response
 
@@ -147,7 +147,9 @@ class TestUpdatesHandlerConsume(base.BaseTestCase):
 
         update = models.Update.query.filter_by(title=u'bodhi-2.0-1.fc17').one()
         self.assertEqual(update.test_gating_status, models.TestGatingStatus.failed)
-        self.assertEqual(update.greenwave_summary_string, u'what have you done‽')
+        self.assertEqual(
+            update.greenwave_summary_string,
+            u'what have you done‽\n Missing: some arbitrary test you disagree with')
 
     # We're going to use side effects to mock but still call work_on_bugs and fetch_test_cases so we
     # can ensure that we aren't raising Exceptions from them, while allowing us to only assert that

--- a/bodhi/tests/server/scripts/test_check_policies.py
+++ b/bodhi/tests/server/scripts/test_check_policies.py
@@ -117,7 +117,9 @@ class TestCheckPolicies(BaseTestCase):
             self.assertEqual(result.exit_code, 0)
             update = self.db.query(models.Update).filter(models.Update.id == update.id).one()
             self.assertEqual(update.test_gating_status, models.TestGatingStatus.failed)
-            self.assertEqual(update.greenwave_summary_string, '1 of 2 tests are failed')
+            self.assertEqual(
+                update.greenwave_summary_string,
+                '1 of 2 tests are failed\n Missing: dist.depcheck')
 
         expected_query = {
             'product_version': 'fedora-17', 'decision_context': 'bodhi_update_push_stable',


### PR DESCRIPTION
This will help making it clearer for user what requirements are currently
missing when one or more tests are missing or have failed.

Signed-off-by: Pierre-Yves Chibon <pingou@pingoured.fr>