### PR TITLE
Cornice querystring validator + functional tests

### DIFF
--- a/bodhi/server/services/builds.py
+++ b/bodhi/server/services/builds.py
@@ -20,12 +20,13 @@
 import math
 
 from cornice import Service
+from cornice.validators import colander_querystring_validator
 from pyramid.exceptions import HTTPNotFound
 from sqlalchemy import func, distinct
 from sqlalchemy.sql import or_
 
 from bodhi.server.models import Update, Build, Package, Release
-from bodhi.server.validators import (colander_querystring_validator, validate_updates,
+from bodhi.server.validators import (validate_updates,
                                      validate_packages, validate_releases)
 import bodhi.server.schemas
 import bodhi.server.security

--- a/bodhi/server/services/comments.py
+++ b/bodhi/server/services/comments.py
@@ -21,7 +21,7 @@
 import math
 
 from cornice import Service
-from cornice.validators import colander_body_validator
+from cornice.validators import colander_body_validator, colander_querystring_validator
 from pyramid.httpexceptions import HTTPBadRequest
 from sqlalchemy import func, distinct
 from sqlalchemy.sql import or_
@@ -29,7 +29,6 @@ from sqlalchemy.sql import or_
 from bodhi.server import log
 from bodhi.server.models import Comment, Build, Update
 from bodhi.server.validators import (
-    colander_querystring_validator,
     validate_packages,
     validate_update,
     validate_updates,

--- a/bodhi/server/services/overrides.py
+++ b/bodhi/server/services/overrides.py
@@ -21,7 +21,7 @@
 import math
 
 from cornice import Service
-from cornice.validators import colander_body_validator
+from cornice.validators import colander_body_validator, colander_querystring_validator
 from pyramid.exceptions import HTTPNotFound
 
 from sqlalchemy import func, distinct
@@ -32,7 +32,6 @@ from bodhi.server.models import Build, BuildrootOverride, Package, Release, User
 import bodhi.server.schemas
 import bodhi.server.services.errors
 from bodhi.server.validators import (
-    colander_querystring_validator,
     validate_override_builds,
     validate_expiration_date,
     validate_packages,

--- a/bodhi/server/services/packages.py
+++ b/bodhi/server/services/packages.py
@@ -20,10 +20,10 @@
 import math
 
 from cornice import Service
+from cornice.validators import colander_querystring_validator
 from sqlalchemy import func, distinct
 from sqlalchemy.sql.expression import case
 
-from bodhi.server import validators
 from bodhi.server.models import Package
 import bodhi.server.schemas
 import bodhi.server.security
@@ -38,7 +38,7 @@ packages = Service(name='packages', path='/packages/',
 @packages.get(
     schema=bodhi.server.schemas.ListPackageSchema, renderer='json',
     error_handler=bodhi.server.services.errors.json_handler,
-    validators=(validators.colander_querystring_validator,))
+    validators=(colander_querystring_validator,))
 def query_packages(request):
     """
     Search for packages via query string parameters.

--- a/bodhi/server/services/releases.py
+++ b/bodhi/server/services/releases.py
@@ -21,7 +21,7 @@
 import math
 
 from cornice import Service
-from cornice.validators import colander_body_validator
+from cornice.validators import colander_body_validator, colander_querystring_validator
 from pyramid.exceptions import HTTPNotFound
 from sqlalchemy import func, distinct
 from sqlalchemy.sql import or_
@@ -37,7 +37,6 @@ from bodhi.server.models import (
     Release,
 )
 from bodhi.server.validators import (
-    colander_querystring_validator,
     validate_tags,
     validate_enums,
     validate_updates,

--- a/bodhi/server/services/stacks.py
+++ b/bodhi/server/services/stacks.py
@@ -21,7 +21,7 @@
 import math
 
 from cornice import Service
-from cornice.validators import colander_body_validator
+from cornice.validators import colander_body_validator, colander_querystring_validator
 from pyramid.exceptions import HTTPForbidden
 from pyramid.view import view_config
 from sqlalchemy import func, distinct
@@ -31,7 +31,7 @@ from bodhi.server import log, notifications, security
 from bodhi.server.config import config
 from bodhi.server.models import Package, Stack, Group, User
 from bodhi.server.util import tokenize
-from bodhi.server.validators import (colander_querystring_validator, validate_packages,
+from bodhi.server.validators import (validate_packages,
                                      validate_stack, validate_requirements)
 import bodhi.server.schemas
 import bodhi.server.services.errors

--- a/bodhi/server/services/updates.py
+++ b/bodhi/server/services/updates.py
@@ -22,7 +22,7 @@ import copy
 import math
 
 from cornice import Service
-from cornice.validators import colander_body_validator
+from cornice.validators import colander_body_validator, colander_querystring_validator
 from sqlalchemy import func, distinct
 from sqlalchemy.sql import or_
 
@@ -43,7 +43,6 @@ import bodhi.server.schemas
 import bodhi.server.services.errors
 import bodhi.server.util
 from bodhi.server.validators import (
-    colander_querystring_validator,
     validate_nvrs,
     validate_uniqueness,
     validate_build_tags,

--- a/bodhi/server/services/user.py
+++ b/bodhi/server/services/user.py
@@ -20,12 +20,13 @@
 import math
 
 from cornice import Service
+from cornice.validators import colander_querystring_validator
 from pyramid.exceptions import HTTPNotFound
 from sqlalchemy import func, distinct
 from sqlalchemy.sql import or_
 
 from bodhi.server.models import Group, Package, Update, User
-from bodhi.server.validators import (colander_querystring_validator, validate_updates,
+from bodhi.server.validators import (validate_updates,
                                      validate_packages, validate_groups)
 import bodhi.server.schemas
 import bodhi.server.security

--- a/bodhi/tests/server/functional/test_packages.py
+++ b/bodhi/tests/server/functional/test_packages.py
@@ -13,11 +13,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
-
-import unittest
-
-import six
-
 from bodhi.server.models import (
     RpmPackage,
 )
@@ -25,7 +20,6 @@ from bodhi.tests.server import base
 
 
 class TestRpmPackagesService(base.BaseTestCase):
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_basic_json(self):
         """ Test querying with no arguments... """
         self.db.add(RpmPackage(name=u'a_second_package'))
@@ -34,7 +28,6 @@ class TestRpmPackagesService(base.BaseTestCase):
         body = resp.json_body
         self.assertEquals(len(body['packages']), 2)
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_filter_by_name(self):
         """ Test that filtering by name returns one package and not the other.
         """
@@ -44,7 +37,6 @@ class TestRpmPackagesService(base.BaseTestCase):
         body = resp.json_body
         self.assertEquals(len(body['packages']), 1)
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_filter_by_like(self):
         """ Test that filtering by like returns one package and not the other.
         """
@@ -54,7 +46,6 @@ class TestRpmPackagesService(base.BaseTestCase):
         body = resp.json_body
         self.assertEquals(len(body['packages']), 1)
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_filter_by_search(self):
         """ Test filtering by search
         """


### PR DESCRIPTION
There was a bug in previous query string validator which causes that default value for some params was None in Python 3. I tried to fix it but then I found a comment about PR in cornice project with query string validator change so I decided to switch to that version and now it works with both Pythons.