### PR TITLE
Force Compose.from_updates() to return a list.

### DIFF
--- a/bodhi/server/models.py
+++ b/bodhi/server/models.py
@@ -3715,7 +3715,9 @@ class Compose(Base):
             # relationship joins on the Compose's compound pk for locked Updates.
             update.locked = True
 
-        return work.values()
+        # We cast to a list here because a dictionary's values() method does not return a list in
+        # Python 3 and the docblock states that a list is returned.
+        return list(work.values())
 
     @property
     def security(self):

--- a/bodhi/tests/server/test_models.py
+++ b/bodhi/tests/server/test_models.py
@@ -481,6 +481,7 @@ class TestCompose(BaseTestCase):
 
         composes = model.Compose.from_updates([update_1, update_2, update_3, update_4])
 
+        self.assertTrue(isinstance(composes, list))
         for c in composes:
             self.db.add(c)
             self.db.flush()


### PR DESCRIPTION
In Python 3, dict.values() returns a dict_values object instead of
a list, but from_updates() documents that it returns a list. This
commit converts the return value into a list so that we have
consistency with the documented API.

Signed-off-by: Randy Barlow <randy@electronsweatshop.com>