### PR TITLE
[BACKPORT] 3.6 backports

### DIFF
--- a/bodhi/server/templates/update.html
+++ b/bodhi/server/templates/update.html
@@ -511,7 +511,7 @@ $(document).ready(function(){
   <div class="col-md-12">
     <h1>
       % if update.locked and update.date_locked:
-          <a href="${request.route_url('compose', release_name=update.compose.release.name, request=update.compose.request.value)}">
+          <a href="${request.route_url('composes', release_name=update.compose.release.name, request=update.compose.request.value)}">
           <span class="fa fa-fw fa-lock text-muted" aria-hidden="true" data-toggle="tooltip" title="This update is currently locked since ${(update.date_locked).strftime('%Y-%m-%d %H:%M:%S')} (UTC) and cannot be modified.">
           </span>
           </a>

--- a/bodhi/server/util.py
+++ b/bodhi/server/util.py
@@ -341,16 +341,19 @@ def avatar(context, username, size):
     https = request.registry.settings.get('prefer_ssl')
 
     @request.cache.cache_on_arguments()
+    def get_libravatar_url(openid, https, size):
+        return libravatar.libravatar_url(
+            openid=openid,
+            https=https,
+            size=size,
+            default='retro',
+        )
+
     def work(username, size):
         openid = "http://%s.id.fedoraproject.org/" % username
         if config.get('libravatar_enabled'):
             if config.get('libravatar_dns'):
-                return libravatar.libravatar_url(
-                    openid=openid,
-                    https=https,
-                    size=size,
-                    default='retro',
-                )
+                return get_libravatar_url(openid, https, size)
             else:
                 query = urlencode({'s': size, 'd': 'retro'})
                 hash = hashlib.sha256(openid.encode('utf-8')).hexdigest()

--- a/devel/ansible/roles/dev/tasks/main.yml
+++ b/devel/ansible/roles/dev/tasks/main.yml
@@ -96,11 +96,11 @@
 # cornice > 1 won't be available until Fedora 28 is released.
 - name: pip install cornice
   pip:
-      name: cornice
+      name: cornice<3.2.0
 
 - name: pip install cornice for Python 3
   pip:
-      name: cornice
+      name: cornice<3.2.0
       executable: pip3
 
 # cornice_sphinx is not packaged in Fedora yet, but won't be available until Fedora 28 is released.

--- a/devel/ci/Dockerfile-header
+++ b/devel/ci/Dockerfile-header
@@ -7,7 +7,7 @@ RUN dnf upgrade -y libsolv || echo "We are not trying to test dnf upgrade, so ig
 # The echo works around https://bugzilla.redhat.com/show_bug.cgi?id=1483553 and any other future dnf
 # upgrade bugs.
 RUN dnf upgrade -y || echo "We are not trying to test dnf upgrade, so ignoring dnf failure."
-RUN dnf install -y \
+RUN dnf install --disablerepo rawhide-modular -y \
     git \
     liberation-mono-fonts \
     packagedb-cli \

--- a/devel/ci/f26-packages
+++ b/devel/ci/f26-packages
@@ -8,8 +8,8 @@
     python-simplemediawiki \
     python-webtest
 
-RUN pip-2 install cornice
+RUN pip-2 install cornice\<3.2.0
 RUN pip-2 install -e git+https://github.com/Cornices/cornice.ext.sphinx.git@master#egg=cornice_sphinx
-RUN pip-3 install cornice
+RUN pip-3 install cornice\<3.2.0
 RUN pip-3 install -e git+https://github.com/Cornices/cornice.ext.sphinx.git@master#egg=cornice_sphinx
 RUN pip-3 install pyramid-fas-openid

--- a/devel/ci/f27-packages
+++ b/devel/ci/f27-packages
@@ -8,8 +8,8 @@
     python-simplemediawiki \
     python-webtest
 
-RUN pip-2 install cornice
+RUN pip-2 install cornice\<3.2.0
 RUN pip-2 install -e git+https://github.com/Cornices/cornice.ext.sphinx.git@master#egg=cornice_sphinx
-RUN pip-3 install cornice
+RUN pip-3 install cornice\<3.2.0
 RUN pip-3 install -e git+https://github.com/Cornices/cornice.ext.sphinx.git@master#egg=cornice_sphinx
 RUN pip-3 install pyramid-fas-openid

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ arrow
 bleach
 click
 colander
-cornice>=3
+cornice>=3,<3.2.0
 cryptography
 dogpile.cache
 fedmsg[consumers]


### PR DESCRIPTION
This PR exists to run CI tests against two commits we are cherry picking back to the 3.6 branch.

These patches were already reviewed in #2288 and #2289.