### PR TITLE
Modify bodhi.server.models.BodhiBase.get() to not require db.

### DIFF
--- a/bodhi/server/__init__.py
+++ b/bodhi/server/__init__.py
@@ -135,7 +135,7 @@ def groupfinder(userid, request):
     """
     from bodhi.server.models import User
     if request.user:
-        user = User.get(request.user.name, request.db)
+        user = User.get(request.user.name)
         return ['group:' + group.name for group in user.groups]
 
 

--- a/bodhi/server/consumers/signed.py
+++ b/bodhi/server/consumers/signed.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright © 2016-2017 Red Hat, Inc.
+# Copyright © 2016-2018 Red Hat, Inc.
 #
 # This file is part of Bodhi.
 #
@@ -108,8 +108,8 @@ class SignedHandler(fedmsg.consumers.FedmsgConsumer):
 
         log.info("%s tagged into %s" % (build_nvr, tag))
 
-        with self.db_factory() as session:
-            build = Build.get(build_nvr, session)
+        with self.db_factory():
+            build = Build.get(build_nvr)
             if not build:
                 log.info("Build was not submitted, skipping")
                 return

--- a/bodhi/server/consumers/updates.py
+++ b/bodhi/server/consumers/updates.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2015-2017 Red Hat Inc., and others.
+# Copyright 2015-2018 Red Hat Inc., and others.
 #
 # This file is part of Bodhi.
 #
@@ -118,12 +118,12 @@ class UpdatesHandler(fedmsg.consumers.FedmsgConsumer):
             return
 
         with self.db_factory() as session:
-            update = Update.get(alias, session)
+            update = Update.get(alias)
             if not update:
                 raise BodhiException("Couldn't find alias '%s' in DB" % alias)
 
             if topic.endswith('update.edit'):
-                bugs = [Bug.get(idx, session) for idx in msg['new_bugs']]
+                bugs = [Bug.get(idx) for idx in msg['new_bugs']]
                 # Sanity check
                 for bug in bugs:
                     assert bug in update.bugs
@@ -137,7 +137,7 @@ class UpdatesHandler(fedmsg.consumers.FedmsgConsumer):
 
         if config['test_gating.required']:
             with self.db_factory() as session:
-                update = Update.get(alias, session)
+                update = Update.get(alias)
                 update.update_test_gating_status()
 
         log.info("Updates Handler done with %s, %s" % (alias, topic))

--- a/bodhi/server/models.py
+++ b/bodhi/server/models.py
@@ -300,18 +300,17 @@ class BodhiBase(object):
     query = Session.query_property()
 
     @classmethod
-    def get(cls, id, db):
+    def get(cls, id):
         """
         Return an instance of the model by using its __get_by__ attribute with id.
 
         Args:
             id (object): An attribute to look up the model by.
-            db (sqlalchemy.orm.session.Session): A database session.
         Returns:
             BodhiBase or None: An instance of the model that matches the id, or ``None`` if no match
             was found.
         """
-        return db.query(cls).filter(or_(
+        return cls.query.filter(or_(
             getattr(cls, col) == id for col in cls.__get_by__
         )).first()
 
@@ -523,7 +522,7 @@ class BodhiBase(object):
         new, same, removed = [], copy.copy(items), []
         if items:
             for item in items:
-                obj = model.get(item, db)
+                obj = model.get(item)
                 if not obj:
                     obj = model(name=item)
                     db.add(obj)
@@ -1973,7 +1972,7 @@ class Update(Base):
             tuple: A 2-tuple of the edited update and a list of dictionaries that describe caveats.
         """
         db = request.db
-        user = User.get(request.user.name, request.db)
+        user = User.get(request.user.name)
         data['user'] = user
         data['title'] = ' '.join([b.nvr for b in data['builds']])
         caveats = []
@@ -2866,7 +2865,7 @@ class Update(Base):
 
         new = []
         for bug_id in bug_ids:
-            bug = Bug.get(int(bug_id), session)
+            bug = Bug.get(int(bug_id))
             if not bug:
                 bug = Bug(bug_id=int(bug_id))
                 session.add(bug)
@@ -4338,7 +4337,7 @@ class BuildrootOverride(Base):
         db = request.db
 
         edited = data.pop('edited')
-        override = cls.get(edited.id, db)
+        override = cls.get(edited.id)
 
         if override is None:
             request.errors.add('body', 'edited',

--- a/bodhi/server/services/builds.py
+++ b/bodhi/server/services/builds.py
@@ -52,7 +52,7 @@ def get_build(request):
             Build with the given NVR.
     """
     nvr = request.matchdict.get('nvr')
-    build = Build.get(nvr, request.db)
+    build = Build.get(nvr)
     if not build:
         request.errors.add('body', 'nvr', 'No such build')
         request.errors.status = HTTPNotFound.code

--- a/bodhi/server/services/overrides.py
+++ b/bodhi/server/services/overrides.py
@@ -73,10 +73,9 @@ def get_override(request):
     Returns:
         dict: A dictionary with key "override" that indexes the override matching the given nvr.
     """
-    db = request.db
     nvr = request.matchdict.get('nvr')
 
-    build = Build.get(nvr, db)
+    build = Build.get(nvr)
 
     if not build:
         request.errors.add('url', 'nvr', 'No such build')
@@ -247,7 +246,7 @@ def save_override(request):
 
     caveats = []
     try:
-        submitter = User.get(request.user.name, request.db)
+        submitter = User.get(request.user.name)
         if edited is None:
             builds = data['builds']
             overrides = []
@@ -259,7 +258,7 @@ def save_override(request):
                 })
             for build in builds:
                 log.info("Creating a new buildroot override: %s" % build.nvr)
-                if BuildrootOverride.get(build.id, request.db):
+                if BuildrootOverride.get(build.id):
                     request.errors.add('body', 'builds',
                                        'Buildroot override for %s already exists' % build.nvr)
                     return
@@ -279,7 +278,7 @@ def save_override(request):
         else:
             log.info("Editing buildroot override: %s" % edited)
 
-            edited = Build.get(edited, request.db)
+            edited = Build.get(edited)
 
             if edited is None:
                 request.errors.add('body', 'edited', 'No such build')

--- a/bodhi/server/services/releases.py
+++ b/bodhi/server/services/releases.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright © 2014-2017 Red Hat Inc., and others.
+# Copyright © 2014-2018 Red Hat Inc., and others.
 #
 # This file is part of Bodhi.
 #
@@ -71,7 +71,7 @@ def get_release_html(request):
         basestring: An HTML representation of the reqeusted Release.
     """
     id = request.matchdict.get('name')
-    release = Release.get(id, request.db)
+    release = Release.get(id)
     if not release:
         request.errors.add('body', 'name', 'No such release')
         request.errors.status = HTTPNotFound.code
@@ -178,7 +178,7 @@ def get_release_json(request):
         bodhi.server.models.Release: The matched Release.
     """
     id = request.matchdict.get('name')
-    release = Release.get(id, request.db)
+    release = Release.get(id)
     if not release:
         request.errors.add('body', 'name', 'No such release')
         request.errors.status = HTTPNotFound.code

--- a/bodhi/server/services/stacks.py
+++ b/bodhi/server/services/stacks.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright © 2014-2017 Red Hat, Inc.
+# Copyright © 2014-2018 Red Hat, Inc.
 #
 # This file is part of Bodhi.
 #
@@ -140,10 +140,10 @@ def save_stack(request):
     """
     data = request.validated
     db = request.db
-    user = User.get(request.user.name, db)
+    user = User.get(request.user.name)
 
     # Fetch or create the stack
-    stack = Stack.get(data['name'], db)
+    stack = Stack.get(data['name'])
     if not stack:
         stack = Stack(name=data['name'], users=[user])
         db.add(stack)
@@ -192,7 +192,7 @@ def save_stack(request):
         additional = list(tokenize(stack.requirements))
 
         for name in new:
-            package = Package.get(name, db)
+            package = Package.get(name)
             original = package.requirements
             original = [] if not original else list(tokenize(original))
             package.requirements = " ".join(list(set(original + additional)))

--- a/bodhi/server/services/updates.py
+++ b/bodhi/server/services/updates.py
@@ -456,7 +456,7 @@ def new_update(request):
             # Also figure out the build type and create the build if absent.
             build_class = ContentType.infer_content_class(
                 base=Build, build=request.buildinfo[nvr]['info'])
-            build = build_class.get(nvr, request.db)
+            build = build_class.get(nvr)
 
             if build is None:
                 log.debug("Adding nvr %s, type %r", nvr, build_class)
@@ -483,7 +483,7 @@ def new_update(request):
         for nvr in data['builds']:
             # At this moment, we are sure the builds are in the database (that is what the commit
             # was for actually).
-            build = Build.get(nvr, request.db)
+            build = Build.get(nvr)
             builds.append(build)
             releases.add(build.release)
 

--- a/bodhi/server/services/user.py
+++ b/bodhi/server/services/user.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2014-2017 Red Hat, Inc. and others
+# Copyright 2014-2018 Red Hat, Inc. and others
 #
 # This file is part of Bodhi.
 #
@@ -65,7 +65,7 @@ def get_user(request):
             user.
     """
     id = request.matchdict.get('name')
-    user = User.get(id, request.db)
+    user = User.get(id)
 
     if not user:
         request.errors.add('body', 'name', 'No such user')

--- a/bodhi/server/validators.py
+++ b/bodhi/server/validators.py
@@ -269,7 +269,7 @@ def validate_builds(request, **kwargs):
         kwargs (dict): The kwargs of the related service definition. Unused.
     """
     edited = request.validated.get('edited')
-    user = User.get(request.user.name, request.db)
+    user = User.get(request.user.name)
 
     if not request.validated.get('builds', []):
         request.errors.add('body', 'builds', "You may not specify an empty list of builds.")
@@ -396,7 +396,7 @@ def validate_acls(request, **kwargs):
         # If you're not logged in, obviously you don't have ACLs.
         request.errors.add('cookies', 'user', 'No ACLs for anonymous user')
         return
-    user = User.get(request.user.name, request.db)
+    user = User.get(request.user.name)
     committers = []
     watchers = []
     groups = []
@@ -623,12 +623,11 @@ def validate_packages(request, **kwargs):
     if packages is None:
         return
 
-    db = request.db
     bad_packages = []
     validated_packages = []
 
     for p in packages:
-        package = Package.get(p, db)
+        package = Package.get(p)
 
         if not package:
             bad_packages.append(p)
@@ -795,7 +794,7 @@ def validate_update(request, **kwargs):
         kwargs (dict): The kwargs of the related service definition. Unused.
     """
     idx = request.validated.get('update')
-    update = Update.get(idx, request.db)
+    update = Update.get(idx)
 
     if update:
         request.validated['update'] = update
@@ -869,11 +868,11 @@ def validate_update_id(request, **kwargs):
         request (pyramid.util.Request): The current request.
         kwargs (dict): The kwargs of the related service definition. Unused.
     """
-    update = Update.get(request.matchdict['id'], request.db)
+    update = Update.get(request.matchdict['id'])
     if update:
         request.validated['update'] = update
     else:
-        package = Package.get(request.matchdict['id'], request.db)
+        package = Package.get(request.matchdict['id'])
         if package:
             query = dict(packages=package.name)
             location = request.route_url('updates', _query=query)
@@ -893,7 +892,7 @@ def _conditionally_get_update(request):
     # responsibility to put the update object back in the request.validated
     # dict.  Note, for speed purposes, sqlalchemy should cache this for us.
     if not isinstance(update, Update) and update is not None:
-        update = Update.get(update, request.db)
+        update = Update.get(update)
 
     return update
 
@@ -963,7 +962,7 @@ def validate_testcase_feedback(request, **kwargs):
     # responsibility to put the update object back in the request.validated
     # dict.  Note, for speed purposes, sqlalchemy should cache this for us.
     if not isinstance(update, Update):
-        update = Update.get(update, request.db)
+        update = Update.get(update)
         if not update:
             request.errors.add('url', 'id', 'Invalid update')
             request.errors.status = HTTPNotFound.code
@@ -1010,7 +1009,7 @@ def validate_comment_id(request, **kwargs):
         request.errors.status = HTTPBadRequest.code
         return
 
-    comment = Comment.get(request.matchdict['id'], request.db)
+    comment = Comment.get(request.matchdict['id'])
 
     if comment:
         request.validated['comment'] = comment
@@ -1062,7 +1061,7 @@ def _validate_override_build(request, nvr, db):
     Returns:
         bodhi.server.models.Build: A build that matches the given nvr.
     """
-    build = Build.get(nvr, db)
+    build = Build.get(nvr)
     if build is not None:
         if not build.release:
             # Oddly, the build has no associated release.  Let's try to figure
@@ -1219,7 +1218,7 @@ def validate_stack(request, **kwargs):
         kwargs (dict): The kwargs of the related service definition. Unused.
     """
     name = request.matchdict.get('name')
-    stack = Stack.get(name, request.db)
+    stack = Stack.get(name)
     if stack:
         request.validated['stack'] = stack
     else:

--- a/bodhi/server/views/generic.py
+++ b/bodhi/server/views/generic.py
@@ -160,7 +160,7 @@ def get_update_counts(releaseid):
     Returns:
         dict: A dictionary expressing the counts, as described above.
     """
-    release = models.Release.get(releaseid, models.Session())
+    release = models.Release.get(releaseid)
     basequery = models.Update.query.filter(models.Update.release == release)
     counts = {}
     counts.update(_get_status_counts(basequery, models.UpdateStatus.pending))

--- a/bodhi/tests/server/services/test_overrides.py
+++ b/bodhi/tests/server/services/test_overrides.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright © 2014-2017 Red Hat, Inc. and others.
+# Copyright © 2014-2018 Red Hat, Inc. and others.
 #
 # This file is part of Bodhi.
 #
@@ -268,7 +268,7 @@ class TestOverridesService(base.BaseTestCase):
     @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch('bodhi.server.notifications.publish')
     def test_create_override(self, publish):
-        release = Release.get(u'F17', self.db)
+        release = Release.get(u'F17')
 
         package = RpmPackage(name=u'not-bodhi')
         self.db.add(package)
@@ -297,7 +297,7 @@ class TestOverridesService(base.BaseTestCase):
     @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch('bodhi.server.notifications.publish')
     def test_create_duplicate_override(self, publish):
-        release = Release.get(u'F17', self.db)
+        release = Release.get(u'F17')
         package = RpmPackage(name=u'not-bodhi')
         self.db.add(package)
         build = RpmBuild(nvr=u'not-bodhi-2.0-2.fc17', package=package, release=release)
@@ -330,7 +330,7 @@ class TestOverridesService(base.BaseTestCase):
     @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch('bodhi.server.notifications.publish')
     def test_create_override_multiple_nvr(self, publish):
-        release = Release.get(u'F17', self.db)
+        release = Release.get(u'F17')
         package = RpmPackage(name=u'not-bodhi')
         self.db.add(package)
         build1 = RpmBuild(nvr=u'not-bodhi-2.0-2.fc17', package=package, release=release)
@@ -374,7 +374,7 @@ class TestOverridesService(base.BaseTestCase):
     @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch('bodhi.server.notifications.publish')
     def test_create_override_too_long(self, publish):
-        release = Release.get(u'F17', self.db)
+        release = Release.get(u'F17')
 
         package = RpmPackage(name=u'not-bodhi')
         self.db.add(package)
@@ -392,7 +392,7 @@ class TestOverridesService(base.BaseTestCase):
     @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch('bodhi.server.notifications.publish')
     def test_create_override_for_newer_build(self, publish):
-        old_build = RpmBuild.get(u'bodhi-2.0-1.fc17', self.db)
+        old_build = RpmBuild.get(u'bodhi-2.0-1.fc17')
 
         build = RpmBuild(nvr=u'bodhi-2.0-2.fc17', package=old_build.package,
                          release=old_build.release)
@@ -417,14 +417,14 @@ class TestOverridesService(base.BaseTestCase):
                           expiration_date.strftime("%Y-%m-%d %H:%M:%S"))
         self.assertEquals(o['expired_date'], None)
 
-        old_build = RpmBuild.get(u'bodhi-2.0-1.fc17', self.db)
+        old_build = RpmBuild.get(u'bodhi-2.0-1.fc17')
 
         self.assertNotEquals(old_build.override['expired_date'], None)
 
     @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch('bodhi.server.notifications.publish')
     def test_cannot_edit_override_build(self, publish):
-        release = Release.get(u'F17', self.db)
+        release = Release.get(u'F17')
 
         old_nvr = u'bodhi-2.0-1.fc17'
 
@@ -481,7 +481,7 @@ class TestOverridesService(base.BaseTestCase):
 
     @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_edit_unexisting_override(self):
-        release = Release.get(u'F17', self.db)
+        release = Release.get(u'F17')
 
         build = RpmBuild(nvr=u'bodhi-2.0-2.fc17', release=release,
                          package=RpmPackage.query.filter_by(name='bodhi').one())
@@ -607,7 +607,7 @@ class TestOverridesService(base.BaseTestCase):
     def test_unexpire_override(self, publish):
         # First expire a buildroot override
         old_nvr = u'bodhi-2.0-1.fc17'
-        override = RpmBuild.get(old_nvr, self.db).override
+        override = RpmBuild.get(old_nvr).override
         override.expire()
         self.db.add(override)
         self.db.flush()

--- a/bodhi/tests/server/services/test_releases.py
+++ b/bodhi/tests/server/services/test_releases.py
@@ -45,7 +45,7 @@ class TestReleasesService(base.BaseTestCase):
             branch=u'f22')
 
         self.db.add(release)
-        self.db.flush()
+        self.db.commit()
 
     def test_404(self):
         self.app.get('/releases/watwatwat', status=404)

--- a/bodhi/tests/server/services/test_updates.py
+++ b/bodhi/tests/server/services/test_updates.py
@@ -485,7 +485,7 @@ class TestNewUpdate(base.BaseTestCase):
     @mock.patch(**mock_valid_requirements)
     def test_new_update_with_existing_build(self, *args):
         """Test submitting a new update with a build already in the database"""
-        package = RpmPackage.get(u'bodhi', self.db)
+        package = RpmPackage.get(u'bodhi')
         self.db.add(RpmBuild(nvr=u'bodhi-2.0.0-3.fc17', package=package))
         self.db.commit()
 
@@ -2504,7 +2504,7 @@ class TestUpdatesService(base.BaseTestCase):
         publish.assert_called_with(topic='update.request.testing', msg=ANY)
 
         # Mark it as testing
-        upd = Update.get(nvr, self.db)
+        upd = Update.get(nvr)
         upd.status = UpdateStatus.testing
         upd.request = None
         self.db.commit()
@@ -2551,7 +2551,7 @@ class TestUpdatesService(base.BaseTestCase):
         publish.assert_called_with(topic='update.request.testing', msg=ANY)
 
         # Mark it as testing
-        upd = Update.get(nvr, self.db)
+        upd = Update.get(nvr)
         upd.status = UpdateStatus.testing
         upd.request = UpdateRequest.stable
         self.db.commit()
@@ -2979,7 +2979,7 @@ class TestUpdatesService(base.BaseTestCase):
     @mock.patch('bodhi.server.notifications.publish')
     def test_testing_request(self, publish, *args):
         """Test submitting a valid testing request"""
-        Update.get(u'bodhi-2.0-1.fc17', self.db).locked = False
+        Update.get(u'bodhi-2.0-1.fc17').locked = False
 
         args = self.get_update()
         args['request'] = None
@@ -3051,7 +3051,7 @@ class TestUpdatesService(base.BaseTestCase):
         args['unstable_karma'] = -1
 
         self.app.post_json('/updates/', args)
-        up = Update.get(nvr, self.db)
+        up = Update.get(nvr)
         up.status = UpdateStatus.pending
         up.request = UpdateRequest.testing
         up.comment(self.db, u'Failed to work', author=u'ralph', karma=-1)
@@ -3077,7 +3077,7 @@ class TestUpdatesService(base.BaseTestCase):
         args['unstable_karma'] = -1
 
         self.app.post_json('/updates/', args)
-        up = Update.get(nvr, self.db)
+        up = Update.get(nvr)
         up.status = UpdateStatus.pending
         up.request = UpdateRequest.testing
         up.comment(self.db, u'Failed to work', author=u'ralph', karma=-1)
@@ -3104,7 +3104,7 @@ class TestUpdatesService(base.BaseTestCase):
         args['unstable_karma'] = -2
 
         self.app.post_json('/updates/', args)
-        up = Update.get(nvr, self.db)
+        up = Update.get(nvr)
         up.status = UpdateStatus.pending
         up.request = UpdateRequest.testing
         up.comment(self.db, u'Failed to work', author=u'ralph', karma=-1)
@@ -3131,7 +3131,7 @@ class TestUpdatesService(base.BaseTestCase):
         args['unstable_karma'] = -2
 
         self.app.post_json('/updates/', args)
-        up = Update.get(nvr, self.db)
+        up = Update.get(nvr)
         up.status = UpdateStatus.testing
         up.request = UpdateRequest.stable
         self.db.commit()
@@ -3180,7 +3180,7 @@ class TestUpdatesService(base.BaseTestCase):
         """
         Test submitting a stable request for an update that has yet to meet the stable requirements.
         """
-        Update.get(u'bodhi-2.0-1.fc17', self.db).locked = False
+        Update.get(u'bodhi-2.0-1.fc17').locked = False
 
         args = self.get_update()
         resp = self.app.post_json(
@@ -3210,7 +3210,7 @@ class TestUpdatesService(base.BaseTestCase):
         args['stable_karma'] = 1
         self.app.post_json('/updates/', args)
 
-        up = Update.get(nvr, self.db)
+        up = Update.get(nvr)
         up.status = UpdateStatus.testing
         up.request = None
         self.assertEqual(len(up.builds), 1)
@@ -3223,7 +3223,7 @@ class TestUpdatesService(base.BaseTestCase):
             '/updates/%s/request' % args['builds'],
             {'request': 'stable', 'csrf_token': self.get_csrf_token()},
             status=400)
-        up = Update.get(nvr, self.db)
+        up = Update.get(nvr)
         self.assertEquals(up.request, None)
         self.assertEquals(up.status, UpdateStatus.testing)
 
@@ -3233,7 +3233,7 @@ class TestUpdatesService(base.BaseTestCase):
             '/updates/%s/request' % args['builds'],
             {'request': 'stable', 'csrf_token': self.get_csrf_token()},
             status=200)
-        up = Update.get(nvr, self.db)
+        up = Update.get(nvr)
         self.assertEquals(up.request, UpdateRequest.stable)
         self.assertEquals(up.status, UpdateStatus.testing)
 
@@ -3675,7 +3675,7 @@ class TestUpdatesService(base.BaseTestCase):
         publish.assert_called_with(topic='update.request.testing', msg=ANY)
 
         # Mark it as testing, tested and give it 2 karma
-        upd = Update.get(nvr, self.db)
+        upd = Update.get(nvr)
         upd.status = UpdateStatus.testing
         upd.request = None
         upd.comment(self.db, u'LGTM', author=u'bob', karma=1)
@@ -3710,14 +3710,14 @@ class TestUpdatesService(base.BaseTestCase):
         publish.assert_called_with(topic='update.request.testing', msg=ANY)
 
         # Mark it as testing and as tested
-        upd = Update.get(nvr, self.db)
+        upd = Update.get(nvr)
         upd.status = UpdateStatus.testing
         upd.request = None
         self.db.commit()
 
         # Have bob +1 it
         upd.comment(self.db, u'LGTM', author=u'bob', karma=1)
-        upd = Update.get(nvr, self.db)
+        upd = Update.get(nvr)
         self.assertEquals(upd.karma, 1)
 
         # Then.. edit it and change the builds!
@@ -3731,7 +3731,7 @@ class TestUpdatesService(base.BaseTestCase):
         self.assertEquals(up['karma'], 0)
 
         # Have bob +1 it again
-        upd = Update.get(new_nvr, self.db)
+        upd = Update.get(new_nvr)
         upd.comment(self.db, u'Ship it!', author=u'bob', karma=1)
 
         # Bob should be able to give karma again since the reset
@@ -3748,7 +3748,7 @@ class TestUpdatesService(base.BaseTestCase):
         self.assertEquals(up['karma'], 0)
 
         # Have bob +1 it again
-        upd = Update.get(newer_nvr, self.db)
+        upd = Update.get(newer_nvr)
         upd.comment(self.db, u'Ship it!', author=u'bob', karma=1)
 
         # Bob should be able to give karma again since the reset
@@ -4239,7 +4239,7 @@ class TestUpdatesService(base.BaseTestCase):
         nvr = u'bodhi-2.0.0-2.fc17'
         args = self.get_update(nvr)
         resp = self.app.post_json('/updates/', args)
-        update = Update.get(nvr, self.db)
+        update = Update.get(nvr)
         update.date_stable = datetime.utcnow()
         update.status = UpdateStatus.stable
         update.pushed = True
@@ -4265,7 +4265,7 @@ class TestUpdatesService(base.BaseTestCase):
         nvr = u'bodhi-2.0.0-2.fc17'
         args = self.get_update(nvr)
         resp = self.app.post_json('/updates/', args)
-        update = Update.get(nvr, self.db)
+        update = Update.get(nvr)
         update.status = UpdateStatus.testing
         update.request = None
         update.pushed = True
@@ -4294,7 +4294,7 @@ class TestUpdatesService(base.BaseTestCase):
         nvr = u'bodhi-2.0.0-2.fc17'
         args = self.get_update(nvr)
         resp = self.app.post_json('/updates/', args)
-        update = Update.get(nvr, self.db)
+        update = Update.get(nvr)
         update.severity = UpdateSeverity.urgent
         update.status = UpdateStatus.testing
         update.request = None
@@ -4324,7 +4324,7 @@ class TestUpdatesService(base.BaseTestCase):
         nvr = u'bodhi-2.0.0-2.fc17'
         args = self.get_update(nvr)
         resp = self.app.post_json('/updates/', args)
-        update = Update.get(nvr, self.db)
+        update = Update.get(nvr)
         update.status = UpdateStatus.testing
         update.request = UpdateRequest.batched
         update.pushed = True
@@ -4353,7 +4353,7 @@ class TestUpdatesService(base.BaseTestCase):
         nvr = u'bodhi-2.0.0-2.fc17'
         args = self.get_update(nvr)
         resp = self.app.post_json('/updates/', args)
-        update = Update.get(nvr, self.db)
+        update = Update.get(nvr)
         update.status = UpdateStatus.testing
         update.request = UpdateRequest.batched
         update.pushed = True
@@ -4382,7 +4382,7 @@ class TestUpdatesService(base.BaseTestCase):
         nvr = u'bodhi-2.0.0-2.fc17'
         args = self.get_update(nvr)
         resp = self.app.post_json('/updates/', args)
-        update = Update.get(nvr, self.db)
+        update = Update.get(nvr)
         update.status = UpdateStatus.testing
         update.request = None
         update.pushed = True
@@ -4410,7 +4410,7 @@ class TestUpdatesService(base.BaseTestCase):
         nvr = u'bodhi-2.0.0-2.fc17'
         args = self.get_update(nvr)
         resp = self.app.post_json('/updates/', args)
-        update = Update.get(nvr, self.db)
+        update = Update.get(nvr)
         update.severity = UpdateSeverity.urgent
         update.status = UpdateStatus.testing
         update.request = None
@@ -4440,7 +4440,7 @@ class TestUpdatesService(base.BaseTestCase):
         nvr = u'bodhi-2.0.0-2.fc17'
         args = self.get_update(nvr)
         resp = self.app.post_json('/updates/', args)
-        update = Update.get(nvr, self.db)
+        update = Update.get(nvr)
         update.status = UpdateStatus.testing
         update.request = UpdateRequest.batched
         update.pushed = True
@@ -4467,7 +4467,7 @@ class TestUpdatesService(base.BaseTestCase):
         nvr = u'bodhi-2.0.0-2.fc17'
         args = self.get_update(nvr)
         resp = self.app.post_json('/updates/', args)
-        update = Update.get(nvr, self.db)
+        update = Update.get(nvr)
         update.status = UpdateStatus.testing
         update.request = None
         update.pushed = True
@@ -4497,7 +4497,7 @@ class TestUpdatesService(base.BaseTestCase):
         nvr = u'bodhi-2.0.0-2.fc17'
         args = self.get_update(nvr)
         resp = self.app.post_json('/updates/', args)
-        update = Update.get(nvr, self.db)
+        update = Update.get(nvr)
         update.critpath = True
         update.status = UpdateStatus.testing
         update.request = UpdateRequest.batched
@@ -4537,7 +4537,7 @@ class TestUpdatesService(base.BaseTestCase):
         publish.assert_called_with(topic='update.request.testing', msg=ANY)
 
         # Marks it as batched
-        upd = Update.get(nvr, self.db)
+        upd = Update.get(nvr)
         upd.status = UpdateStatus.testing
         upd.request = UpdateRequest.batched
         upd.pushed = True
@@ -4548,7 +4548,7 @@ class TestUpdatesService(base.BaseTestCase):
         # Makes sure stable karma is not None
         # Ensures Request doesn't get set to stable automatically since autokarma is disabled
         upd.comment(self.db, u'LGTM', author=u'ralph', karma=1)
-        upd = Update.get(nvr, self.db)
+        upd = Update.get(nvr)
         self.assertEquals(upd.karma, 1)
         self.assertEquals(upd.stable_karma, 1)
         self.assertEquals(upd.status, UpdateStatus.testing)
@@ -4587,7 +4587,7 @@ class TestUpdatesService(base.BaseTestCase):
         publish.assert_called_with(topic='update.request.testing', msg=ANY)
 
         # Marks it as testing
-        upd = Update.get(nvr, self.db)
+        upd = Update.get(nvr)
         upd.status = UpdateStatus.testing
         upd.pushed = True
         upd.request = None
@@ -4598,7 +4598,7 @@ class TestUpdatesService(base.BaseTestCase):
         # Makes sure stable karma is not None
         # Ensures Request doesn't get set to stable automatically since autokarma is disabled
         upd.comment(self.db, u'LGTM', author=u'ralph', karma=1)
-        upd = Update.get(nvr, self.db)
+        upd = Update.get(nvr)
         self.assertEquals(upd.karma, 1)
         self.assertEquals(upd.stable_karma, 1)
         self.assertEquals(upd.status, UpdateStatus.testing)
@@ -4633,7 +4633,7 @@ class TestUpdatesService(base.BaseTestCase):
         publish.assert_called_with(topic='update.request.testing', msg=ANY)
 
         # Create a new expired override
-        upd = Update.get(nvr, self.db)
+        upd = Update.get(nvr)
         override = BuildrootOverride(
             build=upd.builds[0], submitter=user, notes=u'testing',
             expiration_date=datetime.utcnow(), expired_date=datetime.utcnow())
@@ -4707,7 +4707,7 @@ class TestUpdatesService(base.BaseTestCase):
         r = self.app.post_json('/updates/', args)
         publish.assert_called_with(topic='update.request.testing', msg=ANY)
         # Mark it as testing
-        upd = Update.get(nvr1, self.db)
+        upd = Update.get(nvr1)
         upd.status = UpdateStatus.testing
         upd.request = None
         self.db.commit()
@@ -4718,7 +4718,7 @@ class TestUpdatesService(base.BaseTestCase):
         r = self.app.post_json('/updates/', args)
         publish.assert_called_with(topic='update.request.testing', msg=ANY)
         # Mark it as testing
-        upd = Update.get(nvr2, self.db)
+        upd = Update.get(nvr2)
         upd.status = UpdateStatus.testing
         upd.request = None
         self.db.commit()
@@ -4732,14 +4732,14 @@ class TestUpdatesService(base.BaseTestCase):
         self.assertEquals(up['errors'][0]['description'],
                           'Update for bodhi-2.0.0-2.fc17 already exists')
 
-        up = Update.get(nvr2, self.db)
+        up = Update.get(nvr2)
         self.assertEquals(up.title, nvr2)  # nvr1 shouldn't be able to be added
         self.assertEquals(up.status, UpdateStatus.testing)
         self.assertEquals(len(up.builds), 1)
         self.assertEquals(up.builds[0].nvr, nvr2)
 
         # nvr1 update should remain intact
-        up = Update.get(nvr1, self.db)
+        up = Update.get(nvr1)
         self.assertEquals(up.title, nvr1)
         self.assertEquals(up.status, UpdateStatus.testing)
         self.assertEquals(len(up.builds), 1)
@@ -4758,7 +4758,7 @@ class TestUpdatesService(base.BaseTestCase):
         r = self.app.post_json('/updates/', args)
         publish.assert_called_with(topic='update.request.testing', msg=ANY)
 
-        update = Update.get(nvr, self.db)
+        update = Update.get(nvr)
         update.status = UpdateStatus.testing
         update.request = None
         update.critpath = True
@@ -4779,7 +4779,7 @@ class TestUpdatesService(base.BaseTestCase):
         self.assertEquals(up['title'], u'bodhi-2.0.0-3.fc17')
         self.assertEquals(up['karma'], 0)
 
-        update = Update.get(u'bodhi-2.0.0-3.fc17', self.db)
+        update = Update.get(u'bodhi-2.0.0-3.fc17')
         update.status = UpdateStatus.testing
         self.date_testing = update.date_testing + timedelta(days=7)
         update.comment(self.db, u'lgtm', author='friend3', karma=1)

--- a/bodhi/tests/server/test_models.py
+++ b/bodhi/tests/server/test_models.py
@@ -85,7 +85,7 @@ class ModelTest(BaseTestCase):
     def test_get(self):
         if type(self) != ModelTest:
             for col in self.obj.__get_by__:
-                self.assertEqual(self.klass.get(getattr(self.obj, col), self.db), self.obj)
+                self.assertEqual(self.klass.get(getattr(self.obj, col)), self.obj)
 
 
 class TestBodhiBase(BaseTestCase):

--- a/bodhi/tests/server/test_security.py
+++ b/bodhi/tests/server/test_security.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2014-2017 Red Hat, Inc. and others.
+# Copyright 2014-2018 Red Hat, Inc. and others.
 #
 # This file is part of Bodhi.
 #
@@ -228,8 +228,8 @@ class TestRememberMe(base.BaseTestCase):
         }
         req.registry.settings = self.app_settings
         # Ensure the user doesn't exist yet
-        self.assertIsNone(models.User.get(u'lmacken', self.db))
-        self.assertIsNone(models.Group.get(u'releng', self.db))
+        self.assertIsNone(models.User.get(u'lmacken'))
+        self.assertIsNone(models.Group.get(u'releng'))
 
         return req, info
 
@@ -241,7 +241,7 @@ class TestRememberMe(base.BaseTestCase):
             security.remember_me(None, req, info)
 
         # The user should not exist
-        self.assertIsNone(models.User.get(u'lmacken', self.db))
+        self.assertIsNone(models.User.get(u'lmacken'))
 
     def test_empty_groups_ignored(self):
         """Test a user that has an empty string group, which should be ignored."""
@@ -253,7 +253,7 @@ class TestRememberMe(base.BaseTestCase):
 
         security.remember_me(None, req, info)
 
-        user = models.User.get(u'lmacken', self.db)
+        user = models.User.get(u'lmacken')
         self.assertEquals([g.name for g in user.groups], ['releng', 'new_group'])
 
     def test_new_email(self):
@@ -266,7 +266,7 @@ class TestRememberMe(base.BaseTestCase):
 
         security.remember_me(None, req, info)
 
-        user = models.User.get(u'lmacken', self.db)
+        user = models.User.get(u'lmacken')
         self.assertEquals(user.email, u'1337hax0r@example.com')
 
     def test_new_user(self):
@@ -276,7 +276,7 @@ class TestRememberMe(base.BaseTestCase):
         security.remember_me(None, req, info)
 
         # The user should now exist, and be a member of the releng group
-        user = models.User.get(u'lmacken', self.db)
+        user = models.User.get(u'lmacken')
         self.assertEquals(user.name, u'lmacken')
         self.assertEquals(user.email, u'lmacken@fp.o')
         self.assertEquals(len(user.groups), 1)
@@ -292,6 +292,6 @@ class TestRememberMe(base.BaseTestCase):
 
         security.remember_me(None, req, info)
 
-        user = models.User.get(u'lmacken', self.db)
+        user = models.User.get(u'lmacken')
         self.assertEquals(len(user.groups), 0)
-        self.assertEquals(len(models.Group.get(u'releng', self.db).users), 0)
+        self.assertEquals(len(models.Group.get(u'releng').users), 0)


### PR DESCRIPTION
Bodhi has a lot of silly code that passes around a database session
which is not necessary. While working on #2297 today I about
mentally snapped on one of these so decided to go crazy and fix
this one. There are many more to fix, but this patch makes the
world a better place.

Signed-off-by: Randy Barlow <randy@electronsweatshop.com>