### PR TITLE
Do not cache the koji latest candidates call.

### DIFF
--- a/bodhi/server/views/generic.py
+++ b/bodhi/server/views/generic.py
@@ -266,7 +266,6 @@ def latest_candidates(request):
     koji = request.koji
     db = request.db
 
-    @request.cache.cache_on_arguments()
     def work(pkg, testing):
         result = []
         koji.multicall = True


### PR DESCRIPTION
Patrick Uiterwijk suggested dropping this cache, as it can only
ever hurt users. The normal case is that a developer makes a build
and then goes to Bodhi to submit it as an update. In this case, the
cache will be cold and Bodhi will go fetch it from koji, so the
cache doesn't help the normal case. The other case is that a
developer comes to make an update in Bodhi before their build is
complete, and the cache is warmed with builds that do not include
their update. When they come back after the update is complete,
Bodhi has now cached the response from Koji and so will still not
show the build to the user. Thus, the cache does not ever help, and
does hurt.

Signed-off-by: Randy Barlow <randy@electronsweatshop.com>