### PR TITLE
[BACKPORT] Warm up the Release._all_releases cache during web app startup.

### DIFF
--- a/bodhi/server/__init__.py
+++ b/bodhi/server/__init__.py
@@ -176,13 +176,13 @@ def get_releases(request):
     Return a defaultdict describing all Releases keyed by state.
 
     Args:
-        request (pyramid.request.Request): The current web request.
+        request (pyramid.request.Request): The current web request. Unused.
     Returns:
         collections.defaultdict: A dictionary mapping release states to a list of JSON strings
             that describe the Releases that are in those states.
     """
     from bodhi.server.models import Release
-    return Release.all_releases(request.db)
+    return Release.all_releases()
 
 
 def exception_filter(response, request):
@@ -355,4 +355,11 @@ def main(global_config, testing=None, session=None, **settings):
     config.scan('bodhi.server.services')
     config.scan('bodhi.server.captcha')
 
+    # Though importing in the middle of this function is the darkest of evils, we cannot do it any
+    # other way without a backwards-incompatible change. See
+    # https://github.com/fedora-infra/bodhi/issues/2294
+    from bodhi.server import models
+    # Let's warm up the Releases._all_releases cache. We can just call the function - we don't need
+    # to capture the return value.
+    models.Release.all_releases()
     return config.make_wsgi_app()

--- a/bodhi/server/models.py
+++ b/bodhi/server/models.py
@@ -884,12 +884,10 @@ class Release(Base):
         return ' '.join(self.long_name.split()[:-1])
 
     @classmethod
-    def all_releases(cls, session):
+    def all_releases(cls):
         """
         Return a mapping of release states to a list of dictionaries describing the releases.
 
-        Args:
-            session (sqlalchemy.orm.session.Session): A database session.
         Returns:
             defaultdict: Mapping strings of :class:`ReleaseState` names to lists of dictionaries
             that describe the releases in those states.
@@ -897,7 +895,7 @@ class Release(Base):
         if cls._all_releases:
             return cls._all_releases
         releases = defaultdict(list)
-        for release in session.query(cls).order_by(cls.name.desc()).all():
+        for release in cls.query.order_by(cls.name.desc()).all():
             releases[release.state.value].append(release.__json__())
         cls._all_releases = releases
         return cls._all_releases

--- a/bodhi/tests/server/test___init__.py
+++ b/bodhi/tests/server/test___init__.py
@@ -98,11 +98,10 @@ class TestGetReleases(base.BaseTestCase):
     def test_get_releases(self):
         """Assert correct return value from get_releases()."""
         request = testing.DummyRequest(user=base.DummyUser('guest'))
-        request.db = self.db
 
         releases = server.get_releases(request)
 
-        self.assertEqual(releases, models.Release.all_releases(self.db))
+        self.assertEqual(releases, models.Release.all_releases())
 
 
 class TestGetUser(base.BaseTestCase):
@@ -237,6 +236,16 @@ class TestMain(base.BaseTestCase):
         server.main({}, testing='guest', session=self.db, **self.app_settings)
 
         self.assertEqual(config['test'], 'setting')
+
+    def test_warms_up_releases_cache(self):
+        """main() should warm up the _all_releases cache."""
+        # Let's force the release cache to None
+        models.Release._all_releases = None
+
+        server.main({}, testing='guest', session=self.db)
+
+        # The cache should have a release in it now - let's just spot check it
+        self.assertEqual(models.Release._all_releases['current'][0]['name'], 'F17')
 
 
 class TestGetDbSessionForRequest(unittest.TestCase):

--- a/bodhi/tests/server/test_models.py
+++ b/bodhi/tests/server/test_models.py
@@ -630,11 +630,12 @@ class TestRelease(ModelTest):
         self.assertEqual(self.obj.version_int, 11)
 
     def test_all_releases(self):
-        releases = model.Release.all_releases(self.db)
+        releases = model.Release.all_releases()
+
         state = ReleaseState.from_string(list(releases.keys())[0])
         assert 'long_name' in releases[state.value][0], releases
         # Make sure it's the same cached object
-        assert releases is model.Release.all_releases(self.db)
+        assert releases is model.Release.all_releases()
 
 
 class TestReleaseModular(ModelTest):
@@ -660,11 +661,12 @@ class TestReleaseModular(ModelTest):
         self.assertEqual(self.obj.version_int, 11)
 
     def test_all_releases(self):
-        releases = model.Release.all_releases(self.db)
+        releases = model.Release.all_releases()
+
         state = ReleaseState.from_string(list(releases.keys())[0])
         assert 'long_name' in releases[state.value][0], releases
         # Make sure it's the same cached object
-        assert releases is model.Release.all_releases(self.db)
+        assert releases is model.Release.all_releases()
 
 
 class MockWiki(object):


### PR DESCRIPTION
This PR is a backport of #2296 to the 3.6 branch.