### PR TITLE
[BACKPORT] dogpile.cache.expiration_time is now interpreted as an int.

### DIFF
--- a/bodhi/server/config.py
+++ b/bodhi/server/config.py
@@ -407,8 +407,8 @@ class BodhiConfig(dict):
             'value': 'dogpile.cache.dbm',
             'validator': six.text_type},
         'dogpile.cache.expiration_time': {
-            'value': '100',
-            'validator': six.text_type},
+            'value': 100,
+            'validator': int},
         'exclude_mail': {
             'value': ['autoqa', 'taskotron'],
             'validator': _generate_list_validator()},

--- a/bodhi/tests/server/test_config.py
+++ b/bodhi/tests/server/test_config.py
@@ -199,6 +199,18 @@ class BodhiConfigLoadDefaultsTests(unittest.TestCase):
 
 
 class BodhiConfigValidate(unittest.TestCase):
+
+    def test_dogpile_expire_is_int(self):
+        """The dogpile.cache.expiration_time setting should be an int."""
+        c = config.BodhiConfig()
+        c.load_config()
+        c['dogpile.cache.expiration_time'] = '3600'
+
+        c._validate()
+
+        self.assertTrue(isinstance(c['dogpile.cache.expiration_time'], int))
+        self.assertEqual(c['dogpile.cache.expiration_time'], 3600)
+
     def test_koji_settings_are_strs(self):
         """
         Ensure that the koji related settings are strings.


### PR DESCRIPTION
This PR is a backport of #2299 to the 3.6 branch, for CI testing.