### PR TITLE
[BACKPORT] Do not cache the koji latest candidates call.

### DIFF
--- a/bodhi/server/views/generic.py
+++ b/bodhi/server/views/generic.py
@@ -266,7 +266,6 @@ def latest_candidates(request):
     koji = request.koji
     db = request.db
 
-    @request.cache.cache_on_arguments()
     def work(pkg, testing):
         result = []
         koji.multicall = True


### PR DESCRIPTION
This PR backports #2301 to the 3.6 branch.