### PR TITLE
[BACKPORT] Do not require composer configs to be paths that exist in server.

### DIFF
--- a/bodhi/server/config.py
+++ b/bodhi/server/config.py
@@ -203,7 +203,7 @@ def _validate_none_or(validator):
     return _validate
 
 
-def _validate_path(value):
+def validate_path(value):
     """Ensure that value is an existing path on the local filesystem and return it.
 
     Use os.path.exists to ensure that value is an existing path. Return the value if it is, else
@@ -331,7 +331,7 @@ class BodhiConfig(dict):
             'validator': six.text_type},
         'cache_dir': {
             'value': None,
-            'validator': _validate_none_or(_validate_path)},
+            'validator': _validate_none_or(validate_path)},
         'captcha.background_color': {
             'value': '#ffffff',
             'validator': _validate_color},
@@ -340,7 +340,7 @@ class BodhiConfig(dict):
             'validator': _validate_color},
         'captcha.font_path': {
             'value': '/usr/share/fonts/liberation/LiberationMono-Regular.ttf',
-            'validator': _validate_path},
+            'validator': validate_path},
         'captcha.font_size': {
             'value': 36,
             'validator': int},
@@ -469,10 +469,10 @@ class BodhiConfig(dict):
             'validator': _generate_list_validator()},
         'mash_dir': {
             'value': None,
-            'validator': _validate_none_or(_validate_path)},
+            'validator': _validate_none_or(six.text_type)},
         'mash_stage_dir': {
             'value': None,
-            'validator': _validate_none_or(_validate_path)},
+            'validator': _validate_none_or(six.text_type)},
         'max_concurrent_mashes': {
             'value': 2,
             'validator': int},
@@ -526,7 +526,7 @@ class BodhiConfig(dict):
             'validator': six.text_type},
         'pungi.cmd': {
             'value': '/usr/bin/pungi-koji',
-            'validator': _validate_path},
+            'validator': six.text_type},
         'pungi.conf.module': {
             'value': 'pungi.module.conf',
             'validator': six.text_type},

--- a/bodhi/tests/server/consumers/test_masher.py
+++ b/bodhi/tests/server/consumers/test_masher.py
@@ -284,6 +284,18 @@ That was the actual one''' % mash_dir
 
         set_bugtracker.assert_called_once_with()
 
+    @mock.patch.dict('bodhi.server.config.config', {'pungi.cmd': '/does/not/exist'})
+    def test___init___missing_paths(self):
+        """__init__() should raise a ValueError if configured paths do not exist."""
+        for s in ('pungi.cmd', 'mash_dir', 'mash_stage_dir'):
+            with mock.patch.dict('bodhi.server.config.config', {s: '/does/not/exist'}):
+                with self.assertRaises(ValueError) as exc:
+                    Masher(FakeHub(), db_factory=self.db_factory, mash_dir=self.tempdir)
+
+                    self.assertEqual(
+                        str(exc.exception),
+                        '"/does/not/exist" does not exist. Check the {} setting.'.format(s))
+
     @mock.patch('bodhi.server.consumers.masher.initialize_db')
     @mock.patch('bodhi.server.consumers.masher.transactional_session_maker')
     def test___init___without_db_factory(self, transactional_session_maker, initialize_db):

--- a/bodhi/tests/server/test_config.py
+++ b/bodhi/tests/server/test_config.py
@@ -238,6 +238,18 @@ class BodhiConfigValidate(unittest.TestCase):
         self.assertEqual(c['krb_keytab'], '/etc/krb5.bodhi.keytab')
         self.assertEqual(c['krb_principal'], 'bodhi/bodhi@FEDORAPROJECT.ORG')
 
+    def test_composer_paths_not_checked_for_existing(self):
+        """We don't want compose specific paths to be checked for existence."""
+        c = config.BodhiConfig()
+        c.load_config()
+        for s in ('pungi.cmd', 'mash_dir', 'mash_stage_dir'):
+            c[s] = '/does/not/exist'
+
+            # This should not raise an Exception.
+            c._validate()
+
+            self.assertEqual(c[s], '/does/not/exist')
+
     def test_valid_config(self):
         """A valid config should not raise Exceptions."""
         c = config.BodhiConfig()
@@ -429,13 +441,13 @@ class ValidatePathTests(unittest.TestCase):
     def test_path_does_not_exist(self):
         """Test with a path that does not exist."""
         with self.assertRaises(ValueError) as exc:
-            config._validate_path('/does/not/exist')
+            config.validate_path('/does/not/exist')
 
         self.assertEqual(str(exc.exception), '"/does/not/exist" does not exist.')
 
     def test_path_exists(self):
         """Test with a path that exists."""
-        result = config._validate_path(__file__)
+        result = config.validate_path(__file__)
 
         self.assertEqual(result, __file__)
         self.assertTrue(isinstance(result, six.text_type))


### PR DESCRIPTION
This PR is a backport of #2303 for the 3.6 branch.