### PR TITLE
Fix display_name migration and model

### DIFF
--- a/bodhi/server/migrations/versions/be25565a1211_add_a_dislay_name_field_to_the_updates_.py
+++ b/bodhi/server/migrations/versions/be25565a1211_add_a_dislay_name_field_to_the_updates_.py
@@ -16,7 +16,7 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 """
-Add a dislay_name field to the updates table.
+Add a display_name field to the updates table.
 
 Revision ID: be25565a1211
 Revises: 22858ba91115
@@ -33,7 +33,8 @@ down_revision = '22858ba91115'
 
 def upgrade():
     """Add a display_name column to the updates table."""
-    op.add_column('updates', sa.Column('display_name', sa.UnicodeText(), nullable=False))
+    op.add_column('updates', sa.Column('display_name', sa.UnicodeText(), nullable=False,
+                  server_default=u''))
 
 
 def downgrade():

--- a/bodhi/server/models.py
+++ b/bodhi/server/models.py
@@ -1699,7 +1699,7 @@ class Update(Base):
     require_bugs = Column(Boolean, default=False)
     require_testcases = Column(Boolean, default=False)
 
-    display_name = Column(UnicodeText, nullable=False, default='')
+    display_name = Column(UnicodeText, nullable=False, default=u'')
     notes = Column(UnicodeText, nullable=False)  # Mandatory notes
 
     # Enumerated types


### PR DESCRIPTION
Adding non-nullable columns [requires specifying a server-side default][default], and Unicode-encoded columns [should have Unicode-encoded defaults][unicode].

Signed-off-by: Eli Young <elyscape@gmail.com>

Fixes #2337.

[default]: https://github.com/fedora-infra/bodhi/pull/2275#discussion_r185137508
[unicode]: https://github.com/fedora-infra/bodhi/pull/2275#discussion_r185141652