### PR TITLE
Add new privacy_link and legal_link settings.

### DIFF
--- a/bodhi/server/config.py
+++ b/bodhi/server/config.py
@@ -455,6 +455,9 @@ class BodhiConfig(dict):
         'krb_principal': {
             'value': None,
             'validator': _validate_none_or(str)},
+        'legal_link': {
+            'value': '',
+            'validator': six.text_type},
         'libravatar_dns': {
             'value': False,
             'validator': _validate_bool},
@@ -521,6 +524,9 @@ class BodhiConfig(dict):
         'prefer_ssl': {
             'value': None,
             'validator': _validate_none_or(bool)},
+        'privacy_link': {
+            'value': '',
+            'validator': six.text_type},
         'pungi.basepath': {
             'value': '/etc/bodhi',
             'validator': six.text_type},

--- a/bodhi/server/templates/master.html
+++ b/bodhi/server/templates/master.html
@@ -208,6 +208,19 @@
           file issues</a>
           if you have any problems. Read the <a href="https://bodhi.fedoraproject.org/docs">documentation</a>.
         </p>
+        % if request.registry.settings.get('legal_link') or request.registry.settings.get('privacy_link'):
+        <p class="text-muted text-xs-center">
+            % if request.registry.settings.get('legal_link'):
+            <a href="${request.registry.settings.get('legal_link')}">Legal</a>
+            % endif
+            % if request.registry.settings.get('legal_link') and request.registry.settings.get('privacy_link'):
+            |
+            % endif
+            % if request.registry.settings.get('privacy_link'):
+            <a href="${request.registry.settings.get('privacy_link')}">Privacy policy</a>
+            % endif
+        </p>
+        % endif
       </div>
     </div>
 

--- a/bodhi/server/templates/update.html
+++ b/bodhi/server/templates/update.html
@@ -720,7 +720,11 @@ $(document).ready(function(){
                         <div class="alert alert-danger" for="text" style="display:none">
                           <strong></strong> <span class="error"></span>
                         </div>
-                      <p class="pull-right"><small>Comment fields support <a href="#" data-toggle="modal" data-target="#markdown-help">Fedora-Flavored Markdown</a>.</small></p>
+                      <p class="pull-right"><small>Comment fields support <a href="#" data-toggle="modal" data-target="#markdown-help">Fedora-Flavored Markdown</a>.
+                      % if request.registry.settings.get('privacy_link'):
+                      Comments are governed under <a href="${request.registry.settings.get('privacy_link')}">this privacy policy</a>.
+                      % endif
+                      </small></p>
                     </div>
 
                     % if not request.user:

--- a/production.ini
+++ b/production.ini
@@ -42,6 +42,17 @@ use = egg:bodhi-server
 # fedmsg_enabled = False
 
 
+##
+## Legal
+##
+
+# If you set this, Bodhi will display a link in the footer called "Legal" that points to the
+# supplied link.
+# legal_link =
+# If you set this, Bodhi will display a link in the footer called "Privacy policy" that points to
+# the supplied link. It will also link the privacy policy under the comment box.
+# privacy_link =
+
 # Cache_dir is used for writing temporary cache files used in the composer process.
 # cache_dir =
 


### PR DESCRIPTION
If configured, Bodhi can now display privacy and legal links in
its footer. If privacy_link is defined, Bodhi will also link to
the privacy policy under the update comment box.

If privacy_link and legal_link are both defined, the footer will look like this:

![screenshot from 2018-05-02 16-20-09](https://user-images.githubusercontent.com/354506/39549439-d9ce4112-4e2b-11e8-8496-2f726ce094b0.png)

If privacy_link is defined, the comment box has a link to it underneath:

![screenshot from 2018-05-02 16-33-15](https://user-images.githubusercontent.com/354506/39549459-e65e7aaa-4e2b-11e8-9e9b-57685c204c53.png)

Signed-off-by: Randy Barlow <randy@electronsweatshop.com>