### PR TITLE
[BACKPORT] Store greenwave's unsatisfied requirements in its own db column.

### DIFF
--- a/bodhi/server/migrations/versions/59c0f5fbc1b2_add_a_greenwave_unsatisfied_.py
+++ b/bodhi/server/migrations/versions/59c0f5fbc1b2_add_a_greenwave_unsatisfied_.py
@@ -1,0 +1,42 @@
+# Copyright (c) 2018 Red Hat, Inc.
+#
+# This file is part of Bodhi.
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+"""
+Add a greenwave_unsatisfied_requirements column to the updates table.
+
+Revision ID: 59c0f5fbc1b2
+Revises: be25565a1211
+Create Date: 2018-05-01 15:37:07.346034
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '59c0f5fbc1b2'
+down_revision = 'be25565a1211'
+
+
+def upgrade():
+    """Add a greenwave_unsatisfied_requirements to the updates table."""
+    op.add_column('updates',
+                  sa.Column('greenwave_unsatisfied_requirements', sa.UnicodeText(), nullable=True))
+
+
+def downgrade():
+    """Drop the greenwave_unsatisfied_requirements from the updates table."""
+    op.drop_column('updates', 'greenwave_unsatisfied_requirements')

--- a/bodhi/server/models.py
+++ b/bodhi/server/models.py
@@ -1677,6 +1677,9 @@ class Update(Base):
             Greenwave integration was not enabled when the update was created.
         greenwave_summary_string (unicode): A short summary of the outcome from Greenwave
             (e.g. 2 of 32 required tests failed).
+        greenwave_unsatisfied_requirements (unicode): When test_gating_status is failed, Bodhi will
+            set this to a JSON representation of the unsatisfied_requirements field from Greewave's
+            response.
         compose (Compose): The :class:`Compose` that this update is currently being mashed in. The
             update is locked if this is defined.
     """
@@ -1755,6 +1758,7 @@ class Update(Base):
     # Greenwave
     test_gating_status = Column(TestGatingStatus.db_type(), default=None, nullable=True)
     greenwave_summary_string = Column(Unicode(255))
+    greenwave_unsatisfied_requirements = Column(UnicodeText, nullable=True)
 
     # WARNING: consumers/masher.py assumes that this validation is performed!
     @validates('builds')
@@ -1957,14 +1961,11 @@ class Update(Base):
                 self.test_gating_status = TestGatingStatus.ignored
             else:
                 self.test_gating_status = TestGatingStatus.passed
+            self.greenwave_unsatisfied_requirements = None
         else:
             self.test_gating_status = TestGatingStatus.failed
-            missing_reqs = [
-                req['testcase'] for req in
-                decision.get('unsatisfied_requirements', [])
-            ]
-            if missing_reqs:
-                decision['summary'] += '\n Missing: %s' % (', '.join(missing_reqs))
+            self.greenwave_unsatisfied_requirements = json.dumps(
+                decision.get('unsatisfied_requirements', []))
         self.greenwave_summary_string = decision['summary']
 
     @classmethod

--- a/bodhi/server/templates/update.html
+++ b/bodhi/server/templates/update.html
@@ -115,7 +115,8 @@ ${update.type} update for ${update.beautify_title(amp=True) | n}
 
     % if request.registry.settings.get("test_gating.required") is True:
         % if not update.test_gating_passed and update.greenwave_summary_string:
-          var summary = '${update.greenwave_summary_string}';
+          var summary = '${update.greenwave_summary_string}'
+          summary += '${self.util.greenwave_unsatisfied_requirements_html(update)|n}';
           $('#resultsdb h3').after(
              '<div class="alert alert-danger">The update can not be pushed: ' + summary + '</div>');
         % endif

--- a/bodhi/server/util.py
+++ b/bodhi/server/util.py
@@ -552,8 +552,48 @@ def test_gating_status2html(context, status, reason=None):
     html = u'<span class="label label-%s">Tests %s</span>' % (label_class, description)
     from bodhi.server.models import TestGatingStatus
     if status not in [None, TestGatingStatus.ignored, TestGatingStatus.passed] and reason:
-        html += u'<p><a class="gating-summary" href="#automatedtests">%s</a></p>' % (
-                reason.split('\n', 1)[0])
+        html += u'<p><a class="gating-summary" href="#automatedtests">%s</a></p>' % reason
+    return html
+
+
+def greenwave_unsatisfied_requirements_html(context, update):
+    """
+    Return an html representation of the given update's greenwave_unsatisfied_requirements field.
+
+    This function collates the unsatisfied requirements into a heirarchy of requirement type, then
+    test name, and then a list of builds that fail to satisfy that requirement type for that test
+    name.
+
+    Args:
+        context (mako.runtime.Context): Unused.
+        update (bodhi.server.models.Update): The update to render unsatisfied requirements for.
+    Returns:
+        str: A human readable representation of the update's unsatisfied requirements.
+    """
+    if not update.greenwave_unsatisfied_requirements:
+        return ''
+
+    # The Greenwave data is in a list of dictionaries that describe unsatisfied requirements. Let's
+    # collate that data into type of requirement (such as missing test, failed test, etc.) --> test
+    # name --> list of nvrs that fail that test name. To do this, we'll build a dictionary of
+    # dictionaries of lists, like this:
+    #
+    # {'test-result-missing': {'dist.rpmdeplint': ['bodhi-3.6.1-fc28']}}
+    reqs = defaultdict(lambda: defaultdict(list))
+    for r in json.loads(update.greenwave_unsatisfied_requirements):
+        # The Greenwave response contains a lot of duplicate information. For now, let's ignore
+        # anything that isn't a koji build. https://pagure.io/greenwave/issue/169
+        if r['item'].get('type') == 'koji_build':
+            reqs[r['type']][r['testcase']].append(r['item']['item'])
+    # Now that we've built our data structure, let's render it into an HTML snippet that can be
+    # included in the update page.
+    html = '<div>Unsatisfied requirements:'
+    for t in reqs.keys():
+        html = html + '<div>{}: {}</div>'.format(
+            t,
+            ', '.join([' {} ({})'.format(testcase, ', '.join(reqs[t][testcase]))
+                      for testcase in reqs[t].keys()]))
+    html = html + '</div>'
     return html
 
 

--- a/bodhi/tests/server/test_models.py
+++ b/bodhi/tests/server/test_models.py
@@ -2991,7 +2991,7 @@ class TestUpdate(ModelTest):
             "applicable_policies": ["1"],
             "unsatisfied_requirements": [
                 {
-                    'item': {"item": "%s" % update.alias, "type": "koji_build"},
+                    'item': {"item": "%s" % update.builds[0].nvr, "type": "koji_build"},
                     'result_id': "123",
                     'testcase': 'dist.depcheck',
                     'type': 'test-result-failed'
@@ -3004,7 +3004,7 @@ class TestUpdate(ModelTest):
                               'waiverdb.access_token': 'abc'}):
             update.waive_test_results('foo', 'this is not true!')
             wdata = {
-                'subject': {"item": "%s" % update.alias, "type": "koji_build"},
+                'subject': {"item": "%s" % update.builds[0].nvr, "type": "koji_build"},
                 'testcase': 'dist.depcheck',
                 'product_version': update.product_version,
                 'waived': True,

--- a/bodhi/tests/server/test_util.py
+++ b/bodhi/tests/server/test_util.py
@@ -17,6 +17,7 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 import gzip
+import json
 import os
 import shutil
 import subprocess
@@ -208,6 +209,55 @@ class TestCallAPI(unittest.TestCase):
         self.assertEqual(get.mock_calls,
                          [mock.call('url', timeout=60), mock.call('url', timeout=60)])
         sleep.assert_called_once_with(1)
+
+
+class TestGreenwaveUnsatisfiedRequirementsHTML(base.BaseTestCase):
+    """Test the greenwave_unsatisfied_requirements_html() function."""
+
+    def test_no_unsatisfied_requirements(self):
+        u = Update.query.first()
+        u.greenwave_unsatisfied_requirements = None
+
+        self.assertEqual(util.greenwave_unsatisfied_requirements_html(None, u), '')
+
+    def test_unsatisfied_requirements(self):
+        u = Update.query.first()
+        u.greenwave_unsatisfied_requirements = json.dumps([
+            {'testcase': 'dist.rpmdeplint',
+             'item': {'item': 'python-rpdb-0.1.6-7.fc27', 'type': 'koji_build'},
+             'type': 'test-result-missing', 'scenario': None},
+            {'testcase': 'dist.rpmdeplint',
+             'item': {'original_spec_nvr': 'python-rpdb-0.1.6-7.fc27'},
+             'type': 'test-result-missing', 'scenario': None},
+            {'testcase': 'dist.rpmdeplint',
+             'item': {'item': 'FEDORA-2018-6b448bbc48', 'type': 'bodhi_update'},
+             'type': 'test-result-missing', 'scenario': None},
+            {'testcase': 'dist.rpmdeplint',
+             'item': {'item': 'bodhi-3.6.1-1.fc28', 'type': 'koji_build'},
+             'type': 'test-result-missing', 'scenario': None},
+            {'testcase': 'dist.someothertest',
+             'item': {'item': 'bodhi-3.6.1-1.fc28', 'type': 'koji_build'},
+             'type': 'test-result-sucks', 'scenario': None},
+            {'testcase': 'dist.anothertest',
+             'item': {'item': 'python-rpdb-0.1.6-7.fc27', 'type': 'koji_build'},
+             'type': 'test-result-missing', 'scenario': None}])
+
+        html = util.greenwave_unsatisfied_requirements_html(None, u)
+
+        # The bodhi_update type gets ignored in the HTML for now (we might change this later).
+        # We can't assert the order of the divs in the html because they are different between
+        # Python 2 and 3. We also don't really care what order they appear in anyway, so let's just
+        # make sure they appear in the resulting HTML.
+        self.assertTrue(html.startswith('<div>Unsatisfied requirements:'))
+        self.assertIn(
+            ('<div>test-result-missing:  '
+             'dist.rpmdeplint (python-rpdb-0.1.6-7.fc27, bodhi-3.6.1-1.fc28),  '
+             'dist.anothertest (python-rpdb-0.1.6-7.fc27)</div>'),
+            html)
+        self.assertIn(
+            '<div>test-result-sucks:  dist.someothertest (bodhi-3.6.1-1.fc28)</div>', html)
+        # Let's make sure we close things out correctly.
+        self.assertTrue(html.endswith('</div></div>'))
 
 
 class TestKarma2HTML(unittest.TestCase):


### PR DESCRIPTION
This PR backports #2345 for the 3.7 branch. The patch has already been reviewed, so no need for re-review - it is just here to test CI against the 3.7 branch before merging.

fixes #2334
fixes #2335

Signed-off-by: Randy Barlow <randy@electronsweatshop.com>