### PR TITLE
[BACKPORT] Add new privacy_link and legal_link settings.

### DIFF
--- a/bodhi/server/config.py
+++ b/bodhi/server/config.py
@@ -455,6 +455,9 @@ class BodhiConfig(dict):
         'krb_principal': {
             'value': None,
             'validator': _validate_none_or(str)},
+        'legal_link': {
+            'value': '',
+            'validator': six.text_type},
         'libravatar_dns': {
             'value': False,
             'validator': _validate_bool},
@@ -521,6 +524,9 @@ class BodhiConfig(dict):
         'prefer_ssl': {
             'value': None,
             'validator': _validate_none_or(bool)},
+        'privacy_link': {
+            'value': '',
+            'validator': six.text_type},
         'pungi.basepath': {
             'value': '/etc/bodhi',
             'validator': six.text_type},

--- a/bodhi/server/templates/master.html
+++ b/bodhi/server/templates/master.html
@@ -208,6 +208,19 @@
           file issues</a>
           if you have any problems. Read the <a href="https://bodhi.fedoraproject.org/docs">documentation</a>.
         </p>
+        % if request.registry.settings.get('legal_link') or request.registry.settings.get('privacy_link'):
+        <p class="text-muted text-xs-center">
+            % if request.registry.settings.get('legal_link'):
+            <a href="${request.registry.settings.get('legal_link')}">Legal</a>
+            % endif
+            % if request.registry.settings.get('legal_link') and request.registry.settings.get('privacy_link'):
+            |
+            % endif
+            % if request.registry.settings.get('privacy_link'):
+            <a href="${request.registry.settings.get('privacy_link')}">Privacy policy</a>
+            % endif
+        </p>
+        % endif
       </div>
     </div>
 

--- a/bodhi/server/templates/update.html
+++ b/bodhi/server/templates/update.html
@@ -720,7 +720,11 @@ $(document).ready(function(){
                         <div class="alert alert-danger" for="text" style="display:none">
                           <strong></strong> <span class="error"></span>
                         </div>
-                      <p class="pull-right"><small>Comment fields support <a href="#" data-toggle="modal" data-target="#markdown-help">Fedora-Flavored Markdown</a>.</small></p>
+                      <p class="pull-right"><small>Comment fields support <a href="#" data-toggle="modal" data-target="#markdown-help">Fedora-Flavored Markdown</a>.
+                      % if request.registry.settings.get('privacy_link'):
+                      Comments are governed under <a href="${request.registry.settings.get('privacy_link')}">this privacy policy</a>.
+                      % endif
+                      </small></p>
                     </div>
 
                     % if not request.user:

--- a/bodhi/tests/server/services/test_updates.py
+++ b/bodhi/tests/server/services/test_updates.py
@@ -776,10 +776,26 @@ class TestUpdatesService(base.BaseTestCase):
 
         self.assertTrue('RPM' not in res.text)
 
-    def test_home_html(self):
-        resp = self.app.get('/', headers={'Accept': 'text/html'})
+    def test_home_html_legal(self):
+        """Test the home page HTML when a legal link is configured."""
+        with mock.patch.dict(
+                self.app.app.registry.settings, {'legal_link': 'http://loweringthebar.net/'}):
+            resp = self.app.get('/', headers={'Accept': 'text/html'})
+
         self.assertIn('Fedora Updates System', resp)
         self.assertIn('&copy;', resp)
+        self.assertIn('Legal</a>', resp)
+        self.assertIn('http://loweringthebar.net/', resp)
+
+    def test_home_html_no_legal(self):
+        """Test the home page HTML when no legal link is configured."""
+        with mock.patch.dict(self.app.app.registry.settings, {'legal_link': ''}):
+            resp = self.app.get('/', headers={'Accept': 'text/html'})
+
+        self.assertIn('Fedora Updates System', resp)
+        self.assertIn('&copy;', resp)
+        self.assertNotIn('Legal</a>', resp)
+        self.assertNotIn('http://loweringthebar.net/', resp)
 
     @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_edit_add_build_from_different_release(self):
@@ -1296,13 +1312,38 @@ class TestUpdatesService(base.BaseTestCase):
                      headers={'Accept': 'application/atom+xml'},
                      status=406)
 
-    def test_get_single_update_html(self):
+    def test_get_single_update_html_no_privacy_link(self):
+        """Test getting a single update via HTML when no privacy link is configured."""
         id = 'bodhi-2.0-1.fc17'
-        resp = self.app.get('/updates/%s' % id,
-                            headers={'Accept': 'text/html'})
+
+        with mock.patch.dict(self.app.app.registry.settings, {'privacy_link': ''}):
+            resp = self.app.get('/updates/%s' % id,
+                                headers={'Accept': 'text/html'})
+
         self.assertIn('text/html', resp.headers['Content-Type'])
         self.assertIn(id, resp)
         self.assertIn('&copy;', resp)
+        # The privacy policy comment should not be written on the page since by default Bodhi
+        # doesn't have a configured privacy policy.
+        self.assertNotIn('privacy', resp)
+
+    def test_get_single_update_html_privacy_link(self):
+        """Test getting a single update via HTML when a privacy link is configured."""
+        id = 'bodhi-2.0-1.fc17'
+
+        with mock.patch.dict(
+                self.app.app.registry.settings, {'privacy_link': 'https://privacyiscool.com'}):
+            resp = self.app.get('/updates/%s' % id,
+                                headers={'Accept': 'text/html'})
+
+        self.assertIn('text/html', resp.headers['Content-Type'])
+        self.assertIn(id, resp)
+        self.assertIn('&copy;', resp)
+        # The privacy policy comment should not be written on the page since by default Bodhi
+        # doesn't have a configured privacy policy.
+        self.assertIn('Privacy policy', resp)
+        self.assertIn('https://privacyiscool.com', resp)
+        self.assertIn('Comments are governed under', resp)
 
     @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_updates(self):

--- a/production.ini
+++ b/production.ini
@@ -42,6 +42,17 @@ use = egg:bodhi-server
 # fedmsg_enabled = False
 
 
+##
+## Legal
+##
+
+# If you set this, Bodhi will display a link in the footer called "Legal" that points to the
+# supplied link.
+# legal_link =
+# If you set this, Bodhi will display a link in the footer called "Privacy policy" that points to
+# the supplied link. It will also link the privacy policy under the comment box.
+# privacy_link =
+
 # Cache_dir is used for writing temporary cache files used in the composer process.
 # cache_dir =
 


### PR DESCRIPTION
This PR backports the patch from #2347 to the 3.7 branch. The patch has already been reviewed, so no need for re-review - I just want to use the PR to run CI against it.