### PR TITLE
[BACKPORT] Move the greenwave_unsatisfied_requirements migration to be next.

### DIFF
--- a/bodhi/server/migrations/versions/59c0f5fbc1b2_add_a_greenwave_unsatisfied_.py
+++ b/bodhi/server/migrations/versions/59c0f5fbc1b2_add_a_greenwave_unsatisfied_.py
@@ -19,7 +19,7 @@
 Add a greenwave_unsatisfied_requirements column to the updates table.
 
 Revision ID: 59c0f5fbc1b2
-Revises: be25565a1211
+Revises: c21dd18b161a
 Create Date: 2018-05-01 15:37:07.346034
 """
 from alembic import op
@@ -28,7 +28,7 @@ import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision = '59c0f5fbc1b2'
-down_revision = 'be25565a1211'
+down_revision = 'c21dd18b161a'
 
 
 def upgrade():


### PR DESCRIPTION
This PR backports one of the commits from #2358 to the 3.7 branch. It should not be merged until #2358 is reviewed and merged, but it does not require review of its own since we'll use the other PR for review.