### PR TITLE
Make the repo sanity checks much more strict

### DIFF
--- a/bodhi/server/metadata.py
+++ b/bodhi/server/metadata.py
@@ -21,7 +21,6 @@ from datetime import datetime
 import logging
 import os
 import shelve
-import shutil
 import tempfile
 
 from kitchen.text.converters import to_bytes
@@ -57,24 +56,7 @@ def modifyrepo(comp_type, compose_path, filetype, extension, source):
             repodata = os.path.join(repo_path, arch, 'tree', 'repodata')
         else:
             repodata = os.path.join(repo_path, arch, 'os', 'repodata')
-        log.info('Inserting %s.%s into %s', filetype, extension, repodata)
-        target_fname = os.path.join(repodata, '%s.%s' % (filetype, extension))
-        shutil.copyfile(source, target_fname)
-        repomd_xml = os.path.join(repodata, 'repomd.xml')
-        repomd = cr.Repomd(repomd_xml)
-        # create a new record for our repomd.xml
-        rec = cr.RepomdRecord(filetype, target_fname)
-        # compress our metadata file with the comp_type
-        rec_comp = rec.compress_and_fill(cr.SHA256, comp_type)
-        # add hash to the compresed metadata file
-        rec_comp.rename_file()
-        # set type of metadata
-        rec_comp.type = filetype
-        # insert metadata about our metadata in repomd.xml
-        repomd.set_record(rec_comp)
-        with open(repomd_xml, 'w') as repomd_file:
-            repomd_file.write(repomd.xml_dump())
-        os.unlink(target_fname)
+        util.insert_in_repo(comp_type, repodata, filetype, extension, source)
 
 
 class UpdateInfoMetadata(object):

--- a/bodhi/tests/server/test_metadata.py
+++ b/bodhi/tests/server/test_metadata.py
@@ -47,7 +47,7 @@ class UpdateInfoMetadataTestCase(base.BaseTestCase):
         self.tempdir = tempfile.mkdtemp('bodhi')
         self.tempcompdir = join(self.tempdir, 'f17-updates-testing')
         self.temprepo = join(self.tempcompdir, 'compose', 'Everything', 'i386', 'os')
-        mkmetadatadir(join(self.temprepo, 'f17-updates-testing', 'i386'))
+        mkmetadatadir(join(self.temprepo, 'f17-updates-testing', 'i386'), updateinfo=False)
         config['cache_dir'] = os.path.join(self.tempdir, 'cache')
         os.makedirs(config['cache_dir'])
 
@@ -241,8 +241,9 @@ class TestUpdateInfoMetadata(UpdateInfoMetadataTestCase):
         os.makedirs(os.path.join(config['mash_dir'], 'f17-updates-testing'))
 
         # Initialize our temporary repo
-        mkmetadatadir(self.temprepo)
-        mkmetadatadir(join(self.tempcompdir, 'compose', 'Everything', 'source', 'tree'))
+        mkmetadatadir(self.temprepo, updateinfo=False)
+        mkmetadatadir(join(self.tempcompdir, 'compose', 'Everything', 'source', 'tree'),
+                      updateinfo=False)
         self.repodata = join(self.temprepo, 'repodata')
         assert exists(join(self.repodata, 'repomd.xml'))
 
@@ -312,8 +313,9 @@ class TestUpdateInfoMetadata(UpdateInfoMetadataTestCase):
         """
         self._test_extended_metadata(True)
         shutil.rmtree(self.temprepo)
-        mkmetadatadir(self.temprepo)
-        mkmetadatadir(join(self.tempcompdir, 'compose', 'Everything', 'source', 'tree'))
+        mkmetadatadir(self.temprepo, updateinfo=False)
+        mkmetadatadir(join(self.tempcompdir, 'compose', 'Everything', 'source', 'tree'),
+                      updateinfo=False)
         DevBuildsys.__rpms__ = []
         self._test_extended_metadata(True)
 

--- a/devel/ci/Dockerfile-header
+++ b/devel/ci/Dockerfile-header
@@ -14,9 +14,11 @@ RUN dnf install --disablerepo rawhide-modular -y \
     liberation-mono-fonts \
     packagedb-cli \
     python2-createrepo_c \
+    python2-hawkey \
     python2-jinja2 \
     python2-koji \
     python2-librepo \
     python2-yaml \
     python3-createrepo_c \
+    python3-hawkey \
     python3-yaml \

--- a/devel/ci/f27-packages
+++ b/devel/ci/f27-packages
@@ -6,7 +6,8 @@
     python-pyramid-fas-openid \
     python-pytest \
     python-simplemediawiki \
-    python-webtest
+    python-webtest \
+    python2-libcomps
 
 RUN pip-2 install cornice
 RUN pip-2 install -e git+https://github.com/Cornices/cornice.ext.sphinx.git@master#egg=cornice_sphinx

--- a/devel/ci/pip-packages
+++ b/devel/ci/pip-packages
@@ -5,7 +5,9 @@
     python2-devel \
     python3-devel \
     python3-simplemediawiki \
-    redhat-rpm-config
+    redhat-rpm-config \
+    python2-libcomps \
+    python3-libcomps
 
 COPY requirements.txt /bodhi/requirements.txt
 

--- a/devel/ci/rawhide-packages
+++ b/devel/ci/rawhide-packages
@@ -10,4 +10,5 @@
     python3-cornice \
     python3-cornice-sphinx \
     python2-webtest \
-    python3-pyramid-fas-openid
+    python3-pyramid-fas-openid \
+    python2-libcomps

--- a/devel/ci/rpm-packages
+++ b/devel/ci/rpm-packages
@@ -27,6 +27,7 @@
     python3-feedgen \
     python3-flake8 \
     python3-kitchen \
+    python3-libcomps \
     python3-markdown \
     python3-mock \
     python3-munch \

--- a/docs/user/release_notes.rst
+++ b/docs/user/release_notes.rst
@@ -2,6 +2,12 @@
 Release notes
 =============
 
+develop
+-------
+
+The composer now requires hawkey.
+
+
 v3.9.0
 ------
 


### PR DESCRIPTION
This makes us use librepo/hawkey to verify that a repo can be correctly read and used
by DNF, which should prevent us from accepting a repo if DNF will then crash on using
it.

Note: per the hawkey docs, it's obsoleted, and one is supposed to use libhif,
but the libhif (redirected to libdnf) repo says it is being "reworked and is unstable".
From my tests, it seems that hawkey calls libdnf underwater, so I think that this
is reasonable to do for now.

Signed-off-by: Patrick Uiterwijk <puiterwijk@redhat.com>