### PR TITLE
Add descriptive tooltips to updates statuses in web interface.

### DIFF
--- a/bodhi/server/util.py
+++ b/bodhi/server/util.py
@@ -516,7 +516,18 @@ def status2html(context, status):
         'obsolete': 'default',
         'processing': 'info',
     }[status]
-    return "<span class='label label-%s'>%s</span>" % (cls, status)
+    status_desc = {
+        'pending': 'The update has not yet been pushed to the testing or stable repositories.',
+        'testing': 'The package is in the testing repository for people to test.',
+        'stable': 'The package has been released to the stable repository.',
+        'unpushed': 'The update has been removed from testing.',
+        'obsolete': 'The package has been obsoleted by a different update.',
+        'processing': 'Unused.',
+    }[status]
+
+    return ("<span class='text-muted' data-toggle='tooltip' title='%s'>" % (status_desc) +
+            "<span class='label label-%s'>%s</span>" % (cls, status) +
+            "</span>")
 
 
 def test_gating_status2html(context, status, reason=None):


### PR DESCRIPTION
Modify `util.status2html()` to show a tooltip with a meaningful description of what the status means.

Description strings are taken from the docs; I maintained the `processing` status to be consistent with the `UpdateStatus` class, even if it's unused.
Fixes #2150 

Signed-off-by: Mattia Verga <mattia.verga@tiscali.it>