### PR TITLE
Remove a conflicting HTTPForbidden handler.

### DIFF
--- a/bodhi/server/__init__.py
+++ b/bodhi/server/__init__.py
@@ -26,7 +26,6 @@ from munch import munchify
 from pyramid.authentication import AuthTktAuthenticationPolicy
 from pyramid.authorization import ACLAuthorizationPolicy
 from pyramid.config import Configurator
-from pyramid.exceptions import HTTPForbidden
 from pyramid.renderers import JSONP
 from sqlalchemy import engine_from_config, event
 from sqlalchemy.orm import scoped_session, sessionmaker
@@ -305,7 +304,6 @@ def main(global_config, testing=None, session=None, **settings):
     # pyramid.openid
     config.add_route('login', '/login')
     config.add_view('bodhi.server.security.login', route_name='login')
-    config.add_view('bodhi.server.security.login', context=HTTPForbidden)
     config.add_route('logout', '/logout')
     config.add_view('bodhi.server.security.logout', route_name='logout')
     config.add_route('verify_openid', pattern='/dologin.html')

--- a/devel/ansible/roles/dev/tasks/main.yml
+++ b/devel/ansible/roles/dev/tasks/main.yml
@@ -95,11 +95,11 @@
 # cornice > 1 won't be available until Fedora 28 is released.
 - name: pip install cornice
   pip:
-      name: cornice<3.2.0
+      name: cornice
 
 - name: pip install cornice for Python 3
   pip:
-      name: cornice<3.2.0
+      name: cornice
       executable: pip3
 
 # cornice_sphinx is not packaged in Fedora yet, but won't be available until Fedora 28 is released.

--- a/devel/ci/f26-packages
+++ b/devel/ci/f26-packages
@@ -8,8 +8,8 @@
     python-simplemediawiki \
     python-webtest
 
-RUN pip-2 install cornice\<3.2.0
+RUN pip-2 install cornice
 RUN pip-2 install -e git+https://github.com/Cornices/cornice.ext.sphinx.git@master#egg=cornice_sphinx
-RUN pip-3 install cornice\<3.2.0
+RUN pip-3 install cornice
 RUN pip-3 install -e git+https://github.com/Cornices/cornice.ext.sphinx.git@master#egg=cornice_sphinx
 RUN pip-3 install pyramid-fas-openid

--- a/devel/ci/f27-packages
+++ b/devel/ci/f27-packages
@@ -8,8 +8,8 @@
     python-simplemediawiki \
     python-webtest
 
-RUN pip-2 install cornice\<3.2.0
+RUN pip-2 install cornice
 RUN pip-2 install -e git+https://github.com/Cornices/cornice.ext.sphinx.git@master#egg=cornice_sphinx
-RUN pip-3 install cornice\<3.2.0
+RUN pip-3 install cornice
 RUN pip-3 install -e git+https://github.com/Cornices/cornice.ext.sphinx.git@master#egg=cornice_sphinx
 RUN pip-3 install pyramid-fas-openid

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ arrow
 bleach
 click
 colander
-cornice>=3,<3.2.0
+cornice>=3
 cryptography
 dogpile.cache
 fedmsg[consumers]


### PR DESCRIPTION
Beginning with Cornice 3.2.0, conflicting Pyramid configurations
will raise an Exception during application startup. Bodhi had two
views configured to handle HTTPForbidden - one was the
bodhi.server.views.generic.exception_view(), and the other was
bodhi.server.security.login(). This commit removes the routing to
the login() call in favor of the exception_view() call, as logged
in users should not get redirected to the login view, and the code
does not consider whether the user is currently logged in.
Furthermore, this choice is consistent with how Bodhi behaved with
Cornice < 3.2.0.

As a result, Bodhi is now compatible with the latest release of
Cornice.

fixes #2258

Signed-off-by: Randy Barlow <randy@electronsweatshop.com>