### PR TITLE
Use the full path when cd'ing to the Bodhi folder in Vagrant.

### DIFF
--- a/devel/ansible/roles/dev/files/.bashrc
+++ b/devel/ansible/roles/dev/files/.bashrc
@@ -40,4 +40,4 @@ function btest {
 export BODHI_URL="http://localhost:6543/"
 export PYTHONWARNINGS="once"
 
-cd bodhi
+cd /home/vagrant/bodhi


### PR DESCRIPTION
Without this patch, starting tmux inside the Vagrant guest landed
you in /home/vagrant/bodhi/bodhi instead of /home/vagrant/bodhi,
which was annoying. Now it always cd's by full path.

Signed-off-by: Randy Barlow <randy@electronsweatshop.com>