### PR TITLE
Add a css rule to style blockquotes.

### DIFF
--- a/bodhi/server/static/css/site.css
+++ b/bodhi/server/static/css/site.css
@@ -216,6 +216,11 @@ ul.updateslist li {
     overflow-wrap:  break-word; /* new-school */
     padding:        5px;
 }
+.markdown blockquote {
+    margin: 0 1rem;
+    color: #6a737d;
+    border-left: 0.25rem solid #dfe2e5;
+}
 
 #markdown-help strong {
     text-transform: uppercase;


### PR DESCRIPTION
This is intended to be a temporary fix until the rule is applied upstream in fedora-bootstrap. See https://pagure.io/fedora-bootstrap/issue/13

Fixes #2333 

Signed-off-by: Mattia Verga <mattia.verga@tiscali.it>