### PR TITLE
Do not apply Koji tags to ejected updates.

### DIFF
--- a/bodhi/server/buildsys.py
+++ b/bodhi/server/buildsys.py
@@ -172,16 +172,22 @@ class DevBuildsys(Buildsystem):
 
     def moveBuild(self, from_tag, to_tag, build, *args, **kw):
         """Emulate Koji's moveBuild."""
+        if to_tag is None:
+            raise RuntimeError('Attempt to tag {} with None.'.format(build))
         log.debug("moveBuild(%s, %s, %s)" % (from_tag, to_tag, build))
         DevBuildsys.__moved__.append((from_tag, to_tag, build))
 
     def tagBuild(self, tag, build, *args, **kw):
         """Emulate Koji's tagBuild."""
+        if tag is None:
+            raise RuntimeError('Attempt to tag {} with None.'.format(build))
         log.debug("tagBuild(%s, %s)" % (tag, build))
         DevBuildsys.__added__.append((tag, build))
 
     def untagBuild(self, tag, build, *args, **kw):
         """Emulate Koji's untagBuild."""
+        if tag is None:
+            raise RuntimeError('Attempt to untag {} with None.'.format(build))
         log.debug("untagBuild(%s, %s)" % (tag, build))
         DevBuildsys.__untag__.append((tag, build))
 

--- a/bodhi/server/consumers/masher.py
+++ b/bodhi/server/consumers/masher.py
@@ -465,6 +465,10 @@ class ComposerThread(threading.Thread):
             if not result:
                 self.log.warn("%s failed gating: %s" % (update.title, reason))
                 self.eject_from_mash(update, reason)
+        # We may have removed some updates from this compose above, and do we don't want future
+        # reads on self.compose.updates to see those, so let's mark that attribute expired so
+        # sqlalchemy will requery for the composes instead of using its cached copy.
+        self.db.expire(self.compose, ['updates'])
 
     def eject_from_mash(self, update, reason):
         """

--- a/bodhi/server/models.py
+++ b/bodhi/server/models.py
@@ -3556,8 +3556,9 @@ class Update(Base):
         Return the tag the update has requested.
 
         Returns:
-            basestring or None: The Koji tag that corresponds to the update's current request, or
-                None if the method is unable to do so.
+            basestring: The Koji tag that corresponds to the update's current request.
+        Raises:
+            RuntimeError: If a Koji tag is unable to be determined.
         """
         tag = None
         if self.request is UpdateRequest.stable:
@@ -3571,7 +3572,7 @@ class Update(Base):
         elif self.request is UpdateRequest.obsolete:
             tag = self.release.candidate_tag
         if not tag:
-            log.error(
+            raise RuntimeError(
                 'Unable to determine requested tag for %s.' % self.title)
         return tag
 

--- a/bodhi/tests/server/test_models.py
+++ b/bodhi/tests/server/test_models.py
@@ -1721,6 +1721,16 @@ class TestUpdate(ModelTest):
         self.assertEqual(update.mandatory_days_in_testing > update.days_in_testing, True)
         self.assertEqual(update.days_to_stable, 4)
 
+    def test_requested_tag_request_none(self):
+        """requested_tag() should raise RuntimeError if the Update's request is None."""
+        self.obj.request = None
+
+        with self.assertRaises(RuntimeError) as exc:
+            self.obj.requested_tag
+
+        self.assertEqual(str(exc.exception),
+                         'Unable to determine requested tag for {}.'.format(self.obj.title))
+
     def test_side_tag_locked_false(self):
         """Test the side_tag_locked property when it is false."""
         self.obj.status = model.UpdateStatus.side_tag_active


### PR DESCRIPTION
Due to a combination of two bugs, Bodhi's composer attempted to
tag ejected updates' builds with the tag None, which is of course
not a valid tag. This happened due to two bugs. The first was that
the ComposerThread did not refresh its self.compose.updates
attribute after ejecting updates, which meant that ejected updates
were still present in operations it peformed after ejecting them.
Secondly, the Update model has a property that returns the koji tag
that correspond's with the Update's request. Since ejected updates
no longer have a request, this method was returning None and then
the composer was handing that value to the Koji client to tag the
build. The property has been altered to raise a RuntimeError if it
is asked for a Koji tag when there is no request.

In addition to the above, this commit also adjusts the DevBuildsys
such that it will raise an Exception if any build is tagged with
None to help prevent this in the future.

fixes #2368

Signed-off-by: Randy Barlow <randy@electronsweatshop.com>