### PR TITLE
Ensure that the web app closes db connections when done with them.

### DIFF
--- a/bodhi/server/webapp.py
+++ b/bodhi/server/webapp.py
@@ -1,0 +1,73 @@
+# -*- coding: utf-8 -*-
+# Copyright © 2018 Red Hat, Inc.
+#
+# This file is part of Bodhi.
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+"""
+Define Bodhi's WSGI application.
+
+As of the writing of this docblock, this module is a bit misnamed since the webapp is actually
+defined in bodhi.server.__init__. However, that is an anti-pattern with lots of nasty in-line
+imports due to circular dependencies, and this module is intended to solve that problem.
+Unfortunately, it is a backwards-incompatible change to move main() here, so it will remain in
+__init__ until we make a major Bodhi release. See https://github.com/fedora-infra/bodhi/issues/2294
+"""
+
+from pyramid.events import NewRequest, subscriber
+
+from bodhi import server
+
+
+def _complete_database_session(request):
+    """
+    Commit the database changes if no exceptions occurred.
+
+    This is a post-request hook. It handles rolling back or committing the session based on whether
+    an exception occurred or not. To get a database session that's not tied to the request/response
+    cycle, just use the :data:`Session` scoped session.
+
+    Args:
+        request (pyramid.request.Request): The current web request.
+    """
+    _rollback_or_commit(request)
+    server.Session().close()
+    server.Session.remove()
+
+
+@subscriber(NewRequest)
+def _prepare_request(event):
+    """
+    Add callbacks onto every new request.
+
+    This function adds a callback to clean up the database session when the request is finished.
+
+    Args:
+        event (pyramid.events.NewRequest): The new request event.
+    """
+    event.request.add_finished_callback(_complete_database_session)
+
+
+def _rollback_or_commit(request):
+    """
+    Commit the transaction if there are no exceptions, otherwise rollback.
+
+    Args:
+        request (pyramid.request.Request): The current web request.
+    """
+    if request.exception is not None:
+        server.Session().rollback()
+    else:
+        server.Session().commit()

--- a/bodhi/tests/server/services/test_comments.py
+++ b/bodhi/tests/server/services/test_comments.py
@@ -258,7 +258,8 @@ class TestCommentsService(base.BaseTestCase):
             'authtkt.secret': 'whatever',
             'authtkt.secure': True,
         })
-        app = TestApp(main({}, session=self.db, **anonymous_settings))
+        with mock.patch('bodhi.server.Session.remove'):
+            app = TestApp(main({}, session=self.db, **anonymous_settings))
 
         comment = {
             u'update': 'bodhi-2.0-1.fc17',

--- a/bodhi/tests/server/services/test_overrides.py
+++ b/bodhi/tests/server/services/test_overrides.py
@@ -661,7 +661,9 @@ class TestOverridesWebViews(base.BaseTestCase):
             'authtkt.secret': 'whatever',
             'authtkt.secure': True,
         })
-        app = TestApp(main({}, session=self.db, **anonymous_settings))
+        with mock.patch('bodhi.server.Session.remove'):
+            app = TestApp(main({}, session=self.db, **anonymous_settings))
+
         resp = app.get('/overrides/bodhi-2.0-1.fc17',
                        status=200, headers={'Accept': 'text/html'})
         self.assertNotIn('<span>New Buildroot Override Form Requires JavaScript</span>', resp)

--- a/bodhi/tests/server/services/test_releases.py
+++ b/bodhi/tests/server/services/test_releases.py
@@ -55,7 +55,9 @@ class TestReleasesService(base.BaseTestCase):
         """Ensure that an unauthenticated user cannot edit a release, since only an admin should."""
         name = u"F22"
         # Create a new app so we are the anonymous user.
-        app = webtest.TestApp(server.main({}, session=self.db, **self.app_settings))
+        with mock.patch('bodhi.server.Session.remove'):
+            app = webtest.TestApp(server.main({}, session=self.db, **self.app_settings))
+
         res = app.get('/releases/%s' % name, status=200)
         r = res.json_body
         r["edited"] = name

--- a/bodhi/tests/server/test_metadata.py
+++ b/bodhi/tests/server/test_metadata.py
@@ -261,12 +261,11 @@ class TestUpdateInfoMetadata(UpdateInfoMetadataTestCase):
         }]
 
     def tearDown(self):
-        shutil.rmtree(self.tempdir)
         config['mash_stage_dir'] = self._mash_stage_dir
         config['mash_dir'] = self._mash_dir
         config['cache_dir'] = None
         shutil.rmtree(self._new_mash_stage_dir)
-        super(TestUpdateInfoMetadata, self).setUp()
+        super(TestUpdateInfoMetadata, self).tearDown()
 
     def _verify_updateinfo(self, repodata):
         updateinfos = glob.glob(join(repodata, "*-updateinfo.xml*"))

--- a/bodhi/tests/server/test_renderers.py
+++ b/bodhi/tests/server/test_renderers.py
@@ -19,6 +19,7 @@
 
 import copy
 import datetime
+import mock
 import re
 import unittest
 
@@ -52,7 +53,8 @@ class TestRenderers(base.BaseTestCase):
             'captcha.padding': '5',
             'captcha.ttl': '300',
         })
-        app = TestApp(main({}, session=self.db, **settings))
+        with mock.patch('bodhi.server.Session.remove'):
+            app = TestApp(main({}, session=self.db, **settings))
 
         res = app.get('/updates/FEDORA-{}-a3bbe1a8f2'.format(datetime.datetime.utcnow().year),
                       status=200,

--- a/bodhi/tests/server/test_webapp.py
+++ b/bodhi/tests/server/test_webapp.py
@@ -1,0 +1,68 @@
+# -*- coding: utf-8 -*-
+# Copyright © 2018 Red Hat, Inc.
+#
+# This file is part of Bodhi.
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+"""Tests for bodhi.server.webapp."""
+
+import mock
+import unittest
+
+from bodhi.server import webapp
+
+
+class TestCompleteDatabaseSession(unittest.TestCase):
+    """Test the _complete_database_session() function."""
+
+    def test_cleanup_exception(self):
+        """Test for rollback() when there is an Exception."""
+        request = mock.Mock()
+        request.exception = IOError('The Internet ran out of cats.')
+
+        with mock.patch('bodhi.server.Session') as Session_mock:
+            webapp._complete_database_session(request)
+
+        # Since there was an Exception, the session should have been rolled back and closed.
+        self.assertEqual(Session_mock.return_value.rollback.mock_calls, [mock.call()])
+        self.assertEqual(Session_mock.return_value.commit.mock_calls, [])
+        self.assertEqual(Session_mock.return_value.close.mock_calls, [mock.call()])
+        self.assertEqual(Session_mock.remove.mock_calls, [mock.call()])
+
+    def test_cleanup_no_exception(self):
+        """Test cleanup() when there is not an Exception."""
+        request = mock.Mock()
+        request.exception = None
+
+        with mock.patch('bodhi.server.Session') as Session:
+            webapp._complete_database_session(request)
+
+        # Since there was no Exception, the session should have been committed and closed.
+        self.assertEqual(Session.return_value.rollback.mock_calls, [])
+        self.assertEqual(Session.return_value.commit.mock_calls, [mock.call()])
+        self.assertEqual(Session.return_value.close.mock_calls, [mock.call()])
+        self.assertEqual(Session.remove.mock_calls, [mock.call()])
+
+
+class TestPrepareRequest(unittest.TestCase):
+    """Test the _prepare_request() function."""
+
+    def test_adds_db_cleanup_callback(self):
+        event = mock.MagicMock()
+
+        webapp._prepare_request(event)
+
+        event.request.add_finished_callback.assert_called_once_with(
+            webapp._complete_database_session)


### PR DESCRIPTION
Prior to this commit, there was a bug in Bodhi where requests that
did not access the request's db attribute would not close out their
database connection. This happened notably with the /composes/ API,
which only used the scoped session to perform its queries.

The commit refactors Bodhi to use Pyramid's event system to attach
a callback to all requests so that the database session is
committed or rolled back (depending on errors) no matter which way
the database session is acquired, so long as it is still the scoped
session. This approach is more general, and works for code that
uses the old or new styles of accessing database session.

As a result of this refactor, the get_db_session_for_request()
function no longer involves itself in transaction management and
simply returns a scoped database session.

fixes #2385

Signed-off-by: Randy Barlow <randy@electronsweatshop.com>