### PR TITLE
Add new API endpoint to retrieve greenwave's decision about an update and refactor code a little

### DIFF
--- a/bodhi/server/models.py
+++ b/bodhi/server/models.py
@@ -1958,7 +1958,14 @@ class Update(Base):
         return json.dumps(self.greenwave_subject)
 
     def get_test_gating_info(self):
-        """Query Greenwave about this update and returned the information retrieved."""
+        """
+        Query Greenwave about this update and return the information retrieved.
+
+        Returns:
+            dict: The response from Greenwave for this update.
+        Raises:
+            BodhiException: When the ``greenwave_api_url`` is undefined in configuration.
+        """
         if not config.get('greenwave_api_url'):
             raise BodhiException('No greenwave_api_url specified')
 

--- a/bodhi/server/schemas.py
+++ b/bodhi/server/schemas.py
@@ -807,3 +807,12 @@ class WaiveTestResultsSchema(CSRFProtectedSchema, colander.MappingSchema):
         colander.String(),
         missing=None,
     )
+
+
+class GetTestResultsSchema(CSRFProtectedSchema, colander.MappingSchema):
+    """An API schema for bodhi.server.services.updates.get_test_results()."""
+
+    alias = Builds(
+        colander.Sequence(accept_scalar=True),
+        missing=None,
+    )

--- a/bodhi/server/services/updates.py
+++ b/bodhi/server/services/updates.py
@@ -25,6 +25,7 @@ from cornice import Service
 from cornice.validators import colander_body_validator, colander_querystring_validator
 from sqlalchemy import func, distinct
 from sqlalchemy.sql import or_
+from requests import RequestException, Timeout as RequestsTimeout
 
 from bodhi.server import log, security
 from bodhi.server.exceptions import BodhiException, LockedUpdateException
@@ -91,6 +92,13 @@ update_waive_test_results = Service(
     description='Waive test results that block transitioning the update to next state',
     factory=security.PackagerACLFactory,
     cors_origins=bodhi.server.security.cors_origins_rw
+)
+
+update_get_test_results = Service(
+    name='update_get_test_results',
+    path='/updates/{id}/get-test-results',
+    description='Get test results for a specified update',
+    cors_origins=bodhi.server.security.cors_origins_ro,
 )
 
 
@@ -583,3 +591,41 @@ def waive_test_results(request):
         request.errors.add('body', 'request', str(e))
 
     return dict(update=update)
+
+
+@update_get_test_results.get(schema=bodhi.server.schemas.GetTestResultsSchema,
+                             validators=(validate_update_id),
+                             renderer='json',
+                             error_handler=bodhi.server.services.errors.json_handler)
+def get_test_results(request):
+    """
+    Get the test results on a given update when gating is on.
+
+    Args:
+        request (pyramid.request): The current request.
+    Returns:
+        dict: A dictionary mapping the key "update" to the update.
+    """
+    update = request.validated['update']
+
+    decision = None
+    try:
+        decision = update.get_test_gating_info()
+    except RequestsTimeout as e:
+        log.exception("Error querying greenwave for test results - timed out")
+        request.errors.add('body', 'request', str(e))
+        request.errors.status = 504
+    except (RequestException, RuntimeError) as e:
+        log.exception("Error querying greenwave for test results")
+        request.errors.add('body', 'request', str(e))
+        request.errors.status = 502
+    except BodhiException as e:
+        log.exception("Failed to query greenwave for test results")
+        request.errors.add('body', 'request', str(e))
+        request.errors.status = 501
+    except Exception as e:
+        log.exception("Unhandled exception in get_test_results")
+        request.errors.add('body', 'request', str(e))
+        request.errors.status = 500
+
+    return dict(decision=decision)

--- a/bodhi/tests/server/test_models.py
+++ b/bodhi/tests/server/test_models.py
@@ -3208,7 +3208,7 @@ class TestUpdate(ModelTest):
             str(exc.exception),
             ("Can't waive test results on a locked update"))
 
-    @mock.patch('bodhi.server.models.greenwave_api_post')
+    @mock.patch('bodhi.server.util.greenwave_api_post')
     @mock.patch('bodhi.server.util.http_session.post')
     def test_can_waive_multiple_test_results_of_an_update(self, post, greenwave_api_post):
         """Multiple failed tests getting waived should cause multiple calls to waiverdb."""
@@ -3261,7 +3261,7 @@ class TestUpdate(ModelTest):
             else:
                 self.assertEqual(post.mock_calls[i], v)
 
-    @mock.patch('bodhi.server.models.greenwave_api_post')
+    @mock.patch('bodhi.server.util.greenwave_api_post')
     @mock.patch('bodhi.server.models.waiverdb_api_post')
     def test_can_waive_test_results_of_an_update(self, mock_waiverdb, mock_greenwave):
         update = self.obj

--- a/docs/server_api/updates.rst
+++ b/docs/server_api/updates.rst
@@ -3,4 +3,4 @@ Updates
 
 .. cornice-autodoc::
    :modules: bodhi.server.services.updates, bodhi.server.services.zz_redirects
-   :services: bodhi1_update_redirect, update, update_edit, update_request, update_waive_test_results, updates, updates_rss
+   :services: bodhi1_update_redirect, update, update_edit, update_get_test_results, update_request, update_waive_test_results, updates, updates_rss


### PR DESCRIPTION
This is a first PR on the path to adding waiving support to bodhi-cli.

This refactors a little bit of code and adds a new API endpoint where can be retrieved greenwave's decision about an update.

This is currently missing unit-tests, I'll work on them tomorrow, but if someone has a little time to go through it and give a basic ack/nack on the idea itself it would be appreciated.

Thanks