### PR TITLE
Revert "Do not run flake8 on Fedora 29."

### DIFF
--- a/bodhi/client/__init__.py
+++ b/bodhi/client/__init__.py
@@ -547,8 +547,9 @@ def comment(update, text, karma, user, password, url, **kwargs):
 
 @updates.command()
 @staging_option
-@click.option('--arch', help='Specify arch of packages to download, ' +
-              '"all" will retrieve packages from all architectures')
+@click.option('--arch',
+              help=('Specify arch of packages to download, "all" will retrieve packages from all '
+                    'architectures'))
 @click.option('--cves', help='Download update(s) by CVE(s) (comma-separated list)')
 @click.option('--updateid', help='Download update(s) by ID(s) (comma-separated list)')
 @click.option('--builds', help='Download update(s) by build NVR(s) (comma-separated list)')

--- a/bodhi/server/consumers/masher.py
+++ b/bodhi/server/consumers/masher.py
@@ -375,8 +375,8 @@ class ComposerThread(threading.Thread):
         # dist_tag and do everything else other than mashing/updateinfo, since
         # the nightly build-branched cron job mashes for us.
         self.skip_compose = False
-        if (self.compose.release.state is ReleaseState.pending and
-                self.compose.request is UpdateRequest.stable):
+        if self.compose.release.state is ReleaseState.pending \
+                and self.compose.request is UpdateRequest.stable:
             self.skip_compose = True
 
         self.log.info('Running ComposerThread(%s)' % self.id)

--- a/bodhi/server/mail.py
+++ b/bodhi/server/mail.py
@@ -325,9 +325,9 @@ def get_template(update, use_template='fedora_errata_template'):
                     if parent and not bug.parent:
                         log.debug("Skipping tracker bug %s" % bug)
                         continue
-                title = (bug.title != 'Unable to fetch title' and
-                         bug.title != 'Invalid bug number') and \
-                    ' - %s' % bug.title or ''
+                title = (
+                    bug.title != 'Unable to fetch title' and bug.title != 'Invalid bug number') \
+                    and ' - %s' % bug.title or ''
                 info['references'] += u"  [ %d ] Bug #%d%s\n        %s\n" % \
                                       (i, bug.bug_id, title, bug.url)
                 i += 1

--- a/bodhi/server/migrations/versions/06aa0e8aa5d2_drop_the_update_karma_column.py
+++ b/bodhi/server/migrations/versions/06aa0e8aa5d2_drop_the_update_karma_column.py
@@ -48,4 +48,4 @@ def downgrade():
     Raises:
         NotImplemented: This is raised if this function is executed.
     """
-    raise NotImplemented('Downgrade not supported')
+    raise NotImplementedError('Downgrade not supported')

--- a/bodhi/server/migrations/versions/22858ba91115_add_new_side_tag_update_states.py
+++ b/bodhi/server/migrations/versions/22858ba91115_add_new_side_tag_update_states.py
@@ -53,4 +53,4 @@ def upgrade():
 
 def downgrade():
     """Raise an exception explaining that this migration cannot be reversed."""
-    raise NotImplemented('This migration cannot be reversed.')
+    raise NotImplementedError('This migration cannot be reversed.')

--- a/bodhi/server/migrations/versions/ebaab70b2cda_added_field_to_store_mail_template_.py
+++ b/bodhi/server/migrations/versions/ebaab70b2cda_added_field_to_store_mail_template_.py
@@ -40,12 +40,12 @@ def upgrade():
                             sa.sql.column('version', sa.Integer))
     op.execute(releases.update().where(releases.c.id_prefix == "FEDORA")
                                 .values({'mail_template': "fedora_errata_template"}))
-    op.execute(releases.update().where((releases.c.id_prefix == "FEDORA-EPEL") &
-                                       (sa.cast(releases.c.version, sa.Integer()) > 7))
-                                .values({'mail_template': "fedora_epel_errata_template"}))
-    op.execute(releases.update().where((releases.c.id_prefix == "FEDORA-EPEL") &
-                                       (sa.cast(releases.c.version, sa.Integer()) < 8))
-                                .values({'mail_template': "fedora_epel_legacy_errata_template"}))
+    op.execute(releases.update().where(
+        (releases.c.id_prefix == "FEDORA-EPEL") & (sa.cast(releases.c.version, sa.Integer()) > 7))
+        .values({'mail_template': "fedora_epel_errata_template"}))
+    op.execute(releases.update().where(
+        (releases.c.id_prefix == "FEDORA-EPEL") & (sa.cast(releases.c.version, sa.Integer()) < 8))
+        .values({'mail_template': "fedora_epel_legacy_errata_template"}))
     op.execute(releases.update().where(releases.c.id_prefix == "FEDORA-MODULAR")
                                 .values({'mail_template': "fedora_modular_errata_template"}))
 

--- a/bodhi/server/models.py
+++ b/bodhi/server/models.py
@@ -1892,8 +1892,8 @@ class Update(Base):
         comments_since_karma_reset = []
 
         for comment in reversed(self.comments):
-            if (comment.user.name == u'bodhi' and
-                    ('New build' in comment.text or 'Removed build' in comment.text)):
+            if comment.user.name == u'bodhi' and \
+                    ('New build' in comment.text or 'Removed build' in comment.text):
                 # We only want to consider comments since the most recent karma
                 # reset, which happens whenever a build is added or removed
                 # from an Update. Since we are traversing the comments in
@@ -2563,11 +2563,12 @@ class Update(Base):
                         'positive karma from proventesters, along with %d additional karma from '
                         'the community. Or, it must spend %s days in testing without any negative '
                         'feedback')
+                    additional_karma = config.get('critpath.min_karma') \
+                        - config.get('critpath.num_admin_approvals')
                     stern_note = stern_note % (
                         config.get('critpath.min_karma'),
                         config.get('critpath.num_admin_approvals'),
-                        (config.get('critpath.min_karma') -
-                            config.get('critpath.num_admin_approvals')),
+                        additional_karma,
                         config.get('critpath.stable_after_days_without_negative_karma'))
                     if config.get('test_gating.required'):
                         stern_note += ' Additionally, it must pass automated tests.'
@@ -2584,8 +2585,8 @@ class Update(Base):
         flash_notes = ''
         if action in (UpdateRequest.stable, UpdateRequest.batched) and not self.critpath:
             # Check if we've met the karma requirements
-            if (self.stable_karma not in (None, 0) and self.karma >=
-                    self.stable_karma) or self.critpath_approved:
+            if (self.stable_karma not in (None, 0) and self.karma >= self.stable_karma) \
+                    or self.critpath_approved:
                 log.debug('%s meets stable karma requirements' % self.title)
             else:
                 # If we haven't met the stable karma requirements, check if it
@@ -2779,8 +2780,8 @@ class Update(Base):
         mailinglist = None
         sender = config.get('bodhi_email')
         if not sender:
-            log.error("bodhi_email not defined in configuration!  Unable " +
-                      "to send update notice")
+            log.error(("bodhi_email not defined in configuration!  Unable "
+                      "to send update notice"))
             return
 
         # eg: fedora_epel
@@ -3253,8 +3254,8 @@ class Update(Base):
 
             for index, build in enumerate(self.builds):
                 multicall_response = buildinfos[index]
-                if (not isinstance(multicall_response, list) or
-                        not isinstance(multicall_response[0], dict)):
+                if not isinstance(multicall_response, list) \
+                        or not isinstance(multicall_response[0], dict):
                     msg = ("Error retrieving data from Koji for %r: %r" %
                            (build.nvr, multicall_response))
                     log.error(msg)
@@ -4145,8 +4146,8 @@ class Bug(Base):
             comment (basestring or None): The comment to add to the bug. If None, a default message
                 is added to the bug. Defaults to None.
         """
-        if (update.type is UpdateType.security and self.parent and
-                update.status is not UpdateStatus.stable):
+        if update.type is UpdateType.security and self.parent \
+                and update.status is not UpdateStatus.stable:
             log.debug('Not commenting on parent security bug %s', self.bug_id)
         else:
             if not comment:

--- a/bodhi/server/util.py
+++ b/bodhi/server/util.py
@@ -526,9 +526,9 @@ def status2html(context, status):
         'processing': 'Unused.',
     }[status]
 
-    return ("<span class='text-muted' data-toggle='tooltip' title='%s'>" % (status_desc) +
-            "<span class='label label-%s'>%s</span>" % (cls, status) +
-            "</span>")
+    return "<span class='text-muted' data-toggle='tooltip' title='%s'>" % (status_desc) \
+        + "<span class='label label-%s'>%s</span>" % (cls, status) \
+        + "</span>"
 
 
 def greenwave_unsatisfied_requirements_html(context, update):
@@ -945,10 +945,8 @@ def can_waive_test_results(context, update):
     Returns:
         bool: Indicating if the test results can be waived on the given update.
     """
-    return (config.get('test_gating.required') and
-            not update.test_gating_passed and
-            config.get('waiverdb.access_token') and
-            update.status.description != 'stable')
+    return config.get('test_gating.required') and not update.test_gating_passed \
+        and config.get('waiverdb.access_token') and update.status.description != 'stable'
 
 
 def sorted_builds(builds):
@@ -1001,8 +999,7 @@ def sorted_updates(updates):
                 async_.append(build.update)
     log.info('sync = %s' % ([up.title for up in sync],))
     log.info('async_ = %s' % ([up.title for up in async_],))
-    if not (len(set(sync) & set(async_)) == 0 and
-            len(set(sync) | set(async_)) == len(updates)):
+    if not (len(set(sync) & set(async_)) == 0 and len(set(sync) | set(async_)) == len(updates)):
         # There should be absolutely no way to hit this code path, but let's be paranoid, and check
         # every run, to make sure no update gets left behind.
         # It makes sure that there is no update in sync AND async, and that the combination of

--- a/bodhi/server/validators.py
+++ b/bodhi/server/validators.py
@@ -162,8 +162,7 @@ def cache_release(request, build):
         log.warn('Unable to determine release from '
                  'tags: %r build: %r' % (tags, build))
         request.errors.add('body', 'builds',
-                           'Unable to determine release ' +
-                           'from build: %s' % build)
+                           'Unable to determine release from build: %s' % build)
     if not build_rel:
         msg = 'Cannot find release associated with ' + \
             'build: {}, tags: {}'.format(build, tags)

--- a/bodhi/tests/client/test___init__.py
+++ b/bodhi/tests/client/test___init__.py
@@ -223,8 +223,8 @@ class TestDownload(unittest.TestCase):
 
         self.assertEqual(result.exit_code, 0)
         self.assertEqual(result.output,
-                         'WARNING: Some builds not found!\nDownloading packages ' +
-                         'from nodejs-grunt-wrap-0.3.0-2.fc25\n')
+                         ('WARNING: Some builds not found!\nDownloading packages '
+                          'from nodejs-grunt-wrap-0.3.0-2.fc25\n'))
         call.assert_called_once_with((
             'koji', 'download-build', '--arch=noarch', '--arch={}'.format(platform.machine()),
             'nodejs-grunt-wrap-0.3.0-2.fc25'))
@@ -247,8 +247,8 @@ class TestDownload(unittest.TestCase):
 
         self.assertEqual(result.exit_code, 0)
         self.assertEqual(result.output,
-                         'Downloading packages from nodejs-grunt-wrap-0.3.0-2.fc25\n' +
-                         'WARNING: download of nodejs-grunt-wrap-0.3.0-2.fc25 failed!\n')
+                         ('Downloading packages from nodejs-grunt-wrap-0.3.0-2.fc25\n'
+                          'WARNING: download of nodejs-grunt-wrap-0.3.0-2.fc25 failed!\n'))
         call.assert_called_once_with((
             'koji', 'download-build', '--arch=noarch', '--arch={}'.format(platform.machine()),
             'nodejs-grunt-wrap-0.3.0-2.fc25'))

--- a/bodhi/tests/server/consumers/test_masher.py
+++ b/bodhi/tests/server/consumers/test_masher.py
@@ -1262,9 +1262,9 @@ That was the actual one'''
             'f24-updates-161003.1302', 'f24-updates-testing-161001.0424',
             'this_should_get_left_alone', 'f23-updates-should_be_untouched',
             'f23-updates.repocache', 'f23-updates-testing-blank'}
-        actual_dirs = set([d for d in os.listdir(mash_dir)
-                           if os.path.isdir(os.path.join(mash_dir, d)) and
-                           not d.startswith("Fedora-17-updates")])
+        actual_dirs = set([
+            d for d in os.listdir(mash_dir)
+            if os.path.isdir(os.path.join(mash_dir, d)) and not d.startswith("Fedora-17-updates")])
 
         # Assert that remove_old_composes removes the correct items and leaves the rest in place.
         self.assertEqual(actual_dirs, expected_dirs)

--- a/bodhi/tests/server/services/test_updates.py
+++ b/bodhi/tests/server/services/test_updates.py
@@ -306,7 +306,7 @@ class TestNewUpdate(BaseTestCase):
         resp = self.app.get('/updates/%s' % nvr, headers={'Accept': 'text/html'})
 
         self.assertRegexpMatches(str(resp), ('https://koji.fedoraproject.org/koji'
-                                             '/search\?terms=.*\&amp;type=build\&amp;match=glob'))
+                                             r'/search\?terms=.*\&amp;type=build\&amp;match=glob'))
 
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
@@ -321,7 +321,7 @@ class TestNewUpdate(BaseTestCase):
         resp = self.app.get('/updates/%s' % nvr, headers={'Accept': 'text/html'})
 
         self.assertRegexpMatches(str(resp), ('https://koji.fedoraproject.org/koji'
-                                             '/search\?terms=.*\&amp;type=build\&amp;match=glob'))
+                                             r'/search\?terms=.*\&amp;type=build\&amp;match=glob'))
 
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
@@ -337,7 +337,7 @@ class TestNewUpdate(BaseTestCase):
         resp = self.app.get('/updates/%s' % nvr, headers={'Accept': 'text/html'})
 
         self.assertRegexpMatches(str(resp), ('https://host.org'
-                                             '/search\?terms=.*\&amp;type=build\&amp;match=glob'))
+                                             r'/search\?terms=.*\&amp;type=build\&amp;match=glob'))
 
     @mock.patch.dict('bodhi.server.validators.config', {'acl_system': u'dummy'})
     @mock.patch(**mock_uuid4_version1)

--- a/bodhi/tests/server/test_models.py
+++ b/bodhi/tests/server/test_models.py
@@ -2937,8 +2937,7 @@ class TestUpdate(ModelTest):
             expected_msg = expected_msg % (
                 config.get('critpath.min_karma'),
                 config.get('critpath.num_admin_approvals'),
-                (config.get('critpath.min_karma') -
-                    config.get('critpath.num_admin_approvals')),
+                (config.get('critpath.min_karma') - config.get('critpath.num_admin_approvals')),
                 config.get('critpath.stable_after_days_without_negative_karma'))
             expected_msg += ' Additionally, it must pass automated tests.'
             self.assertEqual(str(e), expected_msg)

--- a/devel/test_container.sh
+++ b/devel/test_container.sh
@@ -45,10 +45,7 @@ mkdir -p /usr/local/lib/python$py3_version/site-packages/
 if ! rpm -q python2-flake8; then
     flake8 || fail
 else
-    # flake8 fails to run on Fedora 29 https://github.com/fedora-infra/bodhi/issues/2412
-    if ! grep 29 < /etc/redhat-release; then
-        flake8-2 || fail
-    fi
+    flake8-2 || fail
 fi
 pydocstyle bodhi || fail
 make -C docs clean || fail

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,7 +14,7 @@ width = 80
 [flake8]
 show-source = True
 max-line-length = 100
-exclude = .git,.tox,dist,*egg,build
+exclude = .git,.tox,dist,*egg,build,tools
 ignore = E712
 
 [init_catalog]


### PR DESCRIPTION
This reverts commit c1746f65ab243c2e2bb0d9917596e399a4bdf1a4.

This cannot be merged until https://bugzilla.redhat.com/show_bug.cgi?id=1582075 is fixed.