### PR TITLE
Python 3 ready tests

### DIFF
--- a/bodhi/server/views/metrics.py
+++ b/bodhi/server/views/metrics.py
@@ -39,8 +39,7 @@ def compute_ticks_and_data(db, releases, update_types):
     """
     data, ticks = [], []
 
-    releases = sorted(releases, cmp=lambda x, y:
-                      cmp(int(x.version_int), int(y.version_int)))
+    releases = sorted(releases, key=lambda x: int(x.version_int))
 
     for i, release in enumerate(releases):
         ticks.append([i, release.name])

--- a/bodhi/tests/server/functional/test_admin.py
+++ b/bodhi/tests/server/functional/test_admin.py
@@ -18,8 +18,6 @@
 
 import copy
 
-from webtest import TestApp
-
 from bodhi.server import main
 from bodhi.tests.server import base
 
@@ -42,7 +40,7 @@ class TestAdminView(base.BaseTestCase):
             'authtkt.secret': 'whatever',
             'authtkt.secure': True,
         })
-        app = TestApp(main({}, session=self.db, **anonymous_settings))
+        app = base.BodhiTestApp(main({}, session=self.db, **anonymous_settings))
         res = app.get('/admin/', status=403)
         self.assertIn('<h1>403 <small>Forbidden</small></h1>', res)
         self.assertIn('<p class="lead">Access was denied to this resource.</p>', res)

--- a/bodhi/tests/server/functional/test_stacks.py
+++ b/bodhi/tests/server/functional/test_stacks.py
@@ -13,11 +13,8 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 import copy
-import unittest
 
 import mock
-from webtest import TestApp
-import six
 
 from bodhi.server import main
 from bodhi.server.models import Group, RpmPackage, Stack, User
@@ -49,7 +46,6 @@ class TestStacksService(base.BaseTestCase):
         self.assertEquals(res.json_body['stack']['name'], u'GNOME')
         self.assertEquals(res.json_body['stack']['packages'][0]['name'], u'gnome-shell')
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_stacks(self):
         res = self.app.get('/stacks/')
         body = res.json_body
@@ -57,7 +53,6 @@ class TestStacksService(base.BaseTestCase):
         self.assertEquals(body['stacks'][0]['name'], u'GNOME')
         self.assertEquals(body['stacks'][0]['packages'][0]['name'], u'gnome-shell')
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_stacks_with_pagination(self):
         # Create a second stack
         pkg1 = RpmPackage(name=u'firefox')
@@ -80,41 +75,35 @@ class TestStacksService(base.BaseTestCase):
         self.assertEquals(body['stacks'][0]['name'], 'Firefox')
         self.assertEquals(body['stacks'][0]['packages'][0]['name'], 'firefox')
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_stacks_by_name(self):
         res = self.app.get('/stacks/', {'name': 'GNOME'})
         body = res.json_body
         self.assertEquals(len(body['stacks']), 1)
         self.assertEquals(body['stacks'][0]['name'], 'GNOME')
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_stacks_by_name_mismatch(self):
         res = self.app.get('/stacks/', {'like': u'%KDE%'})
         body = res.json_body
         self.assertEquals(len(body['stacks']), 0)
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_stacks_by_name_match(self):
         res = self.app.get('/stacks/', {'like': '%GN%'})
         body = res.json_body
         self.assertEquals(len(body['stacks']), 1)
         self.assertEquals(body['stacks'][0]['name'], 'GNOME')
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_stacks_by_package_name(self):
         res = self.app.get('/stacks/', {"packages": 'gnome-shell'})
         body = res.json_body
         self.assertEquals(len(body['stacks']), 1)
         self.assertEquals(body['stacks'][0]['name'], 'GNOME')
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_stacks_by_nonexistant_package(self):
         res = self.app.get('/stacks/', {"packages": 'carbunkle'}, status=400)
         self.assertEquals(res.json_body['errors'][0]['name'], 'packages')
         self.assertEquals(res.json_body['errors'][0]['description'],
                           'Invalid packages specified: carbunkle')
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_valid_requirements)
     def test_new_stack(self, *args):
         self.db.add(RpmPackage(name=u'kde-filesystem'))
@@ -131,14 +120,12 @@ class TestStacksService(base.BaseTestCase):
         self.assertEquals(r.packages[0].name, 'kde-filesystem')
         self.assertEquals(r.requirements, u'rpmlint')
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_valid_requirements)
     def test_new_stack_invalid_name(self, *args):
         attrs = {"name": "", 'csrf_token': self.get_csrf_token()}
         res = self.app.post("/stacks/", attrs, status=400)
         self.assertEquals(res.json_body['status'], 'error')
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_valid_requirements)
     def test_new_stack_invalid_requirement(self, *args):
         attrs = {"name": u"Hackey", "packages": "nethack",
@@ -149,7 +136,6 @@ class TestStacksService(base.BaseTestCase):
         c = self.db.query(Stack).filter(Stack.name == attrs["name"]).count()
         self.assertEquals(c, 0)
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_valid_requirements)
     def test_new_stack_valid_requirement(self, *args):
         self.db.add(RpmPackage(name=u'nethack'))
@@ -165,7 +151,6 @@ class TestStacksService(base.BaseTestCase):
         self.assertEquals(len(r.packages), 1)
         self.assertEquals(r.requirements, attrs['requirements'])
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_valid_requirements)
     def test_edit_stack(self, *args):
         self.db.add(RpmPackage(name=u'gnome-music'))
@@ -194,7 +179,6 @@ class TestStacksService(base.BaseTestCase):
         self.assertEquals(res.json_body['status'], 'success')
         self.assertEquals(self.db.query(Stack).count(), 0)
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_valid_requirements)
     def test_edit_stack_remove_package(self, *args):
         self.db.add(RpmPackage(name=u'gnome-music'))
@@ -207,7 +191,6 @@ class TestStacksService(base.BaseTestCase):
         self.assertEquals(len(body['packages']), 1)
         self.assertEquals(body['packages'][0]['name'], 'gnome-music')
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_valid_requirements)
     def test_edit_stack_with_no_group_privs(self, *args):
         self.stack.users = []
@@ -224,7 +207,6 @@ class TestStacksService(base.BaseTestCase):
         self.assertEquals(body['errors'][0]['description'],
                           'guest does not have privileges to modify the GNOME stack')
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_valid_requirements)
     def test_edit_stack_with_no_user_privs(self, *args):
         user = User(name=u'bob')
@@ -241,7 +223,6 @@ class TestStacksService(base.BaseTestCase):
         self.assertEquals(body['errors'][0]['description'],
                           'guest does not have privileges to modify the GNOME stack')
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_valid_requirements)
     def test_edit_stack_with_user_privs(self, *args):
         user = self.db.query(User).filter_by(name=u'guest').one()
@@ -256,7 +237,6 @@ class TestStacksService(base.BaseTestCase):
         self.assertEquals(len(body['packages']), 2)
         self.assertEquals(body['packages'][-1]['name'], 'gnome-music')
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_valid_requirements)
     def test_edit_stack_with_group_privs(self, *args):
         self.stack.users = []

--- a/bodhi/tests/server/functional/test_stacks.py
+++ b/bodhi/tests/server/functional/test_stacks.py
@@ -288,7 +288,7 @@ class TestStacksService(base.BaseTestCase):
             'authtkt.secret': 'whatever',
             'authtkt.secure': True,
         })
-        app = TestApp(main({}, session=self.db, **anonymous_settings))
+        app = base.BodhiTestApp(main({}, session=self.db, **anonymous_settings))
         res = app.get('/stacks/new', status=403)
         self.assertIn('<h1>403 <small>Forbidden</small></h1>', res)
         self.assertIn('<p class="lead">Access was denied to this resource.</p>', res)

--- a/bodhi/tests/server/functional/test_users.py
+++ b/bodhi/tests/server/functional/test_users.py
@@ -35,18 +35,18 @@ class TestUsersService(base.BaseTestCase):
         self.app.get('/users/watwatwat', status=404)
 
     def test_get_single_user(self):
-        res = self.app.get('/users/bodhi', headers={'Accept': 'application/json'})
+        res = self.app.get('/users/bodhi')
         self.assertEquals(res.json_body['user']['name'], 'bodhi')
 
     def test_get_hardcoded_avatar(self):
-        res = self.app.get('/users/bodhi', headers={'Accept': 'application/json'})
+        res = self.app.get('/users/bodhi')
         self.assertEquals(res.json_body['user']['name'], 'bodhi')
         url = 'https://apps.fedoraproject.org/img/icons/bodhi-24.png'
         self.assertEquals(res.json_body['user']['avatar'], url)
 
     @mock.patch.dict(config, {'libravatar_enabled': True})
     def test_get_single_avatar(self):
-        res = self.app.get('/users/guest', headers={'Accept': 'application/json'})
+        res = self.app.get('/users/guest')
         self.assertEquals(res.json_body['user']['name'], 'guest')
 
         base = 'https://seccdn.libravatar.org/avatar/'

--- a/bodhi/tests/server/functional/test_users.py
+++ b/bodhi/tests/server/functional/test_users.py
@@ -12,10 +12,7 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
-import unittest
-
 import mock
-import six
 
 from bodhi.server.config import config
 from bodhi.server.models import Update, User
@@ -74,7 +71,6 @@ class TestUsersService(base.BaseTestCase):
                      headers=dict(accept='application/atom+xml'),
                      status=406)
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_users(self):
         res = self.app.get('/users/')
         self.assertIn('application/json', res.headers['Content-Type'])
@@ -86,7 +82,6 @@ class TestUsersService(base.BaseTestCase):
         self.assertIn(u'anonymous', users)
         self.assertIn(u'bodhi', users)
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_users_jsonp(self):
         res = self.app.get('/users/',
                            {'callback': 'callback'},
@@ -96,7 +91,6 @@ class TestUsersService(base.BaseTestCase):
         self.assertIn('bodhi', res)
         self.assertIn('guest', res)
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_users_rss(self):
         res = self.app.get('/rss/users/',
                            headers=dict(accept='application/atom+xml'))
@@ -104,7 +98,6 @@ class TestUsersService(base.BaseTestCase):
         self.assertIn('bodhi', res)
         self.assertIn('guest', res)
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_like_users(self):
         res = self.app.get('/users/', {'like': 'odh'})
         body = res.json_body
@@ -117,7 +110,6 @@ class TestUsersService(base.BaseTestCase):
         body = res.json_body
         self.assertEquals(len(body['users']), 0)
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_search_users(self):
         """
         Test that the overrides/?search= endpoint works as expected
@@ -142,7 +134,6 @@ class TestUsersService(base.BaseTestCase):
         body = res.json_body
         self.assertEquals(len(body['users']), 0)
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_users_with_pagination(self):
         res = self.app.get('/users/')
         body = res.json_body
@@ -165,31 +156,26 @@ class TestUsersService(base.BaseTestCase):
         self.assertEquals(len(body['users']), 1)
         self.assertIn(body['users'][0]['name'], users)
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_users_by_name(self):
         res = self.app.get('/users/', {"name": 'guest'})
         body = res.json_body
         self.assertEquals(len(body['users']), 1)
         self.assertEquals(body['users'][0]['name'], 'guest')
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_users_by_name_match(self):
         res = self.app.get('/users/', {"name": 'gue%'})
         body = res.json_body
         self.assertEquals(len(body['users']), 1)
         self.assertEquals(body['users'][0]['name'], 'guest')
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_users_by_name_match_miss(self):
         res = self.app.get('/users/', {"name": '%wat%'})
         self.assertEquals(len(res.json_body['users']), 0)
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_users_by_groups(self):
         res = self.app.get('/users/', {"groups": 'packager'})
         self.assertEquals(len(res.json_body['users']), 1)
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_users_by_nonexistant_group(self):
         res = self.app.get('/users/', {"groups": 'carbunkle'}, status=400)
         body = res.json_body
@@ -197,7 +183,6 @@ class TestUsersService(base.BaseTestCase):
         self.assertEquals(body['errors'][0]['description'],
                           'Invalid groups specified: carbunkle')
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_users_by_mixed_nonexistant_group(self):
         res = self.app.get('/users/', {"groups": ['carbunkle', 'packager']}, status=400)
         body = res.json_body
@@ -205,21 +190,18 @@ class TestUsersService(base.BaseTestCase):
         self.assertEquals(body['errors'][0]['description'],
                           'Invalid groups specified: carbunkle')
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_users_by_group_miss(self):
         res = self.app.get('/users/', {"groups": 'provenpackager'})
         body = res.json_body
         self.assertEquals(len(body['users']), 0)
         assert 'errors' not in res.json_body
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_users_by_update_title(self):
         res = self.app.get('/users/', {"updates": 'bodhi-2.0-1.fc17'})
         body = res.json_body
         self.assertEquals(len(body['users']), 1)
         self.assertEquals(body['users'][0]['name'], 'guest')
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_users_by_update_alias(self):
         update = self.db.query(Update).first()
         update.alias = u'some_alias'
@@ -230,7 +212,6 @@ class TestUsersService(base.BaseTestCase):
         self.assertEquals(len(body['users']), 1)
         self.assertEquals(body['users'][0]['name'], 'guest')
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_users_by_nonexistant_update(self):
         res = self.app.get('/users/', {"updates": 'carbunkle'}, status=400)
         body = res.json_body
@@ -238,14 +219,12 @@ class TestUsersService(base.BaseTestCase):
         self.assertEquals(body['errors'][0]['description'],
                           'Invalid updates specified: carbunkle')
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_users_by_package_name(self):
         res = self.app.get('/users/', {"packages": 'bodhi'})
         body = res.json_body
         self.assertEquals(len(body['users']), 1)
         self.assertEquals(body['users'][0]['name'], 'guest')
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_users_by_nonexistant_package(self):
         res = self.app.get('/users/', {"packages": 'carbunkle'}, status=400)
         body = res.json_body

--- a/bodhi/tests/server/services/test_builds.py
+++ b/bodhi/tests/server/services/test_builds.py
@@ -17,10 +17,6 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
-import unittest
-
-import six
-
 from bodhi.server.models import RpmBuild, RpmPackage
 from bodhi.tests.server import base
 
@@ -34,7 +30,6 @@ class TestBuildsService(base.BaseTestCase):
         res = self.app.get('/builds/bodhi-2.0-1.fc17')
         self.assertEquals(res.json_body['nvr'], 'bodhi-2.0-1.fc17')
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_builds(self):
         res = self.app.get('/builds/')
         body = res.json_body
@@ -43,7 +38,6 @@ class TestBuildsService(base.BaseTestCase):
         up = body['builds'][0]
         self.assertEquals(up['nvr'], u'bodhi-2.0-1.fc17')
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_builds_pagination(self):
 
         # First, stuff a second build in there
@@ -66,7 +60,6 @@ class TestBuildsService(base.BaseTestCase):
 
         self.assertNotEquals(build1, build2)
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_builds_by_package(self):
         res = self.app.get('/builds/', {"packages": "bodhi"})
         body = res.json_body
@@ -75,14 +68,12 @@ class TestBuildsService(base.BaseTestCase):
         up = body['builds'][0]
         self.assertEquals(up['nvr'], u'bodhi-2.0-1.fc17')
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_builds_by_unexisting_package(self):
         res = self.app.get('/builds/', {"packages": "flash"}, status=400)
         self.assertEquals(res.json_body['errors'][0]['name'], 'packages')
         self.assertEquals(res.json_body['errors'][0]['description'],
                           'Invalid packages specified: flash')
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_builds_by_release_name(self):
         res = self.app.get('/builds/', {"releases": "F17"})
         body = res.json_body
@@ -91,7 +82,6 @@ class TestBuildsService(base.BaseTestCase):
         up = body['builds'][0]
         self.assertEquals(up['nvr'], u'bodhi-2.0-1.fc17')
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_builds_by_release_version(self):
         res = self.app.get('/builds/', {"releases": "17"})
         body = res.json_body
@@ -100,26 +90,22 @@ class TestBuildsService(base.BaseTestCase):
         up = body['builds'][0]
         self.assertEquals(up['nvr'], u'bodhi-2.0-1.fc17')
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_builds_by_unexisting_release(self):
         res = self.app.get('/builds/', {"releases": "WinXP"}, status=400)
         self.assertEquals(res.json_body['errors'][0]['name'], 'releases')
         self.assertEquals(res.json_body['errors'][0]['description'],
                           'Invalid releases specified: WinXP')
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_builds_by_nvr(self):
         res = self.app.get('/builds/', {"nvr": "bodhi-2.0-1.fc17"})
         up = res.json_body['builds'][0]
         self.assertEquals(up['nvr'], u'bodhi-2.0-1.fc17')
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_builds_by_update_title(self):
         res = self.app.get('/builds/', {"updates": ["bodhi-2.0-1.fc17"]})
         up = res.json_body['builds'][0]
         self.assertEquals(up['nvr'], u'bodhi-2.0-1.fc17')
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_builds_no_rows_per_page(self):
         res = self.app.get('/builds/', {"rows_per_page": None}, status=400)
         self.assertEquals(res.json_body['status'], 'error')

--- a/bodhi/tests/server/services/test_comments.py
+++ b/bodhi/tests/server/services/test_comments.py
@@ -19,10 +19,8 @@
 
 import copy
 from datetime import datetime, timedelta
-import unittest
 
 import mock
-import six
 
 from bodhi.server import main
 from bodhi.server.models import (Comment, Release, Update, UpdateRequest, UpdateStatus, UpdateType,
@@ -72,7 +70,6 @@ class TestCommentsService(base.BaseTestCase):
         comment.update(kwargs)
         return comment
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_invalid_update(self):
         res = self.app.post_json('/comments/', self.make_comment(
             update='bodhi-1.0-2.fc17',
@@ -81,7 +78,6 @@ class TestCommentsService(base.BaseTestCase):
         self.assertEquals(res.json_body['errors'][0]['description'],
                           "Invalid update specified: bodhi-1.0-2.fc17")
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_invalid_karma(self):
         res = self.app.post_json('/comments/',
                                  self.make_comment(karma=-2),
@@ -92,7 +88,6 @@ class TestCommentsService(base.BaseTestCase):
                                  status=400)
         assert '2 is greater than maximum value 1' in res, res
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch('bodhi.server.notifications.publish')
     def test_commenting_with_critpath_feedback(self, publish):
         comment = self.make_comment()
@@ -106,7 +101,6 @@ class TestCommentsService(base.BaseTestCase):
         self.assertEquals(res.json_body['comment']['karma_critpath'], -1)
         publish.assert_called_once_with(topic='update.comment', msg=mock.ANY)
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch('bodhi.server.notifications.publish')
     def test_commenting_with_bug_feedback(self, publish):
         comment = self.make_comment()
@@ -122,7 +116,6 @@ class TestCommentsService(base.BaseTestCase):
         self.assertEquals(len(feedback), 1)
         publish.assert_called_once_with(topic='update.comment', msg=mock.ANY)
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch('bodhi.server.notifications.publish')
     def test_commenting_with_testcase_feedback(self, publish):
         comment = self.make_comment()
@@ -138,7 +131,6 @@ class TestCommentsService(base.BaseTestCase):
         self.assertEquals(len(feedback), 1)
         publish.assert_called_once_with(topic='update.comment', msg=mock.ANY)
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch('bodhi.server.notifications.publish')
     def test_commenting_with_login(self, publish):
         res = self.app.post_json('/comments/', self.make_comment())
@@ -149,7 +141,6 @@ class TestCommentsService(base.BaseTestCase):
         self.assertEquals(res.json_body['comment']['user_id'], 1)
         publish.assert_called_once_with(topic='update.comment', msg=mock.ANY)
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch('bodhi.server.notifications.publish')
     def test_commenting_twice_with_neutral_karma(self, publish):
         res = self.app.post_json('/comments/', self.make_comment())
@@ -168,7 +159,6 @@ class TestCommentsService(base.BaseTestCase):
         self.assertEquals(res.json_body['comment']['user_id'], 1)
         self.assertEquals(publish.call_count, 2)
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch('bodhi.server.notifications.publish')
     def test_commenting_twice_with_double_positive_karma(self, publish):
         res = self.app.post_json('/comments/', self.make_comment(up2, karma=1))
@@ -192,7 +182,6 @@ class TestCommentsService(base.BaseTestCase):
         # Mainly, ensure that the karma didn't increase *again*
         self.assertEquals(res.json_body['comment']['update']['karma'], 1)
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch('bodhi.server.notifications.publish')
     def test_commenting_twice_with_positive_then_negative_karma(self, publish):
         res = self.app.post_json('/comments/', self.make_comment(up2, karma=1))
@@ -217,7 +206,6 @@ class TestCommentsService(base.BaseTestCase):
         self.assertEquals(res.json_body['caveats'][0]['description'],
                           'Your karma standing was reversed.')
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch('bodhi.server.notifications.publish')
     def test_commenting_with_negative_karma(self, publish):
         res = self.app.post_json('/comments/', self.make_comment(up2, karma=-1))
@@ -229,7 +217,6 @@ class TestCommentsService(base.BaseTestCase):
         publish.assert_called_once_with(topic='update.comment', msg=mock.ANY)
         self.assertEquals(res.json_body['comment']['update']['karma'], -1)
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch('bodhi.server.notifications.publish')
     def test_anonymous_commenting_with_email(self, publish):
         res = self.app.post_json('/comments/',
@@ -241,7 +228,6 @@ class TestCommentsService(base.BaseTestCase):
         self.assertEquals(res.json_body['comment']['user_id'], 2)
         publish.assert_called_once_with(topic='update.comment', msg=mock.ANY)
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_anonymous_commenting_with_invalid_email(self):
         res = self.app.post_json('/comments/',
                                  self.make_comment(email='foo'),
@@ -250,7 +236,6 @@ class TestCommentsService(base.BaseTestCase):
         self.assertEquals(res.json_body['errors'][0]['description'],
                           "Invalid email address")
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_anonymous_commenting_with_no_author(self):
         anonymous_settings = copy.copy(self.app_settings)
         anonymous_settings.update({
@@ -273,7 +258,6 @@ class TestCommentsService(base.BaseTestCase):
         self.assertEquals(res.json_body['errors'][0]['description'],
                           "You must provide an author")
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch('bodhi.server.services.comments.Update.comment',
                 side_effect=IOError('IOError. oops!'))
     def test_unexpected_exception(self, exception):
@@ -285,7 +269,6 @@ class TestCommentsService(base.BaseTestCase):
         self.assertEquals(res.json_body['errors'][0]['description'],
                           u'Unable to create comment')
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_get_single_comment(self):
         res = self.app.get('/comments/1')
         self.assertEquals(res.json_body['comment']['update_id'], 1)
@@ -308,7 +291,6 @@ class TestCommentsService(base.BaseTestCase):
     def test_404(self):
         self.app.get('/comments/a', status=400)
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_comments(self):
         res = self.app.get('/comments/')
         body = res.json_body
@@ -318,7 +300,6 @@ class TestCommentsService(base.BaseTestCase):
         self.assertEquals(comment['text'], u'srsly.  pretty good.')
         self.assertEquals(comment['karma'], 0)
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_comments_jsonp(self):
         res = self.app.get('/comments/',
                            {'callback': 'callback'},
@@ -327,20 +308,17 @@ class TestCommentsService(base.BaseTestCase):
         self.assertIn('callback', res)
         self.assertIn('srsly.  pretty good', res)
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_comments_rss(self):
         res = self.app.get('/rss/comments/',
                            headers=dict(accept='application/atom+xml'))
         self.assertIn('application/rss+xml', res.headers['Content-Type'])
         self.assertIn('srsly.  pretty good', res)
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_comments_page(self):
         res = self.app.get('/comments/', headers=dict(accept='text/html'))
         self.assertIn('text/html', res.headers['Content-Type'])
         self.assertIn('libravatar.org', res)
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_search_comments(self):
         res = self.app.get('/comments/', {'like': 'srsly'})
         body = res.json_body
@@ -353,7 +331,6 @@ class TestCommentsService(base.BaseTestCase):
         body = res.json_body
         self.assertEquals(len(body['comments']), 0)
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_comments_pagination(self):
         # Then, test pagination
         res = self.app.get('/comments/',
@@ -370,7 +347,6 @@ class TestCommentsService(base.BaseTestCase):
 
         self.assertNotEquals(comment1, comment2)
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_comments_by_since(self):
         tomorrow = datetime.utcnow() + timedelta(days=1)
         fmt = "%Y-%m-%d %H:%M:%S"
@@ -394,7 +370,6 @@ class TestCommentsService(base.BaseTestCase):
         self.assertEquals(comment['karma'], 1)
         self.assertEquals(comment['user']['name'], u'guest')
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_comments_by_invalid_since(self):
         res = self.app.get('/comments/', {"since": "forever"}, status=400)
         body = res.json_body
@@ -403,7 +378,6 @@ class TestCommentsService(base.BaseTestCase):
         self.assertEquals(error['name'], 'since')
         self.assertEquals(error['description'], 'Invalid date')
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_comments_by_future_date(self):
         """test filtering by future date"""
         tomorrow = datetime.utcnow() + timedelta(days=1)
@@ -413,7 +387,6 @@ class TestCommentsService(base.BaseTestCase):
         body = res.json_body
         self.assertEquals(len(body['comments']), 0)
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_comments_by_anonymous(self):
         res = self.app.get('/comments/', {"anonymous": "false"})
         body = res.json_body
@@ -422,7 +395,6 @@ class TestCommentsService(base.BaseTestCase):
         comment = body['comments'][0]
         self.assertEquals(comment['text'], u'wow. amaze.')
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_comments_by_invalid_anonymous(self):
         res = self.app.get('/comments/', {"anonymous": "lalala"}, status=400)
         body = res.json_body
@@ -432,7 +404,6 @@ class TestCommentsService(base.BaseTestCase):
         proper = "is neither in ('false', '0') nor in ('true', '1')"
         self.assertEquals(error['description'], '"lalala" %s' % proper)
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_comments_by_update(self):
         res = self.app.get('/comments/', {"updates": "bodhi-2.0-1.fc17"})
         body = res.json_body
@@ -441,7 +412,6 @@ class TestCommentsService(base.BaseTestCase):
         comment = body['comments'][0]
         self.assertEquals(comment['text'], u'srsly.  pretty good.')
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_comments_by_update_no_comments(self):
         nvr = u'bodhi-2.0-201.fc17'
         update = Update(
@@ -462,7 +432,6 @@ class TestCommentsService(base.BaseTestCase):
         body = res.json_body
         self.assertEquals(len(body['comments']), 0)
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_comments_by_unexisting_update(self):
         res = self.app.get('/comments/', {"updates": "flash-player"},
                            status=400)
@@ -470,7 +439,6 @@ class TestCommentsService(base.BaseTestCase):
         self.assertEquals(res.json_body['errors'][0]['description'],
                           "Invalid updates specified: flash-player")
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_comments_by_package(self):
         res = self.app.get('/comments/', {"packages": "bodhi"})
         body = res.json_body
@@ -479,7 +447,6 @@ class TestCommentsService(base.BaseTestCase):
         comment = body['comments'][0]
         self.assertEquals(comment['text'], u'srsly.  pretty good.')
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_comments_by_unexisting_package(self):
         res = self.app.get('/comments/', {"packages": "flash-player"},
                            status=400)
@@ -487,7 +454,6 @@ class TestCommentsService(base.BaseTestCase):
         self.assertEquals(res.json_body['errors'][0]['description'],
                           "Invalid packages specified: flash-player")
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_comments_by_username(self):
         res = self.app.get('/comments/', {"user": "guest"})
         body = res.json_body
@@ -496,7 +462,6 @@ class TestCommentsService(base.BaseTestCase):
         comment = body['comments'][0]
         self.assertEquals(comment['text'], u'wow. amaze.')
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_comments_by_unexisting_username(self):
         res = self.app.get('/comments/', {"user": "santa"}, status=400)
         body = res.json_body
@@ -505,7 +470,6 @@ class TestCommentsService(base.BaseTestCase):
         self.assertEquals(res.json_body['errors'][0]['description'],
                           "Invalid user specified: santa")
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_comments_by_update_owner(self):
         res = self.app.get('/comments/', {"update_owner": "guest"})
         body = res.json_body
@@ -514,7 +478,6 @@ class TestCommentsService(base.BaseTestCase):
         comment = body['comments'][0]
         self.assertEquals(comment['text'], u'srsly.  pretty good.')
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_comments_by_update_owner_with_none(self):
         user = User(name=u'ralph')
         self.db.add(user)
@@ -524,7 +487,6 @@ class TestCommentsService(base.BaseTestCase):
         self.assertEquals(len(body['comments']), 0)
         self.assertNotIn('errors', body)
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_comments_by_unexisting_update_owner(self):
         res = self.app.get('/comments/', {"update_owner": "santa"}, status=400)
         body = res.json_body
@@ -533,7 +495,6 @@ class TestCommentsService(base.BaseTestCase):
         self.assertEquals(res.json_body['errors'][0]['description'],
                           "Invalid user specified: santa")
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_comments_with_ignore_user(self):
         res = self.app.get('/comments/', {"ignore_user": "guest"})
         body = res.json_body
@@ -542,7 +503,6 @@ class TestCommentsService(base.BaseTestCase):
         comment = body['comments'][0]
         self.assertEquals(comment['text'], u'srsly.  pretty good.')
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_comments_with_unexisting_ignore_user(self):
         res = self.app.get('/comments/', {"ignore_user": "santa"}, status=400)
         body = res.json_body
@@ -551,19 +511,16 @@ class TestCommentsService(base.BaseTestCase):
         self.assertEquals(res.json_body['errors'][0]['description'],
                           "Invalid user specified: santa")
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_put_json_comment(self):
         """ We only want to POST comments, not PUT. """
         self.app.put_json('/comments/', self.make_comment(), status=405)
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_post_json_comment(self):
         self.app.post_json('/comments/', self.make_comment(text='awesome'))
         up = self.db.query(Update).filter_by(title=u'bodhi-2.0-1.fc17').one()
         self.assertEquals(len(up.comments), 3)
         self.assertEquals(up.comments[-1]['text'], 'awesome')
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_new_comment(self):
         comment = self.make_comment('bodhi-2.0-1.fc17', text='superb')
         r = self.app.post_json('/comments/', comment)
@@ -575,7 +532,6 @@ class TestCommentsService(base.BaseTestCase):
         self.assertEquals(comment['update_title'], u'bodhi-2.0-1.fc17')
         self.assertEquals(comment['karma'], 0)
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_no_self_karma(self):
         " Make sure you can't give +1 karma to your own updates.. "
         comment = self.make_comment('bodhi-2.0-1.fc17', karma=1)
@@ -595,7 +551,6 @@ class TestCommentsService(base.BaseTestCase):
                           "You may not give karma to your own updates.")
         self.assertEquals(comment['karma'], 0)  # This is the real check
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_comment_on_locked_update(self):
         """ Make sure you can comment on locked updates. """
         # Lock it
@@ -614,7 +569,6 @@ class TestCommentsService(base.BaseTestCase):
         self.assertEquals(len(up.comments), 1)  # After
         self.assertEquals(up.karma, 1)          # After
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_comment_on_locked_update_no_threshhold_action(self):
         " Make sure you can't trigger threshold action on locked updates "
         # Lock it

--- a/bodhi/tests/server/services/test_comments.py
+++ b/bodhi/tests/server/services/test_comments.py
@@ -22,7 +22,6 @@ from datetime import datetime, timedelta
 import unittest
 
 import mock
-from webtest import TestApp
 import six
 
 from bodhi.server import main
@@ -259,7 +258,7 @@ class TestCommentsService(base.BaseTestCase):
             'authtkt.secure': True,
         })
         with mock.patch('bodhi.server.Session.remove'):
-            app = TestApp(main({}, session=self.db, **anonymous_settings))
+            app = base.BodhiTestApp(main({}, session=self.db, **anonymous_settings))
 
         comment = {
             u'update': 'bodhi-2.0-1.fc17',

--- a/bodhi/tests/server/services/test_errors.py
+++ b/bodhi/tests/server/services/test_errors.py
@@ -17,8 +17,6 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 """This module contains tests for bodhi.server.services.errors.py"""
-import unittest
-
 import mock
 import six
 
@@ -27,7 +25,6 @@ from bodhi.tests.server import base
 
 class TestHTMLHandlerErrors(base.BaseTestCase):
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch('bodhi.server.services.errors.log.error')
     @mock.patch('bodhi.server.services.errors.status2summary',
                 side_effect=IOError('random error'))

--- a/bodhi/tests/server/services/test_errors.py
+++ b/bodhi/tests/server/services/test_errors.py
@@ -43,4 +43,5 @@ class TestHTMLHandlerErrors(base.BaseTestCase):
         self.assertIn("Traceback (most recent call last):\n", error_log_message)
         self.assertIn("summary=status2summary(errors.status),\n", error_log_message)
         self.assertIn("raise effect\n", error_log_message)
-        self.assertIn("IOError: random error\n", error_log_message)
+        exception_str = 'IOError' if six.PY2 else 'OSError'
+        self.assertIn(exception_str + ": random error\n", error_log_message)

--- a/bodhi/tests/server/services/test_overrides.py
+++ b/bodhi/tests/server/services/test_overrides.py
@@ -22,7 +22,6 @@ import copy
 import unittest
 
 import mock
-from webtest import TestApp
 import six
 
 from bodhi.server.models import BuildrootOverride, RpmBuild, RpmPackage, Release, User
@@ -662,7 +661,7 @@ class TestOverridesWebViews(base.BaseTestCase):
             'authtkt.secure': True,
         })
         with mock.patch('bodhi.server.Session.remove'):
-            app = TestApp(main({}, session=self.db, **anonymous_settings))
+            app = base.BodhiTestApp(main({}, session=self.db, **anonymous_settings))
 
         resp = app.get('/overrides/bodhi-2.0-1.fc17',
                        status=200, headers={'Accept': 'text/html'})
@@ -688,7 +687,7 @@ class TestOverridesWebViews(base.BaseTestCase):
             'authtkt.secret': 'whatever',
             'authtkt.secure': True,
         })
-        app = TestApp(main({}, session=self.db, **anonymous_settings))
+        app = base.BodhiTestApp(main({}, session=self.db, **anonymous_settings))
         resp = app.get('/overrides/new',
                        status=403, headers={'Accept': 'text/html'})
         self.assertIn('<h1>403 <small>Forbidden</small></h1>', resp)

--- a/bodhi/tests/server/services/test_overrides.py
+++ b/bodhi/tests/server/services/test_overrides.py
@@ -19,10 +19,8 @@
 
 from datetime import datetime, timedelta
 import copy
-import unittest
 
 import mock
-import six
 
 from bodhi.server.models import BuildrootOverride, RpmBuild, RpmPackage, Release, User
 from bodhi.server import main
@@ -52,7 +50,6 @@ class TestOverridesService(base.BaseTestCase):
         self.assertEquals(override['submitter']['name'], 'guest')
         self.assertEquals(override['notes'], 'blah blah blah')
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_overrides(self):
         res = self.app.get('/overrides/')
 
@@ -64,21 +61,18 @@ class TestOverridesService(base.BaseTestCase):
         self.assertEquals(override['submitter']['name'], 'guest')
         self.assertEquals(override['notes'], 'blah blah blah')
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_overrides_rss(self):
         res = self.app.get('/rss/overrides/',
                            headers=dict(accept='application/atom+xml'))
         self.assertIn('application/rss+xml', res.headers['Content-Type'])
         self.assertIn('blah blah blah', res)
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_expired_overrides(self):
         res = self.app.get('/overrides/', {'expired': 'true'})
 
         body = res.json_body
         self.assertEquals(len(body['overrides']), 0)
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_notexpired_overrides(self):
         res = self.app.get('/overrides/', {'expired': 'false'})
 
@@ -90,7 +84,6 @@ class TestOverridesService(base.BaseTestCase):
         self.assertEquals(override['submitter']['name'], 'guest')
         self.assertEquals(override['notes'], 'blah blah blah')
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_overrides_by_invalid_expired(self):
         res = self.app.get('/overrides/', {"expired": "lalala"},
                            status=400)
@@ -101,7 +94,6 @@ class TestOverridesService(base.BaseTestCase):
         self.assertEquals(errors[0]['description'],
                           '"lalala" is neither in (\'false\', \'0\') nor in (\'true\', \'1\')')
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_overrides_by_packages(self):
         res = self.app.get('/overrides/', {'packages': 'bodhi'})
 
@@ -113,7 +105,6 @@ class TestOverridesService(base.BaseTestCase):
         self.assertEquals(override['submitter']['name'], 'guest')
         self.assertEquals(override['notes'], 'blah blah blah')
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_overrides_by_packages_without_override(self):
         self.db.add(RpmPackage(name=u'python'))
         self.db.flush()
@@ -123,7 +114,6 @@ class TestOverridesService(base.BaseTestCase):
         body = res.json_body
         self.assertEquals(len(body['overrides']), 0)
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_overrides_by_invalid_packages(self):
         res = self.app.get('/overrides/', {'packages': 'flash-player'},
                            status=400)
@@ -135,7 +125,6 @@ class TestOverridesService(base.BaseTestCase):
         self.assertEquals(errors[0]['description'],
                           'Invalid packages specified: flash-player')
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_overrides_by_releases(self):
         res = self.app.get('/overrides/', {'releases': 'F17'})
 
@@ -147,7 +136,6 @@ class TestOverridesService(base.BaseTestCase):
         self.assertEquals(override['submitter']['name'], 'guest')
         self.assertEquals(override['notes'], 'blah blah blah')
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_overrides_by_builds(self):
         res = self.app.get('/overrides/', {'builds': 'bodhi-2.0-1.fc17'})
 
@@ -159,7 +147,6 @@ class TestOverridesService(base.BaseTestCase):
         self.assertEquals(override['submitter']['name'], 'guest')
         self.assertEquals(override['notes'], 'blah blah blah')
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_overrides_by_releases_without_override(self):
         self.db.add(Release(name=u'F42', long_name=u'Fedora 42',
                             id_prefix=u'FEDORA', version=u'42',
@@ -178,7 +165,6 @@ class TestOverridesService(base.BaseTestCase):
         body = res.json_body
         self.assertEquals(len(body['overrides']), 0)
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_overrides_by_invalid_releases(self):
         res = self.app.get('/overrides/', {'releases': 'F42'},
                            status=400)
@@ -190,7 +176,6 @@ class TestOverridesService(base.BaseTestCase):
         self.assertEquals(errors[0]['description'],
                           'Invalid releases specified: F42')
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_overrides_by_username(self):
         res = self.app.get('/overrides/', {"user": "guest"})
         body = res.json_body
@@ -201,7 +186,6 @@ class TestOverridesService(base.BaseTestCase):
         self.assertEquals(override['submitter']['name'], 'guest')
         self.assertEquals(override['notes'], 'blah blah blah')
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_overrides_by_username_without_override(self):
         self.db.add(User(name=u'bochecha'))
         self.db.flush()
@@ -211,7 +195,6 @@ class TestOverridesService(base.BaseTestCase):
         body = res.json_body
         self.assertEquals(len(body['overrides']), 0)
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_overrides_by_unexisting_username(self):
         res = self.app.get('/overrides/', {"user": "santa"}, status=400)
 
@@ -222,7 +205,6 @@ class TestOverridesService(base.BaseTestCase):
         self.assertEquals(errors[0]['description'],
                           "Invalid user specified: santa")
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_overrides_by_like(self):
         """
         Test that the overrides/?like= endpoint works as expected
@@ -240,7 +222,6 @@ class TestOverridesService(base.BaseTestCase):
         body = res.json_body
         self.assertEquals(len(body['overrides']), 0)
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_overrides_by_search(self):
         """
         Test that the overrides/?search= endpoint works as expected
@@ -701,7 +682,6 @@ class TestOverridesWebViews(base.BaseTestCase):
                             status=200, headers={'Accept': 'text/html'})
         self.assertIn('<h2 class="pull-left m-t-3">New Override</h2>', resp)
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_overrides_list(self):
         """
         Test that the overrides list page shows, and contains the one overrides

--- a/bodhi/tests/server/services/test_releases.py
+++ b/bodhi/tests/server/services/test_releases.py
@@ -17,7 +17,6 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 import mock
-import webtest
 import unittest
 
 import six
@@ -56,7 +55,7 @@ class TestReleasesService(base.BaseTestCase):
         name = u"F22"
         # Create a new app so we are the anonymous user.
         with mock.patch('bodhi.server.Session.remove'):
-            app = webtest.TestApp(server.main({}, session=self.db, **self.app_settings))
+            app = base.BodhiTestApp(server.main({}, session=self.db, **self.app_settings))
 
         res = app.get('/releases/%s' % name, status=200)
         r = res.json_body

--- a/bodhi/tests/server/services/test_releases.py
+++ b/bodhi/tests/server/services/test_releases.py
@@ -17,9 +17,6 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 import mock
-import unittest
-
-import six
 
 from bodhi import server
 from bodhi.server.models import Release, ReleaseState, Update
@@ -49,7 +46,6 @@ class TestReleasesService(base.BaseTestCase):
     def test_404(self):
         self.app.get('/releases/watwatwat', status=404)
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_anonymous_cant_edit_release(self):
         """Ensure that an unauthenticated user cannot edit a release, since only an admin should."""
         name = u"F22"
@@ -81,7 +77,6 @@ class TestReleasesService(base.BaseTestCase):
         res = self.app.get('/releases/Fedora%2022', headers={'Accept': 'application/json'})
         self.assertEquals(res.json_body['name'], 'F22')
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_releases(self):
         res = self.app.get('/releases/')
         body = res.json_body
@@ -90,7 +85,6 @@ class TestReleasesService(base.BaseTestCase):
         self.assertEquals(body['releases'][0]['name'], u'F17')
         self.assertEquals(body['releases'][1]['name'], u'F22')
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_releases_with_pagination(self):
         res = self.app.get('/releases/')
         body = res.json_body
@@ -106,13 +100,11 @@ class TestReleasesService(base.BaseTestCase):
         self.assertEquals(len(body['releases']), 1)
         self.assertEquals(body['releases'][0]['name'], 'F22')
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_releases_by_ids_unknown(self):
         res = self.app.get('/releases/', {"ids": [9234872348923467]})
 
         self.assertEquals(len(res.json_body['releases']), 0)
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_releases_by_ids_plural(self):
         releases = Release.query.all()
 
@@ -122,7 +114,6 @@ class TestReleasesService(base.BaseTestCase):
         self.assertEquals(set([r['name'] for r in res.json_body['releases']]),
                           set([release.name for release in releases]))
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_releases_by_ids_singular(self):
         release = Release.query.all()[0]
 
@@ -131,33 +122,28 @@ class TestReleasesService(base.BaseTestCase):
         self.assertEquals(len(res.json_body['releases']), 1)
         self.assertEquals(res.json_body['releases'][0]['name'], release.name)
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_releases_by_name(self):
         res = self.app.get('/releases/', {"name": 'F22'})
         body = res.json_body
         self.assertEquals(len(body['releases']), 1)
         self.assertEquals(body['releases'][0]['name'], 'F22')
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_releases_by_name_match(self):
         res = self.app.get('/releases/', {"name": '%1%'})
         body = res.json_body
         self.assertEquals(len(body['releases']), 1)
         self.assertEquals(body['releases'][0]['name'], 'F17')
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_releases_by_name_match_miss(self):
         res = self.app.get('/releases/', {"name": '%wat%'})
         self.assertEquals(len(res.json_body['releases']), 0)
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_releases_by_update_title(self):
         res = self.app.get('/releases/', {"updates": 'bodhi-2.0-1.fc17'})
         body = res.json_body
         self.assertEquals(len(body['releases']), 1)
         self.assertEquals(body['releases'][0]['name'], 'F17')
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_releases_by_update_alias(self):
         update = self.db.query(Update).first()
         update.alias = u'some_alias'
@@ -168,28 +154,24 @@ class TestReleasesService(base.BaseTestCase):
         self.assertEquals(len(body['releases']), 1)
         self.assertEquals(body['releases'][0]['name'], 'F17')
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_releases_by_nonexistant_update(self):
         res = self.app.get('/releases/', {"updates": 'carbunkle'}, status=400)
         self.assertEquals(res.json_body['errors'][0]['name'], 'updates')
         self.assertEquals(res.json_body['errors'][0]['description'],
                           'Invalid updates specified: carbunkle')
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_releases_by_package_name(self):
         res = self.app.get('/releases/', {"packages": 'bodhi'})
         body = res.json_body
         self.assertEquals(len(body['releases']), 1)
         self.assertEquals(body['releases'][0]['name'], 'F17')
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_releases_by_nonexistant_package(self):
         res = self.app.get('/releases/', {"packages": 'carbunkle'}, status=400)
         self.assertEquals(res.json_body['errors'][0]['name'], 'packages')
         self.assertEquals(res.json_body['errors'][0]['description'],
                           'Invalid packages specified: carbunkle')
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_new_release(self):
         attrs = {"name": u"F42", "long_name": "Fedora 42", "version": "42",
                  "id_prefix": "FEDORA", "branch": "f42", "dist_tag": "f42",
@@ -213,7 +195,6 @@ class TestReleasesService(base.BaseTestCase):
 
         self.assertEquals(r.state, ReleaseState.disabled)
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch('bodhi.server.services.releases.log.info', side_effect=IOError('BOOM!'))
     def test_save_release_exception_handler(self, info):
         """Test the exception handler in save_release()."""
@@ -240,7 +221,6 @@ class TestReleasesService(base.BaseTestCase):
         self.assertEqual(self.db.query(Release).filter(Release.name == attrs["name"]).count(), 0)
         info.assert_called_once_with('Creating a new release: F42')
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_new_release_invalid_tags(self):
         attrs = {"name": "EL42", "long_name": "EPEL 42", "version": "42",
                  "id_prefix": "FEDORA EPEL", "branch": "f42",
@@ -256,7 +236,6 @@ class TestReleasesService(base.BaseTestCase):
         for error in res.json_body['errors']:
             self.assertEquals(error["description"], "Invalid tag: %s" % attrs[error["name"]])
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_edit_release(self):
         name = u"F22"
 
@@ -300,7 +279,6 @@ class TestReleasesService(base.BaseTestCase):
         self.assertEquals(res.content_type, 'text/html')
         self.assertIn('Fedora 22', res)
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_query_releases_html_two_releases_same_state(self):
         """Test query_releases_html() with two releases in the same state."""
         attrs = {

--- a/bodhi/tests/server/services/test_updates.py
+++ b/bodhi/tests/server/services/test_updates.py
@@ -539,7 +539,8 @@ class TestNewUpdate(BaseTestCase):
         r = self.app.post_json('/updates/', args)
         up = r.json_body
         self.assertEquals(up['title'], u'bodhi-2.0.0-3.fc17')
-        self.assertEquals(up['requirements'], 'upgradepath rpmlint')
+        self.assertTrue('upgradepath' in up['requirements'])
+        self.assertTrue('rpmlint' in up['requirements'])
         publish.assert_called_once_with(
             topic='update.request.testing', msg=mock.ANY)
 

--- a/bodhi/tests/server/services/test_updates.py
+++ b/bodhi/tests/server/services/test_updates.py
@@ -82,14 +82,12 @@ class TestNewUpdate(BaseTestCase):
     """
     This class contains tests for the new_update() function.
     """
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_valid_requirements)
     def test_empty_build_name(self, *args):
         res = self.app.post_json('/updates/', self.get_update([u'']), status=400)
         self.assertEquals(res.json_body['errors'][0]['name'], 'builds.0')
         self.assertEquals(res.json_body['errors'][0]['description'], 'Required')
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_valid_requirements)
     def test_fail_on_edit_with_empty_build_list(self, *args):
         update = self.get_update()
@@ -106,7 +104,6 @@ class TestNewUpdate(BaseTestCase):
             res.json_body['errors'][1]['description'],
             'ACL validation mechanism was unable to determine ACLs.')
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_taskotron_results)
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
@@ -123,14 +120,12 @@ class TestNewUpdate(BaseTestCase):
         publish.assert_called_once_with(
             topic='update.request.testing', msg=mock.ANY)
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_valid_requirements)
     def test_duplicate_build(self, *args):
         res = self.app.post_json(
             '/updates/', self.get_update([u'bodhi-2.0-2.fc17', u'bodhi-2.0-2.fc17']), status=400)
         assert 'Duplicate builds' in res, res
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_valid_requirements)
     def test_multiple_builds_of_same_package(self, *args):
         res = self.app.post_json('/updates/', self.get_update([u'bodhi-2.0-2.fc17',
@@ -138,7 +133,6 @@ class TestNewUpdate(BaseTestCase):
                                  status=400)
         assert 'Multiple bodhi builds specified' in res, res
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_valid_requirements)
     def test_invalid_autokarma(self, *args):
         res = self.app.post_json('/updates/', self.get_update(stable_karma=-1),
@@ -148,14 +142,12 @@ class TestNewUpdate(BaseTestCase):
                                  status=400)
         assert '1 is greater than maximum value -1' in res, res
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_valid_requirements)
     def test_duplicate_update(self, *args):
         res = self.app.post_json('/updates/', self.get_update(u'bodhi-2.0-1.fc17'),
                                  status=400)
         assert 'Update for bodhi-2.0-1.fc17 already exists' in res, res
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_valid_requirements)
     def test_invalid_requirements(self, *args):
         update = self.get_update()
@@ -163,7 +155,6 @@ class TestNewUpdate(BaseTestCase):
         res = self.app.post_json('/updates/', update, status=400)
         assert "Required check doesn't exist" in res, res
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
     def test_no_privs(self, publish, *args):
@@ -187,7 +178,6 @@ class TestNewUpdate(BaseTestCase):
             res.json_body['errors']
         self.assertEquals(publish.call_args_list, [])
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_taskotron_results)
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
@@ -210,7 +200,6 @@ class TestNewUpdate(BaseTestCase):
         publish.assert_called_once_with(
             topic='update.request.testing', msg=mock.ANY)
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_valid_requirements)
     def test_pkgdb_outage(self, *args):
         "Test the case where our call to the pkgdb throws an exception"
@@ -223,7 +212,6 @@ class TestNewUpdate(BaseTestCase):
 
         assert "Unable to access the Package Database" in res, res
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_valid_requirements)
     def test_invalid_acl_system(self, *args):
         with mock.patch.dict(config, {'acl_system': 'null'}):
@@ -232,11 +220,9 @@ class TestNewUpdate(BaseTestCase):
 
         assert "guest does not have commit access to bodhi" in res, res
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_put_json_update(self):
         self.app.put_json('/updates/', self.get_update(), status=405)
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch.dict('bodhi.server.validators.config', {'acl_system': u'dummy'})
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
@@ -245,7 +231,6 @@ class TestNewUpdate(BaseTestCase):
         publish.assert_called_once_with(
             topic='update.request.testing', msg=mock.ANY)
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch.dict('bodhi.server.validators.config', {'acl_system': u'dummy'})
     @mock.patch(**mock_uuid4_version1)
     @mock.patch(**mock_valid_requirements)
@@ -276,7 +261,6 @@ class TestNewUpdate(BaseTestCase):
         publish.assert_called_once_with(
             topic='update.request.testing', msg=mock.ANY)
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch.dict('bodhi.server.validators.config', {'acl_system': u'dummy'})
     @mock.patch(**mock_uuid4_version1)
     @mock.patch(**mock_valid_requirements)
@@ -292,7 +276,6 @@ class TestNewUpdate(BaseTestCase):
         self.assertEquals(up['errors'][0]['description'],
                           "Build does not exist: bodhi-2.0.0-2.fc17")
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch.dict('bodhi.server.validators.config', {'acl_system': u'dummy'})
     @mock.patch(**mock_uuid4_version1)
     @mock.patch(**mock_valid_requirements)
@@ -308,7 +291,6 @@ class TestNewUpdate(BaseTestCase):
         self.assertEquals(up['errors'][0]['description'],
                           "Koji error getting build: bodhi-2.0.0-2.fc17")
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch.dict('bodhi.server.validators.config', {'acl_system': u'dummy'})
     @mock.patch(**mock_uuid4_version1)
     @mock.patch(**mock_valid_requirements)
@@ -348,7 +330,6 @@ class TestNewUpdate(BaseTestCase):
         # At the end, ensure that the right kind of package was created.
         self.assertEquals(self.db.query(ModulePackage).count(), 1)
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_valid_requirements)
     def test_multiple_builds_of_same_module_stream(self, *args):
         self.create_release(u'27M')
@@ -358,7 +339,6 @@ class TestNewUpdate(BaseTestCase):
                                  status=400)
         assert 'Multiple nodejs:6 builds specified' in res, res
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_valid_requirements)
     def test_multiple_builds_of_different_module_stream(self, *args):
         self.create_release(u'27M')
@@ -377,7 +357,6 @@ class TestNewUpdate(BaseTestCase):
         # At the end, ensure that the right kind of packages were created.
         self.assertEquals(self.db.query(ModulePackage).count(), 2)
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_valid_requirements)
     def test_multiple_updates_single_module_steam(self, *args):
         # Ensure there are no module packages in the DB to begin with.
@@ -405,7 +384,6 @@ class TestNewUpdate(BaseTestCase):
         assert updates[2].status.name == 'pending'
         assert updates[2].request.name == 'testing'
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_uuid4_version1)
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
@@ -438,7 +416,6 @@ class TestNewUpdate(BaseTestCase):
         publish.assert_called_once_with(
             topic='update.request.testing', msg=mock.ANY)
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch.dict('bodhi.server.validators.config', {'acl_system': u'dummy'})
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
@@ -453,7 +430,6 @@ class TestNewUpdate(BaseTestCase):
         self.assertEquals(up['bugs'][1]['bug_id'], 5678)
         self.assertEquals(up['bugs'][2]['bug_id'], 12345)
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch.dict('bodhi.server.validators.config', {'acl_system': u'dummy'})
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
@@ -481,7 +457,6 @@ class TestNewUpdate(BaseTestCase):
         self.assertEquals(up['errors'][0]['description'],
                           "Invalid bug ID specified: [u'1234', u'blargh']")
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch.dict('bodhi.server.validators.config', {'acl_system': u'dummy'})
     @mock.patch(**mock_valid_requirements)
     def test_new_update_with_existing_build(self, *args):
@@ -495,7 +470,6 @@ class TestNewUpdate(BaseTestCase):
 
         self.assertEqual(resp.json['title'], 'bodhi-2.0.0-3.fc17')
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch.dict('bodhi.server.validators.config', {'acl_system': u'dummy'})
     @mock.patch(**mock_valid_requirements)
     def test_new_update_with_existing_package(self, *args):
@@ -511,7 +485,6 @@ class TestNewUpdate(BaseTestCase):
         package = self.db.query(RpmPackage).filter_by(name=u'existing-package').one()
         self.assertEqual(package.name, 'existing-package')
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch.dict('bodhi.server.validators.config', {'acl_system': u'dummy'})
     @mock.patch(**mock_valid_requirements)
     def test_new_update_with_missing_package(self, *args):
@@ -524,7 +497,6 @@ class TestNewUpdate(BaseTestCase):
         package = self.db.query(RpmPackage).filter_by(name=u'missing-package').one()
         self.assertEqual(package.name, 'missing-package')
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
     def test_cascade_package_requirements_to_update(self, publish, *args):
@@ -544,7 +516,6 @@ class TestNewUpdate(BaseTestCase):
         publish.assert_called_once_with(
             topic='update.request.testing', msg=mock.ANY)
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
     def test_push_untested_critpath_to_release(self, publish, *args):
@@ -560,7 +531,6 @@ class TestNewUpdate(BaseTestCase):
         publish.assert_called_once_with(
             topic='update.request.testing', msg=mock.ANY)
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
     def test_obsoletion(self, publish, *args):
@@ -606,7 +576,6 @@ class TestNewUpdate(BaseTestCase):
                              '/updates/FEDORA-{}-53345602d5'.format(datetime.now().year)))
         self.assertEquals(up.comments[-1].text, expected_comment)
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
     @mock.patch('bodhi.server.services.updates.Update.new', side_effect=IOError('oops!'))
@@ -623,7 +592,6 @@ class TestNewUpdate(BaseTestCase):
         build = self.db.query(RpmBuild).filter(RpmBuild.nvr == u'bodhi-2.3.2-1.fc17').one()
         self.assertEqual(build.package.name, 'bodhi')
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.services.updates.Update.obsolete_older_updates',
                 side_effect=RuntimeError("bet you didn't see this coming!"))
@@ -665,7 +633,6 @@ class TestSetRequest(BaseTestCase):
     """
     This class contains tests for the set_request() function.
     """
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_valid_requirements)
     def test_set_request_locked_update(self, *args):
         """Ensure that we get an error if trying to set request of a locked update"""
@@ -682,7 +649,6 @@ class TestSetRequest(BaseTestCase):
         self.assertEquals(res.json_body[u'errors'][0][u'description'],
                           "Can't change request on a locked update")
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_valid_requirements)
     def test_set_request_archived_release(self, *args):
         """Ensure that we get an error if trying to setrequest of a update in an archived release"""
@@ -737,7 +703,6 @@ class TestSetRequest(BaseTestCase):
         self.assertEqual(up.request, UpdateRequest.stable)
         self.assertEqual(res.json['update']['request'], 'stable')
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.services.updates.Update.set_request',
                 side_effect=IOError('IOError. oops!'))
@@ -892,7 +857,6 @@ class TestUpdatesService(BaseTestCase):
         self.assertEqual(res.json, expected_json)
         listTags.assert_called_once_with('bodhi-2.0-1.fc17')
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_edit_koji_error(self):
         """Editing an update that references missing builds should raise an error."""
         update = self.db.query(Update).one()
@@ -915,7 +879,6 @@ class TestUpdatesService(BaseTestCase):
         self.assertEqual(res.json, expected_json)
         listTags.assert_called_once_with(update.title)
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_edit_untagged_build(self):
         """Editing an update that references untagged builds should raise an error."""
         update = self.db.query(Update).one()
@@ -957,7 +920,6 @@ class TestUpdatesService(BaseTestCase):
         self.assertIn('<span class="sr-only">Locked</span>', resp)
         self.assertIn('/composes/{}/{}'.format(compose.release.name, compose.request.value), resp)
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_taskotron_results)
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
@@ -996,7 +958,6 @@ class TestUpdatesService(BaseTestCase):
         assert build.update is not None
         self.assertEquals(build.update.notes, u'testing!!!')
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_taskotron_results)
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
@@ -1129,7 +1090,6 @@ class TestUpdatesService(BaseTestCase):
         res = app.get('/updates/%s' % str(nvr), status=200)
         self.assertEqual(res.json_body['can_edit'], False)
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_taskotron_results)
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
@@ -1165,7 +1125,6 @@ class TestUpdatesService(BaseTestCase):
             res.json_body['errors'][0]['description'],
             'Requirement not met Required tests did not pass on this update')
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_taskotron_results)
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
@@ -1201,7 +1160,6 @@ class TestUpdatesService(BaseTestCase):
             res.json_body['errors'][0]['description'],
             'Requirement not met Required tests did not pass on this update')
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_taskotron_results)
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
@@ -1237,7 +1195,6 @@ class TestUpdatesService(BaseTestCase):
             res.json_body['errors'][0]['description'],
             'Requirement not met Required tests did not pass on this update')
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_taskotron_results)
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
@@ -1274,7 +1231,6 @@ class TestUpdatesService(BaseTestCase):
             res.json_body['errors'][0]['description'],
             config.get('not_yet_tested_msg'))
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_taskotron_results)
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
@@ -1310,7 +1266,6 @@ class TestUpdatesService(BaseTestCase):
             res.json_body['errors'][0]['description'],
             'Requirement not met Required tests did not pass on this update')
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_taskotron_results)
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
@@ -1346,7 +1301,6 @@ class TestUpdatesService(BaseTestCase):
             res.json_body['errors'][0]['description'],
             config.get('not_yet_tested_msg'))
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
     def test_old_bodhi1_redirect(self, publish, *args):
@@ -1421,7 +1375,6 @@ class TestUpdatesService(BaseTestCase):
         self.assertIn('https://privacyiscool.com', resp)
         self.assertIn('Comments are governed under', resp)
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_updates(self):
         res = self.app.get('/updates/')
         body = res.json_body
@@ -1451,7 +1404,6 @@ class TestUpdatesService(BaseTestCase):
         self.assertEquals(up['url'],
                           (urlparse.urljoin(config['base_address'], '/updates/%s' % alias)))
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_updates_jsonp(self):
         res = self.app.get('/updates/',
                            {'callback': 'callback'},
@@ -1460,14 +1412,12 @@ class TestUpdatesService(BaseTestCase):
         self.assertIn('callback', res)
         self.assertIn('bodhi-2.0-1.fc17', res)
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_updates_rss(self):
         res = self.app.get('/rss/updates/',
                            headers={'Accept': 'application/atom+xml'})
         self.assertIn('application/rss+xml', res.headers['Content-Type'])
         self.assertIn('bodhi-2.0-1.fc17', res)
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_updates_html(self):
         res = self.app.get('/updates/',
                            headers={'Accept': 'text/html'})
@@ -1475,7 +1425,6 @@ class TestUpdatesService(BaseTestCase):
         self.assertIn('bodhi-2.0-1.fc17', res)
         self.assertIn('&copy;', res)
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_updates_like(self):
         res = self.app.get('/updates/', {'like': 'odh'})
         body = res.json_body
@@ -1488,7 +1437,6 @@ class TestUpdatesService(BaseTestCase):
         body = res.json_body
         self.assertEquals(len(body['updates']), 0)
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_updates_search(self):
         """
         Test that the updates/?search= endpoint works as expected
@@ -1564,7 +1512,6 @@ class TestUpdatesService(BaseTestCase):
 
         self.assertNotEquals(update1, update2)
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_updates_by_approved_since(self):
         now = datetime.utcnow()
 
@@ -1609,7 +1556,6 @@ class TestUpdatesService(BaseTestCase):
         self.assertEquals(len(up['test_cases']), 1)
         self.assertEquals(up['test_cases'][0]['name'], u'Wat')
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_updates_by_invalid_approved_since(self):
         res = self.app.get('/updates/', {"approved_since": "forever"},
                            status=400)
@@ -1619,7 +1565,6 @@ class TestUpdatesService(BaseTestCase):
         self.assertEquals(res.json_body['errors'][0]['description'],
                           'Invalid date')
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_updates_by_approved_before(self):
         # Approve an update
         now = datetime.utcnow()
@@ -1661,7 +1606,6 @@ class TestUpdatesService(BaseTestCase):
         self.assertEquals(len(up['bugs']), 1)
         self.assertEquals(up['bugs'][0]['bug_id'], 12345)
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_updates_by_invalid_approved_before(self):
         res = self.app.get('/updates/', {"approved_before": "forever"},
                            status=400)
@@ -1671,7 +1615,6 @@ class TestUpdatesService(BaseTestCase):
         self.assertEquals(res.json_body['errors'][0]['description'],
                           'Invalid date')
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_updates_by_bugs(self):
         res = self.app.get('/updates/', {"bugs": '12345'})
         body = res.json_body
@@ -1707,13 +1650,11 @@ class TestUpdatesService(BaseTestCase):
         self.assertEquals(res.json_body['errors'][0]['description'],
                           "Invalid bug ID specified: [u'cockroaches']")
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_updates_by_unexisting_bug(self):
         res = self.app.get('/updates/', {"bugs": "19850110"})
         body = res.json_body
         self.assertEquals(len(body['updates']), 0)
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_updates_by_critpath(self):
         res = self.app.get('/updates/', {"critpath": "false"})
         body = res.json_body
@@ -1738,7 +1679,6 @@ class TestUpdatesService(BaseTestCase):
         self.assertEquals(up['alias'], u'FEDORA-%s-a3bbe1a8f2' % YEAR)
         self.assertEquals(up['karma'], 1)
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_updates_by_invalid_critpath(self):
         res = self.app.get('/updates/', {"critpath": "lalala"},
                            status=400)
@@ -1748,7 +1688,6 @@ class TestUpdatesService(BaseTestCase):
         self.assertEquals(res.json_body['errors'][0]['description'],
                           '"lalala" is neither in (\'false\', \'0\') nor in (\'true\', \'1\')')
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_updates_by_cves(self):
         res = self.app.get("/updates/", {"cves": "CVE-1985-0110"})
         body = res.json_body
@@ -1773,13 +1712,11 @@ class TestUpdatesService(BaseTestCase):
         self.assertEquals(up['alias'], u'FEDORA-%s-a3bbe1a8f2' % YEAR)
         self.assertEquals(up['karma'], 1)
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_updates_by_unexisting_cve(self):
         res = self.app.get('/updates/', {"cves": "CVE-2013-1015"})
         body = res.json_body
         self.assertEquals(len(body['updates']), 0)
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_updates_by_invalid_cve(self):
         res = self.app.get('/updates/', {"cves": "WTF-ZOMG-BBQ"},
                            status=400)
@@ -1789,7 +1726,6 @@ class TestUpdatesService(BaseTestCase):
         self.assertEquals(res.json_body['errors'][0]['description'],
                           '"WTF-ZOMG-BBQ" is not a valid CVE id')
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_updates_by_date_submitted_invalid_date(self):
         """test filtering by submitted date with an invalid date"""
         res = self.app.get('/updates/', {"submitted_since": "11-01-1984"}, status=400)
@@ -1799,7 +1735,6 @@ class TestUpdatesService(BaseTestCase):
         self.assertEquals(body['errors'][0]['description'],
                           'Invalid date')
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_updates_by_date_submitted_future_date(self):
         """test filtering by submitted date with future date"""
         tomorrow = datetime.utcnow() + timedelta(days=1)
@@ -1809,7 +1744,6 @@ class TestUpdatesService(BaseTestCase):
         body = res.json_body
         self.assertEquals(len(body['updates']), 0)
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_updates_by_date_submitted_valid(self):
         """test filtering by submitted date with valid data"""
         res = self.app.get('/updates/', {"submitted_since": "1984-11-01"})
@@ -1835,7 +1769,6 @@ class TestUpdatesService(BaseTestCase):
         self.assertEquals(up['alias'], u'FEDORA-%s-a3bbe1a8f2' % YEAR)
         self.assertEquals(up['karma'], 1)
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_updates_by_date_submitted_before_invalid_date(self):
         """test filtering by submitted before date with an invalid date"""
         res = self.app.get('/updates/', {"submitted_before": "11-01-1984"}, status=400)
@@ -1845,14 +1778,12 @@ class TestUpdatesService(BaseTestCase):
         self.assertEquals(body['errors'][0]['description'],
                           'Invalid date')
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_updates_by_date_submitted_before_old_date(self):
         """test filtering by submitted before date with old date"""
         res = self.app.get('/updates/', {"submitted_before": "1975-01-01"})
         body = res.json_body
         self.assertEquals(len(body['updates']), 0)
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_updates_by_date_submitted_before_valid(self):
         """test filtering by submitted before date with valid date"""
         today = datetime.utcnow().strftime("%Y-%m-%d")
@@ -1879,7 +1810,6 @@ class TestUpdatesService(BaseTestCase):
         self.assertEquals(up['alias'], u'FEDORA-%s-a3bbe1a8f2' % YEAR)
         self.assertEquals(up['karma'], 1)
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_updates_by_locked(self):
         Update.query.one().locked = True
         self.db.flush()
@@ -1906,7 +1836,6 @@ class TestUpdatesService(BaseTestCase):
         self.assertEquals(up['alias'], u'FEDORA-%s-a3bbe1a8f2' % YEAR)
         self.assertEquals(up['karma'], 1)
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_updates_by_content_type(self):
         res = self.app.get('/updates/', {"content_type": "module"})
         body = res.json_body
@@ -1916,7 +1845,6 @@ class TestUpdatesService(BaseTestCase):
         body = res.json_body
         self.assertEquals(len(body['updates']), 1)
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_updates_by_invalid_locked(self):
         res = self.app.get('/updates/', {"locked": "maybe"},
                            status=400)
@@ -1926,7 +1854,6 @@ class TestUpdatesService(BaseTestCase):
         self.assertEquals(res.json_body['errors'][0]['description'],
                           '"maybe" is neither in (\'false\', \'0\') nor in (\'true\', \'1\')')
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_updates_by_modified_since(self):
         now = datetime.utcnow()
 
@@ -1967,7 +1894,6 @@ class TestUpdatesService(BaseTestCase):
         self.assertEquals(len(up['bugs']), 1)
         self.assertEquals(up['bugs'][0]['bug_id'], 12345)
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_updates_by_invalid_modified_since(self):
         res = self.app.get('/updates/', {"modified_since": "the dawn of time"},
                            status=400)
@@ -1977,7 +1903,6 @@ class TestUpdatesService(BaseTestCase):
         self.assertEquals(res.json_body['errors'][0]['description'],
                           'Invalid date')
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_updates_by_modified_before(self):
         now = datetime.utcnow()
         tomorrow = now + timedelta(days=1)
@@ -2020,7 +1945,6 @@ class TestUpdatesService(BaseTestCase):
         self.assertEquals(len(up['bugs']), 1)
         self.assertEquals(up['bugs'][0]['bug_id'], 12345)
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_updates_by_invalid_modified_before(self):
         res = self.app.get('/updates/', {"modified_before": "the dawn of time"},
                            status=400)
@@ -2030,7 +1954,6 @@ class TestUpdatesService(BaseTestCase):
         self.assertEquals(res.json_body['errors'][0]['description'],
                           'Invalid date')
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_updates_by_package(self):
         res = self.app.get('/updates/', {"packages": "bodhi"})
         body = res.json_body
@@ -2055,7 +1978,6 @@ class TestUpdatesService(BaseTestCase):
         self.assertEquals(up['alias'], u'FEDORA-%s-a3bbe1a8f2' % YEAR)
         self.assertEquals(up['karma'], 1)
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_updates_by_builds(self):
         res = self.app.get('/updates/', {"builds": "bodhi-3.0-1.fc17"})
         body = res.json_body
@@ -2084,13 +2006,11 @@ class TestUpdatesService(BaseTestCase):
         self.assertEquals(up['alias'], u'FEDORA-%s-a3bbe1a8f2' % YEAR)
         self.assertEquals(up['karma'], 1)
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_updates_by_unexisting_package(self):
         res = self.app.get('/updates/', {"packages": "flash-player"})
         body = res.json_body
         self.assertEquals(len(body['updates']), 0)
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_updates_by_pushed(self):
         res = self.app.get('/updates/', {"pushed": "false"})
         body = res.json_body
@@ -2116,7 +2036,6 @@ class TestUpdatesService(BaseTestCase):
         self.assertEquals(up['karma'], 1)
         self.assertEquals(up['pushed'], False)
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_updates_by_invalid_pushed(self):
         res = self.app.get('/updates/', {"pushed": "who knows?"},
                            status=400)
@@ -2126,7 +2045,6 @@ class TestUpdatesService(BaseTestCase):
         self.assertEquals(res.json_body['errors'][0]['description'],
                           '"who knows?" is neither in (\'false\', \'0\') nor in (\'true\', \'1\')')
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_updates_by_pushed_since(self):
         now = datetime.utcnow()
 
@@ -2166,7 +2084,6 @@ class TestUpdatesService(BaseTestCase):
         self.assertEquals(len(up['bugs']), 1)
         self.assertEquals(up['bugs'][0]['bug_id'], 12345)
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_updates_by_invalid_pushed_since(self):
         res = self.app.get('/updates/', {"pushed_since": "a while ago"},
                            status=400)
@@ -2176,7 +2093,6 @@ class TestUpdatesService(BaseTestCase):
         self.assertEquals(res.json_body['errors'][0]['description'],
                           'Invalid date')
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_updates_by_pushed_before(self):
         now = datetime.utcnow()
         tomorrow = now + timedelta(days=1)
@@ -2218,7 +2134,6 @@ class TestUpdatesService(BaseTestCase):
         self.assertEquals(len(up['bugs']), 1)
         self.assertEquals(up['bugs'][0]['bug_id'], 12345)
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_updates_by_invalid_pushed_before(self):
         res = self.app.get('/updates/', {"pushed_before": "a while ago"},
                            status=400)
@@ -2228,7 +2143,6 @@ class TestUpdatesService(BaseTestCase):
         self.assertEquals(res.json_body['errors'][0]['description'],
                           'Invalid date')
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_updates_by_release_name(self):
         res = self.app.get('/updates/', {"releases": "F17"})
         body = res.json_body
@@ -2253,7 +2167,6 @@ class TestUpdatesService(BaseTestCase):
         self.assertEquals(up['alias'], u'FEDORA-%s-a3bbe1a8f2' % YEAR)
         self.assertEquals(up['karma'], 1)
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_updates_by_singular_release_param(self):
         """
         Test the singular parameter "release" rather than "releases".
@@ -2282,7 +2195,6 @@ class TestUpdatesService(BaseTestCase):
         self.assertEquals(up['alias'], u'FEDORA-%s-a3bbe1a8f2' % YEAR)
         self.assertEquals(up['karma'], 1)
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_updates_by_release_version(self):
         res = self.app.get('/updates/', {"releases": "17"})
         body = res.json_body
@@ -2307,7 +2219,6 @@ class TestUpdatesService(BaseTestCase):
         self.assertEquals(up['alias'], u'FEDORA-%s-a3bbe1a8f2' % YEAR)
         self.assertEquals(up['karma'], 1)
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_updates_by_unexisting_release(self):
         res = self.app.get('/updates/', {"releases": "WinXP"}, status=400)
         body = res.json_body
@@ -2316,7 +2227,6 @@ class TestUpdatesService(BaseTestCase):
         self.assertEquals(res.json_body['errors'][0]['description'],
                           'Invalid releases specified: WinXP')
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_updates_by_request(self):
         res = self.app.get('/updates/', {'request': "testing"})
         body = res.json_body
@@ -2352,7 +2262,6 @@ class TestUpdatesService(BaseTestCase):
                           u'"impossible" is not one of revoke, testing,'
                           ' obsolete, batched, stable, unpush')
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_updates_by_severity(self):
         res = self.app.get('/updates/', {"severity": "medium"})
         body = res.json_body
@@ -2387,7 +2296,6 @@ class TestUpdatesService(BaseTestCase):
         self.assertEquals(res.json_body['errors'][0]['description'],
                           '"schoolmaster" is not one of high, urgent, medium, low, unspecified')
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_updates_by_status(self):
         res = self.app.get('/updates/', {"status": "pending"})
         body = res.json_body
@@ -2412,7 +2320,6 @@ class TestUpdatesService(BaseTestCase):
         self.assertEquals(up['alias'], u'FEDORA-%s-a3bbe1a8f2' % YEAR)
         self.assertEquals(up['karma'], 1)
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_updates_by_status_active_release(self):
         res = self.app.get(
             '/updates/', {"status": "pending", "active_releases": 'true'})
@@ -2438,7 +2345,6 @@ class TestUpdatesService(BaseTestCase):
         self.assertEquals(up['alias'], u'FEDORA-%s-a3bbe1a8f2' % YEAR)
         self.assertEquals(up['karma'], 1)
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_updates_by_status_inactive_release(self):
         rel = self.db.query(Release).filter_by(name='F17').one()
         rel.state = ReleaseState.archived
@@ -2461,7 +2367,6 @@ class TestUpdatesService(BaseTestCase):
             ('"single" is not one of testing, side_tag_expired, processing, obsolete, '
              'pending, stable, unpushed, side_tag_active'))
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_updates_by_suggest(self):
         res = self.app.get('/updates/', {"suggest": "unspecified"})
         body = res.json_body
@@ -2496,7 +2401,6 @@ class TestUpdatesService(BaseTestCase):
         self.assertEquals(res.json_body['errors'][0]['description'],
                           '"no idea" is not one of logout, reboot, unspecified')
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_updates_by_type(self):
         res = self.app.get('/updates/', {"type": "bugfix"})
         body = res.json_body
@@ -2531,7 +2435,6 @@ class TestUpdatesService(BaseTestCase):
         self.assertEquals(res.json_body['errors'][0]['description'],
                           '"not_my" is not one of newpackage, bugfix, security, enhancement')
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_updates_by_username(self):
         res = self.app.get('/updates/', {"user": "guest"})
         body = res.json_body
@@ -2556,7 +2459,6 @@ class TestUpdatesService(BaseTestCase):
         self.assertEquals(up['alias'], u'FEDORA-%s-a3bbe1a8f2' % YEAR)
         self.assertEquals(up['karma'], 1)
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_updates_by_unexisting_username(self):
         res = self.app.get('/updates/', {"user": "santa"},
                            status=400)
@@ -2566,7 +2468,6 @@ class TestUpdatesService(BaseTestCase):
         self.assertEquals(res.json_body['errors'][0]['description'],
                           "Invalid user specified: santa")
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_uuid4_version1)
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
@@ -2618,7 +2519,6 @@ class TestUpdatesService(BaseTestCase):
         self.assertEquals(len(publish.call_args_list), 2)
         publish.assert_called_with(topic='update.edit', msg=ANY)
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
     def test_edit_testing_update_with_new_builds(self, publish, *args):
@@ -2665,7 +2565,6 @@ class TestUpdatesService(BaseTestCase):
         self.assertEquals(len(publish.call_args_list), 3)
         publish.assert_called_with(topic='update.edit', msg=ANY)
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
     def test_edit_testing_update_with_new_builds_with_stable_request(self, publish, *args):
@@ -2712,7 +2611,6 @@ class TestUpdatesService(BaseTestCase):
         self.assertEquals(len(publish.call_args_list), 3)
         publish.assert_called_with(topic='update.edit', msg=ANY)
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
     def test_edit_update_with_different_release(self, publish, *args):
@@ -2749,7 +2647,6 @@ class TestUpdatesService(BaseTestCase):
         self.assertEquals(up['errors'][0]['description'],
                           'Cannot add a F18 build to an F17 update')
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
     def test_edit_stable_update(self, publish, *args):
@@ -2776,7 +2673,6 @@ class TestUpdatesService(BaseTestCase):
         self.assertEquals(up['errors'][0]['description'], "Cannot edit stable updates")
         self.assertEquals(len(publish.call_args_list), 1)
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
     def test_edit_locked_update(self, publish, *args):
@@ -2835,7 +2731,6 @@ class TestUpdatesService(BaseTestCase):
         self.assertEquals(len(publish.call_args_list), 2)
         publish.assert_called_with(topic='update.edit', msg=ANY)
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
     def test_pending_update_on_stable_karma_reached_autopush_enabled(self, publish, *args):
@@ -2861,7 +2756,6 @@ class TestUpdatesService(BaseTestCase):
         self.assertEquals(up.request, UpdateRequest.testing)
         self.assertEquals(up.status, UpdateStatus.pending)
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
     def test_pending_urgent_update_on_stable_karma_reached_autopush_enabled(self, publish, *args):
@@ -2891,7 +2785,6 @@ class TestUpdatesService(BaseTestCase):
         self.assertEquals(up.request, UpdateRequest.stable)
         self.assertEquals(up.status, UpdateStatus.pending)
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_valid_requirements)
     def test_pending_update_on_stable_karma_not_reached(self, publish, *args):
         """ Ensure that pending update does not directly request for stable
@@ -2914,7 +2807,6 @@ class TestUpdatesService(BaseTestCase):
         self.assertEquals(up.request, UpdateRequest.testing)
         self.assertEquals(up.status, UpdateStatus.pending)
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
     def test_pending_update_on_stable_karma_reached_autopush_disabled(self, publish, *args):
@@ -2945,7 +2837,6 @@ class TestUpdatesService(BaseTestCase):
         up.comment(self.db, text, author=u'bodhi')
         self.assertIn('pushed to stable now if the maintainer wishes', up.comments[-1]['text'])
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
     def test_obsoletion_locked_with_open_request(self, publish, *args):
@@ -2965,7 +2856,6 @@ class TestUpdatesService(BaseTestCase):
         self.assertEquals(up.status, UpdateStatus.pending)
         self.assertEquals(up.request, UpdateRequest.testing)
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
     def test_obsoletion_unlocked_with_open_request(self, publish, *args):
@@ -2981,7 +2871,6 @@ class TestUpdatesService(BaseTestCase):
         self.assertEquals(up.status, UpdateStatus.obsolete)
         self.assertEquals(up.request, None)
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
     def test_obsoletion_unlocked_with_open_stable_request(self, publish, *args):
@@ -3001,7 +2890,6 @@ class TestUpdatesService(BaseTestCase):
         self.assertEquals(up.status, UpdateStatus.pending)
         self.assertEquals(up.request, UpdateRequest.stable)
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
     def test_push_to_stable_for_obsolete_update(self, publish, *args):
@@ -3045,7 +2933,6 @@ class TestUpdatesService(BaseTestCase):
         self.assertIn(id, resp)
         self.assertNotIn('Push to Stable', resp)
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_valid_requirements)
     def test_enabled_button_for_autopush(self, *args):
         """Test Enabled button on Update page when autopush is True"""
@@ -3059,7 +2946,6 @@ class TestUpdatesService(BaseTestCase):
         self.assertIn(nvr, resp)
         self.assertIn('Enabled', resp)
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_valid_requirements)
     def test_disabled_button_for_autopush(self, *args):
         """Test Disabled button on Update page when autopush is False"""
@@ -3097,7 +2983,6 @@ class TestUpdatesService(BaseTestCase):
         self.assertEqual(resp['errors'][0]['name'], 'request')
         self.assertEqual(resp['errors'][0]['description'], 'Required')
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_taskotron_results)
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
@@ -3113,7 +2998,6 @@ class TestUpdatesService(BaseTestCase):
         self.assertEqual(resp.json['update']['request'], 'testing')
         self.assertEquals(publish.call_args_list, [])
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_taskotron_results)
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
@@ -3136,7 +3020,6 @@ class TestUpdatesService(BaseTestCase):
         self.assertEqual(resp.json['update']['status'], 'testing')
         publish.assert_called_with(topic='update.request.revoke', msg=mock.ANY)
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_taskotron_results)
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
@@ -3159,7 +3042,6 @@ class TestUpdatesService(BaseTestCase):
         self.assertEqual(resp.json['update']['status'], 'unpushed')
         publish.assert_called_with(topic='update.request.revoke', msg=mock.ANY)
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
     def test_obsolete_if_unstable_with_autopush_enabled_when_pending(self, publish, *args):
@@ -3186,7 +3068,6 @@ class TestUpdatesService(BaseTestCase):
         self.assertEquals(up.status, UpdateStatus.obsolete)
         self.assertEquals(up.request, None)
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
     def test_obsolete_if_unstable_with_autopush_disabled_when_pending(self, publish, *args):
@@ -3212,7 +3093,6 @@ class TestUpdatesService(BaseTestCase):
         self.assertEquals(up.status, UpdateStatus.pending)
         self.assertEquals(up.request, UpdateRequest.testing)
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
     def test_obsolete_if_unstable_karma_not_reached_with_autopush_enabled_when_pending(
@@ -3239,7 +3119,6 @@ class TestUpdatesService(BaseTestCase):
         self.assertEquals(up.status, UpdateStatus.pending)
         self.assertEquals(up.request, UpdateRequest.testing)
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
     def test_obsolete_if_unstable_with_autopush_enabled_when_testing(self, publish, *args):
@@ -3277,7 +3156,6 @@ class TestUpdatesService(BaseTestCase):
         self.assertEquals(up.status, UpdateStatus.obsolete)
         self.assertEquals(up.request, None)
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_taskotron_results)
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
@@ -3297,7 +3175,6 @@ class TestUpdatesService(BaseTestCase):
         self.assertEqual(resp.json['update']['status'], 'unpushed')
         publish.assert_called_with(topic='update.request.unpush', msg=mock.ANY)
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_taskotron_results)
     @mock.patch(**mock_valid_requirements)
     def test_invalid_stable_request(self, *args):
@@ -3316,7 +3193,6 @@ class TestUpdatesService(BaseTestCase):
             resp.json['errors'][0]['description'],
             config.get('not_yet_tested_msg'))
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_taskotron_results)
     @mock.patch(**mock_valid_requirements)
     def test_request_to_stable_based_on_stable_karma(self, *args):
@@ -3361,7 +3237,6 @@ class TestUpdatesService(BaseTestCase):
         self.assertEquals(up.request, UpdateRequest.stable)
         self.assertEquals(up.status, UpdateStatus.testing)
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_taskotron_results)
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
@@ -3389,7 +3264,6 @@ class TestUpdatesService(BaseTestCase):
         publish.assert_called_with(
             topic='update.request.stable', msg=mock.ANY)
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_taskotron_results)
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
@@ -3415,7 +3289,6 @@ class TestUpdatesService(BaseTestCase):
             resp.json['errors'][0]['description'],
             "Can't change request for an archived release")
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_failed_taskotron_results)
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
@@ -3440,7 +3313,6 @@ class TestUpdatesService(BaseTestCase):
         self.assertIn('errors', resp)
         self.assertIn('Required task', resp)
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_absent_taskotron_results)
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
@@ -3465,7 +3337,6 @@ class TestUpdatesService(BaseTestCase):
         self.assertIn('errors', resp)
         self.assertIn('No result found for', resp)
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_taskotron_results)
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
@@ -3497,7 +3368,6 @@ class TestUpdatesService(BaseTestCase):
         except AssertionError:
             pass
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_taskotron_results)
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
@@ -3528,7 +3398,6 @@ class TestUpdatesService(BaseTestCase):
         except AssertionError:
             pass
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_valid_requirements)
     def test_update_with_older_build_in_testing_from_diff_user(self, r):
         """
@@ -3564,14 +3433,12 @@ class TestUpdatesService(BaseTestCase):
         # Ensure the second update was created successfully
         self.db.query(Update).filter_by(title=newtitle).one()
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_valid_requirements)
     def test_updateid_alias(self, *args):
         res = self.app.post_json('/updates/', self.get_update(u'bodhi-2.0.0-3.fc17'))
         json = res.json_body
         self.assertEquals(json['alias'], json['updateid'])
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_updates_by_lowercase_release_name(self):
         res = self.app.get('/updates/', {"releases": "f17"})
         body = res.json_body
@@ -3589,7 +3456,6 @@ class TestUpdatesService(BaseTestCase):
         # But be sure that we don't redirect if the package doesn't exist
         res = self.app.get('/updates/non-existant', status=404)
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_updates_by_alias_and_updateid(self):
         upd = self.db.query(Update).filter(Update.alias.isnot(None)).first()
         res = self.app.get('/updates/', {"alias": upd.alias})
@@ -3613,7 +3479,6 @@ class TestUpdatesService(BaseTestCase):
         body = res.json_body
         self.assertEquals(len(body['updates']), 0)
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
     def test_submitting_multi_release_updates(self, publish, *args):
@@ -3656,7 +3521,6 @@ class TestUpdatesService(BaseTestCase):
         # Make sure two fedmsg messages were published
         self.assertEquals(len(publish.call_args_list), 2)
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
     def test_edit_update_bugs(self, publish, *args):
@@ -3701,7 +3565,6 @@ class TestUpdatesService(BaseTestCase):
         self.assertEquals(up['status'], u'pending')
         self.assertEquals(up['request'], u'testing')
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
     def test_edit_missing_update(self, publish, *args):
@@ -3714,7 +3577,6 @@ class TestUpdatesService(BaseTestCase):
         self.assertEquals(r['status'], 'error')
         self.assertEquals(r['errors'][0]['description'], 'Cannot find update to edit: %s' % edited)
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
     def test_edit_update_and_disable_features(self, publish, *args):
@@ -3754,7 +3616,6 @@ class TestUpdatesService(BaseTestCase):
         self.assertEquals(up['stable_karma'], 3)
         self.assertEquals(up['unstable_karma'], -3)
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
     def test_edit_update_change_type(self, publish, *args):
@@ -3789,7 +3650,6 @@ class TestUpdatesService(BaseTestCase):
         expected = False
         self.assertEquals(actual, expected)
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
     def test_edit_testing_update_reset_karma(self, publish, *args):
@@ -3816,7 +3676,6 @@ class TestUpdatesService(BaseTestCase):
         # This is what we really want to test here.
         self.assertEquals(up['karma'], 0)
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
     def test_edit_testing_update_reset_karma_with_same_tester(self, publish, *args):
@@ -3878,7 +3737,6 @@ class TestUpdatesService(BaseTestCase):
         # Bob should be able to give karma again since the reset
         self.assertEquals(upd.karma, 1)
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
     def test__composite_karma_with_one_negative(self, publish, *args):
@@ -3903,7 +3761,6 @@ class TestUpdatesService(BaseTestCase):
         up = self.db.query(Update).filter_by(title=nvr).one()
         self.assertEqual(up._composite_karma, (0, -1))
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
     def test__composite_karma_with_changed_karma(self, publish, *args):
@@ -3936,7 +3793,6 @@ class TestUpdatesService(BaseTestCase):
         self.assertEqual(up._composite_karma, (1, 0))
         self.assertEquals(up.karma, 1)
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
     def test__composite_karma_with_positive_karma_first(self, publish, *args):
@@ -3969,7 +3825,6 @@ class TestUpdatesService(BaseTestCase):
         self.assertEqual(up._composite_karma, (1, -1))
         self.assertEquals(up.karma, 0)
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
     def test__composite_karma_with_no_negative_karma(self, publish, *args):
@@ -3998,7 +3853,6 @@ class TestUpdatesService(BaseTestCase):
         self.assertEqual(up._composite_karma, (2, 0))
         self.assertEquals(up.karma, 2)
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
     def test__composite_karma_with_anonymous_comment(self, publish, *args):
@@ -4024,7 +3878,6 @@ class TestUpdatesService(BaseTestCase):
         up = self.db.query(Update).filter_by(title=nvr).one()
         self.assertEqual(up._composite_karma, (0, 0))
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
     def test__composite_karma_with_no_feedback(self, publish, *args):
@@ -4046,7 +3899,6 @@ class TestUpdatesService(BaseTestCase):
         up = self.db.query(Update).filter_by(title=nvr).one()
         self.assertEqual(up._composite_karma, (0, 0))
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
     def test_karma_threshold_with_disabled_autopush(self, publish, *args):
@@ -4086,7 +3938,6 @@ class TestUpdatesService(BaseTestCase):
         self.assertEquals(up['stable_karma'], 4)
         self.assertEquals(up['unstable_karma'], -4)
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
     def test_disable_autopush_for_critical_updates(self, publish, *args):
@@ -4123,7 +3974,6 @@ class TestUpdatesService(BaseTestCase):
         # Autopush gets disabled since there is a negative karma from ralph
         self.assertEquals(up.autokarma, False)
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
     def test_autopush_critical_update_with_no_negative_karma(self, publish, *args):
@@ -4160,7 +4010,6 @@ class TestUpdatesService(BaseTestCase):
         up = self.db.query(Update).filter_by(title=resp.json['title']).one()
         self.assertEquals(up.request, UpdateRequest.batched)
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
     def test_manually_push_critical_update_with_negative_karma(self, publish, *args):
@@ -4218,7 +4067,6 @@ class TestUpdatesService(BaseTestCase):
         self.assertIn('text/html', resp.headers['Content-Type'])
         self.assertIn(id, resp)
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
     def test_manually_push_critical_update_with_autopush_turned_off(self, publish, *args):
@@ -4268,7 +4116,6 @@ class TestUpdatesService(BaseTestCase):
         self.assertIn('text/html', resp.headers['Content-Type'])
         self.assertIn(id, resp)
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
     def test_disable_autopush_non_critical_update_with_negative_karma(self, publish, *args):
@@ -4314,7 +4161,6 @@ class TestUpdatesService(BaseTestCase):
         self.assertEquals(up.request, UpdateRequest.testing)
         self.assertEquals(up.status, UpdateStatus.testing)
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
     def test_autopush_non_critical_update_with_no_negative_karma(self, publish, *args):
@@ -4353,7 +4199,6 @@ class TestUpdatesService(BaseTestCase):
         up = self.db.query(Update).filter_by(title=resp.json['title']).one()
         self.assertEquals(up.request, UpdateRequest.batched)
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
     def test_edit_button_not_present_when_stable(self, publish, *args):
@@ -4457,7 +4302,6 @@ class TestUpdatesService(BaseTestCase):
         self.assertNotIn('Push to Stable', resp)
         self.assertIn('Edit', resp)
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
     def test_push_to_stable_button_present_when_karma_reached_urgent(self, publish, *args):
@@ -4487,7 +4331,6 @@ class TestUpdatesService(BaseTestCase):
         self.assertIn('Push to Stable', resp)
         self.assertIn('Edit', resp)
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
     def test_push_to_stable_button_present_when_karma_reached_and_batched(self, publish, *args):
@@ -4516,7 +4359,6 @@ class TestUpdatesService(BaseTestCase):
         self.assertIn('Push to Stable', resp)
         self.assertIn('Edit', resp)
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
     def test_push_to_stable_button_present_when_autokarma_and_batched(self, publish, *args):
@@ -4545,7 +4387,6 @@ class TestUpdatesService(BaseTestCase):
         self.assertIn('Push to Stable', resp)
         self.assertIn('Edit', resp)
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
     def test_push_to_batched_button_present_when_time_reached(self, publish, *args):
@@ -4573,7 +4414,6 @@ class TestUpdatesService(BaseTestCase):
         self.assertNotIn('Push to Stable', resp)
         self.assertIn('Edit', resp)
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
     def test_push_to_stable_button_present_when_time_reached_and_urgent(self, publish, *args):
@@ -4603,7 +4443,6 @@ class TestUpdatesService(BaseTestCase):
         self.assertIn('Push to Stable', resp)
         self.assertIn('Edit', resp)
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
     def test_push_to_stable_button_present_when_time_reached_and_batched(self, publish, *args):
@@ -4631,7 +4470,6 @@ class TestUpdatesService(BaseTestCase):
         self.assertIn('Push to Stable', resp)
         self.assertIn('Edit', resp)
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
     def test_push_to_batched_button_present_when_time_reached_critpath(self, publish, *args):
@@ -4659,7 +4497,6 @@ class TestUpdatesService(BaseTestCase):
         self.assertNotIn('Push to Stable', resp)
         self.assertIn('Edit', resp)
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
     def test_push_to_stable_button_present_when_time_reached_and_batched_critpath(self, publish,
@@ -4781,7 +4618,6 @@ class TestUpdatesService(BaseTestCase):
         self.assertIn(nvr, resp)
         self.assertNotIn('<strong>Update Severity</strong>', resp)
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
     def test_manually_push_to_stable_based_on_karma(self, publish, *args):
@@ -4833,7 +4669,6 @@ class TestUpdatesService(BaseTestCase):
         self.assertIn(id, resp)
         self.assertIn('Push to Stable', resp)
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
     def test_manually_push_to_batched_based_on_karma(self, publish, *args):
@@ -4883,7 +4718,6 @@ class TestUpdatesService(BaseTestCase):
         self.assertIn('Push to Batched', resp)
         self.assertNotIn('Push to Stable', resp)
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
     def test_edit_update_with_expired_override(self, publish, *args):
@@ -4921,7 +4755,6 @@ class TestUpdatesService(BaseTestCase):
         up = r.json_body
         self.assertEquals(up['title'], nvr)
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_taskotron_results)
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
@@ -4960,7 +4793,6 @@ class TestUpdatesService(BaseTestCase):
             ("Cannot submit bodhi ('0', '1.0', '1.fc17') to stable since it is older than "
              "('0', '2.0', '1.fc17')"))
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
     def test_edit_testing_update_with_build_from_different_update(self, publish, *args):
@@ -5011,7 +4843,6 @@ class TestUpdatesService(BaseTestCase):
         self.assertEquals(len(up.builds), 1)
         self.assertEquals(up.builds[0].nvr, nvr1)
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
     def test_meets_testing_requirements_since_karma_reset_critpath(self, publish, *args):
@@ -5055,7 +4886,6 @@ class TestUpdatesService(BaseTestCase):
         self.assertEquals(update.days_to_stable, 0)
         self.assertEqual(update.meets_testing_requirements, True)
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_taskotron_results)
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
@@ -5082,7 +4912,6 @@ class TestUpdatesService(BaseTestCase):
         publish.assert_called_with(
             topic='update.request.batched', msg=mock.ANY)
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
     def test_newpackage_update_bypass_batched(self, publish, *args):
@@ -5113,7 +4942,6 @@ class TestUpdatesService(BaseTestCase):
         up = self.db.query(Update).filter_by(title=resp.json['title']).one()
         self.assertEquals(up.request, UpdateRequest.stable)
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
     def test_urgent_update_bypass_batched(self, publish, *args):
@@ -5144,7 +4972,6 @@ class TestUpdatesService(BaseTestCase):
         up = self.db.query(Update).filter_by(title=resp.json['title']).one()
         self.assertEquals(up.request, UpdateRequest.stable)
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_taskotron_results)
     @mock.patch(**mock_valid_requirements)
     def test_alert_not_displayed_if_no_summary_present(self, publish, *args):
@@ -5171,7 +4998,6 @@ class TestUpdatesService(BaseTestCase):
                 '<div class="alert alert-danger">The update can not be pushed:',
                 resp)
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_taskotron_results)
     @mock.patch(**mock_valid_requirements)
     def test_alert_notdisplayed_if_summary_present_but_gating_off(
@@ -5199,7 +5025,6 @@ class TestUpdatesService(BaseTestCase):
             self.assertNotIn(
                 '<div class="alert alert-danger">The update can not be pushed: \' + summary ', resp)
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_taskotron_results)
     @mock.patch(**mock_valid_requirements)
     def test_alert_displayed_if_summary_present(self, publish, *args):
@@ -5230,7 +5055,6 @@ class TestWaiveTestResults(BaseTestCase):
     """
     This class contains tests for the waive_test_results() function.
     """
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_cannot_waive_test_results_on_locked_update(self, *args):
         """Ensure that we get an error if trying to waive test results of a locked update"""
         nvr = u'bodhi-2.0-1.fc17'
@@ -5246,7 +5070,6 @@ class TestWaiveTestResults(BaseTestCase):
         self.assertEquals(res.json_body[u'errors'][0][u'description'],
                           "Can't waive test results on a locked update")
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_cannot_waive_test_results_when_test_gating_is_off(self, *args):
         """
         Ensure that we get an error if trying to waive test results of an update
@@ -5265,7 +5088,6 @@ class TestWaiveTestResults(BaseTestCase):
         self.assertEquals(res.json_body[u'errors'][0][u'description'],
                           "Test gating is not enabled")
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch('bodhi.server.services.updates.Update.waive_test_results',
                 side_effect=IOError('IOError. oops!'))
     @mock.patch('bodhi.server.services.updates.log.exception')

--- a/bodhi/tests/server/test_renderers.py
+++ b/bodhi/tests/server/test_renderers.py
@@ -23,7 +23,6 @@ import mock
 import re
 import unittest
 
-from webtest import TestApp
 import PIL.Image
 from six import StringIO
 import six
@@ -54,7 +53,7 @@ class TestRenderers(base.BaseTestCase):
             'captcha.ttl': '300',
         })
         with mock.patch('bodhi.server.Session.remove'):
-            app = TestApp(main({}, session=self.db, **settings))
+            app = base.BodhiTestApp(main({}, session=self.db, **settings))
 
         res = app.get('/updates/FEDORA-{}-a3bbe1a8f2'.format(datetime.datetime.utcnow().year),
                       status=200,

--- a/bodhi/tests/server/views/test_generic.py
+++ b/bodhi/tests/server/views/test_generic.py
@@ -19,11 +19,8 @@
 
 from datetime import datetime
 import copy
-import unittest
 
 import mock
-from webtest import TestApp
-import six
 
 from bodhi.server import main, util
 from bodhi.server.models import (
@@ -273,7 +270,6 @@ class TestGenericViews(base.BaseTestCase):
             "</div>"
         )
 
-    @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_metrics(self):
         res = self.app.get('/metrics')
         self.assertIn('$.plot', res)

--- a/bodhi/tests/server/views/test_generic.py
+++ b/bodhi/tests/server/views/test_generic.py
@@ -356,7 +356,7 @@ class TestGenericViews(base.BaseTestCase):
             'authtkt.secret': 'whatever',
             'authtkt.secure': True,
         })
-        app = TestApp(main({}, session=self.db, **anonymous_settings))
+        app = base.BodhiTestApp(main({}, session=self.db, **anonymous_settings))
         res = app.post('/popup_toggle', status=403)
         self.assertIn('<h1>403 <small>Forbidden</small></h1>', res)
         self.assertIn('<p class="lead">Access was denied to this resource.</p>', res)
@@ -374,7 +374,7 @@ class TestGenericViews(base.BaseTestCase):
             'authtkt.secret': 'whatever',
             'authtkt.secure': True,
         })
-        app = TestApp(main({}, session=self.db, **anonymous_settings))
+        app = base.BodhiTestApp(main({}, session=self.db, **anonymous_settings))
         res = app.get('/overrides/new', status=403)
         self.assertIn('<h1>403 <small>Forbidden</small></h1>', res)
         self.assertIn('<p class="lead">Access was denied to this resource.</p>', res)
@@ -392,7 +392,7 @@ class TestGenericViews(base.BaseTestCase):
             'authtkt.secret': 'whatever',
             'authtkt.secure': True,
         })
-        app = TestApp(main({}, session=self.db, **anonymous_settings))
+        app = base.BodhiTestApp(main({}, session=self.db, **anonymous_settings))
         res = app.get('/updates/new', status=403)
         self.assertIn('<h1>403 <small>Forbidden</small></h1>', res)
         self.assertIn('<p class="lead">Access was denied to this resource.</p>', res)


### PR DESCRIPTION
Hello.

As discussed in https://github.com/fedora-infra/bodhi/issues/2350 I've prepared a change which allows me to unblock approx 300 tests in Python 3.

With that applied, there are only 20 tests skipped in Python 3! We can track the work on the rest of failing tests in the https://github.com/fedora-infra/bodhi/issues/2059. Currently, I am unsure when I'll have free cycles to take a look but I think it's still a huge progress.

What do you think?