### PR TITLE
Measure branch coverage.

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,4 +1,5 @@
 [run]
+branch = True
 source = bodhi
 omit =
     bodhi/scripts/*
@@ -8,7 +9,7 @@ omit =
 
 [report]
 precision = 2
-fail_under = 100
+fail_under = 97
 exclude_lines =
     pragma: no cover
     class DevBuildsys


### PR DESCRIPTION
Though Bodhi currently has 99% line test coverage, there are some
branch paths that are not currently covered, so this commit also
reduces the required coverage percentage to 98%.

Signed-off-by: Randy Barlow <randy@electronsweatshop.com>