### PR TITLE
Add unit-tests checking the behavior of the waive result endpoint and allow specifying which tests to waive

### DIFF
--- a/bodhi/server/schemas.py
+++ b/bodhi/server/schemas.py
@@ -108,6 +108,12 @@ class Updates(colander.SequenceSchema):
     update = colander.SchemaNode(colander.String())
 
 
+class Tests(colander.SequenceSchema):
+    """A SequenceSchema to validate a list of Test objects."""
+
+    test = colander.SchemaNode(colander.String())
+
+
 class BugFeedback(colander.MappingSchema):
     """A schema for BugFeedback to be provided via API parameters."""
 
@@ -807,6 +813,7 @@ class WaiveTestResultsSchema(CSRFProtectedSchema, colander.MappingSchema):
         colander.String(),
         missing=None,
     )
+    tests = Tests(colander.Sequence(accept_scalar=True), missing=None, preparer=[util.splitter])
 
 
 class GetTestResultsSchema(CSRFProtectedSchema, colander.MappingSchema):

--- a/bodhi/server/services/updates.py
+++ b/bodhi/server/services/updates.py
@@ -578,9 +578,10 @@ def waive_test_results(request):
     """
     update = request.validated['update']
     comment = request.validated.pop('comment', None)
+    tests = request.validated.pop('tests', None)
 
     try:
-        update.waive_test_results(request.user.name, comment)
+        update.waive_test_results(request.user.name, comment, tests)
     except LockedUpdateException as e:
         request.errors.add('body', 'request', str(e))
     except BodhiException as e:

--- a/bodhi/tests/server/services/test_updates.py
+++ b/bodhi/tests/server/services/test_updates.py
@@ -5078,8 +5078,8 @@ class TestWaiveTestResults(BaseTestCase):
         log_exception.assert_called_once_with("Unhandled exception in waive_test_results")
 
     @mock.patch.dict(config, [('test_gating.required', True)])
-    @mock.patch('bodhi.server.models.waiverdb_api_post')
-    @mock.patch('bodhi.server.models.greenwave_api_post')
+    @mock.patch('bodhi.server.util.waiverdb_api_post')
+    @mock.patch('bodhi.server.util.greenwave_api_post')
     @mock.patch('bodhi.server.models.User.openid', mock.MagicMock(return_value=None))
     @mock.patch('bodhi.server.models.User.avatar', mock.MagicMock(return_value=None))
     def test_waive_test_results_1_unsatisfied_requirement(
@@ -5138,8 +5138,8 @@ class TestWaiveTestResults(BaseTestCase):
         self.assertEqual(res.json_body['update'], up.__json__())
 
     @mock.patch.dict(config, [('test_gating.required', True)])
-    @mock.patch('bodhi.server.models.waiverdb_api_post')
-    @mock.patch('bodhi.server.models.greenwave_api_post')
+    @mock.patch('bodhi.server.util.waiverdb_api_post')
+    @mock.patch('bodhi.server.util.greenwave_api_post')
     @mock.patch('bodhi.server.models.User.openid', mock.MagicMock(return_value=None))
     @mock.patch('bodhi.server.models.User.avatar', mock.MagicMock(return_value=None))
     def test_waive_test_results_2_unsatisfied_requirements(
@@ -5218,6 +5218,241 @@ class TestWaiveTestResults(BaseTestCase):
             )
         ]
         self.assertEqual(waiverdb_api_post.mock_calls, calls)
+
+        self.assertEqual(list(res.json_body.keys()), ['update'])
+        self.assertEqual(res.json_body['update'], up.__json__())
+
+    @mock.patch.dict(config, [('test_gating.required', True)])
+    @mock.patch('bodhi.server.util.waiverdb_api_post')
+    @mock.patch('bodhi.server.util.greenwave_api_post')
+    @mock.patch('bodhi.server.models.User.openid', mock.MagicMock(return_value=None))
+    @mock.patch('bodhi.server.models.User.avatar', mock.MagicMock(return_value=None))
+    def test_waive_test_results_1_of_2_unsatisfied_requirements(
+            self, greenwave_api_post, waiverdb_api_post, *args):
+        """Ensure that waiverdb and greenwaved are properly called when greenwave returns only two
+        unsatisfied requirements but only one of them is waived."""
+        nvr = u'bodhi-2.0-1.fc17'
+        greenwave_api_post.return_value = {
+            u'unsatisfied_requirements': [
+                {
+                    u'item': {
+                        u'item': u'bodhi-2.0-1.fc17',
+                        u'type': u'koji_build'
+                    },
+                    u'scenario': None,
+                    u'testcase': u'dist.rpmdeplint',
+                    u'type': u'test-result-missing'
+                },
+                {
+                    u'item': {
+                        u'item': u'bodhi-2.0-1.fc17',
+                        u'type': u'koji_build'
+                    },
+                    u'scenario': None,
+                    u'testcase': u'atomic_ci_pipeline_results',
+                    u'type': u'test-result-missing'
+                }
+            ],
+        }
+
+        up = self.db.query(Update).filter_by(title=nvr).one()
+        up.test_gating_status = TestGatingStatus.failed
+
+        post_data = dict(
+            update=nvr,
+            tests="atomic_ci_pipeline_results",
+            csrf_token=self.get_csrf_token()
+        )
+        res = self.app.post_json('/updates/%s/waive-test-results' % str(nvr), post_data, status=200)
+
+        greenwave_api_post.assert_called_once_with(
+            'https://greenwave-web-greenwave.app.os.fedoraproject.org/api/v1.0/decision',
+            {
+                'product_version': u'fedora-17',
+                'decision_context': u'bodhi_update_push_testing',
+                'subject': [
+                    {'item': u'bodhi-2.0-1.fc17', 'type': 'koji_build'},
+                    {'original_spec_nvr': u'bodhi-2.0-1.fc17'},
+                    {'item': u'FEDORA-2018-a3bbe1a8f2', 'type': 'bodhi_update'}
+                ]
+            }
+        )
+
+        waiverdb_api_post.assert_called_once_with(
+            'https://waiverdb-web-waiverdb.app.os.fedoraproject.org/api/v1.0/waivers/',
+            {
+                'username': u'guest',
+                'comment': None,
+                'waived': True,
+                'product_version': u'fedora-17',
+                'testcase': u'atomic_ci_pipeline_results',
+                'subject': {
+                    u'item': u'bodhi-2.0-1.fc17', u'type': u'koji_build'
+                }
+            }
+        )
+
+        self.assertEqual(list(res.json_body.keys()), ['update'])
+        self.assertEqual(res.json_body['update'], up.__json__())
+
+    @mock.patch.dict(config, [('test_gating.required', True)])
+    @mock.patch('bodhi.server.util.waiverdb_api_post')
+    @mock.patch('bodhi.server.util.greenwave_api_post')
+    @mock.patch('bodhi.server.models.User.openid', mock.MagicMock(return_value=None))
+    @mock.patch('bodhi.server.models.User.avatar', mock.MagicMock(return_value=None))
+    def test_waive_test_results_2_of_2_unsatisfied_requirements(
+            self, greenwave_api_post, waiverdb_api_post, *args):
+        """Ensure that waiverdb and greenwaved are properly called when greenwave returns only two
+        unsatisfied requirements and both of them are waived."""
+        nvr = u'bodhi-2.0-1.fc17'
+        greenwave_api_post.return_value = {
+            u'unsatisfied_requirements': [
+                {
+                    u'item': {
+                        u'item': u'bodhi-2.0-1.fc17',
+                        u'type': u'koji_build'
+                    },
+                    u'scenario': None,
+                    u'testcase': u'dist.rpmdeplint',
+                    u'type': u'test-result-missing'
+                },
+                {
+                    u'item': {
+                        u'item': u'bodhi-2.0-1.fc17',
+                        u'type': u'koji_build'
+                    },
+                    u'scenario': None,
+                    u'testcase': u'atomic_ci_pipeline_results',
+                    u'type': u'test-result-missing'
+                }
+            ],
+        }
+
+        up = self.db.query(Update).filter_by(title=nvr).one()
+        up.test_gating_status = TestGatingStatus.failed
+
+        post_data = dict(
+            update=nvr,
+            tests=["atomic_ci_pipeline_results", "dist.rpmdeplint"],
+            csrf_token=self.get_csrf_token()
+        )
+        res = self.app.post_json('/updates/%s/waive-test-results' % str(nvr), post_data, status=200)
+
+        greenwave_api_post.assert_called_once_with(
+            'https://greenwave-web-greenwave.app.os.fedoraproject.org/api/v1.0/decision',
+            {
+                'product_version': u'fedora-17',
+                'decision_context': u'bodhi_update_push_testing',
+                'subject': [
+                    {'item': u'bodhi-2.0-1.fc17', 'type': 'koji_build'},
+                    {'original_spec_nvr': u'bodhi-2.0-1.fc17'},
+                    {'item': u'FEDORA-2018-a3bbe1a8f2', 'type': 'bodhi_update'}
+                ]
+            }
+        )
+
+        calls = [
+            mock.call(
+                'https://waiverdb-web-waiverdb.app.os.fedoraproject.org/api/v1.0/waivers/',
+                {
+                    'username': u'guest',
+                    'comment': None,
+                    'waived': True,
+                    'product_version': u'fedora-17',
+                    'testcase': u'dist.rpmdeplint',
+                    'subject': {
+                        u'item': u'bodhi-2.0-1.fc17', u'type': u'koji_build'
+                    }
+                }
+            ),
+            mock.call(
+                'https://waiverdb-web-waiverdb.app.os.fedoraproject.org/api/v1.0/waivers/',
+                {
+                    'username': u'guest',
+                    'comment': None,
+                    'waived': True,
+                    'product_version': u'fedora-17',
+                    'testcase': u'atomic_ci_pipeline_results',
+                    'subject': {
+                        u'item': u'bodhi-2.0-1.fc17', u'type': u'koji_build'
+                    }
+                }
+            )
+        ]
+        self.assertEqual(waiverdb_api_post.mock_calls, calls)
+
+        self.assertEqual(list(res.json_body.keys()), ['update'])
+        self.assertEqual(res.json_body['update'], up.__json__())
+
+    @mock.patch.dict(config, [('test_gating.required', True)])
+    @mock.patch('bodhi.server.util.waiverdb_api_post')
+    @mock.patch('bodhi.server.util.greenwave_api_post')
+    @mock.patch('bodhi.server.models.User.openid', mock.MagicMock(return_value=None))
+    @mock.patch('bodhi.server.models.User.avatar', mock.MagicMock(return_value=None))
+    def test_waive_test_results_unfailing_tests(
+            self, greenwave_api_post, waiverdb_api_post, *args):
+        """Ensure that waiverdb and greenwaved are properly called when greenwave returns only two
+        unsatisfied requirements and one of the two asked to be waived isn't a requirement."""
+        nvr = u'bodhi-2.0-1.fc17'
+        greenwave_api_post.return_value = {
+            u'unsatisfied_requirements': [
+                {
+                    u'item': {
+                        u'item': u'bodhi-2.0-1.fc17',
+                        u'type': u'koji_build'
+                    },
+                    u'scenario': None,
+                    u'testcase': u'dist.rpmdeplint',
+                    u'type': u'test-result-missing'
+                },
+                {
+                    u'item': {
+                        u'item': u'bodhi-2.0-1.fc17',
+                        u'type': u'koji_build'
+                    },
+                    u'scenario': None,
+                    u'testcase': u'atomic_ci_pipeline_results',
+                    u'type': u'test-result-missing'
+                }
+            ],
+        }
+
+        up = self.db.query(Update).filter_by(title=nvr).one()
+        up.test_gating_status = TestGatingStatus.failed
+
+        post_data = dict(
+            update=nvr,
+            tests=["generic_ci_pipeline_results", "dist.rpmdeplint"],
+            csrf_token=self.get_csrf_token()
+        )
+        res = self.app.post_json('/updates/%s/waive-test-results' % str(nvr), post_data, status=200)
+
+        greenwave_api_post.assert_called_once_with(
+            'https://greenwave-web-greenwave.app.os.fedoraproject.org/api/v1.0/decision',
+            {
+                'product_version': u'fedora-17',
+                'decision_context': u'bodhi_update_push_testing',
+                'subject': [
+                    {'item': u'bodhi-2.0-1.fc17', 'type': 'koji_build'},
+                    {'original_spec_nvr': u'bodhi-2.0-1.fc17'},
+                    {'item': u'FEDORA-2018-a3bbe1a8f2', 'type': 'bodhi_update'}
+                ]
+            }
+        )
+
+        waiverdb_api_post.assert_called_once_with(
+            'https://waiverdb-web-waiverdb.app.os.fedoraproject.org/api/v1.0/waivers/',
+            {
+                'username': u'guest',
+                'comment': None,
+                'waived': True,
+                'product_version': u'fedora-17',
+                'testcase': u'dist.rpmdeplint',
+                'subject': {
+                    u'item': u'bodhi-2.0-1.fc17', u'type': u'koji_build'
+                }
+            }
+        )
 
         self.assertEqual(list(res.json_body.keys()), ['update'])
         self.assertEqual(res.json_body['update'], up.__json__())

--- a/bodhi/tests/server/test_models.py
+++ b/bodhi/tests/server/test_models.py
@@ -3262,7 +3262,7 @@ class TestUpdate(ModelTest):
                 self.assertEqual(post.mock_calls[i], v)
 
     @mock.patch('bodhi.server.util.greenwave_api_post')
-    @mock.patch('bodhi.server.models.waiverdb_api_post')
+    @mock.patch('bodhi.server.util.waiverdb_api_post')
     def test_can_waive_test_results_of_an_update(self, mock_waiverdb, mock_greenwave):
         update = self.obj
         update.status = UpdateStatus.testing


### PR DESCRIPTION
Somehow we only had test checking the failures on the endpoint... This is
now testing the success of the endpoint, when querying greenwave and
waiverdb worked.

Signed-off-by: Pierre-Yves Chibon <pingou@pingoured.fr>