### PR TITLE
Stop using async as variable name, it's a keyword since Python 3.7

### DIFF
--- a/bodhi/server/util.py
+++ b/bodhi/server/util.py
@@ -1012,7 +1012,7 @@ def sorted_updates(updates):
             with a multicall.
     """
     builds = defaultdict(set)
-    sync, async = [], []
+    sync, async_ = [], []
     for update in updates:
         for build in update.builds:
             builds[build.nvr_name].add(build)
@@ -1024,22 +1024,22 @@ def sorted_updates(updates):
             for build in sorted_builds(builds[package])[::-1]:
                 if build.update not in sync:
                     sync.append(build.update)
-                if build.update in async:
-                    async.remove(build.update)
+                if build.update in async_:
+                    async_.remove(build.update)
         else:
             build = list(builds[package])[0]
-            if build.update not in async and build.update not in sync:
-                async.append(build.update)
+            if build.update not in async_ and build.update not in sync:
+                async_.append(build.update)
     log.info('sync = %s' % ([up.title for up in sync],))
-    log.info('async = %s' % ([up.title for up in async],))
-    if not (len(set(sync) & set(async)) == 0 and
-            len(set(sync) | set(async)) == len(updates)):
+    log.info('async_ = %s' % ([up.title for up in async_],))
+    if not (len(set(sync) & set(async_)) == 0 and
+            len(set(sync) | set(async_)) == len(updates)):
         # There should be absolutely no way to hit this code path, but let's be paranoid, and check
         # every run, to make sure no update gets left behind.
         # It makes sure that there is no update in sync AND async, and that the combination of
-        # sync OR async is the full set of updates.
+        # sync OR async_ is the full set of updates.
         raise Exception('ERROR! SYNC+ASYNC != UPDATES! sorted_updates failed')  # pragma: no cover
-    return sync, async
+    return sync, async_
 
 
 def cmd(cmd, cwd=None, raise_on_error=False):

--- a/bodhi/tests/server/test_util.py
+++ b/bodhi/tests/server/test_util.py
@@ -1164,10 +1164,10 @@ class TestUtils(base.BaseTestCase):
         u2 = self.create_update(['somepkg-1.0-3.fc24'])
 
         us = [u1, u2]
-        sync, async = util.sorted_updates(us)
+        sync, async_ = util.sorted_updates(us)
 
         assert len(sync) == 2
-        assert len(async) == 0
+        assert len(async_) == 0
         assert sync[0] == u2
         assert sync[1] == u1
 
@@ -1180,14 +1180,14 @@ class TestUtils(base.BaseTestCase):
         u6 = self.create_update(['pkgd-2.0-3.fc24'])
 
         us = [u1, u2, u3, u4, u5, u6]
-        sync, async = util.sorted_updates(us)
+        sync, async_ = util.sorted_updates(us)
 
         # This ordering is because:
         #  u5 contains pkgd-1.0, which is < pkgdb-2.0 from u6
         #  u2 contains somepkg-1.0, which is < somepkg-2.0 from u1
         self.assertEquals(sync, [u5, u6, u2, u1])
         # This ordering is because neither u3 nor u4 overlap with other updates
-        self.assertEquals(async, [u3, u4])
+        self.assertEquals(async_, [u3, u4])
 
     def test_sorted_updates_insanity(self):
         """
@@ -1201,12 +1201,12 @@ class TestUtils(base.BaseTestCase):
         u3 = self.create_update(['pkga-2.0-1.fc24', 'pkgb-1.0-3.fc24'])  # Newer pkga, thus >u2
 
         us = [u1, u2, u3]
-        sync, async = util.sorted_updates(us)
+        sync, async_ = util.sorted_updates(us)
 
         # This ordering is actually insane, since both u2 and u3 contain a newer and an older build
         self.assertEquals(sync, [u2, u3])
         # This ordering is because u1 doesn't overlap with anything
-        self.assertEquals(async, [u1])
+        self.assertEquals(async_, [u1])
 
     def test_splitter(self):
         splitlist = util.splitter(["build-0.1", "build-0.2"])


### PR DESCRIPTION
See https://bugzilla.redhat.com/show_bug.cgi?id=1589990