### PR TITLE
Python 3.7: repr of exceptions changed not to include trailing comma

### DIFF
--- a/bodhi/tests/server/test___init__.py
+++ b/bodhi/tests/server/test___init__.py
@@ -43,7 +43,7 @@ class TestExceptionFilter(unittest.TestCase):
 
         self.assertIs(response, request_response)
         exception.assert_called_once_with(
-            "Unhandled exception raised:  OSError('Your money is gone.',)")
+            "Unhandled exception raised:  {}".format(repr(request_response)))
 
     @mock.patch('bodhi.server.log.exception')
     def test_no_exception(self, exception):

--- a/bodhi/tests/server/test_mail.py
+++ b/bodhi/tests/server/test_mail.py
@@ -287,7 +287,8 @@ class Test_SendMail(unittest.TestCase):
         SMTP.assert_called_once_with('smtp.fp.o')
         smtp.sendmail.assert_called_once_with('archer@spies.com', ['lana@spies.com'], 'hi')
         warn.assert_called_once_with(
-            '"recipient refused" for \'lana@spies.com\', SMTPRecipientsRefused(\'nooope!\',)')
+            '"recipient refused" for \'lana@spies.com\', {}'.format(
+                repr(smtp.sendmail.side_effect)))
         smtp.quit.assert_called_once_with()
 
     @mock.patch.dict('bodhi.server.mail.config', {'smtp_server': ''})


### PR DESCRIPTION
Several tests rely on exact repr of exceptions, so we special case Python 3.7 not to include the comma. Not particularly nice but it gets the job done.

Fixes https://github.com/fedora-infra/bodhi/issues/2438