### PR TITLE
Install python3-ipdb in Vagrant.

### DIFF
--- a/devel/ansible/roles/dev/tasks/main.yml
+++ b/devel/ansible/roles/dev/tasks/main.yml
@@ -76,6 +76,7 @@
       - python3-dogpile-cache
       - python3-fedmsg
       - python3-fedora
+      - python3-ipdb
       - python3-kitchen
       - python3-markdown
       - python3-mock


### PR DESCRIPTION
Signed-off-by: Randy Barlow <randy@electronsweatshop.com>