### PR TITLE
Fix a deprecation warning in setup.cfg for pytest.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -26,7 +26,7 @@ output_dir = bodhi/server/locale
 inherit = true
 add-ignore = D413
 
-[pytest]
+[tool:pytest]
 addopts = --junit-xml=nosetests.xml --cov-config .coveragerc --cov=bodhi --cov-report term --cov-report xml --cov-report html
 
 [update_catalog]


### PR DESCRIPTION
The [pytest] section has been replaced by [tool:pytest].

Signed-off-by: Randy Barlow <randy@electronsweatshop.com>