### PR TITLE
Use a raw string for a regex to silence a DeprecationWarning.

### DIFF
--- a/bodhi/server/models.py
+++ b/bodhi/server/models.py
@@ -848,7 +848,7 @@ class Release(Base):
         Returns:
             int: The version of the release.
         """
-        regex = re.compile('\D+(\d+)[CM]?$')
+        regex = re.compile(r'\D+(\d+)[CM]?$')
         return int(regex.match(self.name).groups()[0])
 
     @property


### PR DESCRIPTION
Prior to this patch, a DeprecationWarning appeared while running
the tests:

```
home/vagrant/bodhi/bodhi/server/models.py:851: DeprecationWarning:
invalid escape sequence \D
  regex = re.compile('\D+(\d+)[CM]?$', flags=re.ASCII)
```

By switching the regex string to a raw string we fix the warning.

Signed-off-by: Randy Barlow <randy@electronsweatshop.com>