### PR TITLE
Close the alembic history process before finishing the test.

### DIFF
--- a/bodhi/tests/server/test_alembic.py
+++ b/bodhi/tests/server/test_alembic.py
@@ -45,3 +45,4 @@ class TestAlembic(unittest.TestCase):
         stdout = proc2.communicate()[0]
         stdout = stdout.strip().split(b'\n')
         self.assertEqual(len(stdout), 1)
+        proc1.communicate()


### PR DESCRIPTION
This eliminates two warnings printed during the tests:

```
usr/lib64/python3.6/contextlib.py:88: ResourceWarning: unclosed file
<_io.BufferedReader name=8>
  next(self.gen)
```

and

```
bodhi/tests/server/test_alembic.py::TestAlembic::test_alembic_history
  /usr/lib64/python3.6/subprocess.py:766: ResourceWarning: subprocess
  5985 is still running
      ResourceWarning, source=self)
```

Signed-off-by: Randy Barlow <randy@electronsweatshop.com>