### PR TITLE
Use warning() instead of warn() for logging.

### DIFF
--- a/bodhi/server/consumers/masher.py
+++ b/bodhi/server/consumers/masher.py
@@ -161,8 +161,8 @@ class Masher(fedmsg.consumers.FedmsgConsumer):
         self.topic = prefix + '.' + env + '.' + hub.config.get('masher_topic')
         self.valid_signer = hub.config.get('releng_fedmsg_certname')
         if not self.valid_signer:
-            log.warn('No releng_fedmsg_certname defined'
-                     'Cert validation disabled')
+            log.warning('No releng_fedmsg_certname defined'
+                        'Cert validation disabled')
         self.max_mashes_sem = threading.BoundedSemaphore(config.get('max_concurrent_mashes'))
 
         # This will ensure that the configured paths exist, and will raise ValueError if any does
@@ -470,7 +470,7 @@ class ComposerThread(threading.Thread):
         for update in self.compose.updates:
             result, reason = update.check_requirements(self.db, config)
             if not result:
-                self.log.warn("%s failed gating: %s" % (update.title, reason))
+                self.log.warning("%s failed gating: %s" % (update.title, reason))
                 self.eject_from_mash(update, reason)
         # We may have removed some updates from this compose above, and do we don't want future
         # reads on self.compose.updates to see those, so let's mark that attribute expired so
@@ -488,7 +488,7 @@ class ComposerThread(threading.Thread):
         """
         update.locked = False
         text = '%s ejected from the push because %r' % (update.title, reason)
-        log.warn(text)
+        log.warning(text)
         update.comment(self.db, text, author=u'bodhi')
         # Remove the pending tag as well
         if update.request is UpdateRequest.stable:
@@ -754,8 +754,8 @@ class ComposerThread(threading.Thread):
                 release.id_prefix.lower().replace('-', '_'))
             test_list = config.get(test_list_key)
             if not test_list:
-                log.warn('%r undefined. Not sending updates-testing digest',
-                         test_list_key)
+                log.warning('%r undefined. Not sending updates-testing digest',
+                            test_list_key)
                 continue
 
             log.debug("Sending digest for updates-testing %s" % prefix)

--- a/bodhi/server/consumers/updates.py
+++ b/bodhi/server/consumers/updates.py
@@ -87,7 +87,7 @@ class UpdatesHandler(fedmsg.consumers.FedmsgConsumer):
 
         self.handle_bugs = bool(config.get('bodhi_email'))
         if not self.handle_bugs:
-            log.warn("No bodhi_email defined; not fetching bug details")
+            log.warning("No bodhi_email defined; not fetching bug details")
         else:
             bug_module.set_bugtracker()
 
@@ -170,7 +170,7 @@ class UpdatesHandler(fedmsg.consumers.FedmsgConsumer):
             bugs (list): A list of bodhi.server.models.Bug instances that we wish to act on.
         """
         if not self.handle_bugs:
-            log.warn("Not configured to handle bugs")
+            log.warning("Not configured to handle bugs")
             return
 
         log.info("Got %i bugs to sync for %r" % (len(bugs), update.alias))

--- a/bodhi/server/mail.py
+++ b/bodhi/server/mail.py
@@ -390,7 +390,7 @@ def _send_mail(from_addr, to_addr, body):
         smtp = smtplib.SMTP(smtp_server)
         smtp.sendmail(from_addr, [to_addr], body)
     except smtplib.SMTPRecipientsRefused as e:
-        log.warn('"recipient refused" for %r, %r' % (to_addr, e))
+        log.warning('"recipient refused" for %r, %r' % (to_addr, e))
     except Exception:
         log.exception('Unable to send mail')
     finally:
@@ -413,7 +413,7 @@ def send_mail(from_addr, to_addr, subject, body_text, headers=None):
     if not from_addr:
         from_addr = config.get('bodhi_email')
     if not from_addr:
-        log.warn('Unable to send mail: bodhi_email not defined in the config')
+        log.warning('Unable to send mail: bodhi_email not defined in the config')
         return
     if to_addr in config.get('exclude_mail'):
         return

--- a/bodhi/server/metadata.py
+++ b/bodhi/server/metadata.py
@@ -147,7 +147,7 @@ class UpdateInfoMetadata(object):
                 if build_obj.update:
                     self.updates.add(build_obj.update)
                 else:
-                    log.warn('%s does not have a corresponding update' % build['nvr'])
+                    log.warning('%s does not have a corresponding update' % build['nvr'])
             else:
                 nonexistent.append(build['nvr'])
         if nonexistent:

--- a/bodhi/server/models.py
+++ b/bodhi/server/models.py
@@ -878,7 +878,7 @@ class Release(Base):
         days = config.get('%s.mandatory_days_in_testing' %
                           self.id_prefix.lower().replace('-', '_'))
         if days is None:
-            log.warn('No mandatory days in testing defined for %s. Defaulting to 0.' % self.name)
+            log.warning('No mandatory days in testing defined for %s. Defaulting to 0.' % self.name)
             return 0
         else:
             return int(days)
@@ -2212,7 +2212,7 @@ class Update(Base):
                 else:
                     # EL6 doesn't have these, and that's okay...
                     # We still warn in case the config gets messed up.
-                    log.warn('%s has no pending_signing_tag' % up.release.name)
+                    log.warning('%s has no pending_signing_tag' % up.release.name)
 
         # And, updates with new or removed builds always get their karma reset.
         # https://github.com/fedora-infra/bodhi/issues/511
@@ -2724,7 +2724,7 @@ class Update(Base):
         """
         log.debug('Adding tag %s to %s' % (tag, self.title))
         if not tag:
-            log.warn("Not adding builds of %s to empty tag" % self.title)
+            log.warning("Not adding builds of %s to empty tag" % self.title)
             return []  # An empty iterator in place of koji multicall
 
         koji = buildsys.get_session()
@@ -2748,7 +2748,7 @@ class Update(Base):
         """
         log.debug('Removing tag %s from %s' % (tag, self.title))
         if not tag:
-            log.warn("Not removing builds of %s from empty tag" % self.title)
+            log.warning("Not removing builds of %s from empty tag" % self.title)
             return []  # An empty iterator in place of koji multicall
 
         return_multicall = not koji
@@ -4161,7 +4161,7 @@ class Bug(Base):
                 if 'testing_bug_epel_msg' in config:
                     template = config['testing_bug_epel_msg']
                 else:
-                    log.warn("No 'testing_bug_epel_msg' found in the config.")
+                    log.warning("No 'testing_bug_epel_msg' found in the config.")
 
             message += template % (config.get('base_address') + update.get_url())
         return message

--- a/bodhi/server/notifications.py
+++ b/bodhi/server/notifications.py
@@ -45,7 +45,7 @@ def init(active=None, cert_prefix=None):
         cert_prefix (basestring): Configures the ``cert_prefix`` setting in the fedmsg_config.
     """
     if not bodhi.server.config.config.get('fedmsg_enabled'):
-        bodhi.server.log.warn("fedmsg disabled.  not initializing.")
+        bodhi.server.log.warning("fedmsg disabled.  not initializing.")
         return
 
     fedmsg_config = fedmsg.config.load_config()
@@ -114,7 +114,7 @@ def publish(topic, msg, force=False):
             after the current database transaction is committed.
     """
     if not bodhi.server.config.config.get('fedmsg_enabled'):
-        _log.warn("fedmsg disabled.  not sending %r" % topic)
+        _log.warning("fedmsg disabled.  not sending %r" % topic)
         return
 
     # Initialize right before we try to publish, but only if we haven't

--- a/bodhi/server/security.py
+++ b/bodhi/server/security.py
@@ -140,7 +140,7 @@ def remember_me(context, request, info, *args, **kw):
     log.debug('remember_me: request.params = %r' % request.params)
     endpoint = request.params['openid.op_endpoint']
     if endpoint != request.registry.settings['openid.provider']:
-        log.warn('Invalid OpenID provider: %s' % endpoint)
+        log.warning('Invalid OpenID provider: %s' % endpoint)
         request.session.flash('Invalid OpenID provider. You can only use: %s' %
                               request.registry.settings['openid.provider'])
         return HTTPFound(location=request.route_url('home'))

--- a/bodhi/server/services/stacks.py
+++ b/bodhi/server/services/stacks.py
@@ -158,8 +158,8 @@ def save_stack(request):
                     log.info('%s is a member of the %s group', user.name, stack.name)
                     break
             else:
-                log.warn('%s is not an owner of the %s stack',
-                         user.name, stack.name)
+                log.warning('%s is not an owner of the %s stack',
+                            user.name, stack.name)
                 log.debug('owners = %s; groups = %s', stack.users, stack.groups)
                 request.errors.add('body', 'name', '%s does not have privileges'
                                    ' to modify the %s stack' % (user.name, stack.name))

--- a/bodhi/server/services/updates.py
+++ b/bodhi/server/services/updates.py
@@ -527,7 +527,7 @@ def new_update(request):
             if len(releases) > 1:
                 result = dict(updates=updates)
     except LockedUpdateException as e:
-        log.warn(str(e))
+        log.warning(str(e))
         request.errors.add('body', 'builds', "%s" % str(e))
         return
     except Exception as e:

--- a/bodhi/server/validators.py
+++ b/bodhi/server/validators.py
@@ -159,7 +159,7 @@ def cache_release(request, build):
     if not build_rel:
         msg = 'Cannot find release associated with ' + \
             'build: {}, tags: {}'.format(build, tags)
-        log.warn(msg)
+        log.warning(msg)
         request.errors.add('body', 'builds', msg)
     # This might end up setting build_rel to None. That is expected, and indicates it failed.
     request.buildinfo[build]['release'] = build_rel
@@ -492,7 +492,7 @@ def validate_acls(request, **kwargs):
             groups = (['ralph', 'bowlofeggs', 'guest'], ['guest'])
             committers, watchers = people
         else:
-            log.warn('No acl_system configured')
+            log.warning('No acl_system configured')
             people = None
 
         buildinfo['people'] = people

--- a/bodhi/tests/server/consumers/test_masher.py
+++ b/bodhi/tests/server/consumers/test_masher.py
@@ -3124,8 +3124,8 @@ class TestComposerThread_send_testing_digest(ComposerThreadBaseTestCase):
         self.assertTrue(update.abs_url() in args[2].decode('utf-8'))
         self.assertTrue(update.title in args[2].decode('utf-8'))
 
-    @mock.patch('bodhi.server.consumers.masher.log.warn')
-    def test_test_list_not_configured(self, warn):
+    @mock.patch('bodhi.server.consumers.masher.log.warning')
+    def test_test_list_not_configured(self, warning):
         """If a test_announce_list setting is not found, a warning should be logged."""
         t = ComposerThread(self.semmock, self._make_msg()['body']['msg']['composes'][0],
                            'bowlofeggs', log, self.Session, self.tempdir)
@@ -3137,7 +3137,7 @@ class TestComposerThread_send_testing_digest(ComposerThreadBaseTestCase):
         with mock.patch.dict(config, {'fedora_test_announce_list': None}):
             t.send_testing_digest()
 
-        warn.assert_called_once_with(
+        warning.assert_called_once_with(
             '%r undefined. Not sending updates-testing digest', 'fedora_test_announce_list')
 
 

--- a/bodhi/tests/server/consumers/test_updates.py
+++ b/bodhi/tests/server/consumers/test_updates.py
@@ -342,8 +342,8 @@ class TestUpdatesHandlerWorkOnBugs(base.BaseTestCase):
 
     @mock.patch.dict(config.config, {'bodhi_email': None})
     @mock.patch('bodhi.server.consumers.updates.log.info')
-    @mock.patch('bodhi.server.consumers.updates.log.warn')
-    def test_bodhi_email_undefined(self, warn, info):
+    @mock.patch('bodhi.server.consumers.updates.log.warning')
+    def test_bodhi_email_undefined(self, warning, info):
         """work_on_bugs() should log a warning and return if bodhi_email is not defined."""
         hub = mock.MagicMock()
         hub.config = {'environment': 'environment',
@@ -355,7 +355,7 @@ class TestUpdatesHandlerWorkOnBugs(base.BaseTestCase):
 
         # We should see warnings about bodhi_email being undefined.
         self.assertEqual(
-            warn.mock_calls,
+            warning.mock_calls,
             [mock.call('No bodhi_email defined; not fetching bug details'),
              mock.call('Not configured to handle bugs')])
         # We should not see info calls about syncing bugs, but we should see one about the handler.

--- a/bodhi/tests/server/test_mail.py
+++ b/bodhi/tests/server/test_mail.py
@@ -277,12 +277,13 @@ class TestSendMail(unittest.TestCase):
 
     @mock.patch.dict('bodhi.server.mail.config', {'bodhi_email': ''})
     @mock.patch('bodhi.server.mail._send_mail')
-    @mock.patch('bodhi.server.mail.log.warn')
-    def test_no_from_addr(self, warn, _send_mail):
+    @mock.patch('bodhi.server.mail.log.warning')
+    def test_no_from_addr(self, warning, _send_mail):
         """If there is no from_addr, a warning should be logged and the function should return."""
         mail.send_mail(None, 'bowlofeggs@example.com', 'R013X', 'Want a c00l w@tch?')
 
-        warn.assert_called_once_with('Unable to send mail: bodhi_email not defined in the config')
+        warning.assert_called_once_with(
+            'Unable to send mail: bodhi_email not defined in the config')
         # The mail should not have been sent
         self.assertEqual(_send_mail.call_count, 0)
 
@@ -326,9 +327,9 @@ class Test_SendMail(unittest.TestCase):
     """Test the _send_mail() function."""
 
     @mock.patch.dict('bodhi.server.mail.config', {'smtp_server': 'smtp.fp.o'})
-    @mock.patch('bodhi.server.mail.log.warn')
+    @mock.patch('bodhi.server.mail.log.warning')
     @mock.patch('bodhi.server.mail.smtplib.SMTP')
-    def test_recipients_refused(self, SMTP, warn):
+    def test_recipients_refused(self, SMTP, warning):
         """If recipients are refused, a warning should be logged and SMTP should be exited."""
         smtp = SMTP.return_value
         smtp.sendmail.side_effect = smtplib.SMTPRecipientsRefused('nooope!')
@@ -337,7 +338,7 @@ class Test_SendMail(unittest.TestCase):
 
         SMTP.assert_called_once_with('smtp.fp.o')
         smtp.sendmail.assert_called_once_with('archer@spies.com', ['lana@spies.com'], 'hi')
-        warn.assert_called_once_with(
+        warning.assert_called_once_with(
             '"recipient refused" for \'lana@spies.com\', {}'.format(
                 repr(smtp.sendmail.side_effect)))
         smtp.quit.assert_called_once_with()

--- a/bodhi/tests/server/test_metadata.py
+++ b/bodhi/tests/server/test_metadata.py
@@ -206,8 +206,8 @@ class TestAddUpdate(UpdateInfoMetadataTestCase):
 class TestFetchUpdates(UpdateInfoMetadataTestCase):
     """Test the UpdateInfoMetadata._fetch_updates() method."""
 
-    @mock.patch('bodhi.server.metadata.log.warn')
-    def test_build_unassociated(self, warn):
+    @mock.patch('bodhi.server.metadata.log.warning')
+    def test_build_unassociated(self, warning):
         """A warning should be logged if the Bodhi Build object is not associated with an Update."""
         update = self.db.query(Update).one()
         update.date_pushed = None
@@ -220,7 +220,7 @@ class TestFetchUpdates(UpdateInfoMetadataTestCase):
         md = UpdateInfoMetadata(update.release, update.request, self.db, self.temprepo,
                                 close_shelf=False)
 
-        warn.assert_called_once_with(
+        warning.assert_called_once_with(
             'TurboGears-1.0.2.2-4.fc17 does not have a corresponding update')
         # Since the Build didn't have an Update, no Update should have been added to md.updates.
         self.assertEqual(md.updates, set([]))

--- a/bodhi/tests/server/test_models.py
+++ b/bodhi/tests/server/test_models.py
@@ -274,11 +274,11 @@ class TestBugDefaultMessage(BaseTestCase):
         self.assertTrue(update.status.description in message)
         self.assertTrue(update.get_url() in message)
 
-    @mock.patch('bodhi.server.models.log.warn')
+    @mock.patch('bodhi.server.models.log.warning')
     @mock.patch.dict(
         config,
         {'stable_bug_msg': '%s%s', 'testing_bug_msg': '%s', 'base_address': 'b'}, clear=True)
-    def test_epel_without_testing_bug_epel_msg(self, warn):
+    def test_epel_without_testing_bug_epel_msg(self, warning):
         """Test with testing_bug_epel_msg undefined."""
         bug = model.Bug()
         update = model.Update.query.first()
@@ -287,7 +287,7 @@ class TestBugDefaultMessage(BaseTestCase):
 
         message = bug.default_message(update)
 
-        warn.assert_called_once_with("No 'testing_bug_epel_msg' found in the config.")
+        warning.assert_called_once_with("No 'testing_bug_epel_msg' found in the config.")
         self.assertTrue(update.builds[0].nvr in message)
         self.assertTrue(update.release.long_name in message)
         self.assertTrue(update.status.description in message)
@@ -1516,12 +1516,12 @@ class TestUpdateEdit(BaseTestCase):
         with self.assertRaises(model.LockedUpdateException):
             model.Update.edit(request, data)
 
-    @mock.patch('bodhi.server.models.log.warn')
-    def test_new_builds_log_when_release_has_no_signing_tag(self, warn):
+    @mock.patch('bodhi.server.models.log.warning')
+    def test_new_builds_log_when_release_has_no_signing_tag(self, warning):
         """If new builds are added from a release with no signing tag, it should log a warning."""
-        package = model.Package(name='python-rpdb')
+        package = model.RpmPackage(name='python-rpdb')
         self.db.add(package)
-        build = model.Build(nvr='python-rpdb-1.3.1.fc17', package=package)
+        build = model.RpmBuild(nvr='python-rpdb-1.3.1.fc17', package=package)
         self.db.add(build)
         update = model.Update.query.first()
         data = {
@@ -1536,7 +1536,7 @@ class TestUpdateEdit(BaseTestCase):
 
         model.Update.edit(request, data)
 
-        warn.assert_called_once_with('F17 has no pending_signing_tag')
+        warning.assert_called_once_with('F17 has no pending_signing_tag')
         update = model.Update.query.first()
         self.assertEqual(set([b.nvr for b in update.builds]),
                          {'bodhi-2.0-1.fc17', 'python-rpdb-1.3.1.fc17'})
@@ -1805,13 +1805,13 @@ class TestUpdate(ModelTest):
 
         self.assertEqual(self.obj.__json__()['content_type'], None)
 
-    @mock.patch('bodhi.server.models.log.warn')
-    def test_add_tag_null(self, warn):
+    @mock.patch('bodhi.server.models.log.warning')
+    def test_add_tag_null(self, warning):
         """Test the add_tag() method with a falsey tag, such as None."""
         result = self.obj.add_tag(tag=None)
 
         self.assertEqual(result, [])
-        warn.assert_called_once_with('Not adding builds of TurboGears-1.0.8-3.fc11 to empty tag')
+        warning.assert_called_once_with('Not adding builds of TurboGears-1.0.8-3.fc11 to empty tag')
 
     def test_autokarma_not_nullable(self):
         """Assert that the autokarma column does not allow NULL values.
@@ -2706,12 +2706,12 @@ class TestUpdate(ModelTest):
 
         self.assertEqual(self.obj.status, UpdateStatus.obsolete)
 
-    @mock.patch('bodhi.server.models.log.warn')
-    def test_remove_tag_emptystring(self, warn):
+    @mock.patch('bodhi.server.models.log.warning')
+    def test_remove_tag_emptystring(self, warning):
         """Test remove_tag() with a tag of ''."""
         self.assertEqual(self.obj.remove_tag(''), [])
 
-        warn.assert_called_once_with(
+        warning.assert_called_once_with(
             'Not removing builds of {} from empty tag'.format(self.obj.title))
 
     def test_revoke_no_request(self):

--- a/bodhi/tests/server/test_notifications.py
+++ b/bodhi/tests/server/test_notifications.py
@@ -79,9 +79,9 @@ class TestInit(unittest.TestCase):
         info.assert_called_once_with('fedmsg initialized')
 
     @mock.patch.dict('bodhi.server.config.config', {'fedmsg_enabled': False})
-    @mock.patch('bodhi.server.log.warn')
+    @mock.patch('bodhi.server.log.warning')
     @mock.patch('bodhi.server.notifications.fedmsg.init')
-    def test_fedmsg_disabled(self, init, warn):
+    def test_fedmsg_disabled(self, init, warning):
         """
         The init() function should log a warning and exit when fedmsg is disabled.
         """
@@ -89,7 +89,7 @@ class TestInit(unittest.TestCase):
 
         # fedmsg.init() should not have been called
         self.assertEqual(init.call_count, 0)
-        warn.assert_called_once_with('fedmsg disabled.  not initializing.')
+        warning.assert_called_once_with('fedmsg disabled.  not initializing.')
 
     @mock.patch.dict('bodhi.server.config.config', {'fedmsg_enabled': True})
     @mock.patch('bodhi.server.log.info')


### PR DESCRIPTION
The warn() logging method is deprecated and has been replaced with
warning().

Signed-off-by: Randy Barlow <randy@electronsweatshop.com>