### PR TITLE
Implement the possibility to waive missing requirements via bodhi-cli

### DIFF
--- a/bodhi/client/bindings.py
+++ b/bodhi/client/bindings.py
@@ -270,6 +270,33 @@ class BodhiClient(OpenIdBaseClient):
                 raise
 
     @errorhandled
+    def waive(self, update, comment, tests=None):
+        """
+        Waive unsatisfied requirements on an update.
+
+        Args:
+            update (basestring): The title of the update.
+            comment (basestring): A comment explaining the waiver.
+            tests (tuple(basestring) or None): The list of unsatisfied requirements
+                to waive. If not specified, all unsatisfied requirements of this
+                update will be waived.
+        Returns:
+            munch.Munch: The response from Bodhi to the request.
+        Raises:
+            UpdateNotFound: If the server returns a 404 error code.
+        """
+        data = {'update': update, 'tests': tests, 'comment': comment, 'csrf_token': self.csrf()}
+        try:
+            return self.send_request('updates/{0}/waive-test-results'.format(update),
+                                     verb='POST', auth=True, data=data)
+        except fedora.client.ServerError as exc:
+            if exc.code == 404:
+                # The Bodhi server gave us a 404 on the resource, so let's raise an UpdateNotFound.
+                raise UpdateNotFound(update)
+            else:
+                raise
+
+    @errorhandled
     def query(self, **kwargs):
         """
         Query bodhi for a list of updates.

--- a/bodhi/tests/client/test_bindings.py
+++ b/bodhi/tests/client/test_bindings.py
@@ -1659,3 +1659,109 @@ class TestGetKojiSession(unittest.TestCase):
 
         exists.assert_called_once_with("/home/dudemcpants/.koji/config")
         mock_open.assert_called_once_with("/etc/koji.conf")
+
+
+class TestBodhiClient_waive(unittest.TestCase):
+    """
+    This class contains tests for BodhiClient.waive().
+    """
+
+    @mock.patch('bodhi.client.bindings.BodhiClient.__init__', return_value=None)
+    @mock.patch.object(bindings.BodhiClient, 'base_url', 'http://example.com/tests/',
+                       create=True)
+    @mock.patch('bodhi.client.bindings.BodhiClient.csrf',
+                mock.MagicMock(return_value='a_csrf_token'))
+    @mock.patch('bodhi.client.bindings.BodhiClient.send_request',
+                side_effect=fedora.client.ServerError(
+                    url='http://example.com/tests/updates/bodhi-2.2.4-99.el7/waive-test-results',
+                    status=404, msg='update not found'))
+    def test_404_error(self, send_request, __init__):
+        """
+        Test for the case when the server returns a 404 error code.
+        """
+        client = bindings.BodhiClient(username='some_user', password='s3kr3t', staging=False)
+
+        with self.assertRaises(bindings.UpdateNotFound) as exc:
+            client.waive('bodhi-2.2.4-1.el7', comment='Expected failure', tests=None)
+
+            self.assertEqual(exc.update, 'bodhi-2.2.4-1.el7')
+
+        send_request.assert_called_once_with(
+            'updates/bodhi-2.2.4-1.el7/waive-test-results', verb='POST', auth=True,
+            data={'comment': 'Expected failure', 'csrf_token': 'a_csrf_token',
+                  'tests': None, 'update': 'bodhi-2.2.4-1.el7'})
+        __init__.assert_called_once_with(username='some_user', password='s3kr3t', staging=False)
+
+    @mock.patch('bodhi.client.bindings.BodhiClient.__init__', return_value=None)
+    @mock.patch.object(bindings.BodhiClient, 'base_url', 'http://example.com/tests/',
+                       create=True)
+    @mock.patch('bodhi.client.bindings.BodhiClient.csrf',
+                mock.MagicMock(return_value='a_csrf_token'))
+    @mock.patch('bodhi.client.bindings.BodhiClient.send_request',
+                return_value=client_test_data.EXAMPLE_UPDATE_MUNCH)
+    def test_successful_waive_some(self, send_request, __init__):
+        """
+        Test with a successful request.
+        """
+        client = bindings.BodhiClient(username='some_user', password='s3kr3t', staging=False)
+
+        response = client.waive(
+            'bodhi-2.2.4-1.el7', comment='Expected failure',
+            tests=('dist.rpmdeplint', 'fedora-atomic-ci')
+        )
+
+        self.assertEqual(response, client_test_data.EXAMPLE_UPDATE_MUNCH)
+        send_request.assert_called_once_with(
+            'updates/bodhi-2.2.4-1.el7/waive-test-results', verb='POST', auth=True,
+            data={'comment': 'Expected failure', 'csrf_token': 'a_csrf_token',
+                  'tests': ('dist.rpmdeplint', 'fedora-atomic-ci'), 'update': 'bodhi-2.2.4-1.el7'})
+        __init__.assert_called_once_with(username='some_user', password='s3kr3t', staging=False)
+
+    @mock.patch('bodhi.client.bindings.BodhiClient.__init__', return_value=None)
+    @mock.patch.object(bindings.BodhiClient, 'base_url', 'http://example.com/tests/',
+                       create=True)
+    @mock.patch('bodhi.client.bindings.BodhiClient.csrf',
+                mock.MagicMock(return_value='a_csrf_token'))
+    @mock.patch('bodhi.client.bindings.BodhiClient.send_request',
+                return_value=client_test_data.EXAMPLE_UPDATE_MUNCH)
+    def test_successful_waive_all(self, send_request, __init__):
+        """
+        Test with a successful request.
+        """
+        client = bindings.BodhiClient(username='some_user', password='s3kr3t', staging=False)
+
+        response = client.waive('bodhi-2.2.4-1.el7', comment='Expected failure', tests=None)
+
+        self.assertEqual(response, client_test_data.EXAMPLE_UPDATE_MUNCH)
+        send_request.assert_called_once_with(
+            'updates/bodhi-2.2.4-1.el7/waive-test-results', verb='POST', auth=True,
+            data={'comment': 'Expected failure', 'csrf_token': 'a_csrf_token',
+                  'tests': None, 'update': 'bodhi-2.2.4-1.el7'})
+        __init__.assert_called_once_with(username='some_user', password='s3kr3t', staging=False)
+
+    @mock.patch('bodhi.client.bindings.BodhiClient.__init__', return_value=None)
+    @mock.patch.object(bindings.BodhiClient, 'base_url', 'http://example.com/tests/',
+                       create=True)
+    @mock.patch('bodhi.client.bindings.BodhiClient.csrf',
+                mock.MagicMock(return_value='a_csrf_token'))
+    @mock.patch('bodhi.client.bindings.BodhiClient.send_request')
+    def test_other_ServerError(self, send_request, __init__):
+        """
+        Test for the case when a non-404 ServerError is raised.
+        """
+        server_error = fedora.client.ServerError(
+            url='http://example.com/tests/updates/bodhi-2.2.4-99.el7/waive-test-results',
+            status=500, msg='Internal server error')
+        send_request.side_effect = server_error
+        client = bindings.BodhiClient(username='some_user', password='s3kr3t', staging=False)
+
+        with self.assertRaises(fedora.client.ServerError) as exc:
+            client.waive('bodhi-2.2.4-1.el7', comment='Expected failure', tests=None)
+
+            self.assertTrue(exc is server_error)
+
+        send_request.assert_called_once_with(
+            'updates/bodhi-2.2.4-1.el7/waive-test-results', verb='POST', auth=True,
+            data={'comment': 'Expected failure', 'csrf_token': 'a_csrf_token',
+                  'tests': None, 'update': 'bodhi-2.2.4-1.el7'})
+        __init__.assert_called_once_with(username='some_user', password='s3kr3t', staging=False)


### PR DESCRIPTION
This commit basically implements the command: bodhi update waive, see
--help for the arguments.
It queries greenwave via bodhi to know the list of unsatisfied
requirements and uses the waiving endpoint in bodhi's API to waive either
all or just some of them.

Signed-off-by: Pierre-Yves Chibon <pingou@pingoured.fr>