### PR TITLE
Use the correct format for return type in a docblock.

### DIFF
--- a/bodhi/server/models.py
+++ b/bodhi/server/models.py
@@ -1884,7 +1884,7 @@ class Update(Base):
         Karma is reset when :class:`Builds <Build>` are added or removed from an update.
 
         Returns:
-            comments (list): class:`Comments <Comment>` since the karma reset.
+            list: class:`Comments <Comment>` since the karma reset.
         """
         # We want to traverse the comments in reverse order so we only consider
         # the most recent comments from any given user and only the comments


### PR DESCRIPTION
comments_since_karma_reset() had a misformatted docblock, which was
causing the docs to fail to build in f27-infra's Koji buildroot.

Signed-off-by: Randy Barlow <randy@electronsweatshop.com>