### PR TITLE
Add support to filter releases by state in the JSON API

### DIFF
--- a/bodhi/server/schemas.py
+++ b/bodhi/server/schemas.py
@@ -339,6 +339,12 @@ class ListReleaseSchema(PaginatedSchema):
         preparer=[util.splitter],
     )
 
+    state = colander.SchemaNode(
+        colander.String(),
+        validator=colander.OneOf(list(ReleaseState.values())),
+        missing=None,
+    )
+
 
 class SaveReleaseSchema(CSRFProtectedSchema, colander.MappingSchema):
     """An API schema for bodhi.server.services.releases.save_release()."""

--- a/bodhi/server/services/releases.py
+++ b/bodhi/server/services/releases.py
@@ -35,6 +35,7 @@ from bodhi.server.models import (
     BuildrootOverride,
     Package,
     Release,
+    ReleaseState,
 )
 from bodhi.server.validators import (
     validate_tags,
@@ -258,6 +259,10 @@ def query_releases_json(request):
     if packages is not None:
         query = query.join(Release.builds).join(Build.package)
         query = query.filter(or_(*[Package.id == p.id for p in packages]))
+
+    state = data.get('state')
+    if state is not None:
+        query = query.filter(Release.state == ReleaseState.from_string(state))
 
     # We can't use ``query.count()`` here because it is naive with respect to
     # all the joins that we're doing above.

--- a/bodhi/tests/server/services/test_releases.py
+++ b/bodhi/tests/server/services/test_releases.py
@@ -195,6 +195,34 @@ class TestReleasesService(base.BaseTestCase):
 
         self.assertEquals(r.state, ReleaseState.disabled)
 
+    def test_list_releases_by_current_state(self):
+        """ Test that we can filter releases using the 'current' state """
+        res = self.app.get('/releases/', {"state": 'current'})
+        body = res.json_body
+        self.assertEquals(len(body['releases']), 1)
+        self.assertEquals(body['releases'][0]['name'], 'F17')
+
+    def test_list_releases_by_disabled_state(self):
+        """ Test that we can filter releases using the 'disabled' state """
+        res = self.app.get('/releases/', {"state": 'disabled'})
+        body = res.json_body
+        self.assertEquals(len(body['releases']), 1)
+        self.assertEquals(body['releases'][0]['name'], 'F22')
+
+    def test_list_releases_by_pending_state(self):
+        """ Test that we can filter releases using the 'pending' state """
+        res = self.app.get('/releases/', {"state": 'pending'})
+        body = res.json_body
+        self.assertEquals(len(body['releases']), 0)
+
+    def test_list_releases_with_a_wrong_state(self):
+        """ Test that we get a 400 error when we use an undefined state """
+        res = self.app.get('/releases/', {"state": 'active'}, status=400)
+        body = res.json_body
+        # the error description is not the same in Python2 and Python3
+        # so let's just make sure we have an error.
+        self.assertEquals(body['status'], 'error')
+
     @mock.patch('bodhi.server.services.releases.log.info', side_effect=IOError('BOOM!'))
     def test_save_release_exception_handler(self, info):
         """Test the exception handler in save_release()."""


### PR DESCRIPTION
This will be useful for fedora-packages to get the list of 'active' releases . Currently it is getting all the releases and checking the state attribute of each release.