### PR TITLE
Fix listing the missing requirements in bodhi-client

### DIFF
--- a/bodhi/client/__init__.py
+++ b/bodhi/client/__init__.py
@@ -695,7 +695,7 @@ def waive(update, show, test, comment, url, **kwargs):
             if test_status.decision.unsatisfied_requirements:
                 click.echo('Missing tests:')
                 for req in test_status.decision.unsatisfied_requirements:
-                    click.echo('  - %s' % req)
+                    click.echo('  - %s' % req.testcase)
             else:
                 click.echo('Missing tests: None')
     else:

--- a/bodhi/tests/client/test___init__.py
+++ b/bodhi/tests/client/test___init__.py
@@ -1824,8 +1824,28 @@ class TestWaive(unittest.TestCase):
             'decision': munch.Munch({
                 'summary': 'Two missing tests',
                 'unsatisfied_requirements': [
-                    'dist.rpmdeplint',
-                    'fedora-atomic-ci',
+                    munch.Munch({
+                        'subject_type': 'koji_build',
+                        'scenario': None,
+                        'testcase': 'dist.rpmdeplint',
+                        'item': munch.Munch({
+                            'item': 'python-arrow-0.8.0-5.fc28',
+                            'type': 'koji_build'
+                        }),
+                        'subject_identifier': 'python-arrow-0.8.0-5.fc28',
+                        'type': 'test-result-missing'
+                    }),
+                    munch.Munch({
+                        'subject_type': 'koji_build',
+                        'scenario': None,
+                        'testcase': 'fedora-atomic-ci',
+                        'item': munch.Munch({
+                            'item': 'python-arrow-0.8.0-5.fc28',
+                            'type': 'koji_build'
+                        }),
+                        'subject_identifier': 'python-arrow-0.8.0-5.fc28',
+                        'type': 'test-result-missing'
+                    }),
                 ]
             }),
         })


### PR DESCRIPTION
It seems that greenwave's output differs now compared to when
this code was written.

Signed-off-by: Pierre-Yves Chibon <pingou@pingoured.fr>