### PR TITLE
Add "host-passthrough" option to fix kernel panic

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -57,6 +57,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     bodhi.vm.provider :libvirt do |domain|
         # Season to taste
         domain.cpus = 4
+        domain.cpu_mode = "host-passthrough"
         domain.graphics_type = "spice"
         # The unit tests use a lot of RAM.
         domain.memory = 2048


### PR DESCRIPTION
Trying to launch Bodhi VM in vagrant with 'vagrant up' ends up in kernel panic.
By following suggestion in https://bugzilla.redhat.com/show_bug.cgi?id=1283989#c6 I was able to run the VM again by adding `domain.cpu_mode = "host-passthrough"` to Vagrantfile.