### PR TITLE
Only logged in users can add karma to updates.

### DIFF
--- a/bodhi/server/templates/update.html
+++ b/bodhi/server/templates/update.html
@@ -766,7 +766,22 @@ $(document).ready(function(){
                         <td data-class="danger">  <input type="radio" name="karma" value="-1"> </td>
                         <td>                      <input type="radio" name="karma" value="0" checked> </td>
                         <td data-class="success"> <input type="radio" name="karma" value="1"> </td>
-                        <td>Is the update generally functional?</td>
+                        % if not request.user:
+                        <td>
+                          <p class="text-muted">Is the update generally functional? (karma)</p>
+                          <p class="text-danger" style="font-size: 0.8rem;">You need to be logged in to add karma!</p>
+                          <script type="text/javascript">
+                            $(document).ready(function(){
+                              var karmaRadio = document.getElementsByName("karma");
+                              for(var i=0, iLen=karmaRadio.length; i<iLen; i++) {
+                                karmaRadio[i].disabled = true;
+                              }
+                            });
+                          </script>
+                        </td>
+                        % else:
+                        <td>Is the update generally functional? (karma)</td>
+                        % endif
                       </tr>
 
                     </table>

--- a/bodhi/server/templates/update.html
+++ b/bodhi/server/templates/update.html
@@ -733,35 +733,6 @@ $(document).ready(function(){
                         </tr>
                       </thead>
 
-                      % for bug in update.bugs:
-                      <tr>
-                        <input type="hidden" name="bug_feedback.${loop.index}.bug_id" value="${bug.bug_id}">
-                        <td data-class="danger">  <input type="radio" name="bug_feedback.${loop.index}.karma" value="-1"> </td>
-                        <td>                      <input type="radio" name="bug_feedback.${loop.index}.karma" value="0" checked> </td>
-                        <td data-class="success"> <input type="radio" name="bug_feedback.${loop.index}.karma" value="1"> </td>
-                        <td>${self.util.bug_link(bug) | n}</td>
-                      </tr>
-                      % endfor
-
-                      % for test in update.full_test_cases:
-                      <tr>
-                        <input type="hidden" name="testcase_feedback.${loop.index}.testcase_name" value="${test.name}">
-                        <td data-class="danger">  <input type="radio" name="testcase_feedback.${loop.index}.karma" value="-1"> </td>
-                        <td>                      <input type="radio" name="testcase_feedback.${loop.index}.karma" value="0" checked> </td>
-                        <td data-class="success"> <input type="radio" name="testcase_feedback.${loop.index}.karma" value="1"> </td>
-                        <td>${self.util.testcase_link(test) | n}</td>
-                      </tr>
-                      % endfor
-
-                      % if update.critpath:
-                      <tr>
-                        <td data-class="danger">  <input type="radio" name="karma_critpath" value="-1"> </td>
-                        <td>                      <input type="radio" name="karma_critpath" value="0" checked> </td>
-                        <td data-class="success"> <input type="radio" name="karma_critpath" value="1"> </td>
-                        <td>Does the system's basic functionality continue to work after this update?</td>
-                      </tr>
-                      % endif
-
                       <tr>
                         <td data-class="danger">  <input type="radio" name="karma" value="-1"> </td>
                         <td>                      <input type="radio" name="karma" value="0" checked> </td>
@@ -783,6 +754,35 @@ $(document).ready(function(){
                         <td>Is the update generally functional? (karma)</td>
                         % endif
                       </tr>
+
+                      % if update.critpath:
+                      <tr>
+                        <td data-class="danger">  <input type="radio" name="karma_critpath" value="-1"> </td>
+                        <td>                      <input type="radio" name="karma_critpath" value="0" checked> </td>
+                        <td data-class="success"> <input type="radio" name="karma_critpath" value="1"> </td>
+                        <td>Does the system's basic functionality continue to work after this update?</td>
+                      </tr>
+                      % endif
+
+                      % for bug in update.bugs:
+                      <tr>
+                        <input type="hidden" name="bug_feedback.${loop.index}.bug_id" value="${bug.bug_id}">
+                        <td data-class="danger">  <input type="radio" name="bug_feedback.${loop.index}.karma" value="-1"> </td>
+                        <td>                      <input type="radio" name="bug_feedback.${loop.index}.karma" value="0" checked> </td>
+                        <td data-class="success"> <input type="radio" name="bug_feedback.${loop.index}.karma" value="1"> </td>
+                        <td>${self.util.bug_link(bug) | n}</td>
+                      </tr>
+                      % endfor
+
+                      % for test in update.full_test_cases:
+                      <tr>
+                        <input type="hidden" name="testcase_feedback.${loop.index}.testcase_name" value="${test.name}">
+                        <td data-class="danger">  <input type="radio" name="testcase_feedback.${loop.index}.karma" value="-1"> </td>
+                        <td>                      <input type="radio" name="testcase_feedback.${loop.index}.karma" value="0" checked> </td>
+                        <td data-class="success"> <input type="radio" name="testcase_feedback.${loop.index}.karma" value="1"> </td>
+                        <td>${self.util.testcase_link(test) | n}</td>
+                      </tr>
+                      % endfor
 
                     </table>
                 </div>

--- a/docs/user/testing.rst
+++ b/docs/user/testing.rst
@@ -15,9 +15,6 @@ describe their experience. Once the update reaches its karma threshold (set by t
 be pushed out to the stable repositories. This will happen automatically if the update is configured
 to use Bodhi's autokarma system, or manually by the packager if it is not.
 
-Unauthenticated users are able to post unofficial karma and comments to the update, but the karma
-will not be counted towards the update's overall karma and is left for the packager to consider.
-
 Some updates will offer testers additional types of karma. Critical path updates will offer the user
 a "critical path karma" option, which asks the tester if the system's basic functionality is
 preserved with the update (for example, does the system still boot). Some updates are associated
@@ -25,6 +22,9 @@ with Bugzilla tickets, and these updates will allow the tester to mark whether t
 bug is addressed by the update. Updates may also be linked to Wiki documents that describe a testing
 plan for the associated packages, and the tester may provide feedback for each of the wiki test
 pages as well.
+
+Unauthenticated users are only able to post comments and additional types of karma to the update, but
+they're not allowed to add votes to the main karma.
 
 
 Automated tests


### PR DESCRIPTION
Anonymous users will no more be able to post main karma to updates. This change will also remind users to log in if they want they're votes to be taken into account by the "autopush to stable" feature.

Users not logged in will see a lock icon and the description greyed out, plus the radio buttons will be disabled:
![immagine](https://user-images.githubusercontent.com/17218209/43091423-5b674d9a-8eaa-11e8-8383-b9fee3f79d13.png)


Fixes #2474 
Signed-off-by: Mattia Verga <mattia.verga@tiscali.it>