### PR TITLE
Install python2-backports-functools_lru_cache in Rawhide CI.

### DIFF
--- a/devel/ci/rawhide-packages
+++ b/devel/ci/rawhide-packages
@@ -1,4 +1,5 @@
     python2-alembic \
+    python2-backports-functools_lru_cache \
     python2-bugzilla \
     python2-cornice \
     python2-cornice-sphinx \


### PR DESCRIPTION
This commit is a temporary workaround for #1607916[0]. Once it is
merged I will open a new pull request to undo it. This should allow
CI to pass until the fix for that issue propagates to the mirrors.

[0] https://bugzilla.redhat.com/show_bug.cgi?id=1607916

Signed-off-by: Randy Barlow <randy@electronsweatshop.com>