### PR TITLE
Add a bci alias for Vagrant development environment.

### DIFF
--- a/devel/ansible/roles/dev/files/.bashrc
+++ b/devel/ansible/roles/dev/files/.bashrc
@@ -9,6 +9,7 @@ fi
 # export SYSTEMD_PAGER=
 
 shopt -s expand_aliases
+alias bci="sudo dnf install -y docker parallel && sudo systemctl enable docker && sudo systemctl start docker && sudo devel/run_tests.sh $@"
 alias bdiff-cover="btest; diff-cover /home/vagrant/bodhi/coverage.xml --compare-branch=develop --fail-under=100"
 alias bdocs="make -C /home/vagrant/bodhi/docs clean && make -C /home/vagrant/bodhi/docs html && make -C /home/vagrant/bodhi/docs man"
 alias blog="sudo journalctl -u bodhi"

--- a/devel/ansible/roles/dev/files/motd
+++ b/devel/ansible/roles/dev/files/motd
@@ -1,6 +1,7 @@
 
 Welcome to the Bodhi development environment! Here are some helpful commands:
 
+bci:         Run the same tests that CI runs locally (supports the same arguments as devel/run_tests.sh)
 bdiff-cover: Run btest and then run diff-cover against the develop branch
 bdocs:       Build Bodhi's documentation.
 bfedmsg:     Display the log of Bodhi's fedmsgs.


### PR DESCRIPTION
This commit adds a new bash alias, bci, for the Vagrant environment
that runs the CI test suite so that developers can locally
reproduce CI test results.

Signed-off-by: Randy Barlow <randy@electronsweatshop.com>