### PR TITLE
Revert "Install python2-backports-functools_lru_cache in Rawhide CI."

### DIFF
--- a/devel/ci/rawhide-packages
+++ b/devel/ci/rawhide-packages
@@ -1,5 +1,4 @@
     python2-alembic \
-    python2-backports-functools_lru_cache \
     python2-bugzilla \
     python2-cornice \
     python2-cornice-sphinx \


### PR DESCRIPTION
This reverts commit e084a42a1330a88529e72ac814c7670630c0a167.

This will not pass CI until the fix for https://bugzilla.redhat.com/show_bug.cgi?id=1607916 propagates to the mirrors.