### PR TITLE
Use podman instead of docker for running CI jobs.

### DIFF
--- a/devel/ci/run_tests.sh
+++ b/devel/ci/run_tests.sh
@@ -22,8 +22,6 @@
 
 
 sudo yum install -y epel-release
-sudo yum install -y bzip2 docker parallel
-
-sudo systemctl start docker
+sudo yum install -y bzip2 podman parallel
 
 BUILD_PARALLEL="-j 4" ./devel/run_tests.sh -a

--- a/devel/run_tests.sh
+++ b/devel/run_tests.sh
@@ -21,7 +21,7 @@
 # containers to test Bodhi across supported Fedora releases (See the RELEASES variable below). You
 # can set the RELEASES environment variable to override the RELEASES for a given test run if you
 # like. You can pass a -x flag to it to get it to exit early if a build or test run fails.
-# It is intended to be run with sudo, since it needs to use docker. Lastly, there is also a -a flag,
+# It is intended to be run with sudo, since it needs to use podman. Lastly, there is also a -a flag,
 # which will copy test results into a test_results folder if provided.
 
 BUILD_PARALLEL=${BUILD_PARALLEL:=""}
@@ -87,9 +87,9 @@ popd
 # tags.
 $PARALLEL sed -i "s/FEDORA_RELEASE/{= s:f:: =}/" devel/ci/Dockerfile-{} ::: $RELEASES
 # Build the containers.
-$PARALLEL $BUILD_PARALLEL "docker build --pull -t bodhi-dev/{} -f devel/ci/Dockerfile-{} . || (echo \"JENKIES FAIL\"; exit 1)" ::: $RELEASES || (echo -e "\n\n\033[0;31mFAILED TO BUILD IMAGE(S)\033[0m\n\n"; exit 1)
+$PARALLEL $BUILD_PARALLEL "podman build --pull -t bodhi-dev/{} -f devel/ci/Dockerfile-{} . || (echo \"JENKIES FAIL\"; exit 1)" ::: $RELEASES || (echo -e "\n\n\033[0;31mFAILED TO BUILD IMAGE(S)\033[0m\n\n"; exit 1)
 
 # Run the tests.
-$PARALLEL docker run --network none --rm $MOUNT_TEST_RESULTS bodhi-dev/{} /bodhi/devel/test_container.sh $PYTEST_ARGS ::: $RELEASES || (tar_results; echo -e "\n\n\033[0;31mTESTS FAILED\033[0m\n\n"; exit 1)
+$PARALLEL podman run --network none --rm $MOUNT_TEST_RESULTS localhost/bodhi-dev/{} /bodhi/devel/test_container.sh $PYTEST_ARGS ::: $RELEASES || (tar_results; echo -e "\n\n\033[0;31mTESTS FAILED\033[0m\n\n"; exit 1)
 tar_results
 echo -e "\n\n\033[0;32mSUCCESS!\033[0m\n\n"

--- a/docs/developer/index.rst
+++ b/docs/developer/index.rst
@@ -101,7 +101,7 @@ Fedora versions using containers.
 
 It is possible for you to run these same tests locally. There is a ``devel/run_tests.sh`` script
 that is used by ``devel/ci/run_tests.sh`` and does the heavy lifting. This script is intended to be
-run as root since it uses ``docker``. It has a handy ``-x`` flag that will cause it to exit
+run as root since it uses ``podman``. It has a handy ``-x`` flag that will cause it to exit
 immediately upon failure. You can also set the ``RELEASES`` environment variable to a list of Fedora
 releases you wish to test in a given run. Thus, if I want to run the tests on only f26 and f27 and I
 want it to exit immediately upon failure, I can execute the script like this::


### PR DESCRIPTION
Signed-off-by: Randy Barlow <randy@electronsweatshop.com>