### PR TITLE
Replace the deprecated assertEquals() with the current assertEqual()

### DIFF
--- a/bodhi/tests/server/consumers/test_masher.py
+++ b/bodhi/tests/server/consumers/test_masher.py
@@ -377,7 +377,7 @@ That was the actual one''' % mash_dir
             self.assertTrue(up.locked)
 
         # Ensure mashtask.start never got sent
-        self.assertEquals(len(publish.call_args_list), 0)
+        self.assertEqual(len(publish.call_args_list), 0)
 
     @mock.patch('bodhi.server.notifications.publish')
     def test_push_invalid_compose(self, publish):
@@ -408,7 +408,7 @@ That was the actual one''' % mash_dir
         self.masher.consume(self._make_msg())
 
         # Ensure that fedmsg was called 4 times
-        self.assertEquals(len(publish.call_args_list), 3)
+        self.assertEqual(len(publish.call_args_list), 3)
 
         # Also, ensure we reported success
         publish.assert_called_with(
@@ -457,7 +457,7 @@ That was the actual one''' % mash_dir
         self.masher.consume(self._make_msg())
 
         # Ensure that fedmsg was called 3 times
-        self.assertEquals(len(publish.call_args_list), 4)
+        self.assertEqual(len(publish.call_args_list), 4)
         # Also, ensure we reported success
         publish.assert_called_with(
             topic="mashtask.complete",
@@ -468,15 +468,15 @@ That was the actual one''' % mash_dir
             force=True)
 
         # Ensure our single update was moved
-        self.assertEquals(len(self.koji.__moved__), 1)
-        self.assertEquals(len(self.koji.__added__), 0)
-        self.assertEquals(self.koji.__moved__[0],
-                          (u'f17-updates-candidate', u'f17-updates-testing', u'bodhi-2.0-1.fc17'))
+        self.assertEqual(len(self.koji.__moved__), 1)
+        self.assertEqual(len(self.koji.__added__), 0)
+        self.assertEqual(self.koji.__moved__[0],
+                         (u'f17-updates-candidate', u'f17-updates-testing', u'bodhi-2.0-1.fc17'))
 
         # The override tag won't get removed until it goes to stable
-        self.assertEquals(self.koji.__untag__[0], (pending_signing_tag, nvr))
-        self.assertEquals(self.koji.__untag__[1], (pending_testing_tag, nvr))
-        self.assertEquals(len(self.koji.__untag__), 2)
+        self.assertEqual(self.koji.__untag__[0], (pending_signing_tag, nvr))
+        self.assertEqual(self.koji.__untag__[1], (pending_testing_tag, nvr))
+        self.assertEqual(len(self.koji.__untag__), 2)
 
         with self.db_factory() as session:
             # Set the update request to stable and the release to pending
@@ -490,10 +490,10 @@ That was the actual one''' % mash_dir
 
         # Ensure that stable updates to pending releases get their
         # tags added, not removed
-        self.assertEquals(len(self.koji.__moved__), 0)
-        self.assertEquals(len(self.koji.__added__), 1)
-        self.assertEquals(self.koji.__added__[0], (u'f17', u'bodhi-2.0-1.fc17'))
-        self.assertEquals(self.koji.__untag__[0], (override_tag, u'bodhi-2.0-1.fc17'))
+        self.assertEqual(len(self.koji.__moved__), 0)
+        self.assertEqual(len(self.koji.__added__), 1)
+        self.assertEqual(self.koji.__added__[0], (u'f17', u'bodhi-2.0-1.fc17'))
+        self.assertEqual(self.koji.__untag__[0], (override_tag, u'bodhi-2.0-1.fc17'))
 
         # Check that the override got expired
         with self.db_factory() as session:
@@ -535,7 +535,7 @@ That was the actual one''' % mash_dir
         self.masher.consume(self._make_msg())
 
         # Ensure that fedmsg was called 5 times
-        self.assertEquals(len(publish.call_args_list), 5)
+        self.assertEqual(len(publish.call_args_list), 5)
         # Also, ensure we reported success
         publish.assert_called_with(
             topic="mashtask.complete",
@@ -546,14 +546,14 @@ That was the actual one''' % mash_dir
             force=True)
 
         # Ensure our two updates were moved
-        self.assertEquals(len(self.koji.__moved__), 2)
-        self.assertEquals(len(self.koji.__added__), 0)
+        self.assertEqual(len(self.koji.__moved__), 2)
+        self.assertEqual(len(self.koji.__added__), 0)
 
         # Ensure the most recent version is tagged last in order to be the 'koji latest-pkg'
-        self.assertEquals(self.koji.__moved__[0],
-                          (u'f17-updates-candidate', u'f17-updates-testing', u'bodhi-2.0-1.fc17'))
-        self.assertEquals(self.koji.__moved__[1],
-                          (u'f17-updates-candidate', u'f17-updates-testing', u'bodhi-2.0-2.fc17'))
+        self.assertEqual(self.koji.__moved__[0],
+                         (u'f17-updates-candidate', u'f17-updates-testing', u'bodhi-2.0-1.fc17'))
+        self.assertEqual(self.koji.__moved__[1],
+                         (u'f17-updates-candidate', u'f17-updates-testing', u'bodhi-2.0-2.fc17'))
 
     @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_taskotron_results)
@@ -573,7 +573,7 @@ That was the actual one''' % mash_dir
 
         t.run()
 
-        self.assertEquals(t.testing_digest[u'Fedora 17'][u'bodhi-2.0-1.fc17'], """\
+        self.assertEqual(t.testing_digest[u'Fedora 17'][u'bodhi-2.0-1.fc17'], """\
 ================================================================================
  libseccomp-2.1.0-1.fc20 (FEDORA-%s-a3bbe1a8f2)
  Enhanced seccomp library
@@ -933,28 +933,28 @@ That was the actual one'''
         # mashing f17
         # complete.testing
         # mashtask.complete
-        self.assertEquals(calls[1], mock.call(
+        self.assertEqual(calls[1], mock.call(
             force=True,
             msg={'repo': u'f18-updates',
                  'ctype': 'rpm',
                  'updates': [u'bodhi-2.0-1.fc18'],
                  'agent': 'bowlofeggs'},
             topic='mashtask.mashing'))
-        self.assertEquals(calls[4], mock.call(
+        self.assertEqual(calls[4], mock.call(
             force=True,
             msg={'success': True,
                  'ctype': 'rpm',
                  'repo': 'f18-updates',
                  'agent': 'bowlofeggs'},
             topic='mashtask.complete'))
-        self.assertEquals(calls[5], mock.call(
+        self.assertEqual(calls[5], mock.call(
             force=True,
             msg={'repo': u'f17-updates-testing',
                  'ctype': 'rpm',
                  'updates': [u'bodhi-2.0-1.fc17'],
                  'agent': 'bowlofeggs'},
             topic='mashtask.mashing'))
-        self.assertEquals(calls[-1], mock.call(
+        self.assertEqual(calls[-1], mock.call(
             force=True,
             msg={'success': True,
                  'ctype': 'rpm',
@@ -1013,28 +1013,28 @@ That was the actual one'''
 
         # Ensure that F17 updates-testing runs before F18
         calls = publish.mock_calls
-        self.assertEquals(calls[1], mock.call(
+        self.assertEqual(calls[1], mock.call(
             msg={'repo': u'f17-updates-testing',
                  'ctype': 'rpm',
                  'updates': [u'bodhi-2.0-1.fc17'],
                  'agent': 'bowlofeggs'},
             force=True,
             topic='mashtask.mashing'))
-        self.assertEquals(calls[3], mock.call(
+        self.assertEqual(calls[3], mock.call(
             msg={'success': True,
                  'ctype': 'rpm',
                  'repo': 'f17-updates-testing',
                  'agent': 'bowlofeggs'},
             force=True,
             topic='mashtask.complete'))
-        self.assertEquals(calls[4], mock.call(
+        self.assertEqual(calls[4], mock.call(
             msg={'repo': u'f18-updates',
                  'ctype': 'rpm',
                  'updates': [u'bodhi-2.0-1.fc18'],
                  'agent': 'bowlofeggs'},
             force=True,
             topic='mashtask.mashing'))
-        self.assertEquals(calls[-1], mock.call(
+        self.assertEqual(calls[-1], mock.call(
             msg={'success': True,
                  'ctype': 'rpm',
                  'repo': 'f18-updates',
@@ -1101,14 +1101,14 @@ That was the actual one'''
                      'updates': [u'bodhi-2.0-1.fc18'],
                      'agent': 'bowlofeggs'},
                 force=True, topic='mashtask.mashing'):
-            self.assertEquals(
+            self.assertEqual(
                 calls[2],
                 mock.call(msg={'repo': u'f17-updates',
                                'ctype': 'rpm',
                                'updates': [u'bodhi-2.0-1.fc17'],
                                'agent': 'bowlofeggs'},
                           force=True, topic='mashtask.mashing'))
-        elif calls[1] == self.assertEquals(
+        elif calls[1] == self.assertEqual(
                 calls[1],
                 mock.call(
                     msg={'repo': u'f17-updates',
@@ -1116,7 +1116,7 @@ That was the actual one'''
                          'updates': [u'bodhi-2.0-1.fc17'],
                          'agent': 'bowlofeggs'},
                     force=True, topic='mashtask.mashing')):
-            self.assertEquals(
+            self.assertEqual(
                 calls[2],
                 mock.call(msg={'repo': u'f18-updates',
                                'ctype': 'rpm',
@@ -1693,14 +1693,14 @@ testmodule:master:20172:2
 
         with self.db_factory() as session:
             up = session.query(Update).one()
-            self.assertEquals(len(up.comments), 2)
+            self.assertEqual(len(up.comments), 2)
 
         self.masher.consume(self._make_msg())
 
         with self.db_factory() as session:
             up = session.query(Update).one()
-            self.assertEquals(len(up.comments), 3)
-            self.assertEquals(up.comments[-1]['text'], u'This update has been pushed to testing.')
+            self.assertEqual(len(up.comments), 3)
+            self.assertEqual(up.comments[-1]['text'], u'This update has been pushed to testing.')
 
     @mock.patch(**mock_taskotron_results)
     @mock.patch('bodhi.server.consumers.masher.PungiComposerThread._wait_for_pungi')
@@ -1717,14 +1717,14 @@ testmodule:master:20172:2
         with self.db_factory() as session:
             up = session.query(Update).one()
             up.request = UpdateRequest.stable
-            self.assertEquals(len(up.comments), 2)
+            self.assertEqual(len(up.comments), 2)
 
         self.masher.consume(self._make_msg())
 
         with self.db_factory() as session:
             up = session.query(Update).one()
-            self.assertEquals(len(up.comments), 3)
-            self.assertEquals(up.comments[-1]['text'], u'This update has been pushed to stable.')
+            self.assertEqual(len(up.comments), 3)
+            self.assertEqual(up.comments[-1]['text'], u'This update has been pushed to stable.')
 
     @mock.patch(**mock_taskotron_results)
     @mock.patch('bodhi.server.consumers.masher.PungiComposerThread._wait_for_pungi')
@@ -1749,8 +1749,8 @@ testmodule:master:20172:2
 
             updates = t.get_security_updates(release.long_name)
 
-            self.assertEquals(len(updates), 1)
-            self.assertEquals(updates[0].title, u.builds[0].nvr)
+            self.assertEqual(len(updates), 1)
+            self.assertEqual(updates[0].title, u.builds[0].nvr)
 
     @mock.patch(**mock_taskotron_results)
     @mock.patch('bodhi.server.consumers.masher.PungiComposerThread._wait_for_pungi')
@@ -1767,14 +1767,14 @@ testmodule:master:20172:2
         with self.db_factory() as session:
             up = session.query(Update).one()
             up.request = UpdateRequest.stable
-            self.assertEquals(len(up.comments), 2)
+            self.assertEqual(len(up.comments), 2)
 
         self.masher.consume(self._make_msg())
 
         with self.db_factory() as session:
             up = session.query(Update).one()
-            self.assertEquals(up.locked, False)
-            self.assertEquals(up.status, UpdateStatus.stable)
+            self.assertEqual(up.locked, False)
+            self.assertEqual(up.status, UpdateStatus.stable)
 
     @mock.patch(**mock_taskotron_results)
     @mock.patch('bodhi.server.consumers.masher.PungiComposerThread._wait_for_pungi')
@@ -1800,8 +1800,8 @@ testmodule:master:20172:2
         # Ensure that the update hasn't changed state
         with self.db_factory() as session:
             up = session.query(Update).one()
-            self.assertEquals(up.request, UpdateRequest.testing)
-            self.assertEquals(up.status, UpdateStatus.pending)
+            self.assertEqual(up.request, UpdateRequest.testing)
+            self.assertEqual(up.status, UpdateStatus.pending)
 
         # Resume the push
         msg = self._make_msg()
@@ -1810,8 +1810,8 @@ testmodule:master:20172:2
 
         with self.db_factory() as session:
             up = session.query(Update).one()
-            self.assertEquals(up.status, UpdateStatus.testing)
-            self.assertEquals(up.request, None)
+            self.assertEqual(up.status, UpdateStatus.testing)
+            self.assertEqual(up.request, None)
 
     @mock.patch(**mock_taskotron_results)
     @mock.patch('bodhi.server.consumers.masher.PungiComposerThread._wait_for_pungi')
@@ -1893,28 +1893,28 @@ testmodule:master:20172:2
                 up = session.query(Update).one()
                 up.request = UpdateRequest.testing
                 up.status = UpdateStatus.pending
-                self.assertEquals(up.stable_karma, 3)
+                self.assertEqual(up.stable_karma, 3)
             self.masher.consume(self._make_msg())
 
         with self.db_factory() as session:
             up = session.query(Update).one()
 
             # Ensure the update is still locked and in testing
-            self.assertEquals(up.locked, True)
-            self.assertEquals(up.status, UpdateStatus.pending)
-            self.assertEquals(up.request, UpdateRequest.testing)
+            self.assertEqual(up.locked, True)
+            self.assertEqual(up.status, UpdateStatus.pending)
+            self.assertEqual(up.request, UpdateRequest.testing)
 
             # Have the update reach the stable karma threshold
-            self.assertEquals(up.karma, 1)
+            self.assertEqual(up.karma, 1)
             up.comment(session, u"foo", 1, u'foo')
-            self.assertEquals(up.karma, 2)
-            self.assertEquals(up.request, UpdateRequest.testing)
+            self.assertEqual(up.karma, 2)
+            self.assertEqual(up.request, UpdateRequest.testing)
             up.comment(session, u"foo", 1, u'bar')
-            self.assertEquals(up.karma, 3)
-            self.assertEquals(up.request, UpdateRequest.testing)
+            self.assertEqual(up.karma, 3)
+            self.assertEqual(up.request, UpdateRequest.testing)
             up.comment(session, u"foo", 1, u'biz')
-            self.assertEquals(up.request, UpdateRequest.testing)
-            self.assertEquals(up.karma, 4)
+            self.assertEqual(up.request, UpdateRequest.testing)
+            self.assertEqual(up.karma, 4)
 
         # finish push and unlock updates
         msg = self._make_msg()
@@ -1924,11 +1924,11 @@ testmodule:master:20172:2
         with self.db_factory() as session:
             up = session.query(Update).one()
             up.comment(session, u"foo", 1, u'baz')
-            self.assertEquals(up.karma, 5)
+            self.assertEqual(up.karma, 5)
 
             # Ensure the masher set the autokarma once the push is done
-            self.assertEquals(up.locked, False)
-            self.assertEquals(up.request, UpdateRequest.batched)
+            self.assertEqual(up.locked, False)
+            self.assertEqual(up.request, UpdateRequest.batched)
 
     @mock.patch(**mock_taskotron_results)
     @mock.patch('bodhi.server.consumers.masher.PungiComposerThread._wait_for_pungi')
@@ -1958,7 +1958,7 @@ testmodule:master:20172:2
             up.request = UpdateRequest.stable
 
         # Ensure that fedmsg was called 3 times
-        self.assertEquals(len(publish.call_args_list), 4)
+        self.assertEqual(len(publish.call_args_list), 4)
         # Also, ensure we reported success
         publish.assert_called_with(
             topic="mashtask.complete",
@@ -2013,13 +2013,13 @@ testmodule:master:20172:2
         with self.db_factory() as session:
             # Ensure that the older update got obsoleted
             up = session.query(Update).filter_by(title=oldbuild).one()
-            self.assertEquals(up.status, UpdateStatus.obsolete)
-            self.assertEquals(up.request, None)
+            self.assertEqual(up.status, UpdateStatus.obsolete)
+            self.assertEqual(up.request, None)
 
             # The latest update should be in testing
             up = session.query(Update).filter_by(title=otherbuild).one()
-            self.assertEquals(up.status, UpdateStatus.testing)
-            self.assertEquals(up.request, None)
+            self.assertEqual(up.status, UpdateStatus.testing)
+            self.assertEqual(up.request, None)
 
     @mock.patch(**mock_taskotron_results)
     @mock.patch('bodhi.server.consumers.masher.PungiComposerThread._wait_for_pungi')

--- a/bodhi/tests/server/functional/test_admin.py
+++ b/bodhi/tests/server/functional/test_admin.py
@@ -28,10 +28,10 @@ class TestAdminView(base.BaseTestCase):
         """Test that authticated user can see the Admin panel"""
         res = self.app.get('/admin/')
         body = res.json_body
-        self.assertEquals(body['principals'][0], 'system.Everyone')
-        self.assertEquals(body['principals'][1], 'system.Authenticated')
-        self.assertEquals(body['principals'][2], 'guest')
-        self.assertEquals(body['user'], 'guest')
+        self.assertEqual(body['principals'][0], 'system.Everyone')
+        self.assertEqual(body['principals'][1], 'system.Authenticated')
+        self.assertEqual(body['principals'][2], 'guest')
+        self.assertEqual(body['user'], 'guest')
 
     def test_admin_unauthed(self):
         """Test that an unauthed user cannot see the admin endpoint"""

--- a/bodhi/tests/server/functional/test_packages.py
+++ b/bodhi/tests/server/functional/test_packages.py
@@ -26,7 +26,7 @@ class TestRpmPackagesService(base.BaseTestCase):
         self.db.commit()
         resp = self.app.get('/packages/')
         body = resp.json_body
-        self.assertEquals(len(body['packages']), 2)
+        self.assertEqual(len(body['packages']), 2)
 
     def test_filter_by_name(self):
         """ Test that filtering by name returns one package and not the other.
@@ -35,7 +35,7 @@ class TestRpmPackagesService(base.BaseTestCase):
         self.db.commit()
         resp = self.app.get('/packages/', dict(name='bodhi'))
         body = resp.json_body
-        self.assertEquals(len(body['packages']), 1)
+        self.assertEqual(len(body['packages']), 1)
 
     def test_filter_by_like(self):
         """ Test that filtering by like returns one package and not the other.
@@ -44,7 +44,7 @@ class TestRpmPackagesService(base.BaseTestCase):
         self.db.commit()
         resp = self.app.get('/packages/', dict(like='odh'))
         body = resp.json_body
-        self.assertEquals(len(body['packages']), 1)
+        self.assertEqual(len(body['packages']), 1)
 
     def test_filter_by_search(self):
         """ Test filtering by search
@@ -55,14 +55,14 @@ class TestRpmPackagesService(base.BaseTestCase):
         # test search
         resp = self.app.get('/packages/', dict(search='bodh'))
         body = resp.json_body
-        self.assertEquals(len(body['packages']), 1)
+        self.assertEqual(len(body['packages']), 1)
 
         # test the search is case-insensitive
         resp = self.app.get('/packages/', dict(search='Bodh'))
         body = resp.json_body
-        self.assertEquals(len(body['packages']), 1)
+        self.assertEqual(len(body['packages']), 1)
 
         # test a search that yields nothing
         resp = self.app.get('/packages/', dict(search='corebird'))
         body = resp.json_body
-        self.assertEquals(len(body['packages']), 0)
+        self.assertEqual(len(body['packages']), 0)

--- a/bodhi/tests/server/functional/test_stacks.py
+++ b/bodhi/tests/server/functional/test_stacks.py
@@ -43,15 +43,15 @@ class TestStacksService(base.BaseTestCase):
 
     def test_get_single_stack(self):
         res = self.app.get('/stacks/GNOME', headers={'Accept': 'application/json'})
-        self.assertEquals(res.json_body['stack']['name'], u'GNOME')
-        self.assertEquals(res.json_body['stack']['packages'][0]['name'], u'gnome-shell')
+        self.assertEqual(res.json_body['stack']['name'], u'GNOME')
+        self.assertEqual(res.json_body['stack']['packages'][0]['name'], u'gnome-shell')
 
     def test_list_stacks(self):
         res = self.app.get('/stacks/')
         body = res.json_body
-        self.assertEquals(len(body['stacks']), 1)
-        self.assertEquals(body['stacks'][0]['name'], u'GNOME')
-        self.assertEquals(body['stacks'][0]['packages'][0]['name'], u'gnome-shell')
+        self.assertEqual(len(body['stacks']), 1)
+        self.assertEqual(body['stacks'][0]['name'], u'GNOME')
+        self.assertEqual(body['stacks'][0]['packages'][0]['name'], u'gnome-shell')
 
     def test_list_stacks_with_pagination(self):
         # Create a second stack
@@ -62,47 +62,47 @@ class TestStacksService(base.BaseTestCase):
 
         res = self.app.get('/stacks/')
         body = res.json_body
-        self.assertEquals(len(body['stacks']), 2)
+        self.assertEqual(len(body['stacks']), 2)
 
         res = self.app.get('/stacks/', {'rows_per_page': 1})
         body = res.json_body
-        self.assertEquals(len(body['stacks']), 1)
-        self.assertEquals(body['stacks'][0]['name'], u'GNOME')
+        self.assertEqual(len(body['stacks']), 1)
+        self.assertEqual(body['stacks'][0]['name'], u'GNOME')
 
         res = self.app.get('/stacks/', {'rows_per_page': 1, 'page': 2})
         body = res.json_body
-        self.assertEquals(len(body['stacks']), 1)
-        self.assertEquals(body['stacks'][0]['name'], 'Firefox')
-        self.assertEquals(body['stacks'][0]['packages'][0]['name'], 'firefox')
+        self.assertEqual(len(body['stacks']), 1)
+        self.assertEqual(body['stacks'][0]['name'], 'Firefox')
+        self.assertEqual(body['stacks'][0]['packages'][0]['name'], 'firefox')
 
     def test_list_stacks_by_name(self):
         res = self.app.get('/stacks/', {'name': 'GNOME'})
         body = res.json_body
-        self.assertEquals(len(body['stacks']), 1)
-        self.assertEquals(body['stacks'][0]['name'], 'GNOME')
+        self.assertEqual(len(body['stacks']), 1)
+        self.assertEqual(body['stacks'][0]['name'], 'GNOME')
 
     def test_list_stacks_by_name_mismatch(self):
         res = self.app.get('/stacks/', {'like': u'%KDE%'})
         body = res.json_body
-        self.assertEquals(len(body['stacks']), 0)
+        self.assertEqual(len(body['stacks']), 0)
 
     def test_list_stacks_by_name_match(self):
         res = self.app.get('/stacks/', {'like': '%GN%'})
         body = res.json_body
-        self.assertEquals(len(body['stacks']), 1)
-        self.assertEquals(body['stacks'][0]['name'], 'GNOME')
+        self.assertEqual(len(body['stacks']), 1)
+        self.assertEqual(body['stacks'][0]['name'], 'GNOME')
 
     def test_list_stacks_by_package_name(self):
         res = self.app.get('/stacks/', {"packages": 'gnome-shell'})
         body = res.json_body
-        self.assertEquals(len(body['stacks']), 1)
-        self.assertEquals(body['stacks'][0]['name'], 'GNOME')
+        self.assertEqual(len(body['stacks']), 1)
+        self.assertEqual(body['stacks'][0]['name'], 'GNOME')
 
     def test_list_stacks_by_nonexistant_package(self):
         res = self.app.get('/stacks/', {"packages": 'carbunkle'}, status=400)
-        self.assertEquals(res.json_body['errors'][0]['name'], 'packages')
-        self.assertEquals(res.json_body['errors'][0]['description'],
-                          'Invalid packages specified: carbunkle')
+        self.assertEqual(res.json_body['errors'][0]['name'], 'packages')
+        self.assertEqual(res.json_body['errors'][0]['description'],
+                         'Invalid packages specified: carbunkle')
 
     @mock.patch(**mock_valid_requirements)
     def test_new_stack(self, *args):
@@ -113,18 +113,18 @@ class TestStacksService(base.BaseTestCase):
                  'csrf_token': self.get_csrf_token()}
         res = self.app.post("/stacks/", attrs, status=200)
         body = res.json_body['stack']
-        self.assertEquals(body['name'], 'KDE')
+        self.assertEqual(body['name'], 'KDE')
         r = self.db.query(Stack).filter(Stack.name == attrs["name"]).one()
-        self.assertEquals(r.name, 'KDE')
-        self.assertEquals(len(r.packages), 2)
-        self.assertEquals(r.packages[0].name, 'kde-filesystem')
-        self.assertEquals(r.requirements, u'rpmlint')
+        self.assertEqual(r.name, 'KDE')
+        self.assertEqual(len(r.packages), 2)
+        self.assertEqual(r.packages[0].name, 'kde-filesystem')
+        self.assertEqual(r.requirements, u'rpmlint')
 
     @mock.patch(**mock_valid_requirements)
     def test_new_stack_invalid_name(self, *args):
         attrs = {"name": "", 'csrf_token': self.get_csrf_token()}
         res = self.app.post("/stacks/", attrs, status=400)
-        self.assertEquals(res.json_body['status'], 'error')
+        self.assertEqual(res.json_body['status'], 'error')
 
     @mock.patch(**mock_valid_requirements)
     def test_new_stack_invalid_requirement(self, *args):
@@ -132,9 +132,9 @@ class TestStacksService(base.BaseTestCase):
                  "requirements": "silly-dilly",
                  "csrf_token": self.get_csrf_token()}
         res = self.app.post("/stacks/", attrs, status=400)
-        self.assertEquals(res.json_body['status'], 'error')
+        self.assertEqual(res.json_body['status'], 'error')
         c = self.db.query(Stack).filter(Stack.name == attrs["name"]).count()
-        self.assertEquals(c, 0)
+        self.assertEqual(c, 0)
 
     @mock.patch(**mock_valid_requirements)
     def test_new_stack_valid_requirement(self, *args):
@@ -145,11 +145,11 @@ class TestStacksService(base.BaseTestCase):
                  "csrf_token": self.get_csrf_token()}
         res = self.app.post("/stacks/", attrs)
         body = res.json_body['stack']
-        self.assertEquals(body['name'], 'Hackey')
+        self.assertEqual(body['name'], 'Hackey')
         r = self.db.query(Stack).filter(Stack.name == attrs["name"]).one()
-        self.assertEquals(r.name, 'Hackey')
-        self.assertEquals(len(r.packages), 1)
-        self.assertEquals(r.requirements, attrs['requirements'])
+        self.assertEqual(r.name, 'Hackey')
+        self.assertEqual(len(r.packages), 1)
+        self.assertEqual(r.requirements, attrs['requirements'])
 
     @mock.patch(**mock_valid_requirements)
     def test_edit_stack(self, *args):
@@ -160,24 +160,24 @@ class TestStacksService(base.BaseTestCase):
                  'csrf_token': self.get_csrf_token()}
         res = self.app.post("/stacks/", attrs, status=200)
         body = res.json_body['stack']
-        self.assertEquals(body['name'], 'GNOME')
-        self.assertEquals(len(body['packages']), 2)
-        self.assertEquals(body['packages'][-1]['name'], 'gnome-music')
-        self.assertEquals(body['description'], 'foo')
-        self.assertEquals(body['requirements'], 'upgradepath')
+        self.assertEqual(body['name'], 'GNOME')
+        self.assertEqual(len(body['packages']), 2)
+        self.assertEqual(body['packages'][-1]['name'], 'gnome-music')
+        self.assertEqual(body['description'], 'foo')
+        self.assertEqual(body['requirements'], 'upgradepath')
 
         # Adding gnome-music to the stack should change its requirements, too.
         package = self.db.query(RpmPackage).filter(RpmPackage.name == u'gnome-music').one()
-        self.assertEquals(package.requirements, attrs['requirements'])
+        self.assertEqual(package.requirements, attrs['requirements'])
 
         # But not gnome-shell, since it was already in the stack.
         package = self.db.query(RpmPackage).filter(RpmPackage.name == u'gnome-shell').one()
-        self.assertEquals(package.requirements, None)
+        self.assertEqual(package.requirements, None)
 
     def test_delete_stack(self):
         res = self.app.delete("/stacks/GNOME")
-        self.assertEquals(res.json_body['status'], 'success')
-        self.assertEquals(self.db.query(Stack).count(), 0)
+        self.assertEqual(res.json_body['status'], 'success')
+        self.assertEqual(self.db.query(Stack).count(), 0)
 
     @mock.patch(**mock_valid_requirements)
     def test_edit_stack_remove_package(self, *args):
@@ -187,9 +187,9 @@ class TestStacksService(base.BaseTestCase):
                  'csrf_token': self.get_csrf_token()}
         res = self.app.post("/stacks/", attrs, status=200)
         body = res.json_body['stack']
-        self.assertEquals(body['name'], 'GNOME')
-        self.assertEquals(len(body['packages']), 1)
-        self.assertEquals(body['packages'][0]['name'], 'gnome-music')
+        self.assertEqual(body['name'], 'GNOME')
+        self.assertEqual(len(body['packages']), 1)
+        self.assertEqual(body['packages'][0]['name'], 'gnome-music')
 
     @mock.patch(**mock_valid_requirements)
     def test_edit_stack_with_no_group_privs(self, *args):
@@ -203,9 +203,9 @@ class TestStacksService(base.BaseTestCase):
                  'csrf_token': self.get_csrf_token()}
         res = self.app.post("/stacks/", attrs, status=403)
         body = res.json_body
-        self.assertEquals(body['status'], 'error')
-        self.assertEquals(body['errors'][0]['description'],
-                          'guest does not have privileges to modify the GNOME stack')
+        self.assertEqual(body['status'], 'error')
+        self.assertEqual(body['errors'][0]['description'],
+                         'guest does not have privileges to modify the GNOME stack')
 
     @mock.patch(**mock_valid_requirements)
     def test_edit_stack_with_no_user_privs(self, *args):
@@ -219,9 +219,9 @@ class TestStacksService(base.BaseTestCase):
                  'csrf_token': self.get_csrf_token()}
         res = self.app.post("/stacks/", attrs, status=403)
         body = res.json_body
-        self.assertEquals(body['status'], 'error')
-        self.assertEquals(body['errors'][0]['description'],
-                          'guest does not have privileges to modify the GNOME stack')
+        self.assertEqual(body['status'], 'error')
+        self.assertEqual(body['errors'][0]['description'],
+                         'guest does not have privileges to modify the GNOME stack')
 
     @mock.patch(**mock_valid_requirements)
     def test_edit_stack_with_user_privs(self, *args):
@@ -233,9 +233,9 @@ class TestStacksService(base.BaseTestCase):
                  'csrf_token': self.get_csrf_token()}
         res = self.app.post("/stacks/", attrs, status=200)
         body = res.json_body['stack']
-        self.assertEquals(body['name'], 'GNOME')
-        self.assertEquals(len(body['packages']), 2)
-        self.assertEquals(body['packages'][-1]['name'], 'gnome-music')
+        self.assertEqual(body['name'], 'GNOME')
+        self.assertEqual(len(body['packages']), 2)
+        self.assertEqual(body['packages'][-1]['name'], 'gnome-music')
 
     @mock.patch(**mock_valid_requirements)
     def test_edit_stack_with_group_privs(self, *args):
@@ -251,9 +251,9 @@ class TestStacksService(base.BaseTestCase):
                  'csrf_token': self.get_csrf_token()}
         res = self.app.post("/stacks/", attrs, status=200)
         body = res.json_body['stack']
-        self.assertEquals(body['name'], 'GNOME')
-        self.assertEquals(len(body['packages']), 2)
-        self.assertEquals(body['packages'][-1]['name'], 'gnome-music')
+        self.assertEqual(body['name'], 'GNOME')
+        self.assertEqual(len(body['packages']), 2)
+        self.assertEqual(body['packages'][-1]['name'], 'gnome-music')
 
     def test_new_stack_form(self):
         res = self.app.get('/stacks/new', status=200)

--- a/bodhi/tests/server/functional/test_users.py
+++ b/bodhi/tests/server/functional/test_users.py
@@ -33,25 +33,25 @@ class TestUsersService(base.BaseTestCase):
 
     def test_get_single_user(self):
         res = self.app.get('/users/bodhi')
-        self.assertEquals(res.json_body['user']['name'], 'bodhi')
+        self.assertEqual(res.json_body['user']['name'], 'bodhi')
 
     def test_get_hardcoded_avatar(self):
         res = self.app.get('/users/bodhi')
-        self.assertEquals(res.json_body['user']['name'], 'bodhi')
+        self.assertEqual(res.json_body['user']['name'], 'bodhi')
         url = 'https://apps.fedoraproject.org/img/icons/bodhi-24.png'
-        self.assertEquals(res.json_body['user']['avatar'], url)
+        self.assertEqual(res.json_body['user']['avatar'], url)
 
     @mock.patch.dict(config, {'libravatar_enabled': True})
     def test_get_single_avatar(self):
         res = self.app.get('/users/guest')
-        self.assertEquals(res.json_body['user']['name'], 'guest')
+        self.assertEqual(res.json_body['user']['name'], 'guest')
 
         base = 'https://seccdn.libravatar.org/avatar/'
         h = 'eb48e08cc23bcd5961de9541ba5156c385cd39799e1dbf511477aa4d4d3a37e7'
         tail = '?d=retro&s=24'
         url = base + h
 
-        self.assertEquals(res.json_body['user']['avatar'][:-len(tail)], url)
+        self.assertEqual(res.json_body['user']['avatar'][:-len(tail)], url)
 
     def test_get_single_user_page(self):
         res = self.app.get('/users/guest', headers=dict(accept='text/html'))
@@ -75,7 +75,7 @@ class TestUsersService(base.BaseTestCase):
         res = self.app.get('/users/')
         self.assertIn('application/json', res.headers['Content-Type'])
         body = res.json_body
-        self.assertEquals(len(body['users']), 3)
+        self.assertEqual(len(body['users']), 3)
 
         users = [user['name'] for user in body['users']]
         self.assertIn(u'guest', users)
@@ -101,14 +101,14 @@ class TestUsersService(base.BaseTestCase):
     def test_like_users(self):
         res = self.app.get('/users/', {'like': 'odh'})
         body = res.json_body
-        self.assertEquals(len(body['users']), 1)
+        self.assertEqual(len(body['users']), 1)
 
         user = body['users'][0]
-        self.assertEquals(user['name'], u'bodhi')
+        self.assertEqual(user['name'], u'bodhi')
 
         res = self.app.get('/users/', {'like': 'wat'})
         body = res.json_body
-        self.assertEquals(len(body['users']), 0)
+        self.assertEqual(len(body['users']), 0)
 
     def test_search_users(self):
         """
@@ -118,89 +118,89 @@ class TestUsersService(base.BaseTestCase):
         # test that search works
         res = self.app.get('/users/', {'search': 'bodh'})
         body = res.json_body
-        self.assertEquals(len(body['users']), 1)
+        self.assertEqual(len(body['users']), 1)
         user = body['users'][0]
-        self.assertEquals(user['name'], u'bodhi')
+        self.assertEqual(user['name'], u'bodhi')
 
         # test that the search is case insensitive
         res = self.app.get('/users/', {'search': 'Bodh'})
         body = res.json_body
-        self.assertEquals(len(body['users']), 1)
+        self.assertEqual(len(body['users']), 1)
         user = body['users'][0]
-        self.assertEquals(user['name'], u'bodhi')
+        self.assertEqual(user['name'], u'bodhi')
 
         # test a search that yields nothing
         res = self.app.get('/users/', {'search': 'wat'})
         body = res.json_body
-        self.assertEquals(len(body['users']), 0)
+        self.assertEqual(len(body['users']), 0)
 
     def test_list_users_with_pagination(self):
         res = self.app.get('/users/')
         body = res.json_body
-        self.assertEquals(len(body['users']), 3)
+        self.assertEqual(len(body['users']), 3)
 
         users = [user['name'] for user in body['users']]
 
         res = self.app.get('/users/', {'rows_per_page': 1})
         body = res.json_body
-        self.assertEquals(len(body['users']), 1)
+        self.assertEqual(len(body['users']), 1)
         self.assertIn(body['users'][0]['name'], users)
 
         res = self.app.get('/users/', {'rows_per_page': 1, 'page': 2})
         body = res.json_body
-        self.assertEquals(len(body['users']), 1)
+        self.assertEqual(len(body['users']), 1)
         self.assertIn(body['users'][0]['name'], users)
 
         res = self.app.get('/users/', {'rows_per_page': 1, 'page': 3})
         body = res.json_body
-        self.assertEquals(len(body['users']), 1)
+        self.assertEqual(len(body['users']), 1)
         self.assertIn(body['users'][0]['name'], users)
 
     def test_list_users_by_name(self):
         res = self.app.get('/users/', {"name": 'guest'})
         body = res.json_body
-        self.assertEquals(len(body['users']), 1)
-        self.assertEquals(body['users'][0]['name'], 'guest')
+        self.assertEqual(len(body['users']), 1)
+        self.assertEqual(body['users'][0]['name'], 'guest')
 
     def test_list_users_by_name_match(self):
         res = self.app.get('/users/', {"name": 'gue%'})
         body = res.json_body
-        self.assertEquals(len(body['users']), 1)
-        self.assertEquals(body['users'][0]['name'], 'guest')
+        self.assertEqual(len(body['users']), 1)
+        self.assertEqual(body['users'][0]['name'], 'guest')
 
     def test_list_users_by_name_match_miss(self):
         res = self.app.get('/users/', {"name": '%wat%'})
-        self.assertEquals(len(res.json_body['users']), 0)
+        self.assertEqual(len(res.json_body['users']), 0)
 
     def test_list_users_by_groups(self):
         res = self.app.get('/users/', {"groups": 'packager'})
-        self.assertEquals(len(res.json_body['users']), 1)
+        self.assertEqual(len(res.json_body['users']), 1)
 
     def test_list_users_by_nonexistant_group(self):
         res = self.app.get('/users/', {"groups": 'carbunkle'}, status=400)
         body = res.json_body
-        self.assertEquals(body['errors'][0]['name'], 'groups')
-        self.assertEquals(body['errors'][0]['description'],
-                          'Invalid groups specified: carbunkle')
+        self.assertEqual(body['errors'][0]['name'], 'groups')
+        self.assertEqual(body['errors'][0]['description'],
+                         'Invalid groups specified: carbunkle')
 
     def test_list_users_by_mixed_nonexistant_group(self):
         res = self.app.get('/users/', {"groups": ['carbunkle', 'packager']}, status=400)
         body = res.json_body
-        self.assertEquals(body['errors'][0]['name'], 'groups')
-        self.assertEquals(body['errors'][0]['description'],
-                          'Invalid groups specified: carbunkle')
+        self.assertEqual(body['errors'][0]['name'], 'groups')
+        self.assertEqual(body['errors'][0]['description'],
+                         'Invalid groups specified: carbunkle')
 
     def test_list_users_by_group_miss(self):
         res = self.app.get('/users/', {"groups": 'provenpackager'})
         body = res.json_body
-        self.assertEquals(len(body['users']), 0)
+        self.assertEqual(len(body['users']), 0)
         assert 'errors' not in res.json_body
 
     def test_list_users_by_update_title(self):
         res = self.app.get('/users/', {"updates": 'bodhi-2.0-1.fc17'})
         body = res.json_body
-        self.assertEquals(len(body['users']), 1)
-        self.assertEquals(body['users'][0]['name'], 'guest')
+        self.assertEqual(len(body['users']), 1)
+        self.assertEqual(body['users'][0]['name'], 'guest')
 
     def test_list_users_by_update_alias(self):
         update = self.db.query(Update).first()
@@ -209,25 +209,25 @@ class TestUsersService(base.BaseTestCase):
 
         res = self.app.get('/users/', {"updates": 'some_alias'})
         body = res.json_body
-        self.assertEquals(len(body['users']), 1)
-        self.assertEquals(body['users'][0]['name'], 'guest')
+        self.assertEqual(len(body['users']), 1)
+        self.assertEqual(body['users'][0]['name'], 'guest')
 
     def test_list_users_by_nonexistant_update(self):
         res = self.app.get('/users/', {"updates": 'carbunkle'}, status=400)
         body = res.json_body
-        self.assertEquals(body['errors'][0]['name'], 'updates')
-        self.assertEquals(body['errors'][0]['description'],
-                          'Invalid updates specified: carbunkle')
+        self.assertEqual(body['errors'][0]['name'], 'updates')
+        self.assertEqual(body['errors'][0]['description'],
+                         'Invalid updates specified: carbunkle')
 
     def test_list_users_by_package_name(self):
         res = self.app.get('/users/', {"packages": 'bodhi'})
         body = res.json_body
-        self.assertEquals(len(body['users']), 1)
-        self.assertEquals(body['users'][0]['name'], 'guest')
+        self.assertEqual(len(body['users']), 1)
+        self.assertEqual(body['users'][0]['name'], 'guest')
 
     def test_list_users_by_nonexistant_package(self):
         res = self.app.get('/users/', {"packages": 'carbunkle'}, status=400)
         body = res.json_body
-        self.assertEquals(body['errors'][0]['name'], 'packages')
-        self.assertEquals(body['errors'][0]['description'],
-                          'Invalid packages specified: carbunkle')
+        self.assertEqual(body['errors'][0]['name'], 'packages')
+        self.assertEqual(body['errors'][0]['description'],
+                         'Invalid packages specified: carbunkle')

--- a/bodhi/tests/server/scripts/test_expire_overrides.py
+++ b/bodhi/tests/server/scripts/test_expire_overrides.py
@@ -85,7 +85,7 @@ class TestMain(BaseTestCase):
 
         log_info.assert_called_once_with("No active buildroot override to expire")
         buildrootoverride = self.db.query(models.BuildrootOverride).all()[0]
-        self.assertEquals(buildrootoverride.expired_date, None)
+        self.assertEqual(buildrootoverride.expired_date, None)
 
     @mock.patch('bodhi.server.scripts.expire_overrides.logging.Logger.info')
     def test_expire(self, log_info):

--- a/bodhi/tests/server/services/test_builds.py
+++ b/bodhi/tests/server/services/test_builds.py
@@ -28,15 +28,15 @@ class TestBuildsService(base.BaseTestCase):
 
     def test_get_single_build(self):
         res = self.app.get('/builds/bodhi-2.0-1.fc17')
-        self.assertEquals(res.json_body['nvr'], 'bodhi-2.0-1.fc17')
+        self.assertEqual(res.json_body['nvr'], 'bodhi-2.0-1.fc17')
 
     def test_list_builds(self):
         res = self.app.get('/builds/')
         body = res.json_body
-        self.assertEquals(len(body['builds']), 1)
+        self.assertEqual(len(body['builds']), 1)
 
         up = body['builds'][0]
-        self.assertEquals(up['nvr'], u'bodhi-2.0-1.fc17')
+        self.assertEqual(up['nvr'], u'bodhi-2.0-1.fc17')
 
     def test_list_builds_pagination(self):
 
@@ -50,12 +50,12 @@ class TestBuildsService(base.BaseTestCase):
         # Then, test pagination
         res = self.app.get('/builds/', {"rows_per_page": 1})
         body = res.json_body
-        self.assertEquals(len(body['builds']), 1)
+        self.assertEqual(len(body['builds']), 1)
         build1 = body['builds'][0]
 
         res = self.app.get('/builds/', {"rows_per_page": 1, "page": 2})
         body = res.json_body
-        self.assertEquals(len(body['builds']), 1)
+        self.assertEqual(len(body['builds']), 1)
         build2 = body['builds'][0]
 
         self.assertNotEquals(build1, build2)
@@ -63,49 +63,49 @@ class TestBuildsService(base.BaseTestCase):
     def test_list_builds_by_package(self):
         res = self.app.get('/builds/', {"packages": "bodhi"})
         body = res.json_body
-        self.assertEquals(len(body['builds']), 1)
+        self.assertEqual(len(body['builds']), 1)
 
         up = body['builds'][0]
-        self.assertEquals(up['nvr'], u'bodhi-2.0-1.fc17')
+        self.assertEqual(up['nvr'], u'bodhi-2.0-1.fc17')
 
     def test_list_builds_by_unexisting_package(self):
         res = self.app.get('/builds/', {"packages": "flash"}, status=400)
-        self.assertEquals(res.json_body['errors'][0]['name'], 'packages')
-        self.assertEquals(res.json_body['errors'][0]['description'],
-                          'Invalid packages specified: flash')
+        self.assertEqual(res.json_body['errors'][0]['name'], 'packages')
+        self.assertEqual(res.json_body['errors'][0]['description'],
+                         'Invalid packages specified: flash')
 
     def test_list_builds_by_release_name(self):
         res = self.app.get('/builds/', {"releases": "F17"})
         body = res.json_body
-        self.assertEquals(len(body['builds']), 1)
+        self.assertEqual(len(body['builds']), 1)
 
         up = body['builds'][0]
-        self.assertEquals(up['nvr'], u'bodhi-2.0-1.fc17')
+        self.assertEqual(up['nvr'], u'bodhi-2.0-1.fc17')
 
     def test_list_builds_by_release_version(self):
         res = self.app.get('/builds/', {"releases": "17"})
         body = res.json_body
-        self.assertEquals(len(body['builds']), 1)
+        self.assertEqual(len(body['builds']), 1)
 
         up = body['builds'][0]
-        self.assertEquals(up['nvr'], u'bodhi-2.0-1.fc17')
+        self.assertEqual(up['nvr'], u'bodhi-2.0-1.fc17')
 
     def test_list_builds_by_unexisting_release(self):
         res = self.app.get('/builds/', {"releases": "WinXP"}, status=400)
-        self.assertEquals(res.json_body['errors'][0]['name'], 'releases')
-        self.assertEquals(res.json_body['errors'][0]['description'],
-                          'Invalid releases specified: WinXP')
+        self.assertEqual(res.json_body['errors'][0]['name'], 'releases')
+        self.assertEqual(res.json_body['errors'][0]['description'],
+                         'Invalid releases specified: WinXP')
 
     def test_list_builds_by_nvr(self):
         res = self.app.get('/builds/', {"nvr": "bodhi-2.0-1.fc17"})
         up = res.json_body['builds'][0]
-        self.assertEquals(up['nvr'], u'bodhi-2.0-1.fc17')
+        self.assertEqual(up['nvr'], u'bodhi-2.0-1.fc17')
 
     def test_list_builds_by_update_title(self):
         res = self.app.get('/builds/', {"updates": ["bodhi-2.0-1.fc17"]})
         up = res.json_body['builds'][0]
-        self.assertEquals(up['nvr'], u'bodhi-2.0-1.fc17')
+        self.assertEqual(up['nvr'], u'bodhi-2.0-1.fc17')
 
     def test_list_builds_no_rows_per_page(self):
         res = self.app.get('/builds/', {"rows_per_page": None}, status=400)
-        self.assertEquals(res.json_body['status'], 'error')
+        self.assertEqual(res.json_body['status'], 'error')

--- a/bodhi/tests/server/services/test_comments.py
+++ b/bodhi/tests/server/services/test_comments.py
@@ -74,9 +74,9 @@ class TestCommentsService(base.BaseTestCase):
         res = self.app.post_json('/comments/', self.make_comment(
             update='bodhi-1.0-2.fc17',
         ), status=404)
-        self.assertEquals(res.json_body['errors'][0]['name'], 'update')
-        self.assertEquals(res.json_body['errors'][0]['description'],
-                          "Invalid update specified: bodhi-1.0-2.fc17")
+        self.assertEqual(res.json_body['errors'][0]['name'], 'update')
+        self.assertEqual(res.json_body['errors'][0]['description'],
+                         "Invalid update specified: bodhi-1.0-2.fc17")
 
     def test_invalid_karma(self):
         res = self.app.post_json('/comments/',
@@ -95,10 +95,10 @@ class TestCommentsService(base.BaseTestCase):
         res = self.app.post_json('/comments/', comment)
         self.assertNotIn('errors', res.json_body)
         self.assertIn('comment', res.json_body)
-        self.assertEquals(res.json_body['comment']['anonymous'], False)
-        self.assertEquals(res.json_body['comment']['text'], 'Test')
-        self.assertEquals(res.json_body['comment']['user_id'], 1)
-        self.assertEquals(res.json_body['comment']['karma_critpath'], -1)
+        self.assertEqual(res.json_body['comment']['anonymous'], False)
+        self.assertEqual(res.json_body['comment']['text'], 'Test')
+        self.assertEqual(res.json_body['comment']['user_id'], 1)
+        self.assertEqual(res.json_body['comment']['karma_critpath'], -1)
         publish.assert_called_once_with(topic='update.comment', msg=mock.ANY)
 
     @mock.patch('bodhi.server.notifications.publish')
@@ -109,12 +109,12 @@ class TestCommentsService(base.BaseTestCase):
         res = self.app.post_json('/comments/', comment)
         self.assertNotIn('errors', res.json_body)
         self.assertIn('comment', res.json_body)
-        self.assertEquals(res.json_body['comment']['anonymous'], False)
-        self.assertEquals(res.json_body['comment']['text'], 'Test')
-        self.assertEquals(res.json_body['comment']['user_id'], 1)
+        self.assertEqual(res.json_body['comment']['anonymous'], False)
+        self.assertEqual(res.json_body['comment']['text'], 'Test')
+        self.assertEqual(res.json_body['comment']['user_id'], 1)
         self.assertIn('bug_feedback', res.json_body['comment'])
         feedback = res.json_body['comment']['bug_feedback']
-        self.assertEquals(len(feedback), 1)
+        self.assertEqual(len(feedback), 1)
         publish.assert_called_once_with(topic='update.comment', msg=mock.ANY)
 
     @mock.patch('bodhi.server.notifications.publish')
@@ -125,12 +125,12 @@ class TestCommentsService(base.BaseTestCase):
         res = self.app.post_json('/comments/', comment)
         self.assertNotIn('errors', res.json_body)
         self.assertIn('comment', res.json_body)
-        self.assertEquals(res.json_body['comment']['anonymous'], False)
-        self.assertEquals(res.json_body['comment']['text'], 'Test')
-        self.assertEquals(res.json_body['comment']['user_id'], 1)
+        self.assertEqual(res.json_body['comment']['anonymous'], False)
+        self.assertEqual(res.json_body['comment']['text'], 'Test')
+        self.assertEqual(res.json_body['comment']['user_id'], 1)
         self.assertIn('testcase_feedback', res.json_body['comment'])
         feedback = res.json_body['comment']['testcase_feedback']
-        self.assertEquals(len(feedback), 1)
+        self.assertEqual(len(feedback), 1)
         publish.assert_called_once_with(topic='update.comment', msg=mock.ANY)
 
     @mock.patch('bodhi.server.notifications.publish')
@@ -138,9 +138,9 @@ class TestCommentsService(base.BaseTestCase):
         res = self.app.post_json('/comments/', self.make_comment())
         self.assertNotIn('errors', res.json_body)
         self.assertIn('comment', res.json_body)
-        self.assertEquals(res.json_body['comment']['anonymous'], False)
-        self.assertEquals(res.json_body['comment']['text'], 'Test')
-        self.assertEquals(res.json_body['comment']['user_id'], 1)
+        self.assertEqual(res.json_body['comment']['anonymous'], False)
+        self.assertEqual(res.json_body['comment']['text'], 'Test')
+        self.assertEqual(res.json_body['comment']['user_id'], 1)
         publish.assert_called_once_with(topic='update.comment', msg=mock.ANY)
 
     @mock.patch('bodhi.server.notifications.publish')
@@ -148,76 +148,76 @@ class TestCommentsService(base.BaseTestCase):
         res = self.app.post_json('/comments/', self.make_comment())
         self.assertNotIn('errors', res.json_body)
         self.assertIn('comment', res.json_body)
-        self.assertEquals(res.json_body['comment']['anonymous'], False)
-        self.assertEquals(res.json_body['comment']['text'], 'Test')
-        self.assertEquals(res.json_body['comment']['user_id'], 1)
+        self.assertEqual(res.json_body['comment']['anonymous'], False)
+        self.assertEqual(res.json_body['comment']['text'], 'Test')
+        self.assertEqual(res.json_body['comment']['user_id'], 1)
         publish.assert_called_once_with(topic='update.comment', msg=mock.ANY)
 
         res = self.app.post_json('/comments/', self.make_comment())
         self.assertNotIn('errors', res.json_body)
         self.assertIn('comment', res.json_body)
-        self.assertEquals(res.json_body['comment']['anonymous'], False)
-        self.assertEquals(res.json_body['comment']['text'], 'Test')
-        self.assertEquals(res.json_body['comment']['user_id'], 1)
-        self.assertEquals(publish.call_count, 2)
+        self.assertEqual(res.json_body['comment']['anonymous'], False)
+        self.assertEqual(res.json_body['comment']['text'], 'Test')
+        self.assertEqual(res.json_body['comment']['user_id'], 1)
+        self.assertEqual(publish.call_count, 2)
 
     @mock.patch('bodhi.server.notifications.publish')
     def test_commenting_twice_with_double_positive_karma(self, publish):
         res = self.app.post_json('/comments/', self.make_comment(up2, karma=1))
         self.assertNotIn('errors', res.json_body)
         self.assertIn('comment', res.json_body)
-        self.assertEquals(res.json_body['comment']['anonymous'], False)
-        self.assertEquals(res.json_body['comment']['text'], 'Test')
-        self.assertEquals(res.json_body['comment']['user_id'], 1)
-        self.assertEquals(res.json_body['comment']['karma'], 1)
+        self.assertEqual(res.json_body['comment']['anonymous'], False)
+        self.assertEqual(res.json_body['comment']['text'], 'Test')
+        self.assertEqual(res.json_body['comment']['user_id'], 1)
+        self.assertEqual(res.json_body['comment']['karma'], 1)
         publish.assert_called_once_with(topic='update.comment', msg=mock.ANY)
-        self.assertEquals(res.json_body['comment']['update']['karma'], 1)
+        self.assertEqual(res.json_body['comment']['update']['karma'], 1)
 
         res = self.app.post_json('/comments/', self.make_comment(up2, karma=1))
         self.assertNotIn('errors', res.json_body)
         self.assertIn('comment', res.json_body)
-        self.assertEquals(res.json_body['comment']['anonymous'], False)
-        self.assertEquals(res.json_body['comment']['text'], 'Test')
-        self.assertEquals(res.json_body['comment']['user_id'], 1)
-        self.assertEquals(publish.call_count, 2)
+        self.assertEqual(res.json_body['comment']['anonymous'], False)
+        self.assertEqual(res.json_body['comment']['text'], 'Test')
+        self.assertEqual(res.json_body['comment']['user_id'], 1)
+        self.assertEqual(publish.call_count, 2)
 
         # Mainly, ensure that the karma didn't increase *again*
-        self.assertEquals(res.json_body['comment']['update']['karma'], 1)
+        self.assertEqual(res.json_body['comment']['update']['karma'], 1)
 
     @mock.patch('bodhi.server.notifications.publish')
     def test_commenting_twice_with_positive_then_negative_karma(self, publish):
         res = self.app.post_json('/comments/', self.make_comment(up2, karma=1))
         self.assertNotIn('errors', res.json_body)
         self.assertIn('comment', res.json_body)
-        self.assertEquals(res.json_body['comment']['anonymous'], False)
-        self.assertEquals(res.json_body['comment']['text'], 'Test')
-        self.assertEquals(res.json_body['comment']['user_id'], 1)
+        self.assertEqual(res.json_body['comment']['anonymous'], False)
+        self.assertEqual(res.json_body['comment']['text'], 'Test')
+        self.assertEqual(res.json_body['comment']['user_id'], 1)
         publish.assert_called_once_with(topic='update.comment', msg=mock.ANY)
-        self.assertEquals(res.json_body['comment']['update']['karma'], 1)
+        self.assertEqual(res.json_body['comment']['update']['karma'], 1)
 
         res = self.app.post_json('/comments/', self.make_comment(up2, karma=-1))
         self.assertNotIn('errors', res.json_body)
         self.assertIn('comment', res.json_body)
-        self.assertEquals(res.json_body['comment']['anonymous'], False)
-        self.assertEquals(res.json_body['comment']['text'], 'Test')
-        self.assertEquals(res.json_body['comment']['user_id'], 1)
-        self.assertEquals(publish.call_count, 2)
+        self.assertEqual(res.json_body['comment']['anonymous'], False)
+        self.assertEqual(res.json_body['comment']['text'], 'Test')
+        self.assertEqual(res.json_body['comment']['user_id'], 1)
+        self.assertEqual(publish.call_count, 2)
 
         # Mainly, ensure that original karma is overwritten..
-        self.assertEquals(res.json_body['comment']['update']['karma'], -1)
-        self.assertEquals(res.json_body['caveats'][0]['description'],
-                          'Your karma standing was reversed.')
+        self.assertEqual(res.json_body['comment']['update']['karma'], -1)
+        self.assertEqual(res.json_body['caveats'][0]['description'],
+                         'Your karma standing was reversed.')
 
     @mock.patch('bodhi.server.notifications.publish')
     def test_commenting_with_negative_karma(self, publish):
         res = self.app.post_json('/comments/', self.make_comment(up2, karma=-1))
         self.assertNotIn('errors', res.json_body)
         self.assertIn('comment', res.json_body)
-        self.assertEquals(res.json_body['comment']['anonymous'], False)
-        self.assertEquals(res.json_body['comment']['text'], 'Test')
-        self.assertEquals(res.json_body['comment']['user_id'], 1)
+        self.assertEqual(res.json_body['comment']['anonymous'], False)
+        self.assertEqual(res.json_body['comment']['text'], 'Test')
+        self.assertEqual(res.json_body['comment']['user_id'], 1)
         publish.assert_called_once_with(topic='update.comment', msg=mock.ANY)
-        self.assertEquals(res.json_body['comment']['update']['karma'], -1)
+        self.assertEqual(res.json_body['comment']['update']['karma'], -1)
 
     @mock.patch('bodhi.server.notifications.publish')
     def test_anonymous_commenting_with_email(self, publish):
@@ -225,18 +225,18 @@ class TestCommentsService(base.BaseTestCase):
                                  self.make_comment(email='w@t.com'))
         self.assertNotIn('errors', res.json_body)
         self.assertIn('comment', res.json_body)
-        self.assertEquals(res.json_body['comment']['anonymous'], True)
-        self.assertEquals(res.json_body['comment']['text'], 'Test')
-        self.assertEquals(res.json_body['comment']['user_id'], 2)
+        self.assertEqual(res.json_body['comment']['anonymous'], True)
+        self.assertEqual(res.json_body['comment']['text'], 'Test')
+        self.assertEqual(res.json_body['comment']['user_id'], 2)
         publish.assert_called_once_with(topic='update.comment', msg=mock.ANY)
 
     def test_anonymous_commenting_with_invalid_email(self):
         res = self.app.post_json('/comments/',
                                  self.make_comment(email='foo'),
                                  status=400)
-        self.assertEquals(res.json_body['errors'][0]['name'], 'email')
-        self.assertEquals(res.json_body['errors'][0]['description'],
-                          "Invalid email address")
+        self.assertEqual(res.json_body['errors'][0]['name'], 'email')
+        self.assertEqual(res.json_body['errors'][0]['description'],
+                         "Invalid email address")
 
     def test_anonymous_commenting_with_no_author(self):
         anonymous_settings = copy.copy(self.app_settings)
@@ -256,9 +256,9 @@ class TestCommentsService(base.BaseTestCase):
 
         res = app.post_json('/comments/', comment, status=400)
 
-        self.assertEquals(res.json_body['errors'][0]['name'], 'email')
-        self.assertEquals(res.json_body['errors'][0]['description'],
-                          "You must provide an author")
+        self.assertEqual(res.json_body['errors'][0]['name'], 'email')
+        self.assertEqual(res.json_body['errors'][0]['description'],
+                         "You must provide an author")
 
     @mock.patch('bodhi.server.services.comments.Update.comment',
                 side_effect=IOError('IOError. oops!'))
@@ -267,15 +267,15 @@ class TestCommentsService(base.BaseTestCase):
 
         res = self.app.post_json('/comments/', self.make_comment(email='w@t.com'), status=400)
 
-        self.assertEquals(res.json_body['status'], 'error')
-        self.assertEquals(res.json_body['errors'][0]['description'],
-                          u'Unable to create comment')
+        self.assertEqual(res.json_body['status'], 'error')
+        self.assertEqual(res.json_body['errors'][0]['description'],
+                         u'Unable to create comment')
 
     def test_get_single_comment(self):
         res = self.app.get('/comments/1')
-        self.assertEquals(res.json_body['comment']['update_id'], 1)
-        self.assertEquals(res.json_body['comment']['user_id'], 1)
-        self.assertEquals(res.json_body['comment']['id'], 1)
+        self.assertEqual(res.json_body['comment']['update_id'], 1)
+        self.assertEqual(res.json_body['comment']['user_id'], 1)
+        self.assertEqual(res.json_body['comment']['id'], 1)
 
     def test_get_single_comment_page(self):
         res = self.app.get('/comments/1', headers=dict(accept='text/html'))
@@ -296,11 +296,11 @@ class TestCommentsService(base.BaseTestCase):
     def test_list_comments(self):
         res = self.app.get('/comments/')
         body = res.json_body
-        self.assertEquals(len(body['comments']), 2)
+        self.assertEqual(len(body['comments']), 2)
 
         comment = body['comments'][0]
-        self.assertEquals(comment['text'], u'srsly.  pretty good.')
-        self.assertEquals(comment['karma'], 0)
+        self.assertEqual(comment['text'], u'srsly.  pretty good.')
+        self.assertEqual(comment['karma'], 0)
 
     def test_list_comments_jsonp(self):
         res = self.app.get('/comments/',
@@ -334,27 +334,27 @@ class TestCommentsService(base.BaseTestCase):
     def test_search_comments(self):
         res = self.app.get('/comments/', {'like': 'srsly'})
         body = res.json_body
-        self.assertEquals(len(body['comments']), 1)
+        self.assertEqual(len(body['comments']), 1)
 
         comment = body['comments'][0]
-        self.assertEquals(comment['text'], u'srsly.  pretty good.')
+        self.assertEqual(comment['text'], u'srsly.  pretty good.')
 
         res = self.app.get('/comments/', {'like': 'wat'})
         body = res.json_body
-        self.assertEquals(len(body['comments']), 0)
+        self.assertEqual(len(body['comments']), 0)
 
     def test_list_comments_pagination(self):
         # Then, test pagination
         res = self.app.get('/comments/',
                            {"rows_per_page": 1})
         body = res.json_body
-        self.assertEquals(len(body['comments']), 1)
+        self.assertEqual(len(body['comments']), 1)
         comment1 = body['comments'][0]
 
         res = self.app.get('/comments/',
                            {"rows_per_page": 1, "page": 2})
         body = res.json_body
-        self.assertEquals(len(body['comments']), 1)
+        self.assertEqual(len(body['comments']), 1)
         comment2 = body['comments'][0]
 
         self.assertNotEquals(comment1, comment2)
@@ -366,7 +366,7 @@ class TestCommentsService(base.BaseTestCase):
         # Try with no comments first
         res = self.app.get('/comments/', {"since": tomorrow.strftime(fmt)})
         body = res.json_body
-        self.assertEquals(len(body['comments']), 0)
+        self.assertEqual(len(body['comments']), 0)
 
         # Now change the time on one to tomorrow
         self.db.query(Comment).first().timestamp = tomorrow
@@ -375,20 +375,20 @@ class TestCommentsService(base.BaseTestCase):
         # And try again
         res = self.app.get('/comments/', {"since": tomorrow.strftime(fmt)})
         body = res.json_body
-        self.assertEquals(len(body['comments']), 1)
+        self.assertEqual(len(body['comments']), 1)
 
         comment = body['comments'][0]
-        self.assertEquals(comment['text'], u'wow. amaze.')
-        self.assertEquals(comment['karma'], 1)
-        self.assertEquals(comment['user']['name'], u'guest')
+        self.assertEqual(comment['text'], u'wow. amaze.')
+        self.assertEqual(comment['karma'], 1)
+        self.assertEqual(comment['user']['name'], u'guest')
 
     def test_list_comments_by_invalid_since(self):
         res = self.app.get('/comments/', {"since": "forever"}, status=400)
         body = res.json_body
-        self.assertEquals(len(body.get('comments', [])), 0)
+        self.assertEqual(len(body.get('comments', [])), 0)
         error = res.json_body['errors'][0]
-        self.assertEquals(error['name'], 'since')
-        self.assertEquals(error['description'], 'Invalid date')
+        self.assertEqual(error['name'], 'since')
+        self.assertEqual(error['description'], 'Invalid date')
 
     def test_list_comments_by_future_date(self):
         """test filtering by future date"""
@@ -397,32 +397,32 @@ class TestCommentsService(base.BaseTestCase):
 
         res = self.app.get('/comments/', {"since": tomorrow})
         body = res.json_body
-        self.assertEquals(len(body['comments']), 0)
+        self.assertEqual(len(body['comments']), 0)
 
     def test_list_comments_by_anonymous(self):
         res = self.app.get('/comments/', {"anonymous": "false"})
         body = res.json_body
-        self.assertEquals(len(body['comments']), 1)
+        self.assertEqual(len(body['comments']), 1)
 
         comment = body['comments'][0]
-        self.assertEquals(comment['text'], u'wow. amaze.')
+        self.assertEqual(comment['text'], u'wow. amaze.')
 
     def test_list_comments_by_invalid_anonymous(self):
         res = self.app.get('/comments/', {"anonymous": "lalala"}, status=400)
         body = res.json_body
-        self.assertEquals(len(body.get('comments', [])), 0)
+        self.assertEqual(len(body.get('comments', [])), 0)
         error = res.json_body['errors'][0]
-        self.assertEquals(error['name'], 'anonymous')
+        self.assertEqual(error['name'], 'anonymous')
         proper = "is neither in ('false', '0') nor in ('true', '1')"
-        self.assertEquals(error['description'], '"lalala" %s' % proper)
+        self.assertEqual(error['description'], '"lalala" %s' % proper)
 
     def test_list_comments_by_update(self):
         res = self.app.get('/comments/', {"updates": "bodhi-2.0-1.fc17"})
         body = res.json_body
-        self.assertEquals(len(body['comments']), 2)
+        self.assertEqual(len(body['comments']), 2)
 
         comment = body['comments'][0]
-        self.assertEquals(comment['text'], u'srsly.  pretty good.')
+        self.assertEqual(comment['text'], u'srsly.  pretty good.')
 
     def test_list_comments_by_update_no_comments(self):
         nvr = u'bodhi-2.0-201.fc17'
@@ -442,53 +442,53 @@ class TestCommentsService(base.BaseTestCase):
 
         res = self.app.get('/comments/', {"updates": nvr})
         body = res.json_body
-        self.assertEquals(len(body['comments']), 0)
+        self.assertEqual(len(body['comments']), 0)
 
     def test_list_comments_by_unexisting_update(self):
         res = self.app.get('/comments/', {"updates": "flash-player"},
                            status=400)
-        self.assertEquals(res.json_body['errors'][0]['name'], 'updates')
-        self.assertEquals(res.json_body['errors'][0]['description'],
-                          "Invalid updates specified: flash-player")
+        self.assertEqual(res.json_body['errors'][0]['name'], 'updates')
+        self.assertEqual(res.json_body['errors'][0]['description'],
+                         "Invalid updates specified: flash-player")
 
     def test_list_comments_by_package(self):
         res = self.app.get('/comments/', {"packages": "bodhi"})
         body = res.json_body
-        self.assertEquals(len(body['comments']), 2)
+        self.assertEqual(len(body['comments']), 2)
 
         comment = body['comments'][0]
-        self.assertEquals(comment['text'], u'srsly.  pretty good.')
+        self.assertEqual(comment['text'], u'srsly.  pretty good.')
 
     def test_list_comments_by_unexisting_package(self):
         res = self.app.get('/comments/', {"packages": "flash-player"},
                            status=400)
-        self.assertEquals(res.json_body['errors'][0]['name'], 'packages')
-        self.assertEquals(res.json_body['errors'][0]['description'],
-                          "Invalid packages specified: flash-player")
+        self.assertEqual(res.json_body['errors'][0]['name'], 'packages')
+        self.assertEqual(res.json_body['errors'][0]['description'],
+                         "Invalid packages specified: flash-player")
 
     def test_list_comments_by_username(self):
         res = self.app.get('/comments/', {"user": "guest"})
         body = res.json_body
-        self.assertEquals(len(body['comments']), 1)
+        self.assertEqual(len(body['comments']), 1)
 
         comment = body['comments'][0]
-        self.assertEquals(comment['text'], u'wow. amaze.')
+        self.assertEqual(comment['text'], u'wow. amaze.')
 
     def test_list_comments_by_unexisting_username(self):
         res = self.app.get('/comments/', {"user": "santa"}, status=400)
         body = res.json_body
-        self.assertEquals(len(body.get('comments', [])), 0)
-        self.assertEquals(res.json_body['errors'][0]['name'], 'user')
-        self.assertEquals(res.json_body['errors'][0]['description'],
-                          "Invalid user specified: santa")
+        self.assertEqual(len(body.get('comments', [])), 0)
+        self.assertEqual(res.json_body['errors'][0]['name'], 'user')
+        self.assertEqual(res.json_body['errors'][0]['description'],
+                         "Invalid user specified: santa")
 
     def test_list_comments_by_update_owner(self):
         res = self.app.get('/comments/', {"update_owner": "guest"})
         body = res.json_body
-        self.assertEquals(len(body['comments']), 2)
+        self.assertEqual(len(body['comments']), 2)
 
         comment = body['comments'][0]
-        self.assertEquals(comment['text'], u'srsly.  pretty good.')
+        self.assertEqual(comment['text'], u'srsly.  pretty good.')
 
     def test_list_comments_by_update_owner_with_none(self):
         user = User(name=u'ralph')
@@ -496,32 +496,32 @@ class TestCommentsService(base.BaseTestCase):
         self.db.flush()
         res = self.app.get('/comments/', {"update_owner": "ralph"})
         body = res.json_body
-        self.assertEquals(len(body['comments']), 0)
+        self.assertEqual(len(body['comments']), 0)
         self.assertNotIn('errors', body)
 
     def test_list_comments_by_unexisting_update_owner(self):
         res = self.app.get('/comments/', {"update_owner": "santa"}, status=400)
         body = res.json_body
-        self.assertEquals(len(body.get('comments', [])), 0)
-        self.assertEquals(res.json_body['errors'][0]['name'], 'update_owner')
-        self.assertEquals(res.json_body['errors'][0]['description'],
-                          "Invalid user specified: santa")
+        self.assertEqual(len(body.get('comments', [])), 0)
+        self.assertEqual(res.json_body['errors'][0]['name'], 'update_owner')
+        self.assertEqual(res.json_body['errors'][0]['description'],
+                         "Invalid user specified: santa")
 
     def test_list_comments_with_ignore_user(self):
         res = self.app.get('/comments/', {"ignore_user": "guest"})
         body = res.json_body
-        self.assertEquals(len(body['comments']), 1)
+        self.assertEqual(len(body['comments']), 1)
         self.assertNotIn('errors', body)
         comment = body['comments'][0]
-        self.assertEquals(comment['text'], u'srsly.  pretty good.')
+        self.assertEqual(comment['text'], u'srsly.  pretty good.')
 
     def test_list_comments_with_unexisting_ignore_user(self):
         res = self.app.get('/comments/', {"ignore_user": "santa"}, status=400)
         body = res.json_body
-        self.assertEquals(len(body.get('comments', [])), 0)
-        self.assertEquals(res.json_body['errors'][0]['name'], 'ignore_user')
-        self.assertEquals(res.json_body['errors'][0]['description'],
-                          "Invalid user specified: santa")
+        self.assertEqual(len(body.get('comments', [])), 0)
+        self.assertEqual(res.json_body['errors'][0]['name'], 'ignore_user')
+        self.assertEqual(res.json_body['errors'][0]['description'],
+                         "Invalid user specified: santa")
 
     def test_put_json_comment(self):
         """ We only want to POST comments, not PUT. """
@@ -530,19 +530,19 @@ class TestCommentsService(base.BaseTestCase):
     def test_post_json_comment(self):
         self.app.post_json('/comments/', self.make_comment(text='awesome'))
         up = self.db.query(Update).filter_by(title=u'bodhi-2.0-1.fc17').one()
-        self.assertEquals(len(up.comments), 3)
-        self.assertEquals(up.comments[-1]['text'], 'awesome')
+        self.assertEqual(len(up.comments), 3)
+        self.assertEqual(up.comments[-1]['text'], 'awesome')
 
     def test_new_comment(self):
         comment = self.make_comment('bodhi-2.0-1.fc17', text='superb')
         r = self.app.post_json('/comments/', comment)
         comment = r.json_body['comment']
-        self.assertEquals(comment['text'], u'superb')
-        self.assertEquals(comment['user']['name'], u'guest')
-        self.assertEquals(comment['author'], u'guest')
-        self.assertEquals(comment['update']['title'], u'bodhi-2.0-1.fc17')
-        self.assertEquals(comment['update_title'], u'bodhi-2.0-1.fc17')
-        self.assertEquals(comment['karma'], 0)
+        self.assertEqual(comment['text'], u'superb')
+        self.assertEqual(comment['user']['name'], u'guest')
+        self.assertEqual(comment['author'], u'guest')
+        self.assertEqual(comment['update']['title'], u'bodhi-2.0-1.fc17')
+        self.assertEqual(comment['update_title'], u'bodhi-2.0-1.fc17')
+        self.assertEqual(comment['karma'], 0)
 
     def test_no_self_karma(self):
         " Make sure you can't give +1 karma to your own updates.. "
@@ -550,18 +550,18 @@ class TestCommentsService(base.BaseTestCase):
         # The author of this comment is "guest"
 
         up = self.db.query(Update).filter_by(title=u'bodhi-2.0-1.fc17').one()
-        self.assertEquals(up.user.name, 'guest')
+        self.assertEqual(up.user.name, 'guest')
 
         r = self.app.post_json('/comments/', comment)
         comment = r.json_body['comment']
-        self.assertEquals(comment['user']['name'], u'guest')
-        self.assertEquals(comment['update']['title'], u'bodhi-2.0-1.fc17')
+        self.assertEqual(comment['user']['name'], u'guest')
+        self.assertEqual(comment['update']['title'], u'bodhi-2.0-1.fc17')
         caveats = r.json_body['caveats']
-        self.assertEquals(len(caveats), 1)
-        self.assertEquals(caveats[0]['name'], 'karma')
-        self.assertEquals(caveats[0]['description'],
-                          "You may not give karma to your own updates.")
-        self.assertEquals(comment['karma'], 0)  # This is the real check
+        self.assertEqual(len(caveats), 1)
+        self.assertEqual(caveats[0]['name'], 'karma')
+        self.assertEqual(caveats[0]['description'],
+                         "You may not give karma to your own updates.")
+        self.assertEqual(comment['karma'], 0)  # This is the real check
 
     def test_comment_on_locked_update(self):
         """ Make sure you can comment on locked updates. """
@@ -570,16 +570,16 @@ class TestCommentsService(base.BaseTestCase):
         up.locked = True
         up.status = UpdateStatus.testing
         up.request = None
-        self.assertEquals(len(up.comments), 0)  # Before
-        self.assertEquals(up.karma, 0)          # Before
+        self.assertEqual(len(up.comments), 0)  # Before
+        self.assertEqual(up.karma, 0)          # Before
         self.db.flush()
 
         comment = self.make_comment(up2, karma=1)
         self.app.post_json('/comments/', comment)
 
         up = self.db.query(Update).filter_by(title=up2).one()
-        self.assertEquals(len(up.comments), 1)  # After
-        self.assertEquals(up.karma, 1)          # After
+        self.assertEqual(len(up.comments), 1)  # After
+        self.assertEqual(up.karma, 1)          # After
 
     def test_comment_on_locked_update_no_threshhold_action(self):
         " Make sure you can't trigger threshold action on locked updates "
@@ -590,16 +590,16 @@ class TestCommentsService(base.BaseTestCase):
         up.request = UpdateStatus.stable
         up.stable_karma = 1
         up.unstable_karma = -1
-        self.assertEquals(len(up.comments), 0)  # Before
-        self.assertEquals(up.karma, 0)          # Before
+        self.assertEqual(len(up.comments), 0)  # Before
+        self.assertEqual(up.karma, 0)          # Before
         self.db.flush()
 
         comment = self.make_comment(up2, karma=-1)
         self.app.post_json('/comments/', comment)
 
         up = self.db.query(Update).filter_by(title=up2).one()
-        self.assertEquals(len(up.comments), 1)  # After
-        self.assertEquals(up.karma, -1)         # After
+        self.assertEqual(len(up.comments), 1)  # After
+        self.assertEqual(up.karma, -1)         # After
         # Ensure that the request did not change .. don't trigger something.
-        self.assertEquals(up.status.value, UpdateStatus.testing.value)
-        self.assertEquals(up.request.value, UpdateRequest.stable.value)
+        self.assertEqual(up.status.value, UpdateStatus.testing.value)
+        self.assertEqual(up.request.value, UpdateRequest.stable.value)

--- a/bodhi/tests/server/services/test_csrf.py
+++ b/bodhi/tests/server/services/test_csrf.py
@@ -28,7 +28,7 @@ class TestCSRFService(base.BaseTestCase):
         """
         res = self.app.get('/csrf', headers={'Accept': 'text/html'}, status=200)
 
-        self.assertEquals(res.body.decode('utf-8'), self.get_csrf_token())
+        self.assertEqual(res.body.decode('utf-8'), self.get_csrf_token())
 
     def test_csrf_json(self):
         """
@@ -36,4 +36,4 @@ class TestCSRFService(base.BaseTestCase):
         """
         res = self.app.get('/csrf', headers={'Accept': 'application/json'}, status=200)
 
-        self.assertEquals(res.body.decode('utf-8'), '{"csrf_token": "%s"}' % self.get_csrf_token())
+        self.assertEqual(res.body.decode('utf-8'), '{"csrf_token": "%s"}' % self.get_csrf_token())

--- a/bodhi/tests/server/services/test_overrides.py
+++ b/bodhi/tests/server/services/test_overrides.py
@@ -46,20 +46,20 @@ class TestOverridesService(base.BaseTestCase):
 
         override = res.json_body['override']
 
-        self.assertEquals(override['build']['nvr'], "bodhi-2.0-1.fc17")
-        self.assertEquals(override['submitter']['name'], 'guest')
-        self.assertEquals(override['notes'], 'blah blah blah')
+        self.assertEqual(override['build']['nvr'], "bodhi-2.0-1.fc17")
+        self.assertEqual(override['submitter']['name'], 'guest')
+        self.assertEqual(override['notes'], 'blah blah blah')
 
     def test_list_overrides(self):
         res = self.app.get('/overrides/')
 
         body = res.json_body
-        self.assertEquals(len(body['overrides']), 1)
+        self.assertEqual(len(body['overrides']), 1)
 
         override = body['overrides'][0]
-        self.assertEquals(override['build']['nvr'], "bodhi-2.0-1.fc17")
-        self.assertEquals(override['submitter']['name'], 'guest')
-        self.assertEquals(override['notes'], 'blah blah blah')
+        self.assertEqual(override['build']['nvr'], "bodhi-2.0-1.fc17")
+        self.assertEqual(override['submitter']['name'], 'guest')
+        self.assertEqual(override['notes'], 'blah blah blah')
 
     def test_list_overrides_rss(self):
         res = self.app.get('/rss/overrides/',
@@ -71,39 +71,39 @@ class TestOverridesService(base.BaseTestCase):
         res = self.app.get('/overrides/', {'expired': 'true'})
 
         body = res.json_body
-        self.assertEquals(len(body['overrides']), 0)
+        self.assertEqual(len(body['overrides']), 0)
 
     def test_list_notexpired_overrides(self):
         res = self.app.get('/overrides/', {'expired': 'false'})
 
         body = res.json_body
-        self.assertEquals(len(body['overrides']), 1)
+        self.assertEqual(len(body['overrides']), 1)
 
         override = body['overrides'][0]
-        self.assertEquals(override['build']['nvr'], "bodhi-2.0-1.fc17")
-        self.assertEquals(override['submitter']['name'], 'guest')
-        self.assertEquals(override['notes'], 'blah blah blah')
+        self.assertEqual(override['build']['nvr'], "bodhi-2.0-1.fc17")
+        self.assertEqual(override['submitter']['name'], 'guest')
+        self.assertEqual(override['notes'], 'blah blah blah')
 
     def test_list_overrides_by_invalid_expired(self):
         res = self.app.get('/overrides/', {"expired": "lalala"},
                            status=400)
         errors = res.json_body['errors']
-        self.assertEquals(len(res.json_body.get('overrides', [])), 0)
-        self.assertEquals(len(errors), 1)
-        self.assertEquals(errors[0]['name'], 'expired')
-        self.assertEquals(errors[0]['description'],
-                          '"lalala" is neither in (\'false\', \'0\') nor in (\'true\', \'1\')')
+        self.assertEqual(len(res.json_body.get('overrides', [])), 0)
+        self.assertEqual(len(errors), 1)
+        self.assertEqual(errors[0]['name'], 'expired')
+        self.assertEqual(errors[0]['description'],
+                         '"lalala" is neither in (\'false\', \'0\') nor in (\'true\', \'1\')')
 
     def test_list_overrides_by_packages(self):
         res = self.app.get('/overrides/', {'packages': 'bodhi'})
 
         body = res.json_body
-        self.assertEquals(len(body['overrides']), 1)
+        self.assertEqual(len(body['overrides']), 1)
 
         override = body['overrides'][0]
-        self.assertEquals(override['build']['nvr'], "bodhi-2.0-1.fc17")
-        self.assertEquals(override['submitter']['name'], 'guest')
-        self.assertEquals(override['notes'], 'blah blah blah')
+        self.assertEqual(override['build']['nvr'], "bodhi-2.0-1.fc17")
+        self.assertEqual(override['submitter']['name'], 'guest')
+        self.assertEqual(override['notes'], 'blah blah blah')
 
     def test_list_overrides_by_packages_without_override(self):
         self.db.add(RpmPackage(name=u'python'))
@@ -112,40 +112,40 @@ class TestOverridesService(base.BaseTestCase):
         res = self.app.get('/overrides/', {'packages': 'python'})
 
         body = res.json_body
-        self.assertEquals(len(body['overrides']), 0)
+        self.assertEqual(len(body['overrides']), 0)
 
     def test_list_overrides_by_invalid_packages(self):
         res = self.app.get('/overrides/', {'packages': 'flash-player'},
                            status=400)
 
         errors = res.json_body['errors']
-        self.assertEquals(len(res.json_body.get('overrides', [])), 0)
-        self.assertEquals(len(errors), 1)
-        self.assertEquals(errors[0]['name'], 'packages')
-        self.assertEquals(errors[0]['description'],
-                          'Invalid packages specified: flash-player')
+        self.assertEqual(len(res.json_body.get('overrides', [])), 0)
+        self.assertEqual(len(errors), 1)
+        self.assertEqual(errors[0]['name'], 'packages')
+        self.assertEqual(errors[0]['description'],
+                         'Invalid packages specified: flash-player')
 
     def test_list_overrides_by_releases(self):
         res = self.app.get('/overrides/', {'releases': 'F17'})
 
         body = res.json_body
-        self.assertEquals(len(body['overrides']), 1)
+        self.assertEqual(len(body['overrides']), 1)
 
         override = body['overrides'][0]
-        self.assertEquals(override['build']['nvr'], "bodhi-2.0-1.fc17")
-        self.assertEquals(override['submitter']['name'], 'guest')
-        self.assertEquals(override['notes'], 'blah blah blah')
+        self.assertEqual(override['build']['nvr'], "bodhi-2.0-1.fc17")
+        self.assertEqual(override['submitter']['name'], 'guest')
+        self.assertEqual(override['notes'], 'blah blah blah')
 
     def test_list_overrides_by_builds(self):
         res = self.app.get('/overrides/', {'builds': 'bodhi-2.0-1.fc17'})
 
         body = res.json_body
-        self.assertEquals(len(body['overrides']), 1)
+        self.assertEqual(len(body['overrides']), 1)
 
         override = body['overrides'][0]
-        self.assertEquals(override['build']['nvr'], "bodhi-2.0-1.fc17")
-        self.assertEquals(override['submitter']['name'], 'guest')
-        self.assertEquals(override['notes'], 'blah blah blah')
+        self.assertEqual(override['build']['nvr'], "bodhi-2.0-1.fc17")
+        self.assertEqual(override['submitter']['name'], 'guest')
+        self.assertEqual(override['notes'], 'blah blah blah')
 
     def test_list_overrides_by_releases_without_override(self):
         self.db.add(Release(name=u'F42', long_name=u'Fedora 42',
@@ -163,28 +163,28 @@ class TestOverridesService(base.BaseTestCase):
         res = self.app.get('/overrides/', {'releases': 'F42'})
 
         body = res.json_body
-        self.assertEquals(len(body['overrides']), 0)
+        self.assertEqual(len(body['overrides']), 0)
 
     def test_list_overrides_by_invalid_releases(self):
         res = self.app.get('/overrides/', {'releases': 'F42'},
                            status=400)
 
         errors = res.json_body['errors']
-        self.assertEquals(len(res.json_body.get('overrides', [])), 0)
-        self.assertEquals(len(errors), 1)
-        self.assertEquals(errors[0]['name'], 'releases')
-        self.assertEquals(errors[0]['description'],
-                          'Invalid releases specified: F42')
+        self.assertEqual(len(res.json_body.get('overrides', [])), 0)
+        self.assertEqual(len(errors), 1)
+        self.assertEqual(errors[0]['name'], 'releases')
+        self.assertEqual(errors[0]['description'],
+                         'Invalid releases specified: F42')
 
     def test_list_overrides_by_username(self):
         res = self.app.get('/overrides/', {"user": "guest"})
         body = res.json_body
-        self.assertEquals(len(body['overrides']), 1)
+        self.assertEqual(len(body['overrides']), 1)
 
         override = body['overrides'][0]
-        self.assertEquals(override['build']['nvr'], "bodhi-2.0-1.fc17")
-        self.assertEquals(override['submitter']['name'], 'guest')
-        self.assertEquals(override['notes'], 'blah blah blah')
+        self.assertEqual(override['build']['nvr'], "bodhi-2.0-1.fc17")
+        self.assertEqual(override['submitter']['name'], 'guest')
+        self.assertEqual(override['notes'], 'blah blah blah')
 
     def test_list_overrides_by_username_without_override(self):
         self.db.add(User(name=u'bochecha'))
@@ -193,17 +193,17 @@ class TestOverridesService(base.BaseTestCase):
         res = self.app.get('/overrides/', {'user': 'bochecha'})
 
         body = res.json_body
-        self.assertEquals(len(body['overrides']), 0)
+        self.assertEqual(len(body['overrides']), 0)
 
     def test_list_overrides_by_unexisting_username(self):
         res = self.app.get('/overrides/', {"user": "santa"}, status=400)
 
         errors = res.json_body['errors']
-        self.assertEquals(len(res.json_body.get('overrides', [])), 0)
-        self.assertEquals(len(errors), 1)
-        self.assertEquals(errors[0]['name'], 'user')
-        self.assertEquals(errors[0]['description'],
-                          "Invalid user specified: santa")
+        self.assertEqual(len(res.json_body.get('overrides', [])), 0)
+        self.assertEqual(len(errors), 1)
+        self.assertEqual(errors[0]['name'], 'user')
+        self.assertEqual(errors[0]['description'],
+                         "Invalid user specified: santa")
 
     def test_list_overrides_by_like(self):
         """
@@ -213,14 +213,14 @@ class TestOverridesService(base.BaseTestCase):
         # test that like works
         res = self.app.get('/overrides/', {"like": "bodh"})
         body = res.json_body
-        self.assertEquals(len(body['overrides']), 1)
+        self.assertEqual(len(body['overrides']), 1)
         override = body['overrides'][0]
-        self.assertEquals(override['build']['nvr'], "bodhi-2.0-1.fc17")
+        self.assertEqual(override['build']['nvr'], "bodhi-2.0-1.fc17")
 
         # test a like that yields nothing
         res = self.app.get('/overrides/', {"like": "corebird"})
         body = res.json_body
-        self.assertEquals(len(body['overrides']), 0)
+        self.assertEqual(len(body['overrides']), 0)
 
     def test_list_overrides_by_search(self):
         """
@@ -230,20 +230,20 @@ class TestOverridesService(base.BaseTestCase):
         # test that search works
         res = self.app.get('/overrides/', {"search": "bodh"})
         body = res.json_body
-        self.assertEquals(len(body['overrides']), 1)
+        self.assertEqual(len(body['overrides']), 1)
         override = body['overrides'][0]
-        self.assertEquals(override['build']['nvr'], "bodhi-2.0-1.fc17")
+        self.assertEqual(override['build']['nvr'], "bodhi-2.0-1.fc17")
 
         # test a search that is case-insensitive
         res = self.app.get('/overrides/', {"search": "Bodh"})
-        self.assertEquals(len(body['overrides']), 1)
+        self.assertEqual(len(body['overrides']), 1)
         override = body['overrides'][0]
-        self.assertEquals(override['build']['nvr'], "bodhi-2.0-1.fc17")
+        self.assertEqual(override['build']['nvr'], "bodhi-2.0-1.fc17")
 
         # test a search that yields nothing
         res = self.app.get('/overrides/', {"search": "corebird"})
         body = res.json_body
-        self.assertEquals(len(body['overrides']), 0)
+        self.assertEqual(len(body['overrides']), 0)
 
     @mock.patch('bodhi.server.notifications.publish')
     def test_create_override(self, publish):
@@ -264,14 +264,14 @@ class TestOverridesService(base.BaseTestCase):
 
         publish.assert_called_once_with(
             topic='buildroot_override.tag', msg=mock.ANY)
-        self.assertEquals(len(publish.call_args_list), 1)
+        self.assertEqual(len(publish.call_args_list), 1)
 
         o = res.json_body
-        self.assertEquals(o['build_id'], build.id)
-        self.assertEquals(o['notes'], 'blah blah blah')
-        self.assertEquals(o['expiration_date'],
-                          expiration_date.strftime("%Y-%m-%d %H:%M:%S"))
-        self.assertEquals(o['expired_date'], None)
+        self.assertEqual(o['build_id'], build.id)
+        self.assertEqual(o['notes'], 'blah blah blah')
+        self.assertEqual(o['expiration_date'],
+                         expiration_date.strftime("%Y-%m-%d %H:%M:%S"))
+        self.assertEqual(o['expired_date'], None)
 
     @mock.patch('bodhi.server.notifications.publish')
     def test_create_duplicate_override(self, publish):
@@ -291,19 +291,19 @@ class TestOverridesService(base.BaseTestCase):
 
         publish.assert_called_once_with(
             topic='buildroot_override.tag', msg=mock.ANY)
-        self.assertEquals(len(publish.call_args_list), 1)
+        self.assertEqual(len(publish.call_args_list), 1)
 
         o = res.json_body
-        self.assertEquals(o['build_id'], build.id)
-        self.assertEquals(o['notes'], 'blah blah blah')
-        self.assertEquals(o['expiration_date'],
-                          expiration_date.strftime("%Y-%m-%d %H:%M:%S"))
-        self.assertEquals(o['expired_date'], None)
+        self.assertEqual(o['build_id'], build.id)
+        self.assertEqual(o['notes'], 'blah blah blah')
+        self.assertEqual(o['expiration_date'],
+                         expiration_date.strftime("%Y-%m-%d %H:%M:%S"))
+        self.assertEqual(o['expired_date'], None)
 
         # Submit it again
         res = self.app.post('/overrides/', data, status=400)
-        self.assertEquals(res.json_body['errors'][0]['description'],
-                          'Buildroot override for %s already exists' % build.nvr)
+        self.assertEqual(res.json_body['errors'][0]['description'],
+                         'Buildroot override for %s already exists' % build.nvr)
 
     @mock.patch('bodhi.server.notifications.publish')
     def test_create_override_multiple_nvr(self, publish):
@@ -330,23 +330,23 @@ class TestOverridesService(base.BaseTestCase):
         }
         res = self.app.post('/overrides/', data)
 
-        self.assertEquals(len(publish.call_args_list), 2)
+        self.assertEqual(len(publish.call_args_list), 2)
 
         result = res.json_body
-        self.assertEquals(result['caveats'][0]['description'],
-                          'Your override submission was split into 2.')
+        self.assertEqual(result['caveats'][0]['description'],
+                         'Your override submission was split into 2.')
 
         o1, o2 = result['overrides']
-        self.assertEquals(o1['build_id'], build1.id)
-        self.assertEquals(o1['notes'], 'blah blah blah')
-        self.assertEquals(o1['expiration_date'],
-                          expiration_date.strftime("%Y-%m-%d %H:%M:%S"))
-        self.assertEquals(o1['expired_date'], None)
-        self.assertEquals(o2['build_id'], build2.id)
-        self.assertEquals(o2['notes'], 'blah blah blah')
-        self.assertEquals(o2['expiration_date'],
-                          expiration_date.strftime("%Y-%m-%d %H:%M:%S"))
-        self.assertEquals(o2['expired_date'], None)
+        self.assertEqual(o1['build_id'], build1.id)
+        self.assertEqual(o1['notes'], 'blah blah blah')
+        self.assertEqual(o1['expiration_date'],
+                         expiration_date.strftime("%Y-%m-%d %H:%M:%S"))
+        self.assertEqual(o1['expired_date'], None)
+        self.assertEqual(o2['build_id'], build2.id)
+        self.assertEqual(o2['notes'], 'blah blah blah')
+        self.assertEqual(o2['expiration_date'],
+                         expiration_date.strftime("%Y-%m-%d %H:%M:%S"))
+        self.assertEqual(o2['expired_date'], None)
 
     @mock.patch('bodhi.server.notifications.publish')
     def test_create_override_too_long(self, publish):
@@ -386,11 +386,11 @@ class TestOverridesService(base.BaseTestCase):
             topic='buildroot_override.untag', msg=mock.ANY)
 
         o = res.json_body
-        self.assertEquals(o['build_id'], build.id)
-        self.assertEquals(o['notes'], 'blah blah blah')
-        self.assertEquals(o['expiration_date'],
-                          expiration_date.strftime("%Y-%m-%d %H:%M:%S"))
-        self.assertEquals(o['expired_date'], None)
+        self.assertEqual(o['build_id'], build.id)
+        self.assertEqual(o['notes'], 'blah blah blah')
+        self.assertEqual(o['expiration_date'],
+                         expiration_date.strftime("%Y-%m-%d %H:%M:%S"))
+        self.assertEqual(o['expired_date'], None)
 
         old_build = RpmBuild.get(u'bodhi-2.0-1.fc17')
 
@@ -421,11 +421,11 @@ class TestOverridesService(base.BaseTestCase):
         res = self.app.post('/overrides/', o)
 
         override = res.json_body
-        self.assertEquals(override['build_id'], old_build_id)
-        self.assertEquals(override['notes'], 'blah blah blah')
-        self.assertEquals(override['expiration_date'], expiration_date)
-        self.assertEquals(override['expired_date'], None)
-        self.assertEquals(len(publish.call_args_list), 0)
+        self.assertEqual(override['build_id'], old_build_id)
+        self.assertEqual(override['notes'], 'blah blah blah')
+        self.assertEqual(override['expiration_date'], expiration_date)
+        self.assertEqual(override['expired_date'], None)
+        self.assertEqual(len(publish.call_args_list), 0)
 
     def test_edit_nonexisting_build(self):
         """
@@ -448,10 +448,10 @@ class TestOverridesService(base.BaseTestCase):
         res = self.app.post('/overrides/', o, status=400)
 
         errors = res.json_body['errors']
-        self.assertEquals(len(errors), 1)
-        self.assertEquals(errors[0]['name'], 'edited')
-        self.assertEquals(errors[0]['description'],
-                          'No such build')
+        self.assertEqual(len(errors), 1)
+        self.assertEqual(errors[0]['name'], 'edited')
+        self.assertEqual(errors[0]['description'],
+                         'No such build')
 
     def test_edit_unexisting_override(self):
         release = Release.get(u'F17')
@@ -473,10 +473,10 @@ class TestOverridesService(base.BaseTestCase):
         res = self.app.post('/overrides/', o, status=400)
 
         errors = res.json_body['errors']
-        self.assertEquals(len(errors), 1)
-        self.assertEquals(errors[0]['name'], 'edited')
-        self.assertEquals(errors[0]['description'],
-                          'No buildroot override for this build')
+        self.assertEqual(len(errors), 1)
+        self.assertEqual(errors[0]['name'], 'edited')
+        self.assertEqual(errors[0]['description'],
+                         'No buildroot override for this build')
 
     @mock.patch('bodhi.server.services.overrides.BuildrootOverride.edit',
                 mock.MagicMock(side_effect=IOError('no db for you!')))
@@ -495,10 +495,10 @@ class TestOverridesService(base.BaseTestCase):
         res = self.app.post('/overrides/', o, status=400)
 
         errors = res.json_body['errors']
-        self.assertEquals(len(errors), 1)
-        self.assertEquals(errors[0]['name'], 'override')
-        self.assertEquals(errors[0]['description'],
-                          'Unable to save buildroot override: no db for you!')
+        self.assertEqual(len(errors), 1)
+        self.assertEqual(errors[0]['name'], 'override')
+        self.assertEqual(errors[0]['description'],
+                         'Unable to save buildroot override: no db for you!')
 
     def test_edit_notes(self):
         old_nvr = u'bodhi-2.0-1.fc17'
@@ -514,10 +514,10 @@ class TestOverridesService(base.BaseTestCase):
         res = self.app.post('/overrides/', o)
 
         override = res.json_body
-        self.assertEquals(override['build_id'], build_id)
-        self.assertEquals(override['notes'], 'blah blah blah blah')
-        self.assertEquals(override['expiration_date'], expiration_date)
-        self.assertEquals(override['expired_date'], None)
+        self.assertEqual(override['build_id'], build_id)
+        self.assertEqual(override['notes'], 'blah blah blah blah')
+        self.assertEqual(override['expiration_date'], expiration_date)
+        self.assertEqual(override['expired_date'], None)
 
     def test_edit_expiration_date(self):
         old_nvr = u'bodhi-2.0-1.fc17'
@@ -533,11 +533,11 @@ class TestOverridesService(base.BaseTestCase):
         res = self.app.post('/overrides/', o)
 
         override = res.json_body
-        self.assertEquals(override['build'], o['build'])
-        self.assertEquals(override['notes'], o['notes'])
-        self.assertEquals(override['expiration_date'],
-                          expiration_date.strftime("%Y-%m-%d %H:%M:%S"))
-        self.assertEquals(override['expired_date'], None)
+        self.assertEqual(override['build'], o['build'])
+        self.assertEqual(override['notes'], o['notes'])
+        self.assertEqual(override['expiration_date'],
+                         expiration_date.strftime("%Y-%m-%d %H:%M:%S"))
+        self.assertEqual(override['expired_date'], None)
 
     def test_edit_fail_on_multiple(self):
         old_nvr = u'bodhi-2.0-1.fc17'
@@ -549,7 +549,7 @@ class TestOverridesService(base.BaseTestCase):
                   'edited': old_nvr, 'csrf_token': self.get_csrf_token()})
         res = self.app.post('/overrides/', o, status=400)
         result = res.json_body
-        self.assertEquals(
+        self.assertEqual(
             result['errors'][0]['description'],
             'Cannot combine multiple NVRs with editing a buildroot override.',
         )
@@ -567,9 +567,9 @@ class TestOverridesService(base.BaseTestCase):
         res = self.app.post('/overrides/', o)
 
         override = res.json_body
-        self.assertEquals(override['build'], o['build'])
-        self.assertEquals(override['notes'], o['notes'])
-        self.assertEquals(override['expiration_date'], o['expiration_date'])
+        self.assertEqual(override['build'], o['build'])
+        self.assertEqual(override['notes'], o['notes'])
+        self.assertEqual(override['expiration_date'], o['expiration_date'])
         self.assertNotEquals(override['expired_date'], None)
         publish.assert_called_once_with(
             topic='buildroot_override.untag', msg=mock.ANY)
@@ -601,10 +601,10 @@ class TestOverridesService(base.BaseTestCase):
         res = self.app.post('/overrides/', o)
 
         override = res.json_body
-        self.assertEquals(override['build'], o['build'])
-        self.assertEquals(override['notes'], o['notes'])
-        self.assertEquals(override['expiration_date'], o['expiration_date'])
-        self.assertEquals(override['expired_date'], None)
+        self.assertEqual(override['build'], o['build'])
+        self.assertEqual(override['notes'], o['notes'])
+        self.assertEqual(override['expiration_date'], o['expiration_date'])
+        self.assertEqual(override['expired_date'], None)
         publish.assert_called_once_with(
             topic='buildroot_override.tag', msg=mock.ANY)
 
@@ -621,14 +621,14 @@ class TestOverridesService(base.BaseTestCase):
 
         publish.assert_called_once_with(
             topic='buildroot_override.tag', msg=mock.ANY)
-        self.assertEquals(len(publish.call_args_list), 1)
+        self.assertEqual(len(publish.call_args_list), 1)
 
         o = res.json_body
-        self.assertEquals(o['nvr'], nvr)
-        self.assertEquals(o['notes'], 'blah blah blah')
-        self.assertEquals(o['expiration_date'],
-                          expiration_date.strftime("%Y-%m-%d %H:%M:%S"))
-        self.assertEquals(o['expired_date'], None)
+        self.assertEqual(o['nvr'], nvr)
+        self.assertEqual(o['notes'], 'blah blah blah')
+        self.assertEqual(o['expiration_date'],
+                         expiration_date.strftime("%Y-%m-%d %H:%M:%S"))
+        self.assertEqual(o['expired_date'], None)
 
 
 class TestOverridesWebViews(base.BaseTestCase):

--- a/bodhi/tests/server/services/test_releases.py
+++ b/bodhi/tests/server/services/test_releases.py
@@ -63,86 +63,86 @@ class TestReleasesService(base.BaseTestCase):
         res = app.post("/releases/", r, status=403)
 
         r = self.db.query(Release).filter(Release.name == name).one()
-        self.assertEquals(r.state, ReleaseState.disabled)
+        self.assertEqual(r.state, ReleaseState.disabled)
 
     def test_get_single_release_by_lower(self):
         res = self.app.get('/releases/f22', headers={'Accept': 'application/json'})
-        self.assertEquals(res.json_body['name'], 'F22')
+        self.assertEqual(res.json_body['name'], 'F22')
 
     def test_get_single_release_by_upper(self):
         res = self.app.get('/releases/F22', headers={'Accept': 'application/json'})
-        self.assertEquals(res.json_body['name'], 'F22')
+        self.assertEqual(res.json_body['name'], 'F22')
 
     def test_get_single_release_by_long(self):
         res = self.app.get('/releases/Fedora%2022', headers={'Accept': 'application/json'})
-        self.assertEquals(res.json_body['name'], 'F22')
+        self.assertEqual(res.json_body['name'], 'F22')
 
     def test_list_releases(self):
         res = self.app.get('/releases/')
         body = res.json_body
-        self.assertEquals(len(body['releases']), 2)
+        self.assertEqual(len(body['releases']), 2)
 
-        self.assertEquals(body['releases'][0]['name'], u'F17')
-        self.assertEquals(body['releases'][1]['name'], u'F22')
+        self.assertEqual(body['releases'][0]['name'], u'F17')
+        self.assertEqual(body['releases'][1]['name'], u'F22')
 
     def test_list_releases_with_pagination(self):
         res = self.app.get('/releases/')
         body = res.json_body
-        self.assertEquals(len(body['releases']), 2)
+        self.assertEqual(len(body['releases']), 2)
 
         res = self.app.get('/releases/', {'rows_per_page': 1})
         body = res.json_body
-        self.assertEquals(len(body['releases']), 1)
-        self.assertEquals(body['releases'][0]['name'], 'F17')
+        self.assertEqual(len(body['releases']), 1)
+        self.assertEqual(body['releases'][0]['name'], 'F17')
 
         res = self.app.get('/releases/', {'rows_per_page': 1, 'page': 2})
         body = res.json_body
-        self.assertEquals(len(body['releases']), 1)
-        self.assertEquals(body['releases'][0]['name'], 'F22')
+        self.assertEqual(len(body['releases']), 1)
+        self.assertEqual(body['releases'][0]['name'], 'F22')
 
     def test_list_releases_by_ids_unknown(self):
         res = self.app.get('/releases/', {"ids": [9234872348923467]})
 
-        self.assertEquals(len(res.json_body['releases']), 0)
+        self.assertEqual(len(res.json_body['releases']), 0)
 
     def test_list_releases_by_ids_plural(self):
         releases = Release.query.all()
 
         res = self.app.get('/releases/', {"ids": [release.id for release in releases]})
 
-        self.assertEquals(len(res.json_body['releases']), len(releases))
-        self.assertEquals(set([r['name'] for r in res.json_body['releases']]),
-                          set([release.name for release in releases]))
+        self.assertEqual(len(res.json_body['releases']), len(releases))
+        self.assertEqual(set([r['name'] for r in res.json_body['releases']]),
+                         set([release.name for release in releases]))
 
     def test_list_releases_by_ids_singular(self):
         release = Release.query.all()[0]
 
         res = self.app.get('/releases/', {"ids": release.id})
 
-        self.assertEquals(len(res.json_body['releases']), 1)
-        self.assertEquals(res.json_body['releases'][0]['name'], release.name)
+        self.assertEqual(len(res.json_body['releases']), 1)
+        self.assertEqual(res.json_body['releases'][0]['name'], release.name)
 
     def test_list_releases_by_name(self):
         res = self.app.get('/releases/', {"name": 'F22'})
         body = res.json_body
-        self.assertEquals(len(body['releases']), 1)
-        self.assertEquals(body['releases'][0]['name'], 'F22')
+        self.assertEqual(len(body['releases']), 1)
+        self.assertEqual(body['releases'][0]['name'], 'F22')
 
     def test_list_releases_by_name_match(self):
         res = self.app.get('/releases/', {"name": '%1%'})
         body = res.json_body
-        self.assertEquals(len(body['releases']), 1)
-        self.assertEquals(body['releases'][0]['name'], 'F17')
+        self.assertEqual(len(body['releases']), 1)
+        self.assertEqual(body['releases'][0]['name'], 'F17')
 
     def test_list_releases_by_name_match_miss(self):
         res = self.app.get('/releases/', {"name": '%wat%'})
-        self.assertEquals(len(res.json_body['releases']), 0)
+        self.assertEqual(len(res.json_body['releases']), 0)
 
     def test_list_releases_by_update_title(self):
         res = self.app.get('/releases/', {"updates": 'bodhi-2.0-1.fc17'})
         body = res.json_body
-        self.assertEquals(len(body['releases']), 1)
-        self.assertEquals(body['releases'][0]['name'], 'F17')
+        self.assertEqual(len(body['releases']), 1)
+        self.assertEqual(body['releases'][0]['name'], 'F17')
 
     def test_list_releases_by_update_alias(self):
         update = self.db.query(Update).first()
@@ -151,26 +151,26 @@ class TestReleasesService(base.BaseTestCase):
 
         res = self.app.get('/releases/', {"updates": 'some_alias'})
         body = res.json_body
-        self.assertEquals(len(body['releases']), 1)
-        self.assertEquals(body['releases'][0]['name'], 'F17')
+        self.assertEqual(len(body['releases']), 1)
+        self.assertEqual(body['releases'][0]['name'], 'F17')
 
     def test_list_releases_by_nonexistant_update(self):
         res = self.app.get('/releases/', {"updates": 'carbunkle'}, status=400)
-        self.assertEquals(res.json_body['errors'][0]['name'], 'updates')
-        self.assertEquals(res.json_body['errors'][0]['description'],
-                          'Invalid updates specified: carbunkle')
+        self.assertEqual(res.json_body['errors'][0]['name'], 'updates')
+        self.assertEqual(res.json_body['errors'][0]['description'],
+                         'Invalid updates specified: carbunkle')
 
     def test_list_releases_by_package_name(self):
         res = self.app.get('/releases/', {"packages": 'bodhi'})
         body = res.json_body
-        self.assertEquals(len(body['releases']), 1)
-        self.assertEquals(body['releases'][0]['name'], 'F17')
+        self.assertEqual(len(body['releases']), 1)
+        self.assertEqual(body['releases'][0]['name'], 'F17')
 
     def test_list_releases_by_nonexistant_package(self):
         res = self.app.get('/releases/', {"packages": 'carbunkle'}, status=400)
-        self.assertEquals(res.json_body['errors'][0]['name'], 'packages')
-        self.assertEquals(res.json_body['errors'][0]['description'],
-                          'Invalid packages specified: carbunkle')
+        self.assertEqual(res.json_body['errors'][0]['name'], 'packages')
+        self.assertEqual(res.json_body['errors'][0]['description'],
+                         'Invalid packages specified: carbunkle')
 
     def test_new_release(self):
         attrs = {"name": u"F42", "long_name": "Fedora 42", "version": "42",
@@ -191,29 +191,29 @@ class TestReleasesService(base.BaseTestCase):
         r = self.db.query(Release).filter(Release.name == attrs["name"]).one()
 
         for k, v in attrs.items():
-            self.assertEquals(getattr(r, k), v)
+            self.assertEqual(getattr(r, k), v)
 
-        self.assertEquals(r.state, ReleaseState.disabled)
+        self.assertEqual(r.state, ReleaseState.disabled)
 
     def test_list_releases_by_current_state(self):
         """ Test that we can filter releases using the 'current' state """
         res = self.app.get('/releases/', {"state": 'current'})
         body = res.json_body
-        self.assertEquals(len(body['releases']), 1)
-        self.assertEquals(body['releases'][0]['name'], 'F17')
+        self.assertEqual(len(body['releases']), 1)
+        self.assertEqual(body['releases'][0]['name'], 'F17')
 
     def test_list_releases_by_disabled_state(self):
         """ Test that we can filter releases using the 'disabled' state """
         res = self.app.get('/releases/', {"state": 'disabled'})
         body = res.json_body
-        self.assertEquals(len(body['releases']), 1)
-        self.assertEquals(body['releases'][0]['name'], 'F22')
+        self.assertEqual(len(body['releases']), 1)
+        self.assertEqual(body['releases'][0]['name'], 'F22')
 
     def test_list_releases_by_pending_state(self):
         """ Test that we can filter releases using the 'pending' state """
         res = self.app.get('/releases/', {"state": 'pending'})
         body = res.json_body
-        self.assertEquals(len(body['releases']), 0)
+        self.assertEqual(len(body['releases']), 0)
 
     def test_list_releases_with_a_wrong_state(self):
         """ Test that we get a 400 error when we use an undefined state """
@@ -221,7 +221,7 @@ class TestReleasesService(base.BaseTestCase):
         body = res.json_body
         # the error description is not the same in Python2 and Python3
         # so let's just make sure we have an error.
-        self.assertEquals(body['status'], 'error')
+        self.assertEqual(body['status'], 'error')
 
     @mock.patch('bodhi.server.services.releases.log.info', side_effect=IOError('BOOM!'))
     def test_save_release_exception_handler(self, info):
@@ -260,9 +260,9 @@ class TestReleasesService(base.BaseTestCase):
                  }
         res = self.app.post("/releases/", attrs, status=400)
 
-        self.assertEquals(len(res.json_body['errors']), 4)
+        self.assertEqual(len(res.json_body['errors']), 4)
         for error in res.json_body['errors']:
-            self.assertEquals(error["description"], "Invalid tag: %s" % attrs[error["name"]])
+            self.assertEqual(error["description"], "Invalid tag: %s" % attrs[error["name"]])
 
     def test_edit_release(self):
         name = u"F22"
@@ -277,11 +277,11 @@ class TestReleasesService(base.BaseTestCase):
         res = self.app.post("/releases/", r, status=200)
 
         r = self.db.query(Release).filter(Release.name == name).one()
-        self.assertEquals(r.state, ReleaseState.current)
+        self.assertEqual(r.state, ReleaseState.current)
 
     def test_get_single_release_html(self):
         res = self.app.get('/releases/f17', headers={'Accept': 'text/html'})
-        self.assertEquals(res.content_type, 'text/html')
+        self.assertEqual(res.content_type, 'text/html')
         self.assertIn('f17-updates-testing', res)
 
     def test_get_single_release_html_two_same_updates_same_month(self):
@@ -292,7 +292,7 @@ class TestReleasesService(base.BaseTestCase):
 
         res = self.app.get('/releases/f17', headers={'Accept': 'text/html'})
 
-        self.assertEquals(res.content_type, 'text/html')
+        self.assertEqual(res.content_type, 'text/html')
         self.assertIn('f17-updates-testing', res)
         # Since the updates are the same type and from the same month, we should see a count of 2 in
         # the graph data.
@@ -304,7 +304,7 @@ class TestReleasesService(base.BaseTestCase):
 
     def test_get_releases_html(self):
         res = self.app.get('/releases/', headers={'Accept': 'text/html'})
-        self.assertEquals(res.content_type, 'text/html')
+        self.assertEqual(res.content_type, 'text/html')
         self.assertIn('Fedora 22', res)
 
     def test_query_releases_html_two_releases_same_state(self):
@@ -324,6 +324,6 @@ class TestReleasesService(base.BaseTestCase):
 
         res = self.app.get('/releases/', headers={'Accept': 'text/html'})
 
-        self.assertEquals(res.content_type, 'text/html')
+        self.assertEqual(res.content_type, 'text/html')
         self.assertIn('Fedora 22', res)
         self.assertIn('Fedora 42', res)

--- a/bodhi/tests/server/services/test_updates.py
+++ b/bodhi/tests/server/services/test_updates.py
@@ -87,8 +87,8 @@ class TestNewUpdate(BaseTestCase):
     @mock.patch(**mock_valid_requirements)
     def test_empty_build_name(self, *args):
         res = self.app.post_json('/updates/', self.get_update([u'']), status=400)
-        self.assertEquals(res.json_body['errors'][0]['name'], 'builds.0')
-        self.assertEquals(res.json_body['errors'][0]['description'], 'Required')
+        self.assertEqual(res.json_body['errors'][0]['name'], 'builds.0')
+        self.assertEqual(res.json_body['errors'][0]['description'], 'Required')
 
     @mock.patch(**mock_valid_requirements)
     def test_fail_on_edit_with_empty_build_list(self, *args):
@@ -96,13 +96,13 @@ class TestNewUpdate(BaseTestCase):
         update['edited'] = update['builds']  # the update title..
         update['builds'] = []
         res = self.app.post_json('/updates/', update, status=400)
-        self.assertEquals(len(res.json_body['errors']), 2)
-        self.assertEquals(res.json_body['errors'][0]['name'], 'builds')
-        self.assertEquals(
+        self.assertEqual(len(res.json_body['errors']), 2)
+        self.assertEqual(res.json_body['errors'][0]['name'], 'builds')
+        self.assertEqual(
             res.json_body['errors'][0]['description'],
             'You may not specify an empty list of builds.')
-        self.assertEquals(res.json_body['errors'][1]['name'], 'builds')
-        self.assertEquals(
+        self.assertEqual(res.json_body['errors'][1]['name'], 'builds')
+        self.assertEqual(
             res.json_body['errors'][1]['description'],
             'ACL validation mechanism was unable to determine ACLs.')
 
@@ -116,8 +116,8 @@ class TestNewUpdate(BaseTestCase):
         update['notes'] = u'This is wünderfül'
         r = self.app.post_json('/updates/', update)
         up = r.json_body
-        self.assertEquals(up['title'], u'bodhi-2.0.0-2.fc17')
-        self.assertEquals(up['notes'], u'This is wünderfül')
+        self.assertEqual(up['title'], u'bodhi-2.0.0-2.fc17')
+        self.assertEqual(up['notes'], u'This is wünderfül')
         self.assertIsNotNone(up['date_submitted'])
         publish.assert_called_once_with(
             topic='update.request.testing', msg=mock.ANY)
@@ -178,7 +178,7 @@ class TestNewUpdate(BaseTestCase):
         }
         assert expected_error in res.json_body['errors'], \
             res.json_body['errors']
-        self.assertEquals(publish.call_args_list, [])
+        self.assertEqual(publish.call_args_list, [])
 
     @mock.patch(**mock_taskotron_results)
     @mock.patch(**mock_valid_requirements)
@@ -240,26 +240,26 @@ class TestNewUpdate(BaseTestCase):
     def test_new_rpm_update(self, publish, *args):
         r = self.app.post_json('/updates/', self.get_update('bodhi-2.0.0-2.fc17'))
         up = r.json_body
-        self.assertEquals(up['title'], u'bodhi-2.0.0-2.fc17')
-        self.assertEquals(up['status'], u'pending')
-        self.assertEquals(up['request'], u'testing')
-        self.assertEquals(up['user']['name'], u'guest')
-        self.assertEquals(up['release']['name'], u'F17')
-        self.assertEquals(up['type'], u'bugfix')
-        self.assertEquals(up['content_type'], u'rpm')
-        self.assertEquals(up['severity'], u'unspecified')
-        self.assertEquals(up['suggest'], u'unspecified')
-        self.assertEquals(up['close_bugs'], True)
+        self.assertEqual(up['title'], u'bodhi-2.0.0-2.fc17')
+        self.assertEqual(up['status'], u'pending')
+        self.assertEqual(up['request'], u'testing')
+        self.assertEqual(up['user']['name'], u'guest')
+        self.assertEqual(up['release']['name'], u'F17')
+        self.assertEqual(up['type'], u'bugfix')
+        self.assertEqual(up['content_type'], u'rpm')
+        self.assertEqual(up['severity'], u'unspecified')
+        self.assertEqual(up['suggest'], u'unspecified')
+        self.assertEqual(up['close_bugs'], True)
         # The notes are inheriting notes from the update that this update obsoleted.
-        self.assertEquals(up['notes'], u'this is a test update\n\n----\n\nUseful details!')
+        self.assertEqual(up['notes'], u'this is a test update\n\n----\n\nUseful details!')
         self.assertIsNotNone(up['date_submitted'])
-        self.assertEquals(up['date_modified'], None)
-        self.assertEquals(up['date_approved'], None)
-        self.assertEquals(up['date_pushed'], None)
-        self.assertEquals(up['locked'], False)
-        self.assertEquals(up['alias'], u'FEDORA-%s-033713b73b' % YEAR)
-        self.assertEquals(up['karma'], 0)
-        self.assertEquals(up['requirements'], 'rpmlint')
+        self.assertEqual(up['date_modified'], None)
+        self.assertEqual(up['date_approved'], None)
+        self.assertEqual(up['date_pushed'], None)
+        self.assertEqual(up['locked'], False)
+        self.assertEqual(up['alias'], u'FEDORA-%s-033713b73b' % YEAR)
+        self.assertEqual(up['karma'], 0)
+        self.assertEqual(up['requirements'], 'rpmlint')
         publish.assert_called_once_with(
             topic='update.request.testing', msg=mock.ANY)
 
@@ -274,9 +274,9 @@ class TestNewUpdate(BaseTestCase):
                                    status=400)
             up = r.json_body
 
-        self.assertEquals(up['status'], 'error')
-        self.assertEquals(up['errors'][0]['description'],
-                          "Build does not exist: bodhi-2.0.0-2.fc17")
+        self.assertEqual(up['status'], 'error')
+        self.assertEqual(up['errors'][0]['description'],
+                         "Build does not exist: bodhi-2.0.0-2.fc17")
 
     @mock.patch.dict('bodhi.server.validators.config', {'acl_system': u'dummy'})
     @mock.patch(**mock_uuid4_version1)
@@ -289,9 +289,9 @@ class TestNewUpdate(BaseTestCase):
                                    status=400)
             up = r.json_body
 
-        self.assertEquals(up['status'], 'error')
-        self.assertEquals(up['errors'][0]['description'],
-                          "Koji error getting build: bodhi-2.0.0-2.fc17")
+        self.assertEqual(up['status'], 'error')
+        self.assertEqual(up['errors'][0]['description'],
+                         "Koji error getting build: bodhi-2.0.0-2.fc17")
 
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
@@ -345,7 +345,7 @@ class TestNewUpdate(BaseTestCase):
     @mock.patch('bodhi.server.notifications.publish')
     def test_new_module_update(self, publish, *args):
         # Ensure there are no module packages in the DB to begin with.
-        self.assertEquals(self.db.query(ModulePackage).count(), 0)
+        self.assertEqual(self.db.query(ModulePackage).count(), 0)
         self.create_release(u'27M')
         # Then, create an update for one.
         data = self.get_update('nginx-master-20170523')
@@ -353,30 +353,30 @@ class TestNewUpdate(BaseTestCase):
         r = self.app.post_json('/updates/', data)
 
         up = r.json_body
-        self.assertEquals(up['title'], u'nginx-master-20170523')
-        self.assertEquals(up['status'], u'pending')
-        self.assertEquals(up['request'], u'testing')
-        self.assertEquals(up['user']['name'], u'guest')
-        self.assertEquals(up['release']['name'], u'F27M')
-        self.assertEquals(up['type'], u'bugfix')
-        self.assertEquals(up['content_type'], u'module')
-        self.assertEquals(up['severity'], u'unspecified')
-        self.assertEquals(up['suggest'], u'unspecified')
-        self.assertEquals(up['close_bugs'], True)
-        self.assertEquals(up['notes'], u'this is a test update')
+        self.assertEqual(up['title'], u'nginx-master-20170523')
+        self.assertEqual(up['status'], u'pending')
+        self.assertEqual(up['request'], u'testing')
+        self.assertEqual(up['user']['name'], u'guest')
+        self.assertEqual(up['release']['name'], u'F27M')
+        self.assertEqual(up['type'], u'bugfix')
+        self.assertEqual(up['content_type'], u'module')
+        self.assertEqual(up['severity'], u'unspecified')
+        self.assertEqual(up['suggest'], u'unspecified')
+        self.assertEqual(up['close_bugs'], True)
+        self.assertEqual(up['notes'], u'this is a test update')
         self.assertIsNotNone(up['date_submitted'])
-        self.assertEquals(up['date_modified'], None)
-        self.assertEquals(up['date_approved'], None)
-        self.assertEquals(up['date_pushed'], None)
-        self.assertEquals(up['locked'], False)
-        self.assertEquals(up['alias'], u'FEDORA-%s-033713b73b' % YEAR)
-        self.assertEquals(up['karma'], 0)
-        self.assertEquals(up['requirements'], 'rpmlint')
+        self.assertEqual(up['date_modified'], None)
+        self.assertEqual(up['date_approved'], None)
+        self.assertEqual(up['date_pushed'], None)
+        self.assertEqual(up['locked'], False)
+        self.assertEqual(up['alias'], u'FEDORA-%s-033713b73b' % YEAR)
+        self.assertEqual(up['karma'], 0)
+        self.assertEqual(up['requirements'], 'rpmlint')
         publish.assert_called_once_with(
             topic='update.request.testing', msg=mock.ANY)
 
         # At the end, ensure that the right kind of package was created.
-        self.assertEquals(self.db.query(ModulePackage).count(), 1)
+        self.assertEqual(self.db.query(ModulePackage).count(), 1)
 
     @mock.patch(**mock_valid_requirements)
     def test_multiple_builds_of_same_module_stream(self, *args):
@@ -403,12 +403,12 @@ class TestNewUpdate(BaseTestCase):
         assert res['title'] == 'nodejs-6-20170101 nodejs-8-20170202'
 
         # At the end, ensure that the right kind of packages were created.
-        self.assertEquals(self.db.query(ModulePackage).count(), 2)
+        self.assertEqual(self.db.query(ModulePackage).count(), 2)
 
     @mock.patch(**mock_valid_requirements)
     def test_multiple_updates_single_module_steam(self, *args):
         # Ensure there are no module packages in the DB to begin with.
-        self.assertEquals(self.db.query(ModulePackage).count(), 0)
+        self.assertEqual(self.db.query(ModulePackage).count(), 0)
         self.create_release(u'27M')
 
         # First create an update for nodejs:6
@@ -418,7 +418,7 @@ class TestNewUpdate(BaseTestCase):
         self.app.post_json('/updates/', self.get_update(u'nodejs-6-20170202'))
 
         # At the end, ensure that the right kind of package was created.
-        self.assertEquals(self.db.query(ModulePackage).count(), 1)
+        self.assertEqual(self.db.query(ModulePackage).count(), 1)
         pkg = self.db.query(ModulePackage).one()
         assert pkg.name == 'nodejs:6'
 
@@ -442,25 +442,25 @@ class TestNewUpdate(BaseTestCase):
         r = self.app.post_json('/updates/', data, status=200)
 
         up = r.json_body
-        self.assertEquals(up['title'], u'mariadb-10.1-10.f28container')
-        self.assertEquals(up['status'], u'pending')
-        self.assertEquals(up['request'], u'testing')
-        self.assertEquals(up['user']['name'], u'guest')
-        self.assertEquals(up['release']['name'], u'F28C')
-        self.assertEquals(up['type'], u'bugfix')
-        self.assertEquals(up['content_type'], u'container')
-        self.assertEquals(up['severity'], u'unspecified')
-        self.assertEquals(up['suggest'], u'unspecified')
-        self.assertEquals(up['close_bugs'], True)
-        self.assertEquals(up['notes'], u'this is a test update')
+        self.assertEqual(up['title'], u'mariadb-10.1-10.f28container')
+        self.assertEqual(up['status'], u'pending')
+        self.assertEqual(up['request'], u'testing')
+        self.assertEqual(up['user']['name'], u'guest')
+        self.assertEqual(up['release']['name'], u'F28C')
+        self.assertEqual(up['type'], u'bugfix')
+        self.assertEqual(up['content_type'], u'container')
+        self.assertEqual(up['severity'], u'unspecified')
+        self.assertEqual(up['suggest'], u'unspecified')
+        self.assertEqual(up['close_bugs'], True)
+        self.assertEqual(up['notes'], u'this is a test update')
         self.assertIsNotNone(up['date_submitted'])
-        self.assertEquals(up['date_modified'], None)
-        self.assertEquals(up['date_approved'], None)
-        self.assertEquals(up['date_pushed'], None)
-        self.assertEquals(up['locked'], False)
-        self.assertEquals(up['alias'], u'FEDORA-%s-033713b73b' % YEAR)
-        self.assertEquals(up['karma'], 0)
-        self.assertEquals(up['requirements'], 'rpmlint')
+        self.assertEqual(up['date_modified'], None)
+        self.assertEqual(up['date_approved'], None)
+        self.assertEqual(up['date_pushed'], None)
+        self.assertEqual(up['locked'], False)
+        self.assertEqual(up['alias'], u'FEDORA-%s-033713b73b' % YEAR)
+        self.assertEqual(up['karma'], 0)
+        self.assertEqual(up['requirements'], 'rpmlint')
         publish.assert_called_once_with(
             topic='update.request.testing', msg=mock.ANY)
 
@@ -473,10 +473,10 @@ class TestNewUpdate(BaseTestCase):
         r = self.app.post_json('/updates/', update)
         up = r.json_body
         # This Update inherits one bug from the Update it obsoleted.
-        self.assertEquals(len(up['bugs']), 3)
-        self.assertEquals(up['bugs'][0]['bug_id'], 1234)
-        self.assertEquals(up['bugs'][1]['bug_id'], 5678)
-        self.assertEquals(up['bugs'][2]['bug_id'], 12345)
+        self.assertEqual(len(up['bugs']), 3)
+        self.assertEqual(up['bugs'][0]['bug_id'], 1234)
+        self.assertEqual(up['bugs'][1]['bug_id'], 5678)
+        self.assertEqual(up['bugs'][2]['bug_id'], 12345)
 
     @mock.patch.dict('bodhi.server.validators.config', {'acl_system': u'dummy'})
     @mock.patch(**mock_valid_requirements)
@@ -487,10 +487,10 @@ class TestNewUpdate(BaseTestCase):
         r = self.app.post_json('/updates/', update)
         up = r.json_body
         # This Update inherits one bug from the Update it obsoleted.
-        self.assertEquals(len(up['bugs']), 3)
-        self.assertEquals(up['bugs'][0]['bug_id'], 1234)
-        self.assertEquals(up['bugs'][1]['bug_id'], 5678)
-        self.assertEquals(up['bugs'][2]['bug_id'], 12345)
+        self.assertEqual(len(up['bugs']), 3)
+        self.assertEqual(up['bugs'][0]['bug_id'], 1234)
+        self.assertEqual(up['bugs'][1]['bug_id'], 5678)
+        self.assertEqual(up['bugs'][2]['bug_id'], 12345)
 
     @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch.dict('bodhi.server.validators.config', {'acl_system': u'dummy'})
@@ -501,9 +501,9 @@ class TestNewUpdate(BaseTestCase):
         update['bugs'] = '1234, blargh'
         r = self.app.post_json('/updates/', update, status=400)
         up = r.json_body
-        self.assertEquals(up['status'], 'error')
-        self.assertEquals(up['errors'][0]['description'],
-                          "Invalid bug ID specified: [u'1234', u'blargh']")
+        self.assertEqual(up['status'], 'error')
+        self.assertEqual(up['errors'][0]['description'],
+                         "Invalid bug ID specified: [u'1234', u'blargh']")
 
     @mock.patch.dict('bodhi.server.validators.config', {'acl_system': u'dummy'})
     @mock.patch(**mock_valid_requirements)
@@ -558,7 +558,7 @@ class TestNewUpdate(BaseTestCase):
         del args['requirements']
         r = self.app.post_json('/updates/', args)
         up = r.json_body
-        self.assertEquals(up['title'], u'bodhi-2.0.0-3.fc17')
+        self.assertEqual(up['title'], u'bodhi-2.0.0-3.fc17')
         self.assertTrue('upgradepath' in up['requirements'])
         self.assertTrue('rpmlint' in up['requirements'])
         publish.assert_called_once_with(
@@ -575,7 +575,7 @@ class TestNewUpdate(BaseTestCase):
         args['request'] = 'stable'
         up = self.app.post_json('/updates/', args).json_body
         self.assertTrue(up['critpath'])
-        self.assertEquals(up['request'], 'testing')
+        self.assertEqual(up['request'], 'testing')
         publish.assert_called_once_with(
             topic='update.request.testing', msg=mock.ANY)
 
@@ -597,12 +597,12 @@ class TestNewUpdate(BaseTestCase):
         args = self.get_update('bodhi-2.0.0-3.fc17')
         with mock.patch(**mock_uuid4_version2):
             r = self.app.post_json('/updates/', args).json_body
-        self.assertEquals(r['request'], 'testing')
+        self.assertEqual(r['request'], 'testing')
 
         # Since we're obsoleting something owned by someone else.
-        self.assertEquals(r['caveats'][0]['description'],
-                          'This update has obsoleted bodhi-2.0.0-2.fc17, '
-                          'and has inherited its bugs and notes.')
+        self.assertEqual(r['caveats'][0]['description'],
+                         'This update has obsoleted bodhi-2.0.0-2.fc17, '
+                         'and has inherited its bugs and notes.')
 
         # Check for the comment multiple ways
         # Note that caveats above don't support markdown, but comments do.
@@ -612,17 +612,17 @@ class TestNewUpdate(BaseTestCase):
         expected_comment = expected_comment.format(
             urlparse.urljoin(config['base_address'],
                              '/updates/FEDORA-{}-033713b73b'.format(datetime.now().year)))
-        self.assertEquals(r['comments'][-1]['text'], expected_comment)
+        self.assertEqual(r['comments'][-1]['text'], expected_comment)
         publish.assert_called_with(
             topic='update.request.testing', msg=mock.ANY)
 
         up = self.db.query(Update).filter_by(title=nvr).one()
-        self.assertEquals(up.status, UpdateStatus.obsolete)
+        self.assertEqual(up.status, UpdateStatus.obsolete)
         expected_comment = u'This update has been obsoleted by [bodhi-2.0.0-3.fc17]({}).'
         expected_comment = expected_comment.format(
             urlparse.urljoin(config['base_address'],
                              '/updates/FEDORA-{}-53345602d5'.format(datetime.now().year)))
-        self.assertEquals(up.comments[-1].text, expected_comment)
+        self.assertEqual(up.comments[-1].text, expected_comment)
 
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
@@ -633,9 +633,9 @@ class TestNewUpdate(BaseTestCase):
 
         r = self.app.post_json('/updates/', update, status=400)
 
-        self.assertEquals(r.json_body['status'], 'error')
-        self.assertEquals(r.json_body['errors'][0]['description'],
-                          "Unable to create update.  oops!")
+        self.assertEqual(r.json_body['status'], 'error')
+        self.assertEqual(r.json_body['errors'][0]['description'],
+                         "Unable to create update.  oops!")
         # Despite the Exception, the RpmBuild should still exist in the database
         build = self.db.query(RpmBuild).filter(RpmBuild.nvr == u'bodhi-2.3.2-1.fc17').one()
         self.assertEqual(build.package.name, 'bodhi')
@@ -659,22 +659,22 @@ class TestNewUpdate(BaseTestCase):
         with mock.patch(**mock_uuid4_version2):
             r = self.app.post_json('/updates/', args).json_body
 
-        self.assertEquals(r['request'], 'testing')
+        self.assertEqual(r['request'], 'testing')
         # The exception handler should have put an error message in the caveats.
-        self.assertEquals(r['caveats'][0]['description'],
-                          "Problem obsoleting older updates: bet you didn't see this coming!")
+        self.assertEqual(r['caveats'][0]['description'],
+                         "Problem obsoleting older updates: bet you didn't see this coming!")
         # Check for the comment multiple ways. The comment will be about the update being submitted
         # for testing instead of being about the obsoletion, since the obsoletion failed.
         # Note that caveats above don't support markdown, but comments do.
         expected_comment = 'This update has been submitted for testing by guest. '
         expected_comment = expected_comment.format(
             urlparse.urljoin(config['base_address'], '/updates/FEDORA-2016-033713b73b'))
-        self.assertEquals(r['comments'][-1]['text'], expected_comment)
+        self.assertEqual(r['comments'][-1]['text'], expected_comment)
         up = self.db.query(Update).filter_by(title=nvr).one()
         # The old update failed to get obsoleted.
-        self.assertEquals(up.status, UpdateStatus.testing)
+        self.assertEqual(up.status, UpdateStatus.testing)
         expected_comment = u'This update has been submitted for testing by guest. '
-        self.assertEquals(up.comments[-1].text, expected_comment)
+        self.assertEqual(up.comments[-1].text, expected_comment)
 
 
 class TestSetRequest(BaseTestCase):
@@ -693,9 +693,9 @@ class TestSetRequest(BaseTestCase):
                          csrf_token=self.app.get('/csrf').json_body['csrf_token'])
         res = self.app.post_json('/updates/%s/request' % str(nvr), post_data, status=400)
 
-        self.assertEquals(res.json_body['status'], 'error')
-        self.assertEquals(res.json_body[u'errors'][0][u'description'],
-                          "Can't change request on a locked update")
+        self.assertEqual(res.json_body['status'], 'error')
+        self.assertEqual(res.json_body[u'errors'][0][u'description'],
+                         "Can't change request on a locked update")
 
     @mock.patch(**mock_valid_requirements)
     def test_set_request_archived_release(self, *args):
@@ -710,9 +710,9 @@ class TestSetRequest(BaseTestCase):
                          csrf_token=self.app.get('/csrf').json_body['csrf_token'])
         res = self.app.post_json('/updates/%s/request' % str(nvr), post_data, status=400)
 
-        self.assertEquals(res.json_body['status'], 'error')
-        self.assertEquals(res.json_body[u'errors'][0][u'description'],
-                          "Can't change request for an archived release")
+        self.assertEqual(res.json_body['status'], 'error')
+        self.assertEqual(res.json_body[u'errors'][0][u'description'],
+                         "Can't change request for an archived release")
 
     @mock.patch.dict(config, {'test_gating.required': True})
     def test_test_gating_status_failed(self):
@@ -730,9 +730,9 @@ class TestSetRequest(BaseTestCase):
 
         up = self.db.query(Update).filter_by(title=nvr).one()
         self.assertEqual(up.request, None)
-        self.assertEquals(res.json_body['status'], 'error')
-        self.assertEquals(res.json_body[u'errors'][0][u'description'],
-                          "Requirement not met Required tests did not pass on this update")
+        self.assertEqual(res.json_body['status'], 'error')
+        self.assertEqual(res.json_body[u'errors'][0][u'description'],
+                         "Requirement not met Required tests did not pass on this update")
 
     @mock.patch.dict(config, {'test_gating.required': True})
     def test_test_gating_status_passed(self):
@@ -769,9 +769,9 @@ class TestSetRequest(BaseTestCase):
                          csrf_token=self.app.get('/csrf').json_body['csrf_token'])
         res = self.app.post_json('/updates/%s/request' % str(nvr), post_data, status=400)
 
-        self.assertEquals(res.json_body['status'], 'error')
-        self.assertEquals(res.json_body['errors'][0]['description'],
-                          u'IOError. oops!')
+        self.assertEqual(res.json_body['status'], 'error')
+        self.assertEqual(res.json_body['errors'][0]['description'],
+                         u'IOError. oops!')
         log_exception.assert_called_once_with("Unhandled exception in set_request")
 
 
@@ -1004,7 +1004,7 @@ class TestUpdatesService(BaseTestCase):
         assert 'bodhi does not have commit access to bodhi' not in res, res
         build = self.db.query(RpmBuild).filter_by(nvr=nvr).one()
         assert build.update is not None
-        self.assertEquals(build.update.notes, u'testing!!!')
+        self.assertEqual(build.update.notes, u'testing!!!')
 
     @mock.patch(**mock_taskotron_results)
     @mock.patch(**mock_valid_requirements)
@@ -1367,14 +1367,14 @@ class TestUpdatesService(BaseTestCase):
         url = '/updates/%s/%s' % (update['alias'], update['title'])
         res = self.app.get(url, status=302)
         target = 'http://localhost/updates/%s' % update['alias']
-        self.assertEquals(res.headers['Location'], target)
+        self.assertEqual(res.headers['Location'], target)
 
     def test_404(self):
         self.app.get('/a', status=404)
 
     def test_get_single_update(self):
         res = self.app.get('/updates/bodhi-2.0-1.fc17', headers={'Accept': 'application/json'})
-        self.assertEquals(res.json_body['update']['title'], 'bodhi-2.0-1.fc17')
+        self.assertEqual(res.json_body['update']['title'], 'bodhi-2.0-1.fc17')
         self.assertIn('application/json', res.headers['Content-Type'])
 
     def test_get_single_update_jsonp(self):
@@ -1426,31 +1426,31 @@ class TestUpdatesService(BaseTestCase):
     def test_list_updates(self):
         res = self.app.get('/updates/')
         body = res.json_body
-        self.assertEquals(len(body['updates']), 1)
+        self.assertEqual(len(body['updates']), 1)
 
         alias = u'FEDORA-%s-a3bbe1a8f2' % YEAR
 
         up = body['updates'][0]
-        self.assertEquals(up['title'], u'bodhi-2.0-1.fc17')
-        self.assertEquals(up['status'], u'pending')
-        self.assertEquals(up['request'], u'testing')
-        self.assertEquals(up['user']['name'], u'guest')
-        self.assertEquals(up['submitter'], u'guest')
-        self.assertEquals(up['release']['name'], u'F17')
-        self.assertEquals(up['type'], u'bugfix')
-        self.assertEquals(up['content_type'], u'rpm')
-        self.assertEquals(up['severity'], u'medium')
-        self.assertEquals(up['suggest'], u'unspecified')
-        self.assertEquals(up['close_bugs'], True)
-        self.assertEquals(up['notes'], u'Useful details!')
-        self.assertEquals(up['date_submitted'], u'1984-11-02 00:00:00')
-        self.assertEquals(up['date_modified'], None)
-        self.assertEquals(up['date_pushed'], None)
-        self.assertEquals(up['locked'], False)
-        self.assertEquals(up['alias'], alias)
-        self.assertEquals(up['karma'], 1)
-        self.assertEquals(up['url'],
-                          (urlparse.urljoin(config['base_address'], '/updates/%s' % alias)))
+        self.assertEqual(up['title'], u'bodhi-2.0-1.fc17')
+        self.assertEqual(up['status'], u'pending')
+        self.assertEqual(up['request'], u'testing')
+        self.assertEqual(up['user']['name'], u'guest')
+        self.assertEqual(up['submitter'], u'guest')
+        self.assertEqual(up['release']['name'], u'F17')
+        self.assertEqual(up['type'], u'bugfix')
+        self.assertEqual(up['content_type'], u'rpm')
+        self.assertEqual(up['severity'], u'medium')
+        self.assertEqual(up['suggest'], u'unspecified')
+        self.assertEqual(up['close_bugs'], True)
+        self.assertEqual(up['notes'], u'Useful details!')
+        self.assertEqual(up['date_submitted'], u'1984-11-02 00:00:00')
+        self.assertEqual(up['date_modified'], None)
+        self.assertEqual(up['date_pushed'], None)
+        self.assertEqual(up['locked'], False)
+        self.assertEqual(up['alias'], alias)
+        self.assertEqual(up['karma'], 1)
+        self.assertEqual(up['url'],
+                         (urlparse.urljoin(config['base_address'], '/updates/%s' % alias)))
 
     def test_list_updates_jsonp(self):
         res = self.app.get('/updates/',
@@ -1493,14 +1493,14 @@ class TestUpdatesService(BaseTestCase):
     def test_updates_like(self):
         res = self.app.get('/updates/', {'like': 'odh'})
         body = res.json_body
-        self.assertEquals(len(body['updates']), 1)
+        self.assertEqual(len(body['updates']), 1)
 
         up = body['updates'][0]
-        self.assertEquals(up['title'], u'bodhi-2.0-1.fc17')
+        self.assertEqual(up['title'], u'bodhi-2.0-1.fc17')
 
         res = self.app.get('/updates/', {'like': 'wat'})
         body = res.json_body
-        self.assertEquals(len(body['updates']), 0)
+        self.assertEqual(len(body['updates']), 0)
 
     def test_updates_search(self):
         """
@@ -1510,50 +1510,50 @@ class TestUpdatesService(BaseTestCase):
         # test that the search works
         res = self.app.get('/updates/', {'search': 'bodh'})
         body = res.json_body
-        self.assertEquals(len(body['updates']), 1)
+        self.assertEqual(len(body['updates']), 1)
         up = body['updates'][0]
-        self.assertEquals(up['title'], u'bodhi-2.0-1.fc17')
+        self.assertEqual(up['title'], u'bodhi-2.0-1.fc17')
 
         # test that the search is case insensitive
         res = self.app.get('/updates/', {'search': 'Bodh'})
         body = res.json_body
-        self.assertEquals(len(body['updates']), 1)
+        self.assertEqual(len(body['updates']), 1)
         up = body['updates'][0]
-        self.assertEquals(up['title'], u'bodhi-2.0-1.fc17')
+        self.assertEqual(up['title'], u'bodhi-2.0-1.fc17')
 
         # test a search that yields nothing
         res = self.app.get('/updates/', {'search': 'wat'})
         body = res.json_body
-        self.assertEquals(len(body['updates']), 0)
+        self.assertEqual(len(body['updates']), 0)
 
         # test a search for an alias
         res = self.app.get(
             '/updates/', {'search': 'FEDORA-{}-a3bbe1a8f2'.format(datetime.utcnow().year)})
         body = res.json_body
-        self.assertEquals(len(body['updates']), 1)
+        self.assertEqual(len(body['updates']), 1)
         up = body['updates'][0]
-        self.assertEquals(up['title'], u'bodhi-2.0-1.fc17')
+        self.assertEqual(up['title'], u'bodhi-2.0-1.fc17')
 
         # test that the search works for leading space
         res = self.app.get('/updates/', {'search': ' bodh'})
         body = res.json_body
-        self.assertEquals(len(body['updates']), 1)
+        self.assertEqual(len(body['updates']), 1)
         up = body['updates'][0]
-        self.assertEquals(up['title'], u'bodhi-2.0-1.fc17')
+        self.assertEqual(up['title'], u'bodhi-2.0-1.fc17')
 
         # test that the search works for trailing space
         res = self.app.get('/updates/', {'search': 'bodh '})
         body = res.json_body
-        self.assertEquals(len(body['updates']), 1)
+        self.assertEqual(len(body['updates']), 1)
         up = body['updates'][0]
-        self.assertEquals(up['title'], u'bodhi-2.0-1.fc17')
+        self.assertEqual(up['title'], u'bodhi-2.0-1.fc17')
 
         # test that the search works for both leading and trailing space
         res = self.app.get('/updates/', {'search': ' bodh '})
         body = res.json_body
-        self.assertEquals(len(body['updates']), 1)
+        self.assertEqual(len(body['updates']), 1)
         up = body['updates'][0]
-        self.assertEquals(up['title'], u'bodhi-2.0-1.fc17')
+        self.assertEqual(up['title'], u'bodhi-2.0-1.fc17')
 
     @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     @mock.patch(**mock_valid_requirements)
@@ -1566,13 +1566,13 @@ class TestUpdatesService(BaseTestCase):
         res = self.app.get('/updates/',
                            {"rows_per_page": 1})
         body = res.json_body
-        self.assertEquals(len(body['updates']), 1)
+        self.assertEqual(len(body['updates']), 1)
         update1 = body['updates'][0]
 
         res = self.app.get('/updates/',
                            {"rows_per_page": 1, "page": 2})
         body = res.json_body
-        self.assertEquals(len(body['updates']), 1)
+        self.assertEqual(len(body['updates']), 1)
         update2 = body['updates'][0]
 
         self.assertNotEquals(update1, update2)
@@ -1584,7 +1584,7 @@ class TestUpdatesService(BaseTestCase):
         res = self.app.get('/updates/',
                            {"approved_since": now.strftime("%Y-%m-%d")})
         body = res.json_body
-        self.assertEquals(len(body['updates']), 0)
+        self.assertEqual(len(body['updates']), 0)
 
         # Now approve one
         self.db.query(Update).first().date_approved = now
@@ -1594,41 +1594,41 @@ class TestUpdatesService(BaseTestCase):
         res = self.app.get('/updates/',
                            {"approved_since": now.strftime("%Y-%m-%d")})
         body = res.json_body
-        self.assertEquals(len(body['updates']), 1)
+        self.assertEqual(len(body['updates']), 1)
 
         up = body['updates'][0]
-        self.assertEquals(up['title'], u'bodhi-2.0-1.fc17')
-        self.assertEquals(up['status'], u'pending')
-        self.assertEquals(up['request'], u'testing')
-        self.assertEquals(up['user']['name'], u'guest')
-        self.assertEquals(up['release']['name'], u'F17')
-        self.assertEquals(up['type'], u'bugfix')
-        self.assertEquals(up['content_type'], u'rpm')
-        self.assertEquals(up['severity'], u'medium')
-        self.assertEquals(up['suggest'], u'unspecified')
-        self.assertEquals(up['close_bugs'], True)
-        self.assertEquals(up['notes'], u'Useful details!')
-        self.assertEquals(up['date_submitted'], u'1984-11-02 00:00:00')
-        self.assertEquals(up['date_approved'], now.strftime("%Y-%m-%d %H:%M:%S"))
-        self.assertEquals(up['date_pushed'], None)
-        self.assertEquals(up['locked'], False)
-        self.assertEquals(up['alias'], u'FEDORA-%s-a3bbe1a8f2' % YEAR)
-        self.assertEquals(up['karma'], 1)
-        self.assertEquals(len(up['bugs']), 1)
-        self.assertEquals(up['bugs'][0]['bug_id'], 12345)
+        self.assertEqual(up['title'], u'bodhi-2.0-1.fc17')
+        self.assertEqual(up['status'], u'pending')
+        self.assertEqual(up['request'], u'testing')
+        self.assertEqual(up['user']['name'], u'guest')
+        self.assertEqual(up['release']['name'], u'F17')
+        self.assertEqual(up['type'], u'bugfix')
+        self.assertEqual(up['content_type'], u'rpm')
+        self.assertEqual(up['severity'], u'medium')
+        self.assertEqual(up['suggest'], u'unspecified')
+        self.assertEqual(up['close_bugs'], True)
+        self.assertEqual(up['notes'], u'Useful details!')
+        self.assertEqual(up['date_submitted'], u'1984-11-02 00:00:00')
+        self.assertEqual(up['date_approved'], now.strftime("%Y-%m-%d %H:%M:%S"))
+        self.assertEqual(up['date_pushed'], None)
+        self.assertEqual(up['locked'], False)
+        self.assertEqual(up['alias'], u'FEDORA-%s-a3bbe1a8f2' % YEAR)
+        self.assertEqual(up['karma'], 1)
+        self.assertEqual(len(up['bugs']), 1)
+        self.assertEqual(up['bugs'][0]['bug_id'], 12345)
 
         # https://github.com/fedora-infra/bodhi/issues/270
-        self.assertEquals(len(up['test_cases']), 1)
-        self.assertEquals(up['test_cases'][0]['name'], u'Wat')
+        self.assertEqual(len(up['test_cases']), 1)
+        self.assertEqual(up['test_cases'][0]['name'], u'Wat')
 
     def test_list_updates_by_invalid_approved_since(self):
         res = self.app.get('/updates/', {"approved_since": "forever"},
                            status=400)
         body = res.json_body
-        self.assertEquals(len(body.get('updates', [])), 0)
-        self.assertEquals(res.json_body['errors'][0]['name'], 'approved_since')
-        self.assertEquals(res.json_body['errors'][0]['description'],
-                          'Invalid date')
+        self.assertEqual(len(body.get('updates', [])), 0)
+        self.assertEqual(res.json_body['errors'][0]['name'], 'approved_since')
+        self.assertEqual(res.json_body['errors'][0]['description'],
+                         'Invalid date')
 
     def test_list_updates_by_approved_before(self):
         # Approve an update
@@ -1640,7 +1640,7 @@ class TestUpdatesService(BaseTestCase):
         res = self.app.get('/updates/',
                            {"approved_before": "1984-11-01"})
         body = res.json_body
-        self.assertEquals(len(body['updates']), 0)
+        self.assertEqual(len(body['updates']), 0)
 
         # Now check we get the update if we use tomorrow
         tomorrow = datetime.utcnow() + timedelta(days=1)
@@ -1648,157 +1648,157 @@ class TestUpdatesService(BaseTestCase):
 
         res = self.app.get('/updates/', {"approved_before": tomorrow})
         body = res.json_body
-        self.assertEquals(len(body['updates']), 1)
+        self.assertEqual(len(body['updates']), 1)
 
         up = body['updates'][0]
-        self.assertEquals(up['title'], u'bodhi-2.0-1.fc17')
-        self.assertEquals(up['status'], u'pending')
-        self.assertEquals(up['request'], u'testing')
-        self.assertEquals(up['user']['name'], u'guest')
-        self.assertEquals(up['release']['name'], u'F17')
-        self.assertEquals(up['type'], u'bugfix')
-        self.assertEquals(up['content_type'], u'rpm')
-        self.assertEquals(up['severity'], u'medium')
-        self.assertEquals(up['suggest'], u'unspecified')
-        self.assertEquals(up['close_bugs'], True)
-        self.assertEquals(up['notes'], u'Useful details!')
-        self.assertEquals(up['date_submitted'], u'1984-11-02 00:00:00')
-        self.assertEquals(up['date_approved'], now.strftime("%Y-%m-%d %H:%M:%S"))
-        self.assertEquals(up['date_pushed'], None)
-        self.assertEquals(up['locked'], False)
-        self.assertEquals(up['alias'], u'FEDORA-%s-a3bbe1a8f2' % YEAR)
-        self.assertEquals(up['karma'], 1)
-        self.assertEquals(len(up['bugs']), 1)
-        self.assertEquals(up['bugs'][0]['bug_id'], 12345)
+        self.assertEqual(up['title'], u'bodhi-2.0-1.fc17')
+        self.assertEqual(up['status'], u'pending')
+        self.assertEqual(up['request'], u'testing')
+        self.assertEqual(up['user']['name'], u'guest')
+        self.assertEqual(up['release']['name'], u'F17')
+        self.assertEqual(up['type'], u'bugfix')
+        self.assertEqual(up['content_type'], u'rpm')
+        self.assertEqual(up['severity'], u'medium')
+        self.assertEqual(up['suggest'], u'unspecified')
+        self.assertEqual(up['close_bugs'], True)
+        self.assertEqual(up['notes'], u'Useful details!')
+        self.assertEqual(up['date_submitted'], u'1984-11-02 00:00:00')
+        self.assertEqual(up['date_approved'], now.strftime("%Y-%m-%d %H:%M:%S"))
+        self.assertEqual(up['date_pushed'], None)
+        self.assertEqual(up['locked'], False)
+        self.assertEqual(up['alias'], u'FEDORA-%s-a3bbe1a8f2' % YEAR)
+        self.assertEqual(up['karma'], 1)
+        self.assertEqual(len(up['bugs']), 1)
+        self.assertEqual(up['bugs'][0]['bug_id'], 12345)
 
     def test_list_updates_by_invalid_approved_before(self):
         res = self.app.get('/updates/', {"approved_before": "forever"},
                            status=400)
         body = res.json_body
-        self.assertEquals(len(body.get('updates', [])), 0)
-        self.assertEquals(res.json_body['errors'][0]['name'], 'approved_before')
-        self.assertEquals(res.json_body['errors'][0]['description'],
-                          'Invalid date')
+        self.assertEqual(len(body.get('updates', [])), 0)
+        self.assertEqual(res.json_body['errors'][0]['name'], 'approved_before')
+        self.assertEqual(res.json_body['errors'][0]['description'],
+                         'Invalid date')
 
     def test_list_updates_by_bugs(self):
         res = self.app.get('/updates/', {"bugs": '12345'})
         body = res.json_body
-        self.assertEquals(len(body['updates']), 1)
+        self.assertEqual(len(body['updates']), 1)
 
         up = body['updates'][0]
-        self.assertEquals(up['title'], u'bodhi-2.0-1.fc17')
-        self.assertEquals(up['status'], u'pending')
-        self.assertEquals(up['request'], u'testing')
-        self.assertEquals(up['user']['name'], u'guest')
-        self.assertEquals(up['release']['name'], u'F17')
-        self.assertEquals(up['type'], u'bugfix')
-        self.assertEquals(up['severity'], u'medium')
-        self.assertEquals(up['suggest'], u'unspecified')
-        self.assertEquals(up['close_bugs'], True)
-        self.assertEquals(up['notes'], u'Useful details!')
-        self.assertEquals(up['date_submitted'], u'1984-11-02 00:00:00')
-        self.assertEquals(up['date_modified'], None)
-        self.assertEquals(up['date_approved'], None)
-        self.assertEquals(up['date_pushed'], None)
-        self.assertEquals(up['locked'], False)
-        self.assertEquals(up['alias'], u'FEDORA-%s-a3bbe1a8f2' % YEAR)
-        self.assertEquals(up['karma'], 1)
-        self.assertEquals(len(up['bugs']), 1)
-        self.assertEquals(up['bugs'][0]['bug_id'], 12345)
+        self.assertEqual(up['title'], u'bodhi-2.0-1.fc17')
+        self.assertEqual(up['status'], u'pending')
+        self.assertEqual(up['request'], u'testing')
+        self.assertEqual(up['user']['name'], u'guest')
+        self.assertEqual(up['release']['name'], u'F17')
+        self.assertEqual(up['type'], u'bugfix')
+        self.assertEqual(up['severity'], u'medium')
+        self.assertEqual(up['suggest'], u'unspecified')
+        self.assertEqual(up['close_bugs'], True)
+        self.assertEqual(up['notes'], u'Useful details!')
+        self.assertEqual(up['date_submitted'], u'1984-11-02 00:00:00')
+        self.assertEqual(up['date_modified'], None)
+        self.assertEqual(up['date_approved'], None)
+        self.assertEqual(up['date_pushed'], None)
+        self.assertEqual(up['locked'], False)
+        self.assertEqual(up['alias'], u'FEDORA-%s-a3bbe1a8f2' % YEAR)
+        self.assertEqual(up['karma'], 1)
+        self.assertEqual(len(up['bugs']), 1)
+        self.assertEqual(up['bugs'][0]['bug_id'], 12345)
 
     @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_updates_by_invalid_bug(self):
         res = self.app.get('/updates/', {"bugs": "cockroaches"}, status=400)
         body = res.json_body
-        self.assertEquals(len(body.get('updates', [])), 0)
-        self.assertEquals(res.json_body['errors'][0]['name'], 'bugs')
-        self.assertEquals(res.json_body['errors'][0]['description'],
-                          "Invalid bug ID specified: [u'cockroaches']")
+        self.assertEqual(len(body.get('updates', [])), 0)
+        self.assertEqual(res.json_body['errors'][0]['name'], 'bugs')
+        self.assertEqual(res.json_body['errors'][0]['description'],
+                         "Invalid bug ID specified: [u'cockroaches']")
 
     def test_list_updates_by_unexisting_bug(self):
         res = self.app.get('/updates/', {"bugs": "19850110"})
         body = res.json_body
-        self.assertEquals(len(body['updates']), 0)
+        self.assertEqual(len(body['updates']), 0)
 
     def test_list_updates_by_critpath(self):
         res = self.app.get('/updates/', {"critpath": "false"})
         body = res.json_body
-        self.assertEquals(len(body['updates']), 1)
+        self.assertEqual(len(body['updates']), 1)
 
         up = body['updates'][0]
-        self.assertEquals(up['title'], u'bodhi-2.0-1.fc17')
-        self.assertEquals(up['status'], u'pending')
-        self.assertEquals(up['request'], u'testing')
-        self.assertEquals(up['user']['name'], u'guest')
-        self.assertEquals(up['release']['name'], u'F17')
-        self.assertEquals(up['type'], u'bugfix')
-        self.assertEquals(up['severity'], u'medium')
-        self.assertEquals(up['suggest'], u'unspecified')
-        self.assertEquals(up['close_bugs'], True)
-        self.assertEquals(up['notes'], u'Useful details!')
-        self.assertEquals(up['date_submitted'], u'1984-11-02 00:00:00')
-        self.assertEquals(up['date_modified'], None)
-        self.assertEquals(up['date_approved'], None)
-        self.assertEquals(up['date_pushed'], None)
-        self.assertEquals(up['locked'], False)
-        self.assertEquals(up['alias'], u'FEDORA-%s-a3bbe1a8f2' % YEAR)
-        self.assertEquals(up['karma'], 1)
+        self.assertEqual(up['title'], u'bodhi-2.0-1.fc17')
+        self.assertEqual(up['status'], u'pending')
+        self.assertEqual(up['request'], u'testing')
+        self.assertEqual(up['user']['name'], u'guest')
+        self.assertEqual(up['release']['name'], u'F17')
+        self.assertEqual(up['type'], u'bugfix')
+        self.assertEqual(up['severity'], u'medium')
+        self.assertEqual(up['suggest'], u'unspecified')
+        self.assertEqual(up['close_bugs'], True)
+        self.assertEqual(up['notes'], u'Useful details!')
+        self.assertEqual(up['date_submitted'], u'1984-11-02 00:00:00')
+        self.assertEqual(up['date_modified'], None)
+        self.assertEqual(up['date_approved'], None)
+        self.assertEqual(up['date_pushed'], None)
+        self.assertEqual(up['locked'], False)
+        self.assertEqual(up['alias'], u'FEDORA-%s-a3bbe1a8f2' % YEAR)
+        self.assertEqual(up['karma'], 1)
 
     def test_list_updates_by_invalid_critpath(self):
         res = self.app.get('/updates/', {"critpath": "lalala"},
                            status=400)
         body = res.json_body
-        self.assertEquals(len(body.get('updates', [])), 0)
-        self.assertEquals(res.json_body['errors'][0]['name'], 'critpath')
-        self.assertEquals(res.json_body['errors'][0]['description'],
-                          '"lalala" is neither in (\'false\', \'0\') nor in (\'true\', \'1\')')
+        self.assertEqual(len(body.get('updates', [])), 0)
+        self.assertEqual(res.json_body['errors'][0]['name'], 'critpath')
+        self.assertEqual(res.json_body['errors'][0]['description'],
+                         '"lalala" is neither in (\'false\', \'0\') nor in (\'true\', \'1\')')
 
     def test_list_updates_by_cves(self):
         res = self.app.get("/updates/", {"cves": "CVE-1985-0110"})
         body = res.json_body
-        self.assertEquals(len(body['updates']), 1)
+        self.assertEqual(len(body['updates']), 1)
 
         up = body['updates'][0]
-        self.assertEquals(up['title'], u'bodhi-2.0-1.fc17')
-        self.assertEquals(up['status'], u'pending')
-        self.assertEquals(up['request'], u'testing')
-        self.assertEquals(up['user']['name'], u'guest')
-        self.assertEquals(up['release']['name'], u'F17')
-        self.assertEquals(up['type'], u'bugfix')
-        self.assertEquals(up['severity'], u'medium')
-        self.assertEquals(up['suggest'], u'unspecified')
-        self.assertEquals(up['close_bugs'], True)
-        self.assertEquals(up['notes'], u'Useful details!')
-        self.assertEquals(up['date_submitted'], u'1984-11-02 00:00:00')
-        self.assertEquals(up['date_modified'], None)
-        self.assertEquals(up['date_approved'], None)
-        self.assertEquals(up['date_pushed'], None)
-        self.assertEquals(up['locked'], False)
-        self.assertEquals(up['alias'], u'FEDORA-%s-a3bbe1a8f2' % YEAR)
-        self.assertEquals(up['karma'], 1)
+        self.assertEqual(up['title'], u'bodhi-2.0-1.fc17')
+        self.assertEqual(up['status'], u'pending')
+        self.assertEqual(up['request'], u'testing')
+        self.assertEqual(up['user']['name'], u'guest')
+        self.assertEqual(up['release']['name'], u'F17')
+        self.assertEqual(up['type'], u'bugfix')
+        self.assertEqual(up['severity'], u'medium')
+        self.assertEqual(up['suggest'], u'unspecified')
+        self.assertEqual(up['close_bugs'], True)
+        self.assertEqual(up['notes'], u'Useful details!')
+        self.assertEqual(up['date_submitted'], u'1984-11-02 00:00:00')
+        self.assertEqual(up['date_modified'], None)
+        self.assertEqual(up['date_approved'], None)
+        self.assertEqual(up['date_pushed'], None)
+        self.assertEqual(up['locked'], False)
+        self.assertEqual(up['alias'], u'FEDORA-%s-a3bbe1a8f2' % YEAR)
+        self.assertEqual(up['karma'], 1)
 
     def test_list_updates_by_unexisting_cve(self):
         res = self.app.get('/updates/', {"cves": "CVE-2013-1015"})
         body = res.json_body
-        self.assertEquals(len(body['updates']), 0)
+        self.assertEqual(len(body['updates']), 0)
 
     def test_list_updates_by_invalid_cve(self):
         res = self.app.get('/updates/', {"cves": "WTF-ZOMG-BBQ"},
                            status=400)
         body = res.json_body
-        self.assertEquals(len(body.get('updates', [])), 0)
-        self.assertEquals(res.json_body['errors'][0]['name'], 'cves.0')
-        self.assertEquals(res.json_body['errors'][0]['description'],
-                          '"WTF-ZOMG-BBQ" is not a valid CVE id')
+        self.assertEqual(len(body.get('updates', [])), 0)
+        self.assertEqual(res.json_body['errors'][0]['name'], 'cves.0')
+        self.assertEqual(res.json_body['errors'][0]['description'],
+                         '"WTF-ZOMG-BBQ" is not a valid CVE id')
 
     def test_list_updates_by_date_submitted_invalid_date(self):
         """test filtering by submitted date with an invalid date"""
         res = self.app.get('/updates/', {"submitted_since": "11-01-1984"}, status=400)
         body = res.json_body
-        self.assertEquals(len(body.get('updates', [])), 0)
-        self.assertEquals(body['errors'][0]['name'], 'submitted_since')
-        self.assertEquals(body['errors'][0]['description'],
-                          'Invalid date')
+        self.assertEqual(len(body.get('updates', [])), 0)
+        self.assertEqual(body['errors'][0]['name'], 'submitted_since')
+        self.assertEqual(body['errors'][0]['description'],
+                         'Invalid date')
 
     def test_list_updates_by_date_submitted_future_date(self):
         """test filtering by submitted date with future date"""
@@ -1807,117 +1807,117 @@ class TestUpdatesService(BaseTestCase):
 
         res = self.app.get('/updates/', {"submitted_since": tomorrow})
         body = res.json_body
-        self.assertEquals(len(body['updates']), 0)
+        self.assertEqual(len(body['updates']), 0)
 
     def test_list_updates_by_date_submitted_valid(self):
         """test filtering by submitted date with valid data"""
         res = self.app.get('/updates/', {"submitted_since": "1984-11-01"})
         body = res.json_body
-        self.assertEquals(len(body['updates']), 1)
+        self.assertEqual(len(body['updates']), 1)
 
         up = body['updates'][0]
-        self.assertEquals(up['title'], u'bodhi-2.0-1.fc17')
-        self.assertEquals(up['status'], u'pending')
-        self.assertEquals(up['request'], u'testing')
-        self.assertEquals(up['user']['name'], u'guest')
-        self.assertEquals(up['release']['name'], u'F17')
-        self.assertEquals(up['type'], u'bugfix')
-        self.assertEquals(up['severity'], u'medium')
-        self.assertEquals(up['suggest'], u'unspecified')
-        self.assertEquals(up['close_bugs'], True)
-        self.assertEquals(up['notes'], u'Useful details!')
-        self.assertEquals(up['date_submitted'], u'1984-11-02 00:00:00')
-        self.assertEquals(up['date_modified'], None)
-        self.assertEquals(up['date_approved'], None)
-        self.assertEquals(up['date_pushed'], None)
-        self.assertEquals(up['locked'], False)
-        self.assertEquals(up['alias'], u'FEDORA-%s-a3bbe1a8f2' % YEAR)
-        self.assertEquals(up['karma'], 1)
+        self.assertEqual(up['title'], u'bodhi-2.0-1.fc17')
+        self.assertEqual(up['status'], u'pending')
+        self.assertEqual(up['request'], u'testing')
+        self.assertEqual(up['user']['name'], u'guest')
+        self.assertEqual(up['release']['name'], u'F17')
+        self.assertEqual(up['type'], u'bugfix')
+        self.assertEqual(up['severity'], u'medium')
+        self.assertEqual(up['suggest'], u'unspecified')
+        self.assertEqual(up['close_bugs'], True)
+        self.assertEqual(up['notes'], u'Useful details!')
+        self.assertEqual(up['date_submitted'], u'1984-11-02 00:00:00')
+        self.assertEqual(up['date_modified'], None)
+        self.assertEqual(up['date_approved'], None)
+        self.assertEqual(up['date_pushed'], None)
+        self.assertEqual(up['locked'], False)
+        self.assertEqual(up['alias'], u'FEDORA-%s-a3bbe1a8f2' % YEAR)
+        self.assertEqual(up['karma'], 1)
 
     def test_list_updates_by_date_submitted_before_invalid_date(self):
         """test filtering by submitted before date with an invalid date"""
         res = self.app.get('/updates/', {"submitted_before": "11-01-1984"}, status=400)
         body = res.json_body
-        self.assertEquals(len(body.get('updates', [])), 0)
-        self.assertEquals(body['errors'][0]['name'], 'submitted_before')
-        self.assertEquals(body['errors'][0]['description'],
-                          'Invalid date')
+        self.assertEqual(len(body.get('updates', [])), 0)
+        self.assertEqual(body['errors'][0]['name'], 'submitted_before')
+        self.assertEqual(body['errors'][0]['description'],
+                         'Invalid date')
 
     def test_list_updates_by_date_submitted_before_old_date(self):
         """test filtering by submitted before date with old date"""
         res = self.app.get('/updates/', {"submitted_before": "1975-01-01"})
         body = res.json_body
-        self.assertEquals(len(body['updates']), 0)
+        self.assertEqual(len(body['updates']), 0)
 
     def test_list_updates_by_date_submitted_before_valid(self):
         """test filtering by submitted before date with valid date"""
         today = datetime.utcnow().strftime("%Y-%m-%d")
         res = self.app.get('/updates/', {"submitted_before": today})
         body = res.json_body
-        self.assertEquals(len(body['updates']), 1)
+        self.assertEqual(len(body['updates']), 1)
 
         up = body['updates'][0]
-        self.assertEquals(up['title'], u'bodhi-2.0-1.fc17')
-        self.assertEquals(up['status'], u'pending')
-        self.assertEquals(up['request'], u'testing')
-        self.assertEquals(up['user']['name'], u'guest')
-        self.assertEquals(up['release']['name'], u'F17')
-        self.assertEquals(up['type'], u'bugfix')
-        self.assertEquals(up['severity'], u'medium')
-        self.assertEquals(up['suggest'], u'unspecified')
-        self.assertEquals(up['close_bugs'], True)
-        self.assertEquals(up['notes'], u'Useful details!')
-        self.assertEquals(up['date_submitted'], u'1984-11-02 00:00:00')
-        self.assertEquals(up['date_modified'], None)
-        self.assertEquals(up['date_approved'], None)
-        self.assertEquals(up['date_pushed'], None)
-        self.assertEquals(up['locked'], False)
-        self.assertEquals(up['alias'], u'FEDORA-%s-a3bbe1a8f2' % YEAR)
-        self.assertEquals(up['karma'], 1)
+        self.assertEqual(up['title'], u'bodhi-2.0-1.fc17')
+        self.assertEqual(up['status'], u'pending')
+        self.assertEqual(up['request'], u'testing')
+        self.assertEqual(up['user']['name'], u'guest')
+        self.assertEqual(up['release']['name'], u'F17')
+        self.assertEqual(up['type'], u'bugfix')
+        self.assertEqual(up['severity'], u'medium')
+        self.assertEqual(up['suggest'], u'unspecified')
+        self.assertEqual(up['close_bugs'], True)
+        self.assertEqual(up['notes'], u'Useful details!')
+        self.assertEqual(up['date_submitted'], u'1984-11-02 00:00:00')
+        self.assertEqual(up['date_modified'], None)
+        self.assertEqual(up['date_approved'], None)
+        self.assertEqual(up['date_pushed'], None)
+        self.assertEqual(up['locked'], False)
+        self.assertEqual(up['alias'], u'FEDORA-%s-a3bbe1a8f2' % YEAR)
+        self.assertEqual(up['karma'], 1)
 
     def test_list_updates_by_locked(self):
         Update.query.one().locked = True
         self.db.flush()
         res = self.app.get('/updates/', {"locked": "true"})
         body = res.json_body
-        self.assertEquals(len(body['updates']), 1)
+        self.assertEqual(len(body['updates']), 1)
 
         up = body['updates'][0]
-        self.assertEquals(up['title'], u'bodhi-2.0-1.fc17')
-        self.assertEquals(up['status'], u'pending')
-        self.assertEquals(up['request'], u'testing')
-        self.assertEquals(up['user']['name'], u'guest')
-        self.assertEquals(up['release']['name'], u'F17')
-        self.assertEquals(up['type'], u'bugfix')
-        self.assertEquals(up['severity'], u'medium')
-        self.assertEquals(up['suggest'], u'unspecified')
-        self.assertEquals(up['close_bugs'], True)
-        self.assertEquals(up['notes'], u'Useful details!')
-        self.assertEquals(up['date_submitted'], u'1984-11-02 00:00:00')
-        self.assertEquals(up['date_modified'], None)
-        self.assertEquals(up['date_approved'], None)
-        self.assertEquals(up['date_pushed'], None)
-        self.assertEquals(up['locked'], True)
-        self.assertEquals(up['alias'], u'FEDORA-%s-a3bbe1a8f2' % YEAR)
-        self.assertEquals(up['karma'], 1)
+        self.assertEqual(up['title'], u'bodhi-2.0-1.fc17')
+        self.assertEqual(up['status'], u'pending')
+        self.assertEqual(up['request'], u'testing')
+        self.assertEqual(up['user']['name'], u'guest')
+        self.assertEqual(up['release']['name'], u'F17')
+        self.assertEqual(up['type'], u'bugfix')
+        self.assertEqual(up['severity'], u'medium')
+        self.assertEqual(up['suggest'], u'unspecified')
+        self.assertEqual(up['close_bugs'], True)
+        self.assertEqual(up['notes'], u'Useful details!')
+        self.assertEqual(up['date_submitted'], u'1984-11-02 00:00:00')
+        self.assertEqual(up['date_modified'], None)
+        self.assertEqual(up['date_approved'], None)
+        self.assertEqual(up['date_pushed'], None)
+        self.assertEqual(up['locked'], True)
+        self.assertEqual(up['alias'], u'FEDORA-%s-a3bbe1a8f2' % YEAR)
+        self.assertEqual(up['karma'], 1)
 
     def test_list_updates_by_content_type(self):
         res = self.app.get('/updates/', {"content_type": "module"})
         body = res.json_body
-        self.assertEquals(len(body['updates']), 0)
+        self.assertEqual(len(body['updates']), 0)
 
         res = self.app.get('/updates/', {"content_type": "rpm"})
         body = res.json_body
-        self.assertEquals(len(body['updates']), 1)
+        self.assertEqual(len(body['updates']), 1)
 
     def test_list_updates_by_invalid_locked(self):
         res = self.app.get('/updates/', {"locked": "maybe"},
                            status=400)
         body = res.json_body
-        self.assertEquals(len(body.get('updates', [])), 0)
-        self.assertEquals(res.json_body['errors'][0]['name'], 'locked')
-        self.assertEquals(res.json_body['errors'][0]['description'],
-                          '"maybe" is neither in (\'false\', \'0\') nor in (\'true\', \'1\')')
+        self.assertEqual(len(body.get('updates', [])), 0)
+        self.assertEqual(res.json_body['errors'][0]['name'], 'locked')
+        self.assertEqual(res.json_body['errors'][0]['description'],
+                         '"maybe" is neither in (\'false\', \'0\') nor in (\'true\', \'1\')')
 
     def test_list_updates_by_modified_since(self):
         now = datetime.utcnow()
@@ -1926,7 +1926,7 @@ class TestUpdatesService(BaseTestCase):
         res = self.app.get('/updates/',
                            {"modified_since": now.strftime("%Y-%m-%d")})
         body = res.json_body
-        self.assertEquals(len(body['updates']), 0)
+        self.assertEqual(len(body['updates']), 0)
 
         # Now approve one
         self.db.query(Update).first().date_modified = now
@@ -1936,37 +1936,37 @@ class TestUpdatesService(BaseTestCase):
         res = self.app.get('/updates/',
                            {"modified_since": now.strftime("%Y-%m-%d")})
         body = res.json_body
-        self.assertEquals(len(body['updates']), 1)
+        self.assertEqual(len(body['updates']), 1)
 
         up = body['updates'][0]
-        self.assertEquals(up['title'], u'bodhi-2.0-1.fc17')
-        self.assertEquals(up['status'], u'pending')
-        self.assertEquals(up['request'], u'testing')
-        self.assertEquals(up['user']['name'], u'guest')
-        self.assertEquals(up['release']['name'], u'F17')
-        self.assertEquals(up['type'], u'bugfix')
-        self.assertEquals(up['severity'], u'medium')
-        self.assertEquals(up['suggest'], u'unspecified')
-        self.assertEquals(up['close_bugs'], True)
-        self.assertEquals(up['notes'], u'Useful details!')
-        self.assertEquals(up['date_submitted'], u'1984-11-02 00:00:00')
-        self.assertEquals(up['date_modified'], now.strftime("%Y-%m-%d %H:%M:%S"))
-        self.assertEquals(up['date_approved'], None)
-        self.assertEquals(up['date_pushed'], None)
-        self.assertEquals(up['locked'], False)
-        self.assertEquals(up['alias'], u'FEDORA-%s-a3bbe1a8f2' % YEAR)
-        self.assertEquals(up['karma'], 1)
-        self.assertEquals(len(up['bugs']), 1)
-        self.assertEquals(up['bugs'][0]['bug_id'], 12345)
+        self.assertEqual(up['title'], u'bodhi-2.0-1.fc17')
+        self.assertEqual(up['status'], u'pending')
+        self.assertEqual(up['request'], u'testing')
+        self.assertEqual(up['user']['name'], u'guest')
+        self.assertEqual(up['release']['name'], u'F17')
+        self.assertEqual(up['type'], u'bugfix')
+        self.assertEqual(up['severity'], u'medium')
+        self.assertEqual(up['suggest'], u'unspecified')
+        self.assertEqual(up['close_bugs'], True)
+        self.assertEqual(up['notes'], u'Useful details!')
+        self.assertEqual(up['date_submitted'], u'1984-11-02 00:00:00')
+        self.assertEqual(up['date_modified'], now.strftime("%Y-%m-%d %H:%M:%S"))
+        self.assertEqual(up['date_approved'], None)
+        self.assertEqual(up['date_pushed'], None)
+        self.assertEqual(up['locked'], False)
+        self.assertEqual(up['alias'], u'FEDORA-%s-a3bbe1a8f2' % YEAR)
+        self.assertEqual(up['karma'], 1)
+        self.assertEqual(len(up['bugs']), 1)
+        self.assertEqual(up['bugs'][0]['bug_id'], 12345)
 
     def test_list_updates_by_invalid_modified_since(self):
         res = self.app.get('/updates/', {"modified_since": "the dawn of time"},
                            status=400)
         body = res.json_body
-        self.assertEquals(len(body.get('updates', [])), 0)
-        self.assertEquals(res.json_body['errors'][0]['name'], 'modified_since')
-        self.assertEquals(res.json_body['errors'][0]['description'],
-                          'Invalid date')
+        self.assertEqual(len(body.get('updates', [])), 0)
+        self.assertEqual(res.json_body['errors'][0]['name'], 'modified_since')
+        self.assertEqual(res.json_body['errors'][0]['description'],
+                         'Invalid date')
 
     def test_list_updates_by_modified_before(self):
         now = datetime.utcnow()
@@ -1977,7 +1977,7 @@ class TestUpdatesService(BaseTestCase):
         res = self.app.get('/updates/',
                            {"modified_before": now.strftime("%Y-%m-%d")})
         body = res.json_body
-        self.assertEquals(len(body['updates']), 0)
+        self.assertEqual(len(body['updates']), 0)
 
         # Now approve one
         self.db.query(Update).first().date_modified = now
@@ -1987,128 +1987,128 @@ class TestUpdatesService(BaseTestCase):
         res = self.app.get('/updates/',
                            {"modified_before": tomorrow})
         body = res.json_body
-        self.assertEquals(len(body['updates']), 1)
+        self.assertEqual(len(body['updates']), 1)
 
         up = body['updates'][0]
-        self.assertEquals(up['title'], u'bodhi-2.0-1.fc17')
-        self.assertEquals(up['status'], u'pending')
-        self.assertEquals(up['request'], u'testing')
-        self.assertEquals(up['user']['name'], u'guest')
-        self.assertEquals(up['release']['name'], u'F17')
-        self.assertEquals(up['type'], u'bugfix')
-        self.assertEquals(up['severity'], u'medium')
-        self.assertEquals(up['suggest'], u'unspecified')
-        self.assertEquals(up['close_bugs'], True)
-        self.assertEquals(up['notes'], u'Useful details!')
-        self.assertEquals(up['date_submitted'], u'1984-11-02 00:00:00')
-        self.assertEquals(up['date_modified'], now.strftime("%Y-%m-%d %H:%M:%S"))
-        self.assertEquals(up['date_approved'], None)
-        self.assertEquals(up['date_pushed'], None)
-        self.assertEquals(up['locked'], False)
-        self.assertEquals(up['alias'], u'FEDORA-%s-a3bbe1a8f2' % YEAR)
-        self.assertEquals(up['karma'], 1)
-        self.assertEquals(len(up['bugs']), 1)
-        self.assertEquals(up['bugs'][0]['bug_id'], 12345)
+        self.assertEqual(up['title'], u'bodhi-2.0-1.fc17')
+        self.assertEqual(up['status'], u'pending')
+        self.assertEqual(up['request'], u'testing')
+        self.assertEqual(up['user']['name'], u'guest')
+        self.assertEqual(up['release']['name'], u'F17')
+        self.assertEqual(up['type'], u'bugfix')
+        self.assertEqual(up['severity'], u'medium')
+        self.assertEqual(up['suggest'], u'unspecified')
+        self.assertEqual(up['close_bugs'], True)
+        self.assertEqual(up['notes'], u'Useful details!')
+        self.assertEqual(up['date_submitted'], u'1984-11-02 00:00:00')
+        self.assertEqual(up['date_modified'], now.strftime("%Y-%m-%d %H:%M:%S"))
+        self.assertEqual(up['date_approved'], None)
+        self.assertEqual(up['date_pushed'], None)
+        self.assertEqual(up['locked'], False)
+        self.assertEqual(up['alias'], u'FEDORA-%s-a3bbe1a8f2' % YEAR)
+        self.assertEqual(up['karma'], 1)
+        self.assertEqual(len(up['bugs']), 1)
+        self.assertEqual(up['bugs'][0]['bug_id'], 12345)
 
     def test_list_updates_by_invalid_modified_before(self):
         res = self.app.get('/updates/', {"modified_before": "the dawn of time"},
                            status=400)
         body = res.json_body
-        self.assertEquals(len(body.get('updates', [])), 0)
-        self.assertEquals(res.json_body['errors'][0]['name'], 'modified_before')
-        self.assertEquals(res.json_body['errors'][0]['description'],
-                          'Invalid date')
+        self.assertEqual(len(body.get('updates', [])), 0)
+        self.assertEqual(res.json_body['errors'][0]['name'], 'modified_before')
+        self.assertEqual(res.json_body['errors'][0]['description'],
+                         'Invalid date')
 
     def test_list_updates_by_package(self):
         res = self.app.get('/updates/', {"packages": "bodhi"})
         body = res.json_body
-        self.assertEquals(len(body['updates']), 1)
+        self.assertEqual(len(body['updates']), 1)
 
         up = body['updates'][0]
-        self.assertEquals(up['title'], u'bodhi-2.0-1.fc17')
-        self.assertEquals(up['status'], u'pending')
-        self.assertEquals(up['request'], u'testing')
-        self.assertEquals(up['user']['name'], u'guest')
-        self.assertEquals(up['release']['name'], u'F17')
-        self.assertEquals(up['type'], u'bugfix')
-        self.assertEquals(up['severity'], u'medium')
-        self.assertEquals(up['suggest'], u'unspecified')
-        self.assertEquals(up['close_bugs'], True)
-        self.assertEquals(up['notes'], u'Useful details!')
-        self.assertEquals(up['date_submitted'], u'1984-11-02 00:00:00')
-        self.assertEquals(up['date_modified'], None)
-        self.assertEquals(up['date_approved'], None)
-        self.assertEquals(up['date_pushed'], None)
-        self.assertEquals(up['locked'], False)
-        self.assertEquals(up['alias'], u'FEDORA-%s-a3bbe1a8f2' % YEAR)
-        self.assertEquals(up['karma'], 1)
+        self.assertEqual(up['title'], u'bodhi-2.0-1.fc17')
+        self.assertEqual(up['status'], u'pending')
+        self.assertEqual(up['request'], u'testing')
+        self.assertEqual(up['user']['name'], u'guest')
+        self.assertEqual(up['release']['name'], u'F17')
+        self.assertEqual(up['type'], u'bugfix')
+        self.assertEqual(up['severity'], u'medium')
+        self.assertEqual(up['suggest'], u'unspecified')
+        self.assertEqual(up['close_bugs'], True)
+        self.assertEqual(up['notes'], u'Useful details!')
+        self.assertEqual(up['date_submitted'], u'1984-11-02 00:00:00')
+        self.assertEqual(up['date_modified'], None)
+        self.assertEqual(up['date_approved'], None)
+        self.assertEqual(up['date_pushed'], None)
+        self.assertEqual(up['locked'], False)
+        self.assertEqual(up['alias'], u'FEDORA-%s-a3bbe1a8f2' % YEAR)
+        self.assertEqual(up['karma'], 1)
 
     def test_list_updates_by_builds(self):
         res = self.app.get('/updates/', {"builds": "bodhi-3.0-1.fc17"})
         body = res.json_body
-        self.assertEquals(len(body['updates']), 0)
+        self.assertEqual(len(body['updates']), 0)
 
         res = self.app.get('/updates/', {"builds": "bodhi-2.0-1.fc17"})
         body = res.json_body
-        self.assertEquals(len(body['updates']), 1)
+        self.assertEqual(len(body['updates']), 1)
 
         up = body['updates'][0]
-        self.assertEquals(up['title'], u'bodhi-2.0-1.fc17')
-        self.assertEquals(up['status'], u'pending')
-        self.assertEquals(up['request'], u'testing')
-        self.assertEquals(up['user']['name'], u'guest')
-        self.assertEquals(up['release']['name'], u'F17')
-        self.assertEquals(up['type'], u'bugfix')
-        self.assertEquals(up['severity'], u'medium')
-        self.assertEquals(up['suggest'], u'unspecified')
-        self.assertEquals(up['close_bugs'], True)
-        self.assertEquals(up['notes'], u'Useful details!')
-        self.assertEquals(up['date_submitted'], u'1984-11-02 00:00:00')
-        self.assertEquals(up['date_modified'], None)
-        self.assertEquals(up['date_approved'], None)
-        self.assertEquals(up['date_pushed'], None)
-        self.assertEquals(up['locked'], False)
-        self.assertEquals(up['alias'], u'FEDORA-%s-a3bbe1a8f2' % YEAR)
-        self.assertEquals(up['karma'], 1)
+        self.assertEqual(up['title'], u'bodhi-2.0-1.fc17')
+        self.assertEqual(up['status'], u'pending')
+        self.assertEqual(up['request'], u'testing')
+        self.assertEqual(up['user']['name'], u'guest')
+        self.assertEqual(up['release']['name'], u'F17')
+        self.assertEqual(up['type'], u'bugfix')
+        self.assertEqual(up['severity'], u'medium')
+        self.assertEqual(up['suggest'], u'unspecified')
+        self.assertEqual(up['close_bugs'], True)
+        self.assertEqual(up['notes'], u'Useful details!')
+        self.assertEqual(up['date_submitted'], u'1984-11-02 00:00:00')
+        self.assertEqual(up['date_modified'], None)
+        self.assertEqual(up['date_approved'], None)
+        self.assertEqual(up['date_pushed'], None)
+        self.assertEqual(up['locked'], False)
+        self.assertEqual(up['alias'], u'FEDORA-%s-a3bbe1a8f2' % YEAR)
+        self.assertEqual(up['karma'], 1)
 
     def test_list_updates_by_unexisting_package(self):
         res = self.app.get('/updates/', {"packages": "flash-player"})
         body = res.json_body
-        self.assertEquals(len(body['updates']), 0)
+        self.assertEqual(len(body['updates']), 0)
 
     def test_list_updates_by_pushed(self):
         res = self.app.get('/updates/', {"pushed": "false"})
         body = res.json_body
-        self.assertEquals(len(body['updates']), 1)
+        self.assertEqual(len(body['updates']), 1)
 
         up = body['updates'][0]
-        self.assertEquals(up['title'], u'bodhi-2.0-1.fc17')
-        self.assertEquals(up['status'], u'pending')
-        self.assertEquals(up['request'], u'testing')
-        self.assertEquals(up['user']['name'], u'guest')
-        self.assertEquals(up['release']['name'], u'F17')
-        self.assertEquals(up['type'], u'bugfix')
-        self.assertEquals(up['severity'], u'medium')
-        self.assertEquals(up['suggest'], u'unspecified')
-        self.assertEquals(up['close_bugs'], True)
-        self.assertEquals(up['notes'], u'Useful details!')
-        self.assertEquals(up['date_submitted'], u'1984-11-02 00:00:00')
-        self.assertEquals(up['date_modified'], None)
-        self.assertEquals(up['date_approved'], None)
-        self.assertEquals(up['date_pushed'], None)
-        self.assertEquals(up['locked'], False)
-        self.assertEquals(up['alias'], u'FEDORA-%s-a3bbe1a8f2' % YEAR)
-        self.assertEquals(up['karma'], 1)
-        self.assertEquals(up['pushed'], False)
+        self.assertEqual(up['title'], u'bodhi-2.0-1.fc17')
+        self.assertEqual(up['status'], u'pending')
+        self.assertEqual(up['request'], u'testing')
+        self.assertEqual(up['user']['name'], u'guest')
+        self.assertEqual(up['release']['name'], u'F17')
+        self.assertEqual(up['type'], u'bugfix')
+        self.assertEqual(up['severity'], u'medium')
+        self.assertEqual(up['suggest'], u'unspecified')
+        self.assertEqual(up['close_bugs'], True)
+        self.assertEqual(up['notes'], u'Useful details!')
+        self.assertEqual(up['date_submitted'], u'1984-11-02 00:00:00')
+        self.assertEqual(up['date_modified'], None)
+        self.assertEqual(up['date_approved'], None)
+        self.assertEqual(up['date_pushed'], None)
+        self.assertEqual(up['locked'], False)
+        self.assertEqual(up['alias'], u'FEDORA-%s-a3bbe1a8f2' % YEAR)
+        self.assertEqual(up['karma'], 1)
+        self.assertEqual(up['pushed'], False)
 
     def test_list_updates_by_invalid_pushed(self):
         res = self.app.get('/updates/', {"pushed": "who knows?"},
                            status=400)
         body = res.json_body
-        self.assertEquals(len(body.get('updates', [])), 0)
-        self.assertEquals(res.json_body['errors'][0]['name'], 'pushed')
-        self.assertEquals(res.json_body['errors'][0]['description'],
-                          '"who knows?" is neither in (\'false\', \'0\') nor in (\'true\', \'1\')')
+        self.assertEqual(len(body.get('updates', [])), 0)
+        self.assertEqual(res.json_body['errors'][0]['name'], 'pushed')
+        self.assertEqual(res.json_body['errors'][0]['description'],
+                         '"who knows?" is neither in (\'false\', \'0\') nor in (\'true\', \'1\')')
 
     def test_list_updates_by_pushed_since(self):
         now = datetime.utcnow()
@@ -2117,7 +2117,7 @@ class TestUpdatesService(BaseTestCase):
         res = self.app.get('/updates/',
                            {"pushed_since": now.strftime("%Y-%m-%d")})
         body = res.json_body
-        self.assertEquals(len(body['updates']), 0)
+        self.assertEqual(len(body['updates']), 0)
 
         # Now approve one
         self.db.query(Update).first().date_pushed = now
@@ -2127,36 +2127,36 @@ class TestUpdatesService(BaseTestCase):
         res = self.app.get('/updates/',
                            {"pushed_since": now.strftime("%Y-%m-%d")})
         body = res.json_body
-        self.assertEquals(len(body['updates']), 1)
+        self.assertEqual(len(body['updates']), 1)
 
         up = body['updates'][0]
-        self.assertEquals(up['title'], u'bodhi-2.0-1.fc17')
-        self.assertEquals(up['status'], u'pending')
-        self.assertEquals(up['request'], u'testing')
-        self.assertEquals(up['user']['name'], u'guest')
-        self.assertEquals(up['release']['name'], u'F17')
-        self.assertEquals(up['type'], u'bugfix')
-        self.assertEquals(up['severity'], u'medium')
-        self.assertEquals(up['suggest'], u'unspecified')
-        self.assertEquals(up['close_bugs'], True)
-        self.assertEquals(up['notes'], u'Useful details!')
-        self.assertEquals(up['date_submitted'], u'1984-11-02 00:00:00')
-        self.assertEquals(up['date_approved'], None)
-        self.assertEquals(up['date_pushed'], now.strftime("%Y-%m-%d %H:%M:%S"))
-        self.assertEquals(up['locked'], False)
-        self.assertEquals(up['alias'], u'FEDORA-%s-a3bbe1a8f2' % YEAR)
-        self.assertEquals(up['karma'], 1)
-        self.assertEquals(len(up['bugs']), 1)
-        self.assertEquals(up['bugs'][0]['bug_id'], 12345)
+        self.assertEqual(up['title'], u'bodhi-2.0-1.fc17')
+        self.assertEqual(up['status'], u'pending')
+        self.assertEqual(up['request'], u'testing')
+        self.assertEqual(up['user']['name'], u'guest')
+        self.assertEqual(up['release']['name'], u'F17')
+        self.assertEqual(up['type'], u'bugfix')
+        self.assertEqual(up['severity'], u'medium')
+        self.assertEqual(up['suggest'], u'unspecified')
+        self.assertEqual(up['close_bugs'], True)
+        self.assertEqual(up['notes'], u'Useful details!')
+        self.assertEqual(up['date_submitted'], u'1984-11-02 00:00:00')
+        self.assertEqual(up['date_approved'], None)
+        self.assertEqual(up['date_pushed'], now.strftime("%Y-%m-%d %H:%M:%S"))
+        self.assertEqual(up['locked'], False)
+        self.assertEqual(up['alias'], u'FEDORA-%s-a3bbe1a8f2' % YEAR)
+        self.assertEqual(up['karma'], 1)
+        self.assertEqual(len(up['bugs']), 1)
+        self.assertEqual(up['bugs'][0]['bug_id'], 12345)
 
     def test_list_updates_by_invalid_pushed_since(self):
         res = self.app.get('/updates/', {"pushed_since": "a while ago"},
                            status=400)
         body = res.json_body
-        self.assertEquals(len(body.get('updates', [])), 0)
-        self.assertEquals(res.json_body['errors'][0]['name'], 'pushed_since')
-        self.assertEquals(res.json_body['errors'][0]['description'],
-                          'Invalid date')
+        self.assertEqual(len(body.get('updates', [])), 0)
+        self.assertEqual(res.json_body['errors'][0]['name'], 'pushed_since')
+        self.assertEqual(res.json_body['errors'][0]['description'],
+                         'Invalid date')
 
     def test_list_updates_by_pushed_before(self):
         now = datetime.utcnow()
@@ -2167,7 +2167,7 @@ class TestUpdatesService(BaseTestCase):
         res = self.app.get('/updates/',
                            {"pushed_before": now.strftime("%Y-%m-%d")})
         body = res.json_body
-        self.assertEquals(len(body['updates']), 0)
+        self.assertEqual(len(body['updates']), 0)
 
         # Now approve one
         self.db.query(Update).first().date_pushed = now
@@ -2177,60 +2177,60 @@ class TestUpdatesService(BaseTestCase):
         res = self.app.get('/updates/',
                            {"pushed_before": tomorrow})
         body = res.json_body
-        self.assertEquals(len(body['updates']), 1)
+        self.assertEqual(len(body['updates']), 1)
 
         up = body['updates'][0]
-        self.assertEquals(up['title'], u'bodhi-2.0-1.fc17')
-        self.assertEquals(up['status'], u'pending')
-        self.assertEquals(up['request'], u'testing')
-        self.assertEquals(up['user']['name'], u'guest')
-        self.assertEquals(up['release']['name'], u'F17')
-        self.assertEquals(up['type'], u'bugfix')
-        self.assertEquals(up['severity'], u'medium')
-        self.assertEquals(up['suggest'], u'unspecified')
-        self.assertEquals(up['close_bugs'], True)
-        self.assertEquals(up['notes'], u'Useful details!')
-        self.assertEquals(up['date_submitted'], u'1984-11-02 00:00:00')
-        self.assertEquals(up['date_approved'], None)
-        self.assertEquals(up['date_pushed'], now.strftime("%Y-%m-%d %H:%M:%S"))
-        self.assertEquals(up['locked'], False)
-        self.assertEquals(up['alias'], u'FEDORA-%s-a3bbe1a8f2' % YEAR)
-        self.assertEquals(up['karma'], 1)
-        self.assertEquals(len(up['bugs']), 1)
-        self.assertEquals(up['bugs'][0]['bug_id'], 12345)
+        self.assertEqual(up['title'], u'bodhi-2.0-1.fc17')
+        self.assertEqual(up['status'], u'pending')
+        self.assertEqual(up['request'], u'testing')
+        self.assertEqual(up['user']['name'], u'guest')
+        self.assertEqual(up['release']['name'], u'F17')
+        self.assertEqual(up['type'], u'bugfix')
+        self.assertEqual(up['severity'], u'medium')
+        self.assertEqual(up['suggest'], u'unspecified')
+        self.assertEqual(up['close_bugs'], True)
+        self.assertEqual(up['notes'], u'Useful details!')
+        self.assertEqual(up['date_submitted'], u'1984-11-02 00:00:00')
+        self.assertEqual(up['date_approved'], None)
+        self.assertEqual(up['date_pushed'], now.strftime("%Y-%m-%d %H:%M:%S"))
+        self.assertEqual(up['locked'], False)
+        self.assertEqual(up['alias'], u'FEDORA-%s-a3bbe1a8f2' % YEAR)
+        self.assertEqual(up['karma'], 1)
+        self.assertEqual(len(up['bugs']), 1)
+        self.assertEqual(up['bugs'][0]['bug_id'], 12345)
 
     def test_list_updates_by_invalid_pushed_before(self):
         res = self.app.get('/updates/', {"pushed_before": "a while ago"},
                            status=400)
         body = res.json_body
-        self.assertEquals(len(body.get('updates', [])), 0)
-        self.assertEquals(res.json_body['errors'][0]['name'], 'pushed_before')
-        self.assertEquals(res.json_body['errors'][0]['description'],
-                          'Invalid date')
+        self.assertEqual(len(body.get('updates', [])), 0)
+        self.assertEqual(res.json_body['errors'][0]['name'], 'pushed_before')
+        self.assertEqual(res.json_body['errors'][0]['description'],
+                         'Invalid date')
 
     def test_list_updates_by_release_name(self):
         res = self.app.get('/updates/', {"releases": "F17"})
         body = res.json_body
-        self.assertEquals(len(body['updates']), 1)
+        self.assertEqual(len(body['updates']), 1)
 
         up = body['updates'][0]
-        self.assertEquals(up['title'], u'bodhi-2.0-1.fc17')
-        self.assertEquals(up['status'], u'pending')
-        self.assertEquals(up['request'], u'testing')
-        self.assertEquals(up['user']['name'], u'guest')
-        self.assertEquals(up['release']['name'], u'F17')
-        self.assertEquals(up['type'], u'bugfix')
-        self.assertEquals(up['severity'], u'medium')
-        self.assertEquals(up['suggest'], u'unspecified')
-        self.assertEquals(up['close_bugs'], True)
-        self.assertEquals(up['notes'], u'Useful details!')
-        self.assertEquals(up['date_submitted'], u'1984-11-02 00:00:00')
-        self.assertEquals(up['date_modified'], None)
-        self.assertEquals(up['date_approved'], None)
-        self.assertEquals(up['date_pushed'], None)
-        self.assertEquals(up['locked'], False)
-        self.assertEquals(up['alias'], u'FEDORA-%s-a3bbe1a8f2' % YEAR)
-        self.assertEquals(up['karma'], 1)
+        self.assertEqual(up['title'], u'bodhi-2.0-1.fc17')
+        self.assertEqual(up['status'], u'pending')
+        self.assertEqual(up['request'], u'testing')
+        self.assertEqual(up['user']['name'], u'guest')
+        self.assertEqual(up['release']['name'], u'F17')
+        self.assertEqual(up['type'], u'bugfix')
+        self.assertEqual(up['severity'], u'medium')
+        self.assertEqual(up['suggest'], u'unspecified')
+        self.assertEqual(up['close_bugs'], True)
+        self.assertEqual(up['notes'], u'Useful details!')
+        self.assertEqual(up['date_submitted'], u'1984-11-02 00:00:00')
+        self.assertEqual(up['date_modified'], None)
+        self.assertEqual(up['date_approved'], None)
+        self.assertEqual(up['date_pushed'], None)
+        self.assertEqual(up['locked'], False)
+        self.assertEqual(up['alias'], u'FEDORA-%s-a3bbe1a8f2' % YEAR)
+        self.assertEqual(up['karma'], 1)
 
     def test_list_updates_by_singular_release_param(self):
         """
@@ -2239,176 +2239,176 @@ class TestUpdatesService(BaseTestCase):
         """
         res = self.app.get('/updates/', {"release": "F17"})
         body = res.json_body
-        self.assertEquals(len(body['updates']), 1)
+        self.assertEqual(len(body['updates']), 1)
 
         up = body['updates'][0]
-        self.assertEquals(up['title'], u'bodhi-2.0-1.fc17')
-        self.assertEquals(up['status'], u'pending')
-        self.assertEquals(up['request'], u'testing')
-        self.assertEquals(up['user']['name'], u'guest')
-        self.assertEquals(up['release']['name'], u'F17')
-        self.assertEquals(up['type'], u'bugfix')
-        self.assertEquals(up['severity'], u'medium')
-        self.assertEquals(up['suggest'], u'unspecified')
-        self.assertEquals(up['close_bugs'], True)
-        self.assertEquals(up['notes'], u'Useful details!')
-        self.assertEquals(up['date_submitted'], u'1984-11-02 00:00:00')
-        self.assertEquals(up['date_modified'], None)
-        self.assertEquals(up['date_approved'], None)
-        self.assertEquals(up['date_pushed'], None)
-        self.assertEquals(up['locked'], False)
-        self.assertEquals(up['alias'], u'FEDORA-%s-a3bbe1a8f2' % YEAR)
-        self.assertEquals(up['karma'], 1)
+        self.assertEqual(up['title'], u'bodhi-2.0-1.fc17')
+        self.assertEqual(up['status'], u'pending')
+        self.assertEqual(up['request'], u'testing')
+        self.assertEqual(up['user']['name'], u'guest')
+        self.assertEqual(up['release']['name'], u'F17')
+        self.assertEqual(up['type'], u'bugfix')
+        self.assertEqual(up['severity'], u'medium')
+        self.assertEqual(up['suggest'], u'unspecified')
+        self.assertEqual(up['close_bugs'], True)
+        self.assertEqual(up['notes'], u'Useful details!')
+        self.assertEqual(up['date_submitted'], u'1984-11-02 00:00:00')
+        self.assertEqual(up['date_modified'], None)
+        self.assertEqual(up['date_approved'], None)
+        self.assertEqual(up['date_pushed'], None)
+        self.assertEqual(up['locked'], False)
+        self.assertEqual(up['alias'], u'FEDORA-%s-a3bbe1a8f2' % YEAR)
+        self.assertEqual(up['karma'], 1)
 
     def test_list_updates_by_release_version(self):
         res = self.app.get('/updates/', {"releases": "17"})
         body = res.json_body
-        self.assertEquals(len(body['updates']), 1)
+        self.assertEqual(len(body['updates']), 1)
 
         up = body['updates'][0]
-        self.assertEquals(up['title'], u'bodhi-2.0-1.fc17')
-        self.assertEquals(up['status'], u'pending')
-        self.assertEquals(up['request'], u'testing')
-        self.assertEquals(up['user']['name'], u'guest')
-        self.assertEquals(up['release']['name'], u'F17')
-        self.assertEquals(up['type'], u'bugfix')
-        self.assertEquals(up['severity'], u'medium')
-        self.assertEquals(up['suggest'], u'unspecified')
-        self.assertEquals(up['close_bugs'], True)
-        self.assertEquals(up['notes'], u'Useful details!')
-        self.assertEquals(up['date_submitted'], u'1984-11-02 00:00:00')
-        self.assertEquals(up['date_modified'], None)
-        self.assertEquals(up['date_approved'], None)
-        self.assertEquals(up['date_pushed'], None)
-        self.assertEquals(up['locked'], False)
-        self.assertEquals(up['alias'], u'FEDORA-%s-a3bbe1a8f2' % YEAR)
-        self.assertEquals(up['karma'], 1)
+        self.assertEqual(up['title'], u'bodhi-2.0-1.fc17')
+        self.assertEqual(up['status'], u'pending')
+        self.assertEqual(up['request'], u'testing')
+        self.assertEqual(up['user']['name'], u'guest')
+        self.assertEqual(up['release']['name'], u'F17')
+        self.assertEqual(up['type'], u'bugfix')
+        self.assertEqual(up['severity'], u'medium')
+        self.assertEqual(up['suggest'], u'unspecified')
+        self.assertEqual(up['close_bugs'], True)
+        self.assertEqual(up['notes'], u'Useful details!')
+        self.assertEqual(up['date_submitted'], u'1984-11-02 00:00:00')
+        self.assertEqual(up['date_modified'], None)
+        self.assertEqual(up['date_approved'], None)
+        self.assertEqual(up['date_pushed'], None)
+        self.assertEqual(up['locked'], False)
+        self.assertEqual(up['alias'], u'FEDORA-%s-a3bbe1a8f2' % YEAR)
+        self.assertEqual(up['karma'], 1)
 
     def test_list_updates_by_unexisting_release(self):
         res = self.app.get('/updates/', {"releases": "WinXP"}, status=400)
         body = res.json_body
-        self.assertEquals(len(body.get('updates', [])), 0)
-        self.assertEquals(res.json_body['errors'][0]['name'], 'releases')
-        self.assertEquals(res.json_body['errors'][0]['description'],
-                          'Invalid releases specified: WinXP')
+        self.assertEqual(len(body.get('updates', [])), 0)
+        self.assertEqual(res.json_body['errors'][0]['name'], 'releases')
+        self.assertEqual(res.json_body['errors'][0]['description'],
+                         'Invalid releases specified: WinXP')
 
     def test_list_updates_by_request(self):
         res = self.app.get('/updates/', {'request': "testing"})
         body = res.json_body
-        self.assertEquals(len(body['updates']), 1)
+        self.assertEqual(len(body['updates']), 1)
 
         up = body['updates'][0]
-        self.assertEquals(up['title'], u'bodhi-2.0-1.fc17')
-        self.assertEquals(up['status'], u'pending')
-        self.assertEquals(up['request'], u'testing')
-        self.assertEquals(up['user']['name'], u'guest')
-        self.assertEquals(up['release']['name'], u'F17')
-        self.assertEquals(up['type'], u'bugfix')
-        self.assertEquals(up['severity'], u'medium')
-        self.assertEquals(up['suggest'], u'unspecified')
-        self.assertEquals(up['close_bugs'], True)
-        self.assertEquals(up['notes'], u'Useful details!')
-        self.assertEquals(up['date_submitted'], u'1984-11-02 00:00:00')
-        self.assertEquals(up['date_modified'], None)
-        self.assertEquals(up['date_approved'], None)
-        self.assertEquals(up['date_pushed'], None)
-        self.assertEquals(up['locked'], False)
-        self.assertEquals(up['alias'], u'FEDORA-%s-a3bbe1a8f2' % YEAR)
-        self.assertEquals(up['karma'], 1)
+        self.assertEqual(up['title'], u'bodhi-2.0-1.fc17')
+        self.assertEqual(up['status'], u'pending')
+        self.assertEqual(up['request'], u'testing')
+        self.assertEqual(up['user']['name'], u'guest')
+        self.assertEqual(up['release']['name'], u'F17')
+        self.assertEqual(up['type'], u'bugfix')
+        self.assertEqual(up['severity'], u'medium')
+        self.assertEqual(up['suggest'], u'unspecified')
+        self.assertEqual(up['close_bugs'], True)
+        self.assertEqual(up['notes'], u'Useful details!')
+        self.assertEqual(up['date_submitted'], u'1984-11-02 00:00:00')
+        self.assertEqual(up['date_modified'], None)
+        self.assertEqual(up['date_approved'], None)
+        self.assertEqual(up['date_pushed'], None)
+        self.assertEqual(up['locked'], False)
+        self.assertEqual(up['alias'], u'FEDORA-%s-a3bbe1a8f2' % YEAR)
+        self.assertEqual(up['karma'], 1)
 
     @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_updates_by_unexisting_request(self):
         res = self.app.get('/updates/', {"request": "impossible"},
                            status=400)
         body = res.json_body
-        self.assertEquals(len(body.get('updates', [])), 0)
-        self.assertEquals(res.json_body['errors'][0]['name'], 'request')
-        self.assertEquals(res.json_body['errors'][0]['description'],
-                          u'"impossible" is not one of revoke, testing,'
-                          ' obsolete, batched, stable, unpush')
+        self.assertEqual(len(body.get('updates', [])), 0)
+        self.assertEqual(res.json_body['errors'][0]['name'], 'request')
+        self.assertEqual(res.json_body['errors'][0]['description'],
+                         u'"impossible" is not one of revoke, testing,'
+                         ' obsolete, batched, stable, unpush')
 
     def test_list_updates_by_severity(self):
         res = self.app.get('/updates/', {"severity": "medium"})
         body = res.json_body
-        self.assertEquals(len(body['updates']), 1)
+        self.assertEqual(len(body['updates']), 1)
 
         up = body['updates'][0]
-        self.assertEquals(up['title'], u'bodhi-2.0-1.fc17')
-        self.assertEquals(up['status'], u'pending')
-        self.assertEquals(up['request'], u'testing')
-        self.assertEquals(up['user']['name'], u'guest')
-        self.assertEquals(up['release']['name'], u'F17')
-        self.assertEquals(up['type'], u'bugfix')
-        self.assertEquals(up['severity'], u'medium')
-        self.assertEquals(up['suggest'], u'unspecified')
-        self.assertEquals(up['close_bugs'], True)
-        self.assertEquals(up['notes'], u'Useful details!')
-        self.assertEquals(up['date_submitted'], u'1984-11-02 00:00:00')
-        self.assertEquals(up['date_modified'], None)
-        self.assertEquals(up['date_approved'], None)
-        self.assertEquals(up['date_pushed'], None)
-        self.assertEquals(up['locked'], False)
-        self.assertEquals(up['alias'], u'FEDORA-%s-a3bbe1a8f2' % YEAR)
-        self.assertEquals(up['karma'], 1)
+        self.assertEqual(up['title'], u'bodhi-2.0-1.fc17')
+        self.assertEqual(up['status'], u'pending')
+        self.assertEqual(up['request'], u'testing')
+        self.assertEqual(up['user']['name'], u'guest')
+        self.assertEqual(up['release']['name'], u'F17')
+        self.assertEqual(up['type'], u'bugfix')
+        self.assertEqual(up['severity'], u'medium')
+        self.assertEqual(up['suggest'], u'unspecified')
+        self.assertEqual(up['close_bugs'], True)
+        self.assertEqual(up['notes'], u'Useful details!')
+        self.assertEqual(up['date_submitted'], u'1984-11-02 00:00:00')
+        self.assertEqual(up['date_modified'], None)
+        self.assertEqual(up['date_approved'], None)
+        self.assertEqual(up['date_pushed'], None)
+        self.assertEqual(up['locked'], False)
+        self.assertEqual(up['alias'], u'FEDORA-%s-a3bbe1a8f2' % YEAR)
+        self.assertEqual(up['karma'], 1)
 
     @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_updates_by_unexisting_severity(self):
         res = self.app.get('/updates/', {"severity": "schoolmaster"},
                            status=400)
         body = res.json_body
-        self.assertEquals(len(body.get('updates', [])), 0)
-        self.assertEquals(res.json_body['errors'][0]['name'], 'severity')
-        self.assertEquals(res.json_body['errors'][0]['description'],
-                          '"schoolmaster" is not one of high, urgent, medium, low, unspecified')
+        self.assertEqual(len(body.get('updates', [])), 0)
+        self.assertEqual(res.json_body['errors'][0]['name'], 'severity')
+        self.assertEqual(res.json_body['errors'][0]['description'],
+                         '"schoolmaster" is not one of high, urgent, medium, low, unspecified')
 
     def test_list_updates_by_status(self):
         res = self.app.get('/updates/', {"status": "pending"})
         body = res.json_body
-        self.assertEquals(len(body['updates']), 1)
+        self.assertEqual(len(body['updates']), 1)
 
         up = body['updates'][0]
-        self.assertEquals(up['title'], u'bodhi-2.0-1.fc17')
-        self.assertEquals(up['status'], u'pending')
-        self.assertEquals(up['request'], u'testing')
-        self.assertEquals(up['user']['name'], u'guest')
-        self.assertEquals(up['release']['name'], u'F17')
-        self.assertEquals(up['type'], u'bugfix')
-        self.assertEquals(up['severity'], u'medium')
-        self.assertEquals(up['suggest'], u'unspecified')
-        self.assertEquals(up['close_bugs'], True)
-        self.assertEquals(up['notes'], u'Useful details!')
-        self.assertEquals(up['date_submitted'], u'1984-11-02 00:00:00')
-        self.assertEquals(up['date_modified'], None)
-        self.assertEquals(up['date_approved'], None)
-        self.assertEquals(up['date_pushed'], None)
-        self.assertEquals(up['locked'], False)
-        self.assertEquals(up['alias'], u'FEDORA-%s-a3bbe1a8f2' % YEAR)
-        self.assertEquals(up['karma'], 1)
+        self.assertEqual(up['title'], u'bodhi-2.0-1.fc17')
+        self.assertEqual(up['status'], u'pending')
+        self.assertEqual(up['request'], u'testing')
+        self.assertEqual(up['user']['name'], u'guest')
+        self.assertEqual(up['release']['name'], u'F17')
+        self.assertEqual(up['type'], u'bugfix')
+        self.assertEqual(up['severity'], u'medium')
+        self.assertEqual(up['suggest'], u'unspecified')
+        self.assertEqual(up['close_bugs'], True)
+        self.assertEqual(up['notes'], u'Useful details!')
+        self.assertEqual(up['date_submitted'], u'1984-11-02 00:00:00')
+        self.assertEqual(up['date_modified'], None)
+        self.assertEqual(up['date_approved'], None)
+        self.assertEqual(up['date_pushed'], None)
+        self.assertEqual(up['locked'], False)
+        self.assertEqual(up['alias'], u'FEDORA-%s-a3bbe1a8f2' % YEAR)
+        self.assertEqual(up['karma'], 1)
 
     def test_list_updates_by_status_active_release(self):
         res = self.app.get(
             '/updates/', {"status": "pending", "active_releases": 'true'})
         body = res.json_body
-        self.assertEquals(len(body['updates']), 1)
+        self.assertEqual(len(body['updates']), 1)
 
         up = body['updates'][0]
-        self.assertEquals(up['title'], u'bodhi-2.0-1.fc17')
-        self.assertEquals(up['status'], u'pending')
-        self.assertEquals(up['request'], u'testing')
-        self.assertEquals(up['user']['name'], u'guest')
-        self.assertEquals(up['release']['name'], u'F17')
-        self.assertEquals(up['type'], u'bugfix')
-        self.assertEquals(up['severity'], u'medium')
-        self.assertEquals(up['suggest'], u'unspecified')
-        self.assertEquals(up['close_bugs'], True)
-        self.assertEquals(up['notes'], u'Useful details!')
-        self.assertEquals(up['date_submitted'], u'1984-11-02 00:00:00')
-        self.assertEquals(up['date_modified'], None)
-        self.assertEquals(up['date_approved'], None)
-        self.assertEquals(up['date_pushed'], None)
-        self.assertEquals(up['locked'], False)
-        self.assertEquals(up['alias'], u'FEDORA-%s-a3bbe1a8f2' % YEAR)
-        self.assertEquals(up['karma'], 1)
+        self.assertEqual(up['title'], u'bodhi-2.0-1.fc17')
+        self.assertEqual(up['status'], u'pending')
+        self.assertEqual(up['request'], u'testing')
+        self.assertEqual(up['user']['name'], u'guest')
+        self.assertEqual(up['release']['name'], u'F17')
+        self.assertEqual(up['type'], u'bugfix')
+        self.assertEqual(up['severity'], u'medium')
+        self.assertEqual(up['suggest'], u'unspecified')
+        self.assertEqual(up['close_bugs'], True)
+        self.assertEqual(up['notes'], u'Useful details!')
+        self.assertEqual(up['date_submitted'], u'1984-11-02 00:00:00')
+        self.assertEqual(up['date_modified'], None)
+        self.assertEqual(up['date_approved'], None)
+        self.assertEqual(up['date_pushed'], None)
+        self.assertEqual(up['locked'], False)
+        self.assertEqual(up['alias'], u'FEDORA-%s-a3bbe1a8f2' % YEAR)
+        self.assertEqual(up['karma'], 1)
 
     def test_list_updates_by_status_inactive_release(self):
         rel = self.db.query(Release).filter_by(name='F17').one()
@@ -2418,16 +2418,16 @@ class TestUpdatesService(BaseTestCase):
         res = self.app.get(
             '/updates/', {"status": "pending", "active_releases": 'true'})
         body = res.json_body
-        self.assertEquals(len(body['updates']), 0)
+        self.assertEqual(len(body['updates']), 0)
 
     @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_updates_by_unexisting_status(self):
         res = self.app.get('/updates/', {"status": "single"},
                            status=400)
         body = res.json_body
-        self.assertEquals(len(body.get('updates', [])), 0)
-        self.assertEquals(res.json_body['errors'][0]['name'], 'status')
-        self.assertEquals(
+        self.assertEqual(len(body.get('updates', [])), 0)
+        self.assertEqual(res.json_body['errors'][0]['name'], 'status')
+        self.assertEqual(
             res.json_body['errors'][0]['description'],
             ('"single" is not one of testing, side_tag_expired, processing, obsolete, '
              'pending, stable, unpushed, side_tag_active'))
@@ -2435,103 +2435,103 @@ class TestUpdatesService(BaseTestCase):
     def test_list_updates_by_suggest(self):
         res = self.app.get('/updates/', {"suggest": "unspecified"})
         body = res.json_body
-        self.assertEquals(len(body['updates']), 1)
+        self.assertEqual(len(body['updates']), 1)
 
         up = body['updates'][0]
-        self.assertEquals(up['title'], u'bodhi-2.0-1.fc17')
-        self.assertEquals(up['status'], u'pending')
-        self.assertEquals(up['request'], u'testing')
-        self.assertEquals(up['user']['name'], u'guest')
-        self.assertEquals(up['release']['name'], u'F17')
-        self.assertEquals(up['type'], u'bugfix')
-        self.assertEquals(up['severity'], u'medium')
-        self.assertEquals(up['suggest'], u'unspecified')
-        self.assertEquals(up['close_bugs'], True)
-        self.assertEquals(up['notes'], u'Useful details!')
-        self.assertEquals(up['date_submitted'], u'1984-11-02 00:00:00')
-        self.assertEquals(up['date_modified'], None)
-        self.assertEquals(up['date_approved'], None)
-        self.assertEquals(up['date_pushed'], None)
-        self.assertEquals(up['locked'], False)
-        self.assertEquals(up['alias'], u'FEDORA-%s-a3bbe1a8f2' % YEAR)
-        self.assertEquals(up['karma'], 1)
+        self.assertEqual(up['title'], u'bodhi-2.0-1.fc17')
+        self.assertEqual(up['status'], u'pending')
+        self.assertEqual(up['request'], u'testing')
+        self.assertEqual(up['user']['name'], u'guest')
+        self.assertEqual(up['release']['name'], u'F17')
+        self.assertEqual(up['type'], u'bugfix')
+        self.assertEqual(up['severity'], u'medium')
+        self.assertEqual(up['suggest'], u'unspecified')
+        self.assertEqual(up['close_bugs'], True)
+        self.assertEqual(up['notes'], u'Useful details!')
+        self.assertEqual(up['date_submitted'], u'1984-11-02 00:00:00')
+        self.assertEqual(up['date_modified'], None)
+        self.assertEqual(up['date_approved'], None)
+        self.assertEqual(up['date_pushed'], None)
+        self.assertEqual(up['locked'], False)
+        self.assertEqual(up['alias'], u'FEDORA-%s-a3bbe1a8f2' % YEAR)
+        self.assertEqual(up['karma'], 1)
 
     @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_updates_by_unexisting_suggest(self):
         res = self.app.get('/updates/', {"suggest": "no idea"},
                            status=400)
         body = res.json_body
-        self.assertEquals(len(body.get('updates', [])), 0)
-        self.assertEquals(res.json_body['errors'][0]['name'], 'suggest')
-        self.assertEquals(res.json_body['errors'][0]['description'],
-                          '"no idea" is not one of logout, reboot, unspecified')
+        self.assertEqual(len(body.get('updates', [])), 0)
+        self.assertEqual(res.json_body['errors'][0]['name'], 'suggest')
+        self.assertEqual(res.json_body['errors'][0]['description'],
+                         '"no idea" is not one of logout, reboot, unspecified')
 
     def test_list_updates_by_type(self):
         res = self.app.get('/updates/', {"type": "bugfix"})
         body = res.json_body
-        self.assertEquals(len(body['updates']), 1)
+        self.assertEqual(len(body['updates']), 1)
 
         up = body['updates'][0]
-        self.assertEquals(up['title'], u'bodhi-2.0-1.fc17')
-        self.assertEquals(up['status'], u'pending')
-        self.assertEquals(up['request'], u'testing')
-        self.assertEquals(up['user']['name'], u'guest')
-        self.assertEquals(up['release']['name'], u'F17')
-        self.assertEquals(up['type'], u'bugfix')
-        self.assertEquals(up['severity'], u'medium')
-        self.assertEquals(up['suggest'], u'unspecified')
-        self.assertEquals(up['close_bugs'], True)
-        self.assertEquals(up['notes'], u'Useful details!')
-        self.assertEquals(up['date_submitted'], u'1984-11-02 00:00:00')
-        self.assertEquals(up['date_modified'], None)
-        self.assertEquals(up['date_approved'], None)
-        self.assertEquals(up['date_pushed'], None)
-        self.assertEquals(up['locked'], False)
-        self.assertEquals(up['alias'], u'FEDORA-%s-a3bbe1a8f2' % YEAR)
-        self.assertEquals(up['karma'], 1)
+        self.assertEqual(up['title'], u'bodhi-2.0-1.fc17')
+        self.assertEqual(up['status'], u'pending')
+        self.assertEqual(up['request'], u'testing')
+        self.assertEqual(up['user']['name'], u'guest')
+        self.assertEqual(up['release']['name'], u'F17')
+        self.assertEqual(up['type'], u'bugfix')
+        self.assertEqual(up['severity'], u'medium')
+        self.assertEqual(up['suggest'], u'unspecified')
+        self.assertEqual(up['close_bugs'], True)
+        self.assertEqual(up['notes'], u'Useful details!')
+        self.assertEqual(up['date_submitted'], u'1984-11-02 00:00:00')
+        self.assertEqual(up['date_modified'], None)
+        self.assertEqual(up['date_approved'], None)
+        self.assertEqual(up['date_pushed'], None)
+        self.assertEqual(up['locked'], False)
+        self.assertEqual(up['alias'], u'FEDORA-%s-a3bbe1a8f2' % YEAR)
+        self.assertEqual(up['karma'], 1)
 
     @unittest.skipIf(six.PY3, 'Not working with Python 3 yet')
     def test_list_updates_by_unexisting_type(self):
         res = self.app.get('/updates/', {"type": "not_my"},
                            status=400)
         body = res.json_body
-        self.assertEquals(len(body.get('updates', [])), 0)
-        self.assertEquals(res.json_body['errors'][0]['name'], 'type')
-        self.assertEquals(res.json_body['errors'][0]['description'],
-                          '"not_my" is not one of newpackage, bugfix, security, enhancement')
+        self.assertEqual(len(body.get('updates', [])), 0)
+        self.assertEqual(res.json_body['errors'][0]['name'], 'type')
+        self.assertEqual(res.json_body['errors'][0]['description'],
+                         '"not_my" is not one of newpackage, bugfix, security, enhancement')
 
     def test_list_updates_by_username(self):
         res = self.app.get('/updates/', {"user": "guest"})
         body = res.json_body
-        self.assertEquals(len(body['updates']), 1)
+        self.assertEqual(len(body['updates']), 1)
 
         up = body['updates'][0]
-        self.assertEquals(up['title'], u'bodhi-2.0-1.fc17')
-        self.assertEquals(up['status'], u'pending')
-        self.assertEquals(up['request'], u'testing')
-        self.assertEquals(up['user']['name'], u'guest')
-        self.assertEquals(up['release']['name'], u'F17')
-        self.assertEquals(up['type'], u'bugfix')
-        self.assertEquals(up['severity'], u'medium')
-        self.assertEquals(up['suggest'], u'unspecified')
-        self.assertEquals(up['close_bugs'], True)
-        self.assertEquals(up['notes'], u'Useful details!')
-        self.assertEquals(up['date_submitted'], u'1984-11-02 00:00:00')
-        self.assertEquals(up['date_modified'], None)
-        self.assertEquals(up['date_approved'], None)
-        self.assertEquals(up['date_pushed'], None)
-        self.assertEquals(up['locked'], False)
-        self.assertEquals(up['alias'], u'FEDORA-%s-a3bbe1a8f2' % YEAR)
-        self.assertEquals(up['karma'], 1)
+        self.assertEqual(up['title'], u'bodhi-2.0-1.fc17')
+        self.assertEqual(up['status'], u'pending')
+        self.assertEqual(up['request'], u'testing')
+        self.assertEqual(up['user']['name'], u'guest')
+        self.assertEqual(up['release']['name'], u'F17')
+        self.assertEqual(up['type'], u'bugfix')
+        self.assertEqual(up['severity'], u'medium')
+        self.assertEqual(up['suggest'], u'unspecified')
+        self.assertEqual(up['close_bugs'], True)
+        self.assertEqual(up['notes'], u'Useful details!')
+        self.assertEqual(up['date_submitted'], u'1984-11-02 00:00:00')
+        self.assertEqual(up['date_modified'], None)
+        self.assertEqual(up['date_approved'], None)
+        self.assertEqual(up['date_pushed'], None)
+        self.assertEqual(up['locked'], False)
+        self.assertEqual(up['alias'], u'FEDORA-%s-a3bbe1a8f2' % YEAR)
+        self.assertEqual(up['karma'], 1)
 
     def test_list_updates_by_unexisting_username(self):
         res = self.app.get('/updates/', {"user": "santa"},
                            status=400)
         body = res.json_body
-        self.assertEquals(len(body.get('updates', [])), 0)
-        self.assertEquals(res.json_body['errors'][0]['name'], 'user')
-        self.assertEquals(res.json_body['errors'][0]['description'],
-                          "Invalid user specified: santa")
+        self.assertEqual(len(body.get('updates', [])), 0)
+        self.assertEqual(res.json_body['errors'][0]['name'], 'user')
+        self.assertEqual(res.json_body['errors'][0]['description'],
+                         "Invalid user specified: santa")
 
     @mock.patch(**mock_uuid4_version1)
     @mock.patch(**mock_valid_requirements)
@@ -2545,24 +2545,24 @@ class TestUpdatesService(BaseTestCase):
         args['requirements'] = 'upgradepath'
         r = self.app.post_json('/updates/', args)
         up = r.json_body
-        self.assertEquals(up['title'], u'bodhi-2.0.0-3.fc17')
-        self.assertEquals(up['status'], u'pending')
-        self.assertEquals(up['request'], u'testing')
-        self.assertEquals(up['user']['name'], u'guest')
-        self.assertEquals(up['release']['name'], u'F17')
-        self.assertEquals(up['type'], u'bugfix')
-        self.assertEquals(up['severity'], u'unspecified')
-        self.assertEquals(up['suggest'], u'unspecified')
-        self.assertEquals(up['close_bugs'], True)
-        self.assertEquals(up['notes'], u'this is a test update')
+        self.assertEqual(up['title'], u'bodhi-2.0.0-3.fc17')
+        self.assertEqual(up['status'], u'pending')
+        self.assertEqual(up['request'], u'testing')
+        self.assertEqual(up['user']['name'], u'guest')
+        self.assertEqual(up['release']['name'], u'F17')
+        self.assertEqual(up['type'], u'bugfix')
+        self.assertEqual(up['severity'], u'unspecified')
+        self.assertEqual(up['suggest'], u'unspecified')
+        self.assertEqual(up['close_bugs'], True)
+        self.assertEqual(up['notes'], u'this is a test update')
         self.assertIsNotNone(up['date_submitted'])
         self.assertIsNotNone(up['date_modified'], None)
-        self.assertEquals(up['date_approved'], None)
-        self.assertEquals(up['date_pushed'], None)
-        self.assertEquals(up['locked'], False)
-        self.assertEquals(up['alias'], u'FEDORA-%s-033713b73b' % YEAR)
-        self.assertEquals(up['karma'], 0)
-        self.assertEquals(up['requirements'], 'upgradepath')
+        self.assertEqual(up['date_approved'], None)
+        self.assertEqual(up['date_pushed'], None)
+        self.assertEqual(up['locked'], False)
+        self.assertEqual(up['alias'], u'FEDORA-%s-033713b73b' % YEAR)
+        self.assertEqual(up['karma'], 0)
+        self.assertEqual(up['requirements'], 'upgradepath')
         comment = textwrap.dedent("""
         guest edited this update.
 
@@ -2577,11 +2577,11 @@ class TestUpdatesService(BaseTestCase):
         Karma has been reset.
         """).strip()
         self.assertMultiLineEqual(up['comments'][-1]['text'], comment)
-        self.assertEquals(len(up['builds']), 1)
-        self.assertEquals(up['builds'][0]['nvr'], u'bodhi-2.0.0-3.fc17')
-        self.assertEquals(self.db.query(RpmBuild).filter_by(nvr=u'bodhi-2.0.0-2.fc17').first(),
-                          None)
-        self.assertEquals(len(publish.call_args_list), 2)
+        self.assertEqual(len(up['builds']), 1)
+        self.assertEqual(up['builds'][0]['nvr'], u'bodhi-2.0.0-3.fc17')
+        self.assertEqual(self.db.query(RpmBuild).filter_by(nvr=u'bodhi-2.0.0-2.fc17').first(),
+                         None)
+        self.assertEqual(len(publish.call_args_list), 2)
         publish.assert_called_with(topic='update.edit', msg=ANY)
 
     @mock.patch(**mock_valid_requirements)
@@ -2602,11 +2602,11 @@ class TestUpdatesService(BaseTestCase):
         args['builds'] = 'bodhi-2.0.0-3.fc17'
         r = self.app.post_json('/updates/', args)
         up = r.json_body
-        self.assertEquals(up['title'], u'bodhi-2.0.0-3.fc17')
-        self.assertEquals(up['status'], u'pending')
-        self.assertEquals(up['request'], u'testing')
-        self.assertEquals(up['comments'][-1]['text'],
-                          u'This update has been submitted for testing by guest. ')
+        self.assertEqual(up['title'], u'bodhi-2.0.0-3.fc17')
+        self.assertEqual(up['status'], u'pending')
+        self.assertEqual(up['request'], u'testing')
+        self.assertEqual(up['comments'][-1]['text'],
+                         u'This update has been submitted for testing by guest. ')
         comment = textwrap.dedent("""
         guest edited this update.
 
@@ -2621,13 +2621,13 @@ class TestUpdatesService(BaseTestCase):
         Karma has been reset.
         """).strip()
         self.assertMultiLineEqual(up['comments'][-2]['text'], comment)
-        self.assertEquals(up['comments'][-4]['text'],
-                          u'This update has been submitted for testing by guest. ')
-        self.assertEquals(len(up['builds']), 1)
-        self.assertEquals(up['builds'][0]['nvr'], u'bodhi-2.0.0-3.fc17')
-        self.assertEquals(self.db.query(RpmBuild).filter_by(nvr=u'bodhi-2.0.0-2.fc17').first(),
-                          None)
-        self.assertEquals(len(publish.call_args_list), 3)
+        self.assertEqual(up['comments'][-4]['text'],
+                         u'This update has been submitted for testing by guest. ')
+        self.assertEqual(len(up['builds']), 1)
+        self.assertEqual(up['builds'][0]['nvr'], u'bodhi-2.0.0-3.fc17')
+        self.assertEqual(self.db.query(RpmBuild).filter_by(nvr=u'bodhi-2.0.0-2.fc17').first(),
+                         None)
+        self.assertEqual(len(publish.call_args_list), 3)
         publish.assert_called_with(topic='update.edit', msg=ANY)
 
     @mock.patch(**mock_valid_requirements)
@@ -2656,11 +2656,11 @@ class TestUpdatesService(BaseTestCase):
         args['builds'] = ['a-1.0-1.fc17', 'b-2.0-1.fc17', 'c-1.0-1.fc17']
         r = self.app.post_json('/updates/', args)
         up = r.json_body
-        self.assertEquals(up['title'], u'a-1.0-1.fc17 b-2.0-1.fc17 c-1.0-1.fc17')
-        self.assertEquals(up['status'], u'pending')
-        self.assertEquals(up['request'], u'testing')
-        self.assertEquals(up['comments'][-1]['text'],
-                          u'This update has been submitted for testing by guest. ')
+        self.assertEqual(up['title'], u'a-1.0-1.fc17 b-2.0-1.fc17 c-1.0-1.fc17')
+        self.assertEqual(up['status'], u'pending')
+        self.assertEqual(up['request'], u'testing')
+        self.assertEqual(up['comments'][-1]['text'],
+                         u'This update has been submitted for testing by guest. ')
         comment = textwrap.dedent("""
         guest edited this update.
 
@@ -2675,13 +2675,13 @@ class TestUpdatesService(BaseTestCase):
         Karma has been reset.
         """).strip()
         self.assertMultiLineEqual(up['comments'][-2]['text'], comment)
-        self.assertEquals(up['comments'][-3]['text'],
-                          u'This update has been submitted for testing by guest. ')
-        self.assertEquals(len(up['builds']), 3)
-        self.assertEquals(up['builds'][0]['nvr'], u'a-1.0-1.fc17')
-        self.assertEquals(up['builds'][1]['nvr'], u'c-1.0-1.fc17')
-        self.assertEquals(up['builds'][2]['nvr'], u'b-2.0-1.fc17')
-        self.assertEquals(len(publish.call_args_list), 3)
+        self.assertEqual(up['comments'][-3]['text'],
+                         u'This update has been submitted for testing by guest. ')
+        self.assertEqual(len(up['builds']), 3)
+        self.assertEqual(up['builds'][0]['nvr'], u'a-1.0-1.fc17')
+        self.assertEqual(up['builds'][1]['nvr'], u'c-1.0-1.fc17')
+        self.assertEqual(up['builds'][2]['nvr'], u'b-2.0-1.fc17')
+        self.assertEqual(len(publish.call_args_list), 3)
         publish.assert_called_with(topic='update.edit', msg=ANY)
 
     @mock.patch(**mock_valid_requirements)
@@ -2702,11 +2702,11 @@ class TestUpdatesService(BaseTestCase):
         args['builds'] = 'bodhi-2.0.0-3.fc17'
         r = self.app.post_json('/updates/', args)
         up = r.json_body
-        self.assertEquals(up['title'], u'bodhi-2.0.0-3.fc17')
-        self.assertEquals(up['status'], u'pending')
-        self.assertEquals(up['request'], u'testing')
-        self.assertEquals(up['comments'][-1]['text'],
-                          u'This update has been submitted for testing by guest. ')
+        self.assertEqual(up['title'], u'bodhi-2.0.0-3.fc17')
+        self.assertEqual(up['status'], u'pending')
+        self.assertEqual(up['request'], u'testing')
+        self.assertEqual(up['comments'][-1]['text'],
+                         u'This update has been submitted for testing by guest. ')
         comment = textwrap.dedent("""
         guest edited this update.
 
@@ -2721,13 +2721,13 @@ class TestUpdatesService(BaseTestCase):
         Karma has been reset.
         """).strip()
         self.assertMultiLineEqual(up['comments'][-2]['text'], comment)
-        self.assertEquals(up['comments'][-4]['text'],
-                          u'This update has been submitted for testing by guest. ')
-        self.assertEquals(len(up['builds']), 1)
-        self.assertEquals(up['builds'][0]['nvr'], u'bodhi-2.0.0-3.fc17')
-        self.assertEquals(self.db.query(RpmBuild).filter_by(nvr=u'bodhi-2.0.0-2.fc17').first(),
-                          None)
-        self.assertEquals(len(publish.call_args_list), 3)
+        self.assertEqual(up['comments'][-4]['text'],
+                         u'This update has been submitted for testing by guest. ')
+        self.assertEqual(len(up['builds']), 1)
+        self.assertEqual(up['builds'][0]['nvr'], u'bodhi-2.0.0-3.fc17')
+        self.assertEqual(self.db.query(RpmBuild).filter_by(nvr=u'bodhi-2.0.0-2.fc17').first(),
+                         None)
+        self.assertEqual(len(publish.call_args_list), 3)
         publish.assert_called_with(topic='update.edit', msg=ANY)
 
     @mock.patch(**mock_valid_requirements)
@@ -2762,15 +2762,15 @@ class TestUpdatesService(BaseTestCase):
         r = self.app.post_json('/updates/', args, status=400)
         up = r.json_body
 
-        self.assertEquals(up['status'], 'error')
-        self.assertEquals(up['errors'][0]['description'],
-                          'Cannot add a F18 build to an F17 update')
+        self.assertEqual(up['status'], 'error')
+        self.assertEqual(up['errors'][0]['description'],
+                         'Cannot add a F18 build to an F17 update')
 
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
     def test_edit_stable_update(self, publish, *args):
         """Make sure we can't edit stable updates"""
-        self.assertEquals(publish.call_args_list, [])
+        self.assertEqual(publish.call_args_list, [])
 
         # First, create a testing update
         nvr = u'bodhi-2.0.0-2.fc17'
@@ -2788,9 +2788,9 @@ class TestUpdatesService(BaseTestCase):
         args['builds'] = 'bodhi-2.0.0-3.fc17'
         r = self.app.post_json('/updates/', args, status=400)
         up = r.json_body
-        self.assertEquals(up['status'], 'error')
-        self.assertEquals(up['errors'][0]['description'], "Cannot edit stable updates")
-        self.assertEquals(len(publish.call_args_list), 1)
+        self.assertEqual(up['status'], 'error')
+        self.assertEqual(up['errors'][0]['description'], "Cannot edit stable updates")
+        self.assertEqual(len(publish.call_args_list), 1)
 
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
@@ -2811,43 +2811,43 @@ class TestUpdatesService(BaseTestCase):
         args['edited'] = args['builds']
         args['notes'] = 'Some new notes'
         up = self.app.post_json('/updates/', args, status=200).json_body
-        self.assertEquals(up['notes'], 'Some new notes')
+        self.assertEqual(up['notes'], 'Some new notes')
 
         # Changing the builds should fail
         args['notes'] = 'And yet some other notes'
         args['builds'] = 'bodhi-2.0.0-3.fc17'
         r = self.app.post_json('/updates/', args, status=400).json_body
-        self.assertEquals(r['status'], 'error')
+        self.assertEqual(r['status'], 'error')
         self.assertIn('errors', r)
         self.assertIn({u'description': u"Can't add builds to a locked update",
                        u'location': u'body', u'name': u'builds'},
                       r['errors'])
         up = self.db.query(Update).get(up_id)
-        self.assertEquals(up.notes, 'Some new notes')
+        self.assertEqual(up.notes, 'Some new notes')
         build = self.db.query(RpmBuild).filter_by(nvr=nvr).one()
-        self.assertEquals(up.builds, [build])
+        self.assertEqual(up.builds, [build])
 
         # Changing the request should fail
         args['notes'] = 'Still new notes'
         args['builds'] = args['edited']
         args['request'] = 'stable'
         r = self.app.post_json('/updates/', args, status=400).json_body
-        self.assertEquals(r['status'], 'error')
+        self.assertEqual(r['status'], 'error')
         self.assertIn('errors', r)
         self.assertIn(
             {u'description': u"Can't change the request on a locked update", u'location': u'body',
              u'name': u'builds'},
             r['errors'])
         up = self.db.query(Update).get(up_id)
-        self.assertEquals(up.notes, 'Some new notes')
+        self.assertEqual(up.notes, 'Some new notes')
         # We need to re-retrieve the build since we started a new transaction in the call to
         # /updates
         build = self.db.query(RpmBuild).filter_by(nvr=nvr).one()
-        self.assertEquals(up.builds, [build])
-        self.assertEquals(up.request, None)
+        self.assertEqual(up.builds, [build])
+        self.assertEqual(up.request, None)
 
         # At the end of the day, two fedmsg messages should have gone out.
-        self.assertEquals(len(publish.call_args_list), 2)
+        self.assertEqual(len(publish.call_args_list), 2)
         publish.assert_called_with(topic='update.edit', msg=ANY)
 
     @mock.patch(**mock_valid_requirements)
@@ -2871,9 +2871,9 @@ class TestUpdatesService(BaseTestCase):
         up.comment(self.db, u'LGTM', author=u'bowlofeggs', karma=1)
         up = self.db.query(Update).filter_by(title=nvr).one()
 
-        self.assertEquals(up.karma, 2)
-        self.assertEquals(up.request, UpdateRequest.testing)
-        self.assertEquals(up.status, UpdateStatus.pending)
+        self.assertEqual(up.karma, 2)
+        self.assertEqual(up.request, UpdateRequest.testing)
+        self.assertEqual(up.status, UpdateStatus.pending)
 
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
@@ -2900,9 +2900,9 @@ class TestUpdatesService(BaseTestCase):
         up.comment(self.db, u'LGTM', author=u'bowlofeggs', karma=1)
         up = self.db.query(Update).filter_by(title=nvr).one()
 
-        self.assertEquals(up.karma, 2)
-        self.assertEquals(up.request, UpdateRequest.stable)
-        self.assertEquals(up.status, UpdateStatus.pending)
+        self.assertEqual(up.karma, 2)
+        self.assertEqual(up.request, UpdateRequest.stable)
+        self.assertEqual(up.status, UpdateStatus.pending)
 
     @mock.patch(**mock_valid_requirements)
     def test_pending_update_on_stable_karma_not_reached(self, publish, *args):
@@ -2922,9 +2922,9 @@ class TestUpdatesService(BaseTestCase):
         up.comment(self.db, u'WFM', author=u'dustymabe', karma=1)
         up = self.db.query(Update).filter_by(title=nvr).one()
 
-        self.assertEquals(up.karma, 1)
-        self.assertEquals(up.request, UpdateRequest.testing)
-        self.assertEquals(up.status, UpdateStatus.pending)
+        self.assertEqual(up.karma, 1)
+        self.assertEqual(up.request, UpdateRequest.testing)
+        self.assertEqual(up.status, UpdateStatus.pending)
 
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
@@ -2948,9 +2948,9 @@ class TestUpdatesService(BaseTestCase):
         up.comment(self.db, u'LGTM', author=u'bowlofeggs', karma=1)
         up = self.db.query(Update).filter_by(title=nvr).one()
 
-        self.assertEquals(up.karma, 2)
-        self.assertEquals(up.status, UpdateStatus.pending)
-        self.assertEquals(up.request, UpdateRequest.testing)
+        self.assertEqual(up.karma, 2)
+        self.assertEqual(up.status, UpdateStatus.pending)
+        self.assertEqual(up.request, UpdateRequest.testing)
 
         text = six.text_type(config.get('testing_approval_msg_based_on_karma'))
         up.comment(self.db, text, author=u'bodhi')
@@ -2969,11 +2969,11 @@ class TestUpdatesService(BaseTestCase):
 
         args = self.get_update('bodhi-2.0.0-3.fc17')
         r = self.app.post_json('/updates/', args).json_body
-        self.assertEquals(r['request'], 'testing')
+        self.assertEqual(r['request'], 'testing')
 
         up = self.db.query(Update).filter_by(title=nvr).one()
-        self.assertEquals(up.status, UpdateStatus.pending)
-        self.assertEquals(up.request, UpdateRequest.testing)
+        self.assertEqual(up.status, UpdateStatus.pending)
+        self.assertEqual(up.request, UpdateRequest.testing)
 
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
@@ -2984,11 +2984,11 @@ class TestUpdatesService(BaseTestCase):
 
         args = self.get_update('bodhi-2.0.0-3.fc17')
         r = self.app.post_json('/updates/', args).json_body
-        self.assertEquals(r['request'], 'testing')
+        self.assertEqual(r['request'], 'testing')
 
         up = self.db.query(Update).filter_by(title=nvr).one()
-        self.assertEquals(up.status, UpdateStatus.obsolete)
-        self.assertEquals(up.request, None)
+        self.assertEqual(up.status, UpdateStatus.obsolete)
+        self.assertEqual(up.request, None)
 
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
@@ -3003,11 +3003,11 @@ class TestUpdatesService(BaseTestCase):
 
         args = self.get_update('bodhi-2.0.0-3.fc17')
         r = self.app.post_json('/updates/', args).json_body
-        self.assertEquals(r['request'], 'testing')
+        self.assertEqual(r['request'], 'testing')
 
         up = self.db.query(Update).filter_by(title=nvr).one()
-        self.assertEquals(up.status, UpdateStatus.pending)
-        self.assertEquals(up.request, UpdateRequest.stable)
+        self.assertEqual(up.status, UpdateStatus.pending)
+        self.assertEqual(up.request, UpdateRequest.stable)
 
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
@@ -3032,17 +3032,17 @@ class TestUpdatesService(BaseTestCase):
         args = self.get_update(new_nvr)
         with mock.patch(**mock_uuid4_version2):
             r = self.app.post_json('/updates/', args).json_body
-        self.assertEquals(r['request'], 'testing')
+        self.assertEqual(r['request'], 'testing')
         publish.assert_called_with(
             topic='update.request.testing', msg=mock.ANY)
 
         up = self.db.query(Update).filter_by(title=nvr).one()
-        self.assertEquals(up.status, UpdateStatus.obsolete)
+        self.assertEqual(up.status, UpdateStatus.obsolete)
         expected_comment = u'This update has been obsoleted by [bodhi-2.0.0-3.fc17]({}).'
         expected_comment = expected_comment.format(
             urlparse.urljoin(config['base_address'],
                              '/updates/FEDORA-{}-53345602d5'.format(datetime.now().year)))
-        self.assertEquals(up.comments[-1].text, expected_comment)
+        self.assertEqual(up.comments[-1].text, expected_comment)
 
         # Check Push to Stable button for obsolete update
         id = 'bodhi-2.0.0-2.fc17'
@@ -3115,7 +3115,7 @@ class TestUpdatesService(BaseTestCase):
             '/updates/%s/request' % args['builds'],
             {'request': 'testing', 'csrf_token': self.get_csrf_token()})
         self.assertEqual(resp.json['update']['request'], 'testing')
-        self.assertEquals(publish.call_args_list, [])
+        self.assertEqual(publish.call_args_list, [])
 
     @mock.patch(**mock_taskotron_results)
     @mock.patch(**mock_valid_requirements)
@@ -3183,9 +3183,9 @@ class TestUpdatesService(BaseTestCase):
         self.db.commit()
 
         up = self.db.query(Update).filter_by(title=nvr).one()
-        self.assertEquals(up.karma, -1)
-        self.assertEquals(up.status, UpdateStatus.obsolete)
-        self.assertEquals(up.request, None)
+        self.assertEqual(up.karma, -1)
+        self.assertEqual(up.status, UpdateStatus.obsolete)
+        self.assertEqual(up.request, None)
 
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
@@ -3208,9 +3208,9 @@ class TestUpdatesService(BaseTestCase):
         self.db.commit()
 
         up = self.db.query(Update).filter_by(title=nvr).one()
-        self.assertEquals(up.karma, -1)
-        self.assertEquals(up.status, UpdateStatus.pending)
-        self.assertEquals(up.request, UpdateRequest.testing)
+        self.assertEqual(up.karma, -1)
+        self.assertEqual(up.status, UpdateStatus.pending)
+        self.assertEqual(up.request, UpdateRequest.testing)
 
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
@@ -3234,9 +3234,9 @@ class TestUpdatesService(BaseTestCase):
         self.db.commit()
 
         up = self.db.query(Update).filter_by(title=nvr).one()
-        self.assertEquals(up.karma, -1)
-        self.assertEquals(up.status, UpdateStatus.pending)
-        self.assertEquals(up.request, UpdateRequest.testing)
+        self.assertEqual(up.karma, -1)
+        self.assertEqual(up.status, UpdateStatus.pending)
+        self.assertEqual(up.request, UpdateRequest.testing)
 
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
@@ -3270,10 +3270,10 @@ class TestUpdatesService(BaseTestCase):
         up.comment(self.db, u'Still not working', author=u'bob', karma=-1)
         up = self.db.query(Update).filter_by(title=nvr).one()
 
-        self.assertEquals(up.karma, -2)
-        self.assertEquals(up.autokarma, True)
-        self.assertEquals(up.status, UpdateStatus.obsolete)
-        self.assertEquals(up.request, None)
+        self.assertEqual(up.karma, -2)
+        self.assertEqual(up.autokarma, True)
+        self.assertEqual(up.status, UpdateStatus.obsolete)
+        self.assertEqual(up.request, None)
 
     @mock.patch(**mock_taskotron_results)
     @mock.patch(**mock_valid_requirements)
@@ -3343,8 +3343,8 @@ class TestUpdatesService(BaseTestCase):
             {'request': 'stable', 'csrf_token': self.get_csrf_token()},
             status=400)
         up = Update.get(nvr)
-        self.assertEquals(up.request, None)
-        self.assertEquals(up.status, UpdateStatus.testing)
+        self.assertEqual(up.request, None)
+        self.assertEqual(up.status, UpdateStatus.testing)
 
         # Checks Success for requesting to stable push after the update reaches stable karma
         up.comment(self.db, u'LGTM', author=u'ralph', karma=1)
@@ -3353,8 +3353,8 @@ class TestUpdatesService(BaseTestCase):
             {'request': 'stable', 'csrf_token': self.get_csrf_token()},
             status=200)
         up = Update.get(nvr)
-        self.assertEquals(up.request, UpdateRequest.stable)
-        self.assertEquals(up.status, UpdateStatus.testing)
+        self.assertEqual(up.request, UpdateRequest.stable)
+        self.assertEqual(up.status, UpdateStatus.testing)
 
     @mock.patch(**mock_taskotron_results)
     @mock.patch(**mock_valid_requirements)
@@ -3542,12 +3542,12 @@ class TestUpdatesService(BaseTestCase):
         resp = self.app.post_json('/updates/', args)
 
         # Note that this does **not** obsolete the other update
-        self.assertEquals(len(resp.json_body['caveats']), 1)
-        self.assertEquals(resp.json_body['caveats'][0]['description'],
-                          "Please be aware that there is another update in "
-                          "flight owned by bob, containing "
-                          "bodhi-2.0-2.fc17.  Are you coordinating with "
-                          "them?")
+        self.assertEqual(len(resp.json_body['caveats']), 1)
+        self.assertEqual(resp.json_body['caveats'][0]['description'],
+                         "Please be aware that there is another update in "
+                         "flight owned by bob, containing "
+                         "bodhi-2.0-2.fc17.  Are you coordinating with "
+                         "them?")
 
         # Ensure the second update was created successfully
         self.db.query(Update).filter_by(title=newtitle).one()
@@ -3556,21 +3556,21 @@ class TestUpdatesService(BaseTestCase):
     def test_updateid_alias(self, *args):
         res = self.app.post_json('/updates/', self.get_update(u'bodhi-2.0.0-3.fc17'))
         json = res.json_body
-        self.assertEquals(json['alias'], json['updateid'])
+        self.assertEqual(json['alias'], json['updateid'])
 
     def test_list_updates_by_lowercase_release_name(self):
         res = self.app.get('/updates/', {"releases": "f17"})
         body = res.json_body
-        self.assertEquals(len(body['updates']), 1)
+        self.assertEqual(len(body['updates']), 1)
 
         up = body['updates'][0]
-        self.assertEquals(up['title'], u'bodhi-2.0-1.fc17')
+        self.assertEqual(up['title'], u'bodhi-2.0-1.fc17')
 
     def test_redirect_to_package(self):
         "When you visit /updates/package, redirect to /updates/?packages=..."
         res = self.app.get('/updates/bodhi', status=302)
         target = 'http://localhost/updates/?packages=bodhi'
-        self.assertEquals(res.headers['Location'], target)
+        self.assertEqual(res.headers['Location'], target)
 
         # But be sure that we don't redirect if the package doesn't exist
         res = self.app.get('/updates/non-existant', status=404)
@@ -3579,24 +3579,24 @@ class TestUpdatesService(BaseTestCase):
         upd = self.db.query(Update).filter(Update.alias.isnot(None)).first()
         res = self.app.get('/updates/', {"alias": upd.alias})
         body = res.json_body
-        self.assertEquals(len(body['updates']), 1)
+        self.assertEqual(len(body['updates']), 1)
         up = body['updates'][0]
         # We need to refetch the update since the call to /updates/ committed the transaction.
         upd = self.db.query(Update).filter(Update.alias.isnot(None)).first()
-        self.assertEquals(up['title'], upd.title)
-        self.assertEquals(up['alias'], upd.alias)
+        self.assertEqual(up['title'], upd.title)
+        self.assertEqual(up['alias'], upd.alias)
 
         res = self.app.get('/updates/', {"updateid": upd.alias})
         body = res.json_body
-        self.assertEquals(len(body['updates']), 1)
+        self.assertEqual(len(body['updates']), 1)
         up = body['updates'][0]
         # We need to refetch the update since the call to /updates/ committed the transaction.
         upd = self.db.query(Update).filter(Update.alias.isnot(None)).first()
-        self.assertEquals(up['title'], upd.title)
+        self.assertEqual(up['title'], upd.title)
 
         res = self.app.get('/updates/', {"updateid": 'BLARG'})
         body = res.json_body
-        self.assertEquals(len(body['updates']), 0)
+        self.assertEqual(len(body['updates']), 0)
 
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
@@ -3626,19 +3626,19 @@ class TestUpdatesService(BaseTestCase):
         data = r.json_body
 
         self.assertIn('caveats', data)
-        self.assertEquals(len(data['caveats']), 2)
-        self.assertEquals(data['caveats'][0]['description'],
-                          "Your update is being split into 2, one for each release.")
-        self.assertEquals(
+        self.assertEqual(len(data['caveats']), 2)
+        self.assertEqual(data['caveats'][0]['description'],
+                         "Your update is being split into 2, one for each release.")
+        self.assertEqual(
             data['caveats'][1]['description'],
             "This update has obsoleted bodhi-2.0-1.fc17, and has inherited its bugs and notes.")
 
         self.assertIn('updates', data)
-        self.assertEquals(len(data['updates']), 2)
+        self.assertEqual(len(data['updates']), 2)
 
         publish.assert_called_with(topic='update.request.testing', msg=ANY)
         # Make sure two fedmsg messages were published
-        self.assertEquals(len(publish.call_args_list), 2)
+        self.assertEqual(len(publish.call_args_list), 2)
 
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
@@ -3648,7 +3648,7 @@ class TestUpdatesService(BaseTestCase):
         args['bugs'] = '56789'
         r = self.app.post_json('/updates/', args)
         # This has two bugs because it obsoleted another update and inherited its bugs.
-        self.assertEquals(len(r.json['bugs']), 2)
+        self.assertEqual(len(r.json['bugs']), 2)
         publish.assert_called_with(topic='update.request.testing', msg=ANY)
 
         # Pretend it was pushed to testing and tested
@@ -3665,12 +3665,12 @@ class TestUpdatesService(BaseTestCase):
         r = self.app.post_json('/updates/', args)
         up = r.json_body
 
-        self.assertEquals(len(up['bugs']), 2)
+        self.assertEqual(len(up['bugs']), 2)
         bug_ids = [bug['bug_id'] for bug in up['bugs']]
         self.assertIn(56789, bug_ids)
         self.assertIn(98765, bug_ids)
-        self.assertEquals(up['status'], u'pending')
-        self.assertEquals(up['request'], u'testing')
+        self.assertEqual(up['status'], u'pending')
+        self.assertEqual(up['request'], u'testing')
 
         # now remove a bug
         args['edited'] = args['builds']
@@ -3678,11 +3678,11 @@ class TestUpdatesService(BaseTestCase):
         args['bugs'] = '98765'
         r = self.app.post_json('/updates/', args)
         up = r.json_body
-        self.assertEquals(len(up['bugs']), 1)
+        self.assertEqual(len(up['bugs']), 1)
         bug_ids = [bug['bug_id'] for bug in up['bugs']]
         self.assertIn(98765, bug_ids)
-        self.assertEquals(up['status'], u'pending')
-        self.assertEquals(up['request'], u'testing')
+        self.assertEqual(up['status'], u'pending')
+        self.assertEqual(up['request'], u'testing')
 
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
@@ -3693,8 +3693,8 @@ class TestUpdatesService(BaseTestCase):
         args = self.get_update(build)
         args['edited'] = edited
         r = self.app.post_json('/updates/', args, status=400).json_body
-        self.assertEquals(r['status'], 'error')
-        self.assertEquals(r['errors'][0]['description'], 'Cannot find update to edit: %s' % edited)
+        self.assertEqual(r['status'], 'error')
+        self.assertEqual(r['errors'][0]['description'], 'Cannot find update to edit: %s' % edited)
 
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
@@ -3705,10 +3705,10 @@ class TestUpdatesService(BaseTestCase):
         publish.assert_called_with(topic='update.request.testing', msg=ANY)
 
         up = r.json_body
-        self.assertEquals(up['require_testcases'], True)
-        self.assertEquals(up['require_bugs'], False)
-        self.assertEquals(up['stable_karma'], 3)
-        self.assertEquals(up['unstable_karma'], -3)
+        self.assertEqual(up['require_testcases'], True)
+        self.assertEqual(up['require_bugs'], False)
+        self.assertEqual(up['stable_karma'], 3)
+        self.assertEqual(up['unstable_karma'], -3)
 
         # Pretend it was pushed to testing and tested
         update = self.db.query(Update).filter_by(title=build).one()
@@ -3727,13 +3727,13 @@ class TestUpdatesService(BaseTestCase):
 
         r = self.app.post_json('/updates/', args)
         up = r.json_body
-        self.assertEquals(up['status'], u'testing')
-        self.assertEquals(up['request'], None)
+        self.assertEqual(up['status'], u'testing')
+        self.assertEqual(up['request'], None)
 
-        self.assertEquals(up['require_bugs'], True)
-        self.assertEquals(up['require_testcases'], False)
-        self.assertEquals(up['stable_karma'], 3)
-        self.assertEquals(up['unstable_karma'], -3)
+        self.assertEqual(up['require_bugs'], True)
+        self.assertEqual(up['require_testcases'], False)
+        self.assertEqual(up['stable_karma'], 3)
+        self.assertEqual(up['unstable_karma'], -3)
 
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
@@ -3744,7 +3744,7 @@ class TestUpdatesService(BaseTestCase):
         r = self.app.post_json('/updates/', args)
         publish.assert_called_with(topic='update.request.testing', msg=ANY)
         up = r.json_body
-        self.assertEquals(up['type'], u'newpackage')
+        self.assertEqual(up['type'], u'newpackage')
 
         # Pretend it was pushed to testing and tested
         update = self.db.query(Update).filter_by(title=build).one()
@@ -3758,16 +3758,16 @@ class TestUpdatesService(BaseTestCase):
         args['type'] = 'bugfix'
         r = self.app.post_json('/updates/', args)
         up = r.json_body
-        self.assertEquals(up['status'], u'testing')
-        self.assertEquals(up['request'], None)
-        self.assertEquals(up['type'], u'bugfix')
+        self.assertEqual(up['status'], u'testing')
+        self.assertEqual(up['request'], None)
+        self.assertEqual(up['type'], u'bugfix')
 
     def test_update_meeting_requirements_present(self):
         """ Check that the requirements boolean is present in our JSON """
         res = self.app.get('/updates/bodhi-2.0-1.fc17', headers={'Accept': 'application/json'})
         actual = res.json_body['update']['meets_testing_requirements']
         expected = False
-        self.assertEquals(actual, expected)
+        self.assertEqual(actual, expected)
 
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
@@ -3791,9 +3791,9 @@ class TestUpdatesService(BaseTestCase):
         args['builds'] = 'bodhi-2.0.0-3.fc17'
         r = self.app.post_json('/updates/', args)
         up = r.json_body
-        self.assertEquals(up['title'], u'bodhi-2.0.0-3.fc17')
+        self.assertEqual(up['title'], u'bodhi-2.0.0-3.fc17')
         # This is what we really want to test here.
-        self.assertEquals(up['karma'], 0)
+        self.assertEqual(up['karma'], 0)
 
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
@@ -3820,7 +3820,7 @@ class TestUpdatesService(BaseTestCase):
         # Have bob +1 it
         upd.comment(self.db, u'LGTM', author=u'bob', karma=1)
         upd = Update.get(nvr)
-        self.assertEquals(upd.karma, 1)
+        self.assertEqual(upd.karma, 1)
 
         # Then.. edit it and change the builds!
         new_nvr = u'bodhi-2.0.0-3.fc17'
@@ -3828,16 +3828,16 @@ class TestUpdatesService(BaseTestCase):
         args['builds'] = new_nvr
         r = self.app.post_json('/updates/', args)
         up = r.json_body
-        self.assertEquals(up['title'], new_nvr)
+        self.assertEqual(up['title'], new_nvr)
         # This is what we really want to test here.
-        self.assertEquals(up['karma'], 0)
+        self.assertEqual(up['karma'], 0)
 
         # Have bob +1 it again
         upd = Update.get(new_nvr)
         upd.comment(self.db, u'Ship it!', author=u'bob', karma=1)
 
         # Bob should be able to give karma again since the reset
-        self.assertEquals(upd.karma, 1)
+        self.assertEqual(upd.karma, 1)
 
         # Then.. edit it and change the builds!
         newer_nvr = u'bodhi-2.0.0-4.fc17'
@@ -3845,16 +3845,16 @@ class TestUpdatesService(BaseTestCase):
         args['builds'] = newer_nvr
         r = self.app.post_json('/updates/', args)
         up = r.json_body
-        self.assertEquals(up['title'], newer_nvr)
+        self.assertEqual(up['title'], newer_nvr)
         # This is what we really want to test here.
-        self.assertEquals(up['karma'], 0)
+        self.assertEqual(up['karma'], 0)
 
         # Have bob +1 it again
         upd = Update.get(newer_nvr)
         upd.comment(self.db, u'Ship it!', author=u'bob', karma=1)
 
         # Bob should be able to give karma again since the reset
-        self.assertEquals(upd.karma, 1)
+        self.assertEqual(upd.karma, 1)
 
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
@@ -3910,7 +3910,7 @@ class TestUpdatesService(BaseTestCase):
         up.comment(self.db, u'wfm', author=u'ralph', karma=1)
         up = self.db.query(Update).filter_by(title=nvr).one()
         self.assertEqual(up._composite_karma, (1, 0))
-        self.assertEquals(up.karma, 1)
+        self.assertEqual(up.karma, 1)
 
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
@@ -3942,7 +3942,7 @@ class TestUpdatesService(BaseTestCase):
         up.comment(self.db, u'Failed to work', author=u'bowlofeggs', karma=-1)
         up = self.db.query(Update).filter_by(title=nvr).one()
         self.assertEqual(up._composite_karma, (1, -1))
-        self.assertEquals(up.karma, 0)
+        self.assertEqual(up.karma, 0)
 
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
@@ -3970,7 +3970,7 @@ class TestUpdatesService(BaseTestCase):
         up.comment(self.db, u' ', author=u'bowlofeggs', karma=1)
         up = self.db.query(Update).filter_by(title=nvr).one()
         self.assertEqual(up._composite_karma, (2, 0))
-        self.assertEquals(up.karma, 2)
+        self.assertEqual(up.karma, 2)
 
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
@@ -4031,9 +4031,9 @@ class TestUpdatesService(BaseTestCase):
         publish.assert_called_with(topic='update.request.testing', msg=ANY)
 
         up = r.json_body
-        self.assertEquals(up['autokarma'], False)
-        self.assertEquals(up['stable_karma'], 3)
-        self.assertEquals(up['unstable_karma'], -3)
+        self.assertEqual(up['autokarma'], False)
+        self.assertEqual(up['stable_karma'], 3)
+        self.assertEqual(up['unstable_karma'], -3)
 
         # Pretend it was pushed to testing
         update = self.db.query(Update).filter_by(title=build).one()
@@ -4051,11 +4051,11 @@ class TestUpdatesService(BaseTestCase):
 
         r = self.app.post_json('/updates/', args)
         up = r.json_body
-        self.assertEquals(up['status'], u'testing')
-        self.assertEquals(up['request'], None)
-        self.assertEquals(up['autokarma'], False)
-        self.assertEquals(up['stable_karma'], 4)
-        self.assertEquals(up['unstable_karma'], -4)
+        self.assertEqual(up['status'], u'testing')
+        self.assertEqual(up['request'], None)
+        self.assertEqual(up['autokarma'], False)
+        self.assertEqual(up['stable_karma'], 4)
+        self.assertEqual(up['unstable_karma'], -4)
 
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
@@ -4070,7 +4070,7 @@ class TestUpdatesService(BaseTestCase):
         args['autokarma'] = True
         resp = self.app.post_json('/updates/', args)
         self.assertTrue(resp.json['critpath'])
-        self.assertEquals(resp.json['request'], 'testing')
+        self.assertEqual(resp.json['request'], 'testing')
         publish.assert_called_with(topic='update.request.testing', msg=ANY)
 
         up = self.db.query(Update).filter_by(title=resp.json['title']).one()
@@ -4086,12 +4086,12 @@ class TestUpdatesService(BaseTestCase):
         up.comment(self.db, u'wfm', author=u'bowlofeggs', karma=1)
         up = self.db.query(Update).filter_by(title=resp.json['title']).one()
 
-        self.assertEquals(up.karma, 0)
-        self.assertEquals(up.status, UpdateStatus.testing)
-        self.assertEquals(up.request, None)
+        self.assertEqual(up.karma, 0)
+        self.assertEqual(up.status, UpdateStatus.testing)
+        self.assertEqual(up.request, None)
 
         # Autopush gets disabled since there is a negative karma from ralph
-        self.assertEquals(up.autokarma, False)
+        self.assertEqual(up.autokarma, False)
 
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
@@ -4109,7 +4109,7 @@ class TestUpdatesService(BaseTestCase):
 
         resp = self.app.post_json('/updates/', args)
         self.assertTrue(resp.json['critpath'])
-        self.assertEquals(resp.json['request'], 'testing')
+        self.assertEqual(resp.json['request'], 'testing')
         publish.assert_called_with(topic='update.request.testing', msg=ANY)
 
         up = self.db.query(Update).filter_by(title=resp.json['title']).one()
@@ -4121,13 +4121,13 @@ class TestUpdatesService(BaseTestCase):
 
         up.comment(self.db, u'LGTM', author=u'bowlofeggs', karma=1)
         up = self.db.query(Update).filter_by(title=resp.json['title']).one()
-        self.assertEquals(up.karma, 2)
+        self.assertEqual(up.karma, 2)
 
         # No negative karma: Update gets automatically marked as stable
-        self.assertEquals(up.autokarma, True)
+        self.assertEqual(up.autokarma, True)
 
         up = self.db.query(Update).filter_by(title=resp.json['title']).one()
-        self.assertEquals(up.request, UpdateRequest.batched)
+        self.assertEqual(up.request, UpdateRequest.batched)
 
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
@@ -4150,7 +4150,7 @@ class TestUpdatesService(BaseTestCase):
 
         resp = self.app.post_json('/updates/', args)
         self.assertTrue(resp.json['critpath'])
-        self.assertEquals(resp.json['request'], 'testing')
+        self.assertEqual(resp.json['request'], 'testing')
         publish.assert_called_with(topic='update.request.testing', msg=ANY)
 
         up = self.db.query(Update).filter_by(title=resp.json['title']).one()
@@ -4172,13 +4172,13 @@ class TestUpdatesService(BaseTestCase):
         up.comment(self.db, u'LGTM', author=u'trishnag', karma=1)
         up = self.db.query(Update).filter_by(title=resp.json['title']).one()
 
-        self.assertEquals(up.karma, 3)
-        self.assertEquals(up.autokarma, False)
+        self.assertEqual(up.karma, 3)
+        self.assertEqual(up.autokarma, False)
         # The request should still be at testing. This assertion tests for
         # https://github.com/fedora-infra/bodhi/issues/989 where karma comments were resetting the
         # request to None.
-        self.assertEquals(up.request, UpdateRequest.testing)
-        self.assertEquals(up.status, UpdateStatus.testing)
+        self.assertEqual(up.request, UpdateRequest.testing)
+        self.assertEqual(up.status, UpdateStatus.testing)
 
         id = 'kernel-3.11.5-300.fc17'
         resp = self.app.get('/updates/%s' % id,
@@ -4205,7 +4205,7 @@ class TestUpdatesService(BaseTestCase):
 
         resp = self.app.post_json('/updates/', args)
         self.assertTrue(resp.json['critpath'])
-        self.assertEquals(resp.json['request'], 'testing')
+        self.assertEqual(resp.json['request'], 'testing')
         publish.assert_called_with(topic='update.request.testing', msg=ANY)
 
         up = self.db.query(Update).filter_by(title=resp.json['title']).one()
@@ -4221,13 +4221,13 @@ class TestUpdatesService(BaseTestCase):
         up.comment(self.db, u'LGTM', author=u'puiterwijk', karma=1)
         up = self.db.query(Update).filter_by(title=resp.json['title']).one()
 
-        self.assertEquals(up.karma, 3)
-        self.assertEquals(up.autokarma, False)
+        self.assertEqual(up.karma, 3)
+        self.assertEqual(up.autokarma, False)
         # The request should still be at testing. This assertion tests for
         # https://github.com/fedora-infra/bodhi/issues/989 where karma comments were resetting the
         # request to None.
-        self.assertEquals(up.request, UpdateRequest.testing)
-        self.assertEquals(up.status, UpdateStatus.testing)
+        self.assertEqual(up.request, UpdateRequest.testing)
+        self.assertEqual(up.status, UpdateStatus.testing)
 
         id = 'kernel-3.11.5-300.fc17'
         resp = self.app.get('/updates/%s' % id,
@@ -4250,7 +4250,7 @@ class TestUpdatesService(BaseTestCase):
         args['unstable_karma'] = -3
 
         resp = self.app.post_json('/updates/', args)
-        self.assertEquals(resp.json['request'], 'testing')
+        self.assertEqual(resp.json['request'], 'testing')
         publish.assert_called_with(topic='update.request.testing', msg=ANY)
 
         up = self.db.query(Update).filter_by(title=resp.json['title']).one()
@@ -4261,7 +4261,7 @@ class TestUpdatesService(BaseTestCase):
         up = self.db.query(Update).filter_by(title=resp.json['title']).one()
 
         expected_comment = config.get('disable_automatic_push_to_stable')
-        self.assertEquals(up.comments[3].text, expected_comment)
+        self.assertEqual(up.comments[3].text, expected_comment)
 
         up.comment(self.db, u'LGTM Now', author=u'ralph', karma=1)
         up = self.db.query(Update).filter_by(title=resp.json['title']).one()
@@ -4272,13 +4272,13 @@ class TestUpdatesService(BaseTestCase):
         up.comment(self.db, u'LGTM', author=u'puiterwijk', karma=1)
         up = self.db.query(Update).filter_by(title=resp.json['title']).one()
 
-        self.assertEquals(up.karma, 3)
-        self.assertEquals(up.autokarma, False)
+        self.assertEqual(up.karma, 3)
+        self.assertEqual(up.autokarma, False)
 
         # Request and Status remains testing since the autopush is disabled
         up = self.db.query(Update).filter_by(title=resp.json['title']).one()
-        self.assertEquals(up.request, UpdateRequest.testing)
-        self.assertEquals(up.status, UpdateStatus.testing)
+        self.assertEqual(up.request, UpdateRequest.testing)
+        self.assertEqual(up.status, UpdateStatus.testing)
 
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
@@ -4299,7 +4299,7 @@ class TestUpdatesService(BaseTestCase):
         args['unstable_karma'] = -2
 
         resp = self.app.post_json('/updates/', args)
-        self.assertEquals(resp.json['request'], 'testing')
+        self.assertEqual(resp.json['request'], 'testing')
         publish.assert_called_with(topic='update.request.testing', msg=ANY)
 
         up = self.db.query(Update).filter_by(title=resp.json['title']).one()
@@ -4313,10 +4313,10 @@ class TestUpdatesService(BaseTestCase):
         up = self.db.query(Update).filter_by(title=resp.json['title']).one()
 
         # No negative karma: Update gets automatically marked as stable
-        self.assertEquals(up.autokarma, True)
+        self.assertEqual(up.autokarma, True)
 
         up = self.db.query(Update).filter_by(title=resp.json['title']).one()
-        self.assertEquals(up.request, UpdateRequest.batched)
+        self.assertEqual(up.request, UpdateRequest.batched)
 
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
@@ -4770,12 +4770,12 @@ class TestUpdatesService(BaseTestCase):
         # Ensures Request doesn't get set to stable automatically since autokarma is disabled
         upd.comment(self.db, u'LGTM', author=u'ralph', karma=1)
         upd = Update.get(nvr)
-        self.assertEquals(upd.karma, 1)
-        self.assertEquals(upd.stable_karma, 1)
-        self.assertEquals(upd.status, UpdateStatus.testing)
-        self.assertEquals(upd.request, UpdateRequest.batched)
-        self.assertEquals(upd.autokarma, False)
-        self.assertEquals(upd.pushed, True)
+        self.assertEqual(upd.karma, 1)
+        self.assertEqual(upd.stable_karma, 1)
+        self.assertEqual(upd.status, UpdateStatus.testing)
+        self.assertEqual(upd.request, UpdateRequest.batched)
+        self.assertEqual(upd.autokarma, False)
+        self.assertEqual(upd.pushed, True)
 
         text = six.text_type(config.get('testing_approval_msg_based_on_karma'))
         upd.comment(self.db, text, author=u'bodhi')
@@ -4819,11 +4819,11 @@ class TestUpdatesService(BaseTestCase):
         # Ensures Request doesn't get set to stable automatically since autokarma is disabled
         upd.comment(self.db, u'LGTM', author=u'ralph', karma=1)
         upd = Update.get(nvr)
-        self.assertEquals(upd.karma, 1)
-        self.assertEquals(upd.stable_karma, 1)
-        self.assertEquals(upd.status, UpdateStatus.testing)
-        self.assertEquals(upd.request, None)
-        self.assertEquals(upd.autokarma, False)
+        self.assertEqual(upd.karma, 1)
+        self.assertEqual(upd.stable_karma, 1)
+        self.assertEqual(upd.status, UpdateStatus.testing)
+        self.assertEqual(upd.request, None)
+        self.assertEqual(upd.autokarma, False)
 
         text = six.text_type(config.get('testing_approval_msg_based_on_karma'))
         upd.comment(self.db, text, author=u'bodhi')
@@ -4865,14 +4865,14 @@ class TestUpdatesService(BaseTestCase):
         args['builds'] = new_nvr
         r = self.app.post_json('/updates/', args)
         up = r.json_body
-        self.assertEquals(up['title'], new_nvr)
+        self.assertEqual(up['title'], new_nvr)
 
         # Change it back to ensure we can still reference the older build
         args['edited'] = args['builds']
         args['builds'] = nvr
         r = self.app.post_json('/updates/', args)
         up = r.json_body
-        self.assertEquals(up['title'], nvr)
+        self.assertEqual(up['title'], nvr)
 
     @mock.patch(**mock_taskotron_results)
     @mock.patch(**mock_valid_requirements)
@@ -4945,22 +4945,22 @@ class TestUpdatesService(BaseTestCase):
         args['builds'] = '%s,%s' % (nvr1, nvr2)
         r = self.app.post_json('/updates/', args, status=400)
         up = r.json_body
-        self.assertEquals(up['status'], 'error')
-        self.assertEquals(up['errors'][0]['description'],
-                          'Update for bodhi-2.0.0-2.fc17 already exists')
+        self.assertEqual(up['status'], 'error')
+        self.assertEqual(up['errors'][0]['description'],
+                         'Update for bodhi-2.0.0-2.fc17 already exists')
 
         up = Update.get(nvr2)
-        self.assertEquals(up.title, nvr2)  # nvr1 shouldn't be able to be added
-        self.assertEquals(up.status, UpdateStatus.testing)
-        self.assertEquals(len(up.builds), 1)
-        self.assertEquals(up.builds[0].nvr, nvr2)
+        self.assertEqual(up.title, nvr2)  # nvr1 shouldn't be able to be added
+        self.assertEqual(up.status, UpdateStatus.testing)
+        self.assertEqual(len(up.builds), 1)
+        self.assertEqual(up.builds[0].nvr, nvr2)
 
         # nvr1 update should remain intact
         up = Update.get(nvr1)
-        self.assertEquals(up.title, nvr1)
-        self.assertEquals(up.status, UpdateStatus.testing)
-        self.assertEquals(len(up.builds), 1)
-        self.assertEquals(up.builds[0].nvr, nvr1)
+        self.assertEqual(up.title, nvr1)
+        self.assertEqual(up.status, UpdateStatus.testing)
+        self.assertEqual(len(up.builds), 1)
+        self.assertEqual(up.builds[0].nvr, nvr1)
 
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
@@ -4992,8 +4992,8 @@ class TestUpdatesService(BaseTestCase):
         r = self.app.post_json('/updates/', args)
         up = r.json_body
 
-        self.assertEquals(up['title'], u'bodhi-2.0.0-3.fc17')
-        self.assertEquals(up['karma'], 0)
+        self.assertEqual(up['title'], u'bodhi-2.0.0-3.fc17')
+        self.assertEqual(up['karma'], 0)
 
         update = Update.get(u'bodhi-2.0.0-3.fc17')
         update.status = UpdateStatus.testing
@@ -5002,7 +5002,7 @@ class TestUpdatesService(BaseTestCase):
         update.comment(self.db, u'lgtm2', author='friend4', karma=1)
         self.db.commit()
 
-        self.assertEquals(update.days_to_stable, 0)
+        self.assertEqual(update.days_to_stable, 0)
         self.assertEqual(update.meets_testing_requirements, True)
 
     @mock.patch(**mock_taskotron_results)
@@ -5044,7 +5044,7 @@ class TestUpdatesService(BaseTestCase):
         args['stable_karma'] = 2
 
         resp = self.app.post_json('/updates/', args)
-        self.assertEquals(resp.json['request'], 'testing')
+        self.assertEqual(resp.json['request'], 'testing')
         publish.assert_called_with(topic='update.request.testing', msg=ANY)
 
         up = self.db.query(Update).filter_by(title=resp.json['title']).one()
@@ -5059,7 +5059,7 @@ class TestUpdatesService(BaseTestCase):
         up = self.db.query(Update).filter_by(title=resp.json['title']).one()
 
         up = self.db.query(Update).filter_by(title=resp.json['title']).one()
-        self.assertEquals(up.request, UpdateRequest.stable)
+        self.assertEqual(up.request, UpdateRequest.stable)
 
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
@@ -5074,7 +5074,7 @@ class TestUpdatesService(BaseTestCase):
         args['stable_karma'] = 2
 
         resp = self.app.post_json('/updates/', args)
-        self.assertEquals(resp.json['request'], 'testing')
+        self.assertEqual(resp.json['request'], 'testing')
         publish.assert_called_with(topic='update.request.testing', msg=ANY)
 
         up = self.db.query(Update).filter_by(title=resp.json['title']).one()
@@ -5089,7 +5089,7 @@ class TestUpdatesService(BaseTestCase):
         up = self.db.query(Update).filter_by(title=resp.json['title']).one()
 
         up = self.db.query(Update).filter_by(title=resp.json['title']).one()
-        self.assertEquals(up.request, UpdateRequest.stable)
+        self.assertEqual(up.request, UpdateRequest.stable)
 
 
 class TestWaiveTestResults(BaseTestCase):
@@ -5107,9 +5107,9 @@ class TestWaiveTestResults(BaseTestCase):
                          csrf_token=self.app.get('/csrf').json_body['csrf_token'])
         res = self.app.post_json('/updates/%s/waive-test-results' % str(nvr), post_data, status=400)
 
-        self.assertEquals(res.json_body['status'], 'error')
-        self.assertEquals(res.json_body[u'errors'][0][u'description'],
-                          "Can't waive test results on a locked update")
+        self.assertEqual(res.json_body['status'], 'error')
+        self.assertEqual(res.json_body[u'errors'][0][u'description'],
+                         "Can't waive test results on a locked update")
 
     def test_cannot_waive_test_results_when_test_gating_is_off(self, *args):
         """
@@ -5125,9 +5125,9 @@ class TestWaiveTestResults(BaseTestCase):
                          csrf_token=self.app.get('/csrf').json_body['csrf_token'])
         res = self.app.post_json('/updates/%s/waive-test-results' % str(nvr), post_data, status=400)
 
-        self.assertEquals(res.json_body['status'], 'error')
-        self.assertEquals(res.json_body[u'errors'][0][u'description'],
-                          "Test gating is not enabled")
+        self.assertEqual(res.json_body['status'], 'error')
+        self.assertEqual(res.json_body[u'errors'][0][u'description'],
+                         "Test gating is not enabled")
 
     @mock.patch('bodhi.server.services.updates.Update.waive_test_results',
                 side_effect=IOError('IOError. oops!'))
@@ -5143,9 +5143,9 @@ class TestWaiveTestResults(BaseTestCase):
                          csrf_token=self.app.get('/csrf').json_body['csrf_token'])
         res = self.app.post_json('/updates/%s/waive-test-results' % str(nvr), post_data, status=400)
 
-        self.assertEquals(res.json_body['status'], 'error')
-        self.assertEquals(res.json_body['errors'][0]['description'],
-                          u'IOError. oops!')
+        self.assertEqual(res.json_body['status'], 'error')
+        self.assertEqual(res.json_body['errors'][0]['description'],
+                         u'IOError. oops!')
         log_exception.assert_called_once_with("Unhandled exception in waive_test_results")
 
     @mock.patch.dict(config, [('test_gating.required', True)])

--- a/bodhi/tests/server/test_metadata.py
+++ b/bodhi/tests/server/test_metadata.py
@@ -83,53 +83,53 @@ class TestAddUpdate(UpdateInfoMetadataTestCase):
         md.shelf.close()
 
         self.assertEqual(len(md.uinfo.updates), 1)
-        self.assertEquals(md.uinfo.updates[0].title, update.title)
-        self.assertEquals(md.uinfo.updates[0].release, update.release.long_name)
-        self.assertEquals(md.uinfo.updates[0].status, update.status.value)
-        self.assertEquals(md.uinfo.updates[0].updated_date, update.date_modified)
-        self.assertEquals(md.uinfo.updates[0].fromstr, config.get('bodhi_email'))
-        self.assertEquals(md.uinfo.updates[0].rights, config.get('updateinfo_rights'))
-        self.assertEquals(md.uinfo.updates[0].description, update.notes)
-        self.assertEquals(md.uinfo.updates[0].id, update.alias)
-        self.assertEquals(md.uinfo.updates[0].severity, 'Moderate')
+        self.assertEqual(md.uinfo.updates[0].title, update.title)
+        self.assertEqual(md.uinfo.updates[0].release, update.release.long_name)
+        self.assertEqual(md.uinfo.updates[0].status, update.status.value)
+        self.assertEqual(md.uinfo.updates[0].updated_date, update.date_modified)
+        self.assertEqual(md.uinfo.updates[0].fromstr, config.get('bodhi_email'))
+        self.assertEqual(md.uinfo.updates[0].rights, config.get('updateinfo_rights'))
+        self.assertEqual(md.uinfo.updates[0].description, update.notes)
+        self.assertEqual(md.uinfo.updates[0].id, update.alias)
+        self.assertEqual(md.uinfo.updates[0].severity, 'Moderate')
         self.assertEqual(len(md.uinfo.updates[0].references), 2)
         bug = md.uinfo.updates[0].references[0]
-        self.assertEquals(bug.href, update.bugs[0].url)
-        self.assertEquals(bug.id, '12345')
-        self.assertEquals(bug.type, 'bugzilla')
+        self.assertEqual(bug.href, update.bugs[0].url)
+        self.assertEqual(bug.id, '12345')
+        self.assertEqual(bug.type, 'bugzilla')
         cve = md.uinfo.updates[0].references[1]
-        self.assertEquals(cve.type, 'cve')
-        self.assertEquals(cve.href, update.cves[0].url)
-        self.assertEquals(cve.id, update.cves[0].cve_id)
+        self.assertEqual(cve.type, 'cve')
+        self.assertEqual(cve.href, update.cves[0].url)
+        self.assertEqual(cve.id, update.cves[0].cve_id)
         self.assertEqual(len(md.uinfo.updates[0].collections), 1)
         col = md.uinfo.updates[0].collections[0]
-        self.assertEquals(col.name, update.release.long_name)
-        self.assertEquals(col.shortname, update.release.name)
+        self.assertEqual(col.name, update.release.long_name)
+        self.assertEqual(col.shortname, update.release.name)
         self.assertEqual(len(col.packages), 2)
         pkg = col.packages[0]
-        self.assertEquals(pkg.epoch, '0')
+        self.assertEqual(pkg.epoch, '0')
         # It's a little goofy, but the DevBuildsys is going to return TurboGears rpms when its
         # listBuildRPMs() method is called, so let's just roll with it.
-        self.assertEquals(pkg.name, 'TurboGears')
-        self.assertEquals(
+        self.assertEqual(pkg.name, 'TurboGears')
+        self.assertEqual(
             pkg.src,
             ('https://download.fedoraproject.org/pub/fedora/linux/updates/17/SRPMS/T/'
              'TurboGears-1.0.2.2-2.fc17.src.rpm'))
-        self.assertEquals(pkg.version, '1.0.2.2')
+        self.assertEqual(pkg.version, '1.0.2.2')
         self.assertFalse(pkg.reboot_suggested)
-        self.assertEquals(pkg.arch, 'src')
-        self.assertEquals(pkg.filename, 'TurboGears-1.0.2.2-2.fc17.src.rpm')
+        self.assertEqual(pkg.arch, 'src')
+        self.assertEqual(pkg.filename, 'TurboGears-1.0.2.2-2.fc17.src.rpm')
         pkg = col.packages[1]
-        self.assertEquals(pkg.epoch, '0')
-        self.assertEquals(pkg.name, 'TurboGears')
-        self.assertEquals(
+        self.assertEqual(pkg.epoch, '0')
+        self.assertEqual(pkg.name, 'TurboGears')
+        self.assertEqual(
             pkg.src,
             ('https://download.fedoraproject.org/pub/fedora/linux/updates/17/i386/T/'
              'TurboGears-1.0.2.2-2.fc17.noarch.rpm'))
-        self.assertEquals(pkg.version, '1.0.2.2')
+        self.assertEqual(pkg.version, '1.0.2.2')
         self.assertFalse(pkg.reboot_suggested)
-        self.assertEquals(pkg.arch, 'noarch')
-        self.assertEquals(pkg.filename, 'TurboGears-1.0.2.2-2.fc17.noarch.rpm')
+        self.assertEqual(pkg.arch, 'noarch')
+        self.assertEqual(pkg.filename, 'TurboGears-1.0.2.2-2.fc17.noarch.rpm')
 
     def test_date_modified_none(self):
         """The metadata should use utcnow() if an update's date_modified is None."""
@@ -176,7 +176,7 @@ class TestAddUpdate(UpdateInfoMetadataTestCase):
         col = md.uinfo.updates[0].collections[0]
         self.assertEqual(len(col.packages), 1)
         pkg = col.packages[0]
-        self.assertEquals(
+        self.assertEqual(
             pkg.src,
             ('https://download.fedoraproject.org/pub/fedora/linux/updates/17/aarch64/T/'
              'TurboGears-1.0.2.2-2.fc17.aarch64.rpm'))
@@ -200,7 +200,7 @@ class TestAddUpdate(UpdateInfoMetadataTestCase):
         col = md.uinfo.updates[0].collections[0]
         self.assertEqual(len(col.packages), 1)
         pkg = col.packages[0]
-        self.assertEquals(pkg.epoch, '42')
+        self.assertEqual(pkg.epoch, '42')
 
 
 class TestFetchUpdates(UpdateInfoMetadataTestCase):
@@ -340,41 +340,41 @@ class TestUpdateInfoMetadata(UpdateInfoMetadataTestCase):
         notice = self.get_notice(uinfo, 'mutt-1.5.14-1.fc13')
         self.assertIsNone(notice)
 
-        self.assertEquals(len(uinfo.updates), 1)
+        self.assertEqual(len(uinfo.updates), 1)
         notice = uinfo.updates[0]
 
         self.assertIsNotNone(notice)
-        self.assertEquals(notice.title, update.title)
-        self.assertEquals(notice.release, update.release.long_name)
-        self.assertEquals(notice.status, update.status.value)
+        self.assertEqual(notice.title, update.title)
+        self.assertEqual(notice.release, update.release.long_name)
+        self.assertEqual(notice.status, update.status.value)
         if update.date_modified:
-            self.assertEquals(notice.updated_date, update.date_modified)
-        self.assertEquals(notice.fromstr, config.get('bodhi_email'))
-        self.assertEquals(notice.rights, config.get('updateinfo_rights'))
-        self.assertEquals(notice.description, update.notes)
-        self.assertEquals(notice.id, update.alias)
-        self.assertEquals(notice.severity, 'Moderate')
+            self.assertEqual(notice.updated_date, update.date_modified)
+        self.assertEqual(notice.fromstr, config.get('bodhi_email'))
+        self.assertEqual(notice.rights, config.get('updateinfo_rights'))
+        self.assertEqual(notice.description, update.notes)
+        self.assertEqual(notice.id, update.alias)
+        self.assertEqual(notice.severity, 'Moderate')
         bug = notice.references[0]
-        self.assertEquals(bug.href, update.bugs[0].url)
-        self.assertEquals(bug.id, '12345')
-        self.assertEquals(bug.type, 'bugzilla')
+        self.assertEqual(bug.href, update.bugs[0].url)
+        self.assertEqual(bug.id, '12345')
+        self.assertEqual(bug.type, 'bugzilla')
         cve = notice.references[1]
-        self.assertEquals(cve.type, 'cve')
-        self.assertEquals(cve.href, update.cves[0].url)
-        self.assertEquals(cve.id, update.cves[0].cve_id)
+        self.assertEqual(cve.type, 'cve')
+        self.assertEqual(cve.href, update.cves[0].url)
+        self.assertEqual(cve.id, update.cves[0].cve_id)
 
         col = notice.collections[0]
-        self.assertEquals(col.name, update.release.long_name)
-        self.assertEquals(col.shortname, update.release.name)
+        self.assertEqual(col.name, update.release.long_name)
+        self.assertEqual(col.shortname, update.release.name)
 
         pkg = col.packages[0]
-        self.assertEquals(pkg.epoch, '0')
-        self.assertEquals(pkg.name, 'TurboGears')
-        self.assertEquals(
+        self.assertEqual(pkg.epoch, '0')
+        self.assertEqual(pkg.name, 'TurboGears')
+        self.assertEqual(
             pkg.src,
             ('https://download.fedoraproject.org/pub/fedora/linux/updates/testing/17/SRPMS/T/'
              'TurboGears-1.0.2.2-2.fc17.src.rpm'))
-        self.assertEquals(pkg.version, '1.0.2.2')
+        self.assertEqual(pkg.version, '1.0.2.2')
         self.assertFalse(pkg.reboot_suggested)
-        self.assertEquals(pkg.arch, 'src')
-        self.assertEquals(pkg.filename, 'TurboGears-1.0.2.2-2.fc17.src.rpm')
+        self.assertEqual(pkg.arch, 'src')
+        self.assertEqual(pkg.filename, 'TurboGears-1.0.2.2-2.fc17.src.rpm')

--- a/bodhi/tests/server/test_schemas.py
+++ b/bodhi/tests/server/test_schemas.py
@@ -40,4 +40,4 @@ class TestSchemas(unittest.TestCase):
         }
         schema = schemas.SaveCommentSchema()
         nested_structure = schema.unflatten(flat_structure)
-        self.assertEquals(nested_structure, expected)
+        self.assertEqual(nested_structure, expected)

--- a/bodhi/tests/server/test_security.py
+++ b/bodhi/tests/server/test_security.py
@@ -171,7 +171,7 @@ class TestLogout(base.BaseTestCase):
     def test_logout(self):
         """Test the logout redirect"""
         resp = self.app.get('/logout', status=302)
-        self.assertEquals(resp.location, 'http://localhost/')
+        self.assertEqual(resp.location, 'http://localhost/')
 
 
 class TestPackagerACLFactory(base.BaseTestCase):
@@ -254,7 +254,7 @@ class TestRememberMe(base.BaseTestCase):
         security.remember_me(None, req, info)
 
         user = models.User.get(u'lmacken')
-        self.assertEquals([g.name for g in user.groups], ['releng', 'new_group'])
+        self.assertEqual([g.name for g in user.groups], ['releng', 'new_group'])
 
     def test_new_email(self):
         """Assert that the user gets their e-mail address updated."""
@@ -267,7 +267,7 @@ class TestRememberMe(base.BaseTestCase):
         security.remember_me(None, req, info)
 
         user = models.User.get(u'lmacken')
-        self.assertEquals(user.email, u'1337hax0r@example.com')
+        self.assertEqual(user.email, u'1337hax0r@example.com')
 
     def test_new_user(self):
         """Test the post-login hook"""
@@ -277,10 +277,10 @@ class TestRememberMe(base.BaseTestCase):
 
         # The user should now exist, and be a member of the releng group
         user = models.User.get(u'lmacken')
-        self.assertEquals(user.name, u'lmacken')
-        self.assertEquals(user.email, u'lmacken@fp.o')
-        self.assertEquals(len(user.groups), 1)
-        self.assertEquals(user.groups[0].name, u'releng')
+        self.assertEqual(user.name, u'lmacken')
+        self.assertEqual(user.email, u'lmacken@fp.o')
+        self.assertEqual(len(user.groups), 1)
+        self.assertEqual(user.groups[0].name, u'releng')
 
     def test_user_groups_removed(self):
         """Test that a user that has been removed from a group gets marked as removed upon login."""
@@ -293,5 +293,5 @@ class TestRememberMe(base.BaseTestCase):
         security.remember_me(None, req, info)
 
         user = models.User.get(u'lmacken')
-        self.assertEquals(len(user.groups), 0)
-        self.assertEquals(len(models.Group.get(u'releng').users), 0)
+        self.assertEqual(len(user.groups), 0)
+        self.assertEqual(len(models.Group.get(u'releng').users), 0)

--- a/bodhi/tests/server/test_util.py
+++ b/bodhi/tests/server/test_util.py
@@ -1208,9 +1208,9 @@ class TestUtils(base.BaseTestCase):
         # This ordering is because:
         #  u5 contains pkgd-1.0, which is < pkgdb-2.0 from u6
         #  u2 contains somepkg-1.0, which is < somepkg-2.0 from u1
-        self.assertEquals(sync, [u5, u6, u2, u1])
+        self.assertEqual(sync, [u5, u6, u2, u1])
         # This ordering is because neither u3 nor u4 overlap with other updates
-        self.assertEquals(async_, [u3, u4])
+        self.assertEqual(async_, [u3, u4])
 
     def test_sorted_updates_insanity(self):
         """
@@ -1227,9 +1227,9 @@ class TestUtils(base.BaseTestCase):
         sync, async_ = util.sorted_updates(us)
 
         # This ordering is actually insane, since both u2 and u3 contain a newer and an older build
-        self.assertEquals(sync, [u2, u3])
+        self.assertEqual(sync, [u2, u3])
         # This ordering is because u1 doesn't overlap with anything
-        self.assertEquals(async_, [u1])
+        self.assertEqual(async_, [u1])
 
     def test_splitter(self):
         splitlist = util.splitter(["build-0.1", "build-0.2"])

--- a/bodhi/tests/server/views/test_generic.py
+++ b/bodhi/tests/server/views/test_generic.py
@@ -63,7 +63,7 @@ class TestGenericViews(base.BaseTestCase):
 
     def test_markdown(self):
         res = self.app.get('/markdown', {'text': 'wat'}, status=200)
-        self.assertEquals(
+        self.assertEqual(
             res.json_body['html'],
             '<div class="markdown">'
             '<p>wat</p>'
@@ -72,7 +72,7 @@ class TestGenericViews(base.BaseTestCase):
 
     def test_markdown_with_html_blocked_tag(self):
         res = self.app.get('/markdown', {'text': '<script>bold</script>'}, status=200)
-        self.assertEquals(
+        self.assertEqual(
             res.json_body['html'],
             '<div class="markdown">'
             '&lt;script&gt;bold&lt;/script&gt;\n'
@@ -81,7 +81,7 @@ class TestGenericViews(base.BaseTestCase):
 
     def test_markdown_with_html_whitelisted_tag(self):
         res = self.app.get('/markdown', {'text': '<pre>sudo dnf install pants</pre>'}, status=200)
-        self.assertEquals(
+        self.assertEqual(
             res.json_body['html'],
             '<div class="markdown">'
             '<pre>sudo dnf install pants</pre>\n'
@@ -92,7 +92,7 @@ class TestGenericViews(base.BaseTestCase):
         res = self.app.get('/markdown',
                            {'text': '<b onclick="alert(\'pants\')">bold</b>'},
                            status=200)
-        self.assertEquals(
+        self.assertEqual(
             res.json_body['html'],
             '<div class="markdown">'
             '<p><b>bold</b></p>'
@@ -103,7 +103,7 @@ class TestGenericViews(base.BaseTestCase):
         res = self.app.get('/markdown',
                            {'text': '<img src="pants.png">'},
                            status=200)
-        self.assertEquals(
+        self.assertEqual(
             res.json_body['html'],
             '<div class="markdown">'
             '<p><img src="pants.png"></p>'
@@ -114,7 +114,7 @@ class TestGenericViews(base.BaseTestCase):
         res = self.app.get('/markdown', {
             'text': 'my @colleague is distinguished',
         }, status=200)
-        self.assertEquals(
+        self.assertEqual(
             res.json_body['html'],
             '<div class="markdown">'
             '<p>my <a href="http://localhost/users/colleague">@colleague</a>'
@@ -126,7 +126,7 @@ class TestGenericViews(base.BaseTestCase):
         res = self.app.get('/markdown', {
             'text': '@pingou is on it',
         }, status=200)
-        self.assertEquals(
+        self.assertEqual(
             res.json_body['html'],
             '<div class="markdown">'
             '<p><a href="http://localhost/users/pingou">@pingou</a>'
@@ -138,7 +138,7 @@ class TestGenericViews(base.BaseTestCase):
         res = self.app.get('/markdown', {
             'text': '@kevin, thanks for that',
         }, status=200)
-        self.assertEquals(
+        self.assertEqual(
             res.json_body['html'],
             '<div class="markdown">'
             '<p><a href="http://localhost/users/kevin">@kevin</a>'
@@ -150,7 +150,7 @@ class TestGenericViews(base.BaseTestCase):
         res = self.app.get('/markdown', {
             'text': 'I vote for @number80',
         }, status=200)
-        self.assertEquals(
+        self.assertEqual(
             res.json_body['html'],
             '<div class="markdown">'
             '<p>I vote for '
@@ -162,7 +162,7 @@ class TestGenericViews(base.BaseTestCase):
         res = self.app.get('/markdown', {
             'text': 'Crazy.  #12345 is still busted.',
         }, status=200)
-        self.assertEquals(
+        self.assertEqual(
             res.json_body['html'],
             '<div class="markdown">'
             '<p>Crazy.  #12345 is still busted.</p>'
@@ -173,7 +173,7 @@ class TestGenericViews(base.BaseTestCase):
         res = self.app.get('/markdown', {
             'text': 'Crazy.  RHBZ#12345 is still busted.',
         }, status=200)
-        self.assertEquals(
+        self.assertEqual(
             res.json_body['html'],
             '<div class="markdown">'
             '<p>Crazy.  '
@@ -190,7 +190,7 @@ class TestGenericViews(base.BaseTestCase):
         res = self.app.get('/markdown', {
             'text': 'Crazy.  (RHBZ#12345) is still busted.',
         }, status=200)
-        self.assertEquals(
+        self.assertEqual(
             res.json_body['html'],
             '<div class="markdown">'
             '<p>Crazy.  '
@@ -203,7 +203,7 @@ class TestGenericViews(base.BaseTestCase):
         res = self.app.get('/markdown', {
             'text': 'Crazy.  upstream#12345 is still busted.',
         }, status=200)
-        self.assertEquals(
+        self.assertEqual(
             res.json_body['html'],
             '<div class="markdown">'
             '<p>Crazy.  upstream#12345 is still busted.</p>'
@@ -219,7 +219,7 @@ class TestGenericViews(base.BaseTestCase):
         res = self.app.get('/markdown', {
             'text': 'Crazy.  aRHBZa#12345 is still busted.',
         }, status=200)
-        self.assertEquals(
+        self.assertEqual(
             res.json_body['html'],
             '<div class="markdown">'
             '<p>Crazy.  aRHBZa#12345 is still busted.</p>'
@@ -230,7 +230,7 @@ class TestGenericViews(base.BaseTestCase):
         res = self.app.get('/markdown', {
             'text': '```\nsudo dnf install bodhi\n```',
         }, status=200)
-        self.assertEquals(
+        self.assertEqual(
             res.json_body['html'],
             '<div class="markdown">'
             '<pre><code>sudo dnf install bodhi\n</code></pre>\n'
@@ -241,7 +241,7 @@ class TestGenericViews(base.BaseTestCase):
         res = self.app.get('/markdown', {
             'text': 'email me at dude@mcpants.org',
         }, status=200)
-        self.assertEquals(
+        self.assertEqual(
             res.json_body['html'],
             '<div class="markdown">'
             '<p>email me at <a href="mailto:dude@mcpants.org">dude@mcpants.org</a></p>'
@@ -252,7 +252,7 @@ class TestGenericViews(base.BaseTestCase):
         res = self.app.get('/markdown', {
             'text': 'email me at <dude@mcpants.org>',
         }, status=200)
-        self.assertEquals(
+        self.assertEqual(
             res.json_body['html'],
             '<div class="markdown">'
             '<p>email me at <a href="mailto:dude@mcpants.org">dude@mcpants.org</a></p>'
@@ -263,7 +263,7 @@ class TestGenericViews(base.BaseTestCase):
         res = self.app.get('/markdown', {
             'text': 'http://getfedora.org',
         }, status=200)
-        self.assertEquals(
+        self.assertEqual(
             res.json_body['html'],
             '<div class="markdown">'
             '<p><a href="http://getfedora.org">http://getfedora.org</a></p>'
@@ -274,7 +274,7 @@ class TestGenericViews(base.BaseTestCase):
         res = self.app.get('/markdown', {
             'text': 'getfedora.org',
         }, status=200)
-        self.assertEquals(
+        self.assertEqual(
             res.json_body['html'],
             '<div class="markdown">'
             '<p><a href="http://getfedora.org">getfedora.org</a></p>'
@@ -294,7 +294,7 @@ class TestGenericViews(base.BaseTestCase):
         self.assertIn('f17-updates-testing', body)
         self.assertIn('f17-updates-testing-pending', body)
         self.assertIn('f17-override', body)
-        self.assertEquals(body['f17-updates'], 'TurboGears-1.0.2.2-2.fc17')
+        self.assertEqual(body['f17-updates'], 'TurboGears-1.0.2.2-2.fc17')
 
     @mock.patch("bodhi.server.buildsys.DevBuildsys.getLatestBuilds", side_effect=Exception())
     def test_latest_builds_exception(self, mock_getlatestbuilds):
@@ -315,25 +315,25 @@ class TestGenericViews(base.BaseTestCase):
     def test_candidate(self):
         res = self.app.get('/latest_candidates')
         body = res.json_body
-        self.assertEquals(body, [])
+        self.assertEqual(body, [])
 
         res = self.app.get('/latest_candidates', {'package': 'TurboGears'})
         body = res.json_body
-        self.assertEquals(len(body), 2)
-        self.assertEquals(body[0]['nvr'], 'TurboGears-1.0.2.2-2.fc17')
-        self.assertEquals(body[0]['id'], 16058)
-        self.assertEquals(body[1]['nvr'], 'TurboGears-1.0.2.2-3.fc17')
-        self.assertEquals(body[1]['id'], 16059)
+        self.assertEqual(len(body), 2)
+        self.assertEqual(body[0]['nvr'], 'TurboGears-1.0.2.2-2.fc17')
+        self.assertEqual(body[0]['id'], 16058)
+        self.assertEqual(body[1]['nvr'], 'TurboGears-1.0.2.2-3.fc17')
+        self.assertEqual(body[1]['id'], 16059)
 
         res = self.app.get('/latest_candidates', {'package': 'TurboGears', 'testing': True})
         body = res.json_body
-        self.assertEquals(len(body), 3)
-        self.assertEquals(body[0]['nvr'], 'TurboGears-1.0.2.2-2.fc17')
-        self.assertEquals(body[0]['id'], 16058)
-        self.assertEquals(body[1]['nvr'], 'TurboGears-1.0.2.2-3.fc17')
-        self.assertEquals(body[1]['id'], 16059)
-        self.assertEquals(body[2]['nvr'], 'TurboGears-1.0.2.2-4.fc17')
-        self.assertEquals(body[2]['id'], 16060)
+        self.assertEqual(len(body), 3)
+        self.assertEqual(body[0]['nvr'], 'TurboGears-1.0.2.2-2.fc17')
+        self.assertEqual(body[0]['id'], 16058)
+        self.assertEqual(body[1]['nvr'], 'TurboGears-1.0.2.2-3.fc17')
+        self.assertEqual(body[1]['id'], 16059)
+        self.assertEqual(body[2]['nvr'], 'TurboGears-1.0.2.2-4.fc17')
+        self.assertEqual(body[2]['id'], 16060)
 
     def test_version(self):
         res = self.app.get('/api_version')


### PR DESCRIPTION
Signed-off-by: Pierre-Yves Chibon <pingou@pingoured.fr>