### PR TITLE
Make Release.from_tags() more predictable

### DIFF
--- a/bodhi/server/models.py
+++ b/bodhi/server/models.py
@@ -947,6 +947,8 @@ class Release(Base):
         """
         tag_types, tag_rels = cls.get_tags(session)
         for tag in tags:
+            if tag not in tag_rels:
+                continue
             release = session.query(cls).filter_by(name=tag_rels[tag]).first()
             if release:
                 return release

--- a/bodhi/server/validators.py
+++ b/bodhi/server/validators.py
@@ -155,14 +155,7 @@ def cache_release(request, build):
     tags = cache_tags(request, build)
     if tags is None:
         return None
-    build_rel = None
-    try:
-        build_rel = Release.from_tags(tags, request.db)
-    except KeyError:
-        log.warn('Unable to determine release from '
-                 'tags: %r build: %r' % (tags, build))
-        request.errors.add('body', 'builds',
-                           'Unable to determine release from build: %s' % build)
+    build_rel = Release.from_tags(tags, request.db)
     if not build_rel:
         msg = 'Cannot find release associated with ' + \
             'build: {}, tags: {}'.format(build, tags)

--- a/bodhi/tests/server/services/test_updates.py
+++ b/bodhi/tests/server/services/test_updates.py
@@ -872,8 +872,6 @@ class TestUpdatesService(BaseTestCase):
         expected_json = {
             u'status': u'error',
             u'errors': [
-                {u'description': u'Unable to determine release from build: bodhi-3.2.0-1.fc27',
-                 u'location': u'body', u'name': u'builds'},
                 {u'description': (
                     u"Cannot find release associated with build: bodhi-3.2.0-1.fc27, "
                     u"tags: [u'f27-updates-candidate', u'f27', u'f27-updates-testing']"),


### PR DESCRIPTION
IIRC, while doing some debugging of a test setup, I noticed that [tag, unknownTag] worked, but [unknownTag, tag] didn't, and found this. It's mostly a cleanup though probably results in better errors in some cases when going through the code paths that didn't catch KeyError.

<hr>

If Release.from_tags() was called with a tag not associated with any
release, it would raise KeyError (unless an earlier tag in the list
was found first.) This was unexpected from the documentation - and was
handled by one caller but not others. Change it to return None in
this case - this was handled by all callers.