### PR TITLE
Set a git user and e-mail for the CI rebase.

### DIFF
--- a/devel/ci/githubprb-project.yml
+++ b/devel/ci/githubprb-project.yml
@@ -88,6 +88,8 @@
             env > jenkins-env
             $ssh_cmd yum -y install rsync
             # Checkout the pull request that we received from the githubPRB plugin
+            git config --global user.email "bodhi-ci@fedoraproject.org"
+            git config --global user.name "Bodhi CI"
             git rebase --preserve-merges origin/${{ghprbTargetBranch}} \
             && rsync -e "ssh $sshopts" -Ha $(pwd)/ $CICO_hostname:payload \
             && /usr/bin/timeout {timeout} $ssh_cmd -t "cd payload && {ci_cmd}"


### PR DESCRIPTION
CI began to fail recently at the git rebase step with this message:

+ git rebase --preserve-merges origin/develop

*** Please tell me who you are.

Run

  git config --global user.email "you@example.com"
  git config --global user.name "Your Name"

to set your account's default identity.
Omit --global to set the identity only in this repository.

fatal: unable to auto-detect email address (got 'bodhi@slave03.(none)')
You need to set your committer info first

This commit sets the e-mail and name so that git will be happy with
the rebase.

Signed-off-by: Randy Barlow <randy@electronsweatshop.com>