### PR TITLE
Use assertRegex() instead of assertRegexpMatches().

### DIFF
--- a/bodhi/tests/server/services/test_overrides.py
+++ b/bodhi/tests/server/services/test_overrides.py
@@ -786,5 +786,5 @@ class TestOverridesWebViews(base.BaseTestCase):
         resp = self.app.get('/overrides/bodhi-2.0-1.fc17',
                             status=200, headers={'Accept': 'text/html'})
 
-        self.assertRegexpMatches(str(resp), ('Expired\\n.*<span class="text-muted" '
-                                             'data-toggle="tooltip" title=".*"> just now </span>'))
+        self.assertRegex(str(resp), ('Expired\\n.*<span class="text-muted" '
+                                     'data-toggle="tooltip" title=".*"> just now </span>'))

--- a/bodhi/tests/server/services/test_updates.py
+++ b/bodhi/tests/server/services/test_updates.py
@@ -294,8 +294,8 @@ class TestNewUpdate(BaseTestCase):
 
         resp = self.app.get('/updates/%s' % nvr, headers={'Accept': 'text/html'})
 
-        self.assertRegexpMatches(str(resp), ('https://koji.fedoraproject.org/koji'
-                                             r'/search\?terms=.*\&amp;type=build\&amp;match=glob'))
+        self.assertRegex(str(resp), ('https://koji.fedoraproject.org/koji'
+                                     r'/search\?terms=.*\&amp;type=build\&amp;match=glob'))
 
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
@@ -309,8 +309,8 @@ class TestNewUpdate(BaseTestCase):
 
         resp = self.app.get('/updates/%s' % nvr, headers={'Accept': 'text/html'})
 
-        self.assertRegexpMatches(str(resp), ('https://koji.fedoraproject.org/koji'
-                                             r'/search\?terms=.*\&amp;type=build\&amp;match=glob'))
+        self.assertRegex(str(resp), ('https://koji.fedoraproject.org/koji'
+                                     r'/search\?terms=.*\&amp;type=build\&amp;match=glob'))
 
     @mock.patch(**mock_valid_requirements)
     @mock.patch('bodhi.server.notifications.publish')
@@ -325,8 +325,8 @@ class TestNewUpdate(BaseTestCase):
 
         resp = self.app.get('/updates/%s' % nvr, headers={'Accept': 'text/html'})
 
-        self.assertRegexpMatches(str(resp), ('https://host.org'
-                                             r'/search\?terms=.*\&amp;type=build\&amp;match=glob'))
+        self.assertRegex(str(resp), ('https://host.org'
+                                     r'/search\?terms=.*\&amp;type=build\&amp;match=glob'))
 
     @mock.patch.dict('bodhi.server.validators.config', {'acl_system': u'dummy'})
     @mock.patch(**mock_uuid4_version1)
@@ -1011,8 +1011,8 @@ class TestEditUpdateForm(BaseTestCase):
 
         resp = self.app.get('/updates/bodhi-2.0-1.fc17/edit',
                             headers={'accept': 'text/html'})
-        self.assertRegexpMatches(str(resp), ('<input type="radio" name="severity" '
-                                             'value="unspecified"\\n.*disabled="disabled"\\n.*>'))
+        self.assertRegex(str(resp), ('<input type="radio" name="severity" '
+                                     'value="unspecified"\\n.*disabled="disabled"\\n.*>'))
 
 
 class TestUpdatesService(BaseTestCase):

--- a/bodhi/tests/server/views/test_generic.py
+++ b/bodhi/tests/server/views/test_generic.py
@@ -59,8 +59,8 @@ class TestGenericViews(base.BaseTestCase):
 
         res = self.app.get('/', headers={'Accept': 'text/html'})
 
-        self.assertRegexpMatches(str(res), ('status=testing&critpath=True.*'
-                                 'Latest Critical Path Updates in Need of Testing'))
+        self.assertRegex(str(res), ('status=testing&critpath=True.*'
+                         'Latest Critical Path Updates in Need of Testing'))
 
     def test_markdown(self):
         res = self.app.get('/markdown', {'text': 'wat'}, status=200)


### PR DESCRIPTION
This fixes a few DeprecationWarnings.

Signed-off-by: Randy Barlow <randy@electronsweatshop.com>