### PR TITLE
Correct a typo in the release notes.

### DIFF
--- a/docs/user/release_notes.rst
+++ b/docs/user/release_notes.rst
@@ -323,7 +323,7 @@ Bug fixes
   (:issue:`2297`).
 * Interpret the ``dogpile.cache.expiration_time`` as an ``int`` instead of a ``str``
   (:issue:`2299`).
-* Do not cache the Koji latest composes (:issue:`2301`).
+* Do not cache the Koji latest candidates (:issue:`2301`).
 * Do not require the web server to have Pungi installed since it does not use it (:issue:`2303`).
 
 


### PR DESCRIPTION
The release notes referenced "Koji latest composes", and was
intended to say "Koji latest candidates".

Signed-off-by: Randy Barlow <randy@electronsweatshop.com>