### PR TITLE
Move util.mkmetadatadir() to bodhi.tests.server.base.

### DIFF
--- a/bodhi/server/util.py
+++ b/bodhi/server/util.py
@@ -133,55 +133,6 @@ def insert_in_repo(comp_type, repodata, filetype, extension, source):
     os.unlink(target_fname)
 
 
-def mkmetadatadir(path, updateinfo=None, comps=None):
-    """
-    Generate package metadata for a given directory.
-
-    If the metadata doesn't exist, then create it.
-
-    Args:
-        path (basestring): The directory to generate metadata for.
-        updateinfo (basestring or None or bool): The updateinfo to insert instead of example.
-            No updateinfo is inserted if False is passed. Passing True provides undefined
-            behavior.
-        comps (basestring or None): The comps to insert instead of example.
-    """
-    compsfile = '''<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE comps PUBLIC "-//Red Hat, Inc.//DTD Comps info//EN" "comps.dtd">
-<comps>
-  <group>
-    <id>testable</id>
-    <_name>Testable</_name>
-    <_description>comps group for testing</_description>
-    <packagelist>
-      <packagereq>testpkg</packagereq>
-    </packagelist>
-  </group>
-</comps>'''
-    updateinfofile = ''
-    if not os.path.isdir(path):
-        os.makedirs(path)
-    if not comps:
-        comps = os.path.join(path, 'comps.xml')
-        with open(comps, 'w') as f:
-            f.write(compsfile)
-    if updateinfo is None:
-        updateinfo = os.path.join(path, 'updateinfo.xml')
-        with open(updateinfo, 'w') as f:
-            f.write(updateinfofile)
-
-    subprocess.check_call(['createrepo_c',
-                           '--groupfile', 'comps.xml',
-                           '--deltas',
-                           '--xz',
-                           '--database',
-                           '--quiet',
-                           path])
-    if updateinfo is not False:
-        insert_in_repo(cr.XZ, os.path.join(path, 'repodata'), 'updateinfo', 'xml',
-                       os.path.join(path, 'updateinfo.xml'))
-
-
 def flash_log(msg):
     """
     Log the given message at debug level.

--- a/bodhi/tests/server/consumers/test_masher.py
+++ b/bodhi/tests/server/consumers/test_masher.py
@@ -44,7 +44,6 @@ from bodhi.server.models import (
     Build, BuildrootOverride, Compose, ComposeState, ContainerBuild, FlatpakBuild,
     Release, ReleaseState, RpmBuild, TestGatingStatus, Update, UpdateRequest, UpdateStatus,
     UpdateType, User, ModuleBuild, ContentType, Package)
-from bodhi.server.util import mkmetadatadir
 from bodhi.tests.server import base
 
 
@@ -745,7 +744,7 @@ That was the actual one'''
         # test with valid repodata
         for arch in ('i386', 'x86_64', 'armhfp'):
             repo = os.path.join(t.path, 'compose', 'Everything', arch, 'os')
-            mkmetadatadir(repo)
+            base.mkmetadatadir(repo)
             os.makedirs(os.path.join(repo, 'Packages', 'a'))
             name = 'test.rpm'
             if arch == 'armhfp':
@@ -753,7 +752,7 @@ That was the actual one'''
             with open(os.path.join(repo, 'Packages', 'a', name), 'w') as tf:
                 tf.write('foo')
 
-        mkmetadatadir(os.path.join(t.path, 'compose', 'Everything', 'source', 'tree'))
+        base.mkmetadatadir(os.path.join(t.path, 'compose', 'Everything', 'source', 'tree'))
         os.makedirs(os.path.join(t.path, 'compose', 'Everything', 'source', 'tree', 'Packages',
                                  'a'))
         with open(os.path.join(t.path, 'compose', 'Everything', 'source', 'tree', 'Packages', 'a',
@@ -784,7 +783,7 @@ That was the actual one'''
         # test with valid repodata
         for arch in ('i386', 'x86_64', 'armhfp'):
             repo = os.path.join(t.path, 'compose', 'Everything', arch, 'os')
-            mkmetadatadir(repo)
+            base.mkmetadatadir(repo)
 
             # test with truncated/busted repodata
             xml = os.path.join(t.path, 'compose', 'Everything', arch, 'os', 'repodata',
@@ -823,11 +822,11 @@ That was the actual one'''
         # test with valid repodata
         for arch in ('i386', 'x86_64', 'armhfp'):
             repo = os.path.join(t.path, 'compose', 'Everything', arch, 'os')
-            mkmetadatadir(repo)
+            base.mkmetadatadir(repo)
             os.makedirs(os.path.join(repo, 'Packages', 'a'))
             os.symlink('/dev/null', os.path.join(repo, 'Packages', 'a', 'test.notrpm'))
 
-        mkmetadatadir(os.path.join(t.path, 'compose', 'Everything', 'source', 'tree'))
+        base.mkmetadatadir(os.path.join(t.path, 'compose', 'Everything', 'source', 'tree'))
         os.makedirs(os.path.join(t.path, 'compose', 'Everything', 'source', 'tree', 'Packages',
                                  'a'))
         os.symlink('/dev/null', os.path.join(t.path, 'compose', 'Everything', 'source', 'tree',
@@ -861,10 +860,10 @@ That was the actual one'''
         # test with valid repodata
         for arch in ('i386', 'x86_64', 'armhfp'):
             repo = os.path.join(t.path, 'compose', 'Everything', arch, 'os')
-            mkmetadatadir(repo)
+            base.mkmetadatadir(repo)
             shutil.rmtree(os.path.join(t.path, 'compose', 'Everything', arch, 'os', 'Packages'))
 
-        mkmetadatadir(os.path.join(t.path, 'compose', 'Everything', 'source', 'tree'))
+        base.mkmetadatadir(os.path.join(t.path, 'compose', 'Everything', 'source', 'tree'))
 
         assert 'completed_repo' in t._checkpoints
         save_state.reset_mock()

--- a/bodhi/tests/server/test_metadata.py
+++ b/bodhi/tests/server/test_metadata.py
@@ -33,7 +33,6 @@ from bodhi.server.buildsys import (setup_buildsystem, teardown_buildsystem,
 from bodhi.server.config import config
 from bodhi.server.models import Release, Update, UpdateRequest, UpdateStatus
 from bodhi.server.metadata import UpdateInfoMetadata
-from bodhi.server.util import mkmetadatadir
 from bodhi.tests.server import base, create_update
 
 
@@ -47,7 +46,7 @@ class UpdateInfoMetadataTestCase(base.BaseTestCase):
         self.tempdir = tempfile.mkdtemp('bodhi')
         self.tempcompdir = join(self.tempdir, 'f17-updates-testing')
         self.temprepo = join(self.tempcompdir, 'compose', 'Everything', 'i386', 'os')
-        mkmetadatadir(join(self.temprepo, 'f17-updates-testing', 'i386'), updateinfo=False)
+        base.mkmetadatadir(join(self.temprepo, 'f17-updates-testing', 'i386'), updateinfo=False)
         config['cache_dir'] = os.path.join(self.tempdir, 'cache')
         os.makedirs(config['cache_dir'])
 
@@ -241,9 +240,9 @@ class TestUpdateInfoMetadata(UpdateInfoMetadataTestCase):
         os.makedirs(os.path.join(config['mash_dir'], 'f17-updates-testing'))
 
         # Initialize our temporary repo
-        mkmetadatadir(self.temprepo, updateinfo=False)
-        mkmetadatadir(join(self.tempcompdir, 'compose', 'Everything', 'source', 'tree'),
-                      updateinfo=False)
+        base.mkmetadatadir(self.temprepo, updateinfo=False)
+        base.mkmetadatadir(join(self.tempcompdir, 'compose', 'Everything', 'source', 'tree'),
+                           updateinfo=False)
         self.repodata = join(self.temprepo, 'repodata')
         assert exists(join(self.repodata, 'repomd.xml'))
 
@@ -313,9 +312,9 @@ class TestUpdateInfoMetadata(UpdateInfoMetadataTestCase):
         """
         self._test_extended_metadata(True)
         shutil.rmtree(self.temprepo)
-        mkmetadatadir(self.temprepo, updateinfo=False)
-        mkmetadatadir(join(self.tempcompdir, 'compose', 'Everything', 'source', 'tree'),
-                      updateinfo=False)
+        base.mkmetadatadir(self.temprepo, updateinfo=False)
+        base.mkmetadatadir(join(self.tempcompdir, 'compose', 'Everything', 'source', 'tree'),
+                           updateinfo=False)
         DevBuildsys.__rpms__ = []
         self._test_extended_metadata(True)
 

--- a/bodhi/tests/server/test_util.py
+++ b/bodhi/tests/server/test_util.py
@@ -537,7 +537,7 @@ class TestSanityCheckRepodata(unittest.TestCase):
 
     def test_correct_repo(self):
         """No Exception should be raised if the repo is normal."""
-        util.mkmetadatadir(self.tempdir)
+        base.mkmetadatadir(self.tempdir)
 
         # No exception should be raised here.
         util.sanity_check_repodata(self.tempdir)
@@ -547,7 +547,7 @@ class TestSanityCheckRepodata(unittest.TestCase):
         updateinfo = os.path.join(self.tempdir, 'updateinfo.xml')
         with open(updateinfo, 'w') as uinfo:
             uinfo.write('<id/>')
-        util.mkmetadatadir(self.tempdir, updateinfo=updateinfo)
+        base.mkmetadatadir(self.tempdir, updateinfo=updateinfo)
 
         with self.assertRaises(util.RepodataException) as exc:
             util.sanity_check_repodata(self.tempdir)
@@ -559,7 +559,7 @@ class TestSanityCheckRepodata(unittest.TestCase):
         comps = os.path.join(self.tempdir, 'comps.xml')
         with open(comps, 'w') as uinfo:
             uinfo.write('this is not even xml')
-        util.mkmetadatadir(self.tempdir, comps=comps)
+        base.mkmetadatadir(self.tempdir, comps=comps)
 
         with self.assertRaises(util.RepodataException) as exc:
             util.sanity_check_repodata(self.tempdir)
@@ -571,7 +571,7 @@ class TestSanityCheckRepodata(unittest.TestCase):
         comps = os.path.join(self.tempdir, 'comps.xml')
         with open(comps, 'w') as uinfo:
             uinfo.write('<whatever />')
-        util.mkmetadatadir(self.tempdir, comps=comps)
+        base.mkmetadatadir(self.tempdir, comps=comps)
 
         with self.assertRaises(util.RepodataException) as exc:
             util.sanity_check_repodata(self.tempdir)
@@ -580,7 +580,7 @@ class TestSanityCheckRepodata(unittest.TestCase):
 
     def test_repomd_missing_updateinfo(self):
         """If the updateinfo data tag is missing in repomd.xml, an Exception should be raised."""
-        util.mkmetadatadir(self.tempdir)
+        base.mkmetadatadir(self.tempdir)
         repomd_path = os.path.join(self.tempdir, 'repodata', 'repomd.xml')
         repomd = ElementTree.parse(repomd_path)
         ElementTree.register_namespace('', 'http://linux.duke.edu/metadata/repo')


### PR DESCRIPTION
I noticed that mkmetadatadir() was only used by the tests, and that
it was included in bodhi.server.util(). This commit moves the
function into the tests.

Signed-off-by: Randy Barlow <randy@electronsweatshop.com>