### PR TITLE
Document that Bodhi now fully supports Python 3.

### DIFF
--- a/docs/user/release_notes.rst
+++ b/docs/user/release_notes.rst
@@ -2,6 +2,15 @@
 Release notes
 =============
 
+develop
+-------
+
+Dependency changes
+^^^^^^^^^^^^^^^^^^
+
+* Bodhi now fully supports Python 3.
+
+
 v3.10.0
 -------
 


### PR DESCRIPTION
Signed-off-by: Randy Barlow <randy@electronsweatshop.com>