### PR TITLE
Define the PYTHONPATH when building the docs.

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -47,7 +47,7 @@ schema:
 	@PYTHONPATH=.. ./generate_db_schema
 
 html: schema
-	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
+	@PYTHONPATH=.. $(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."
 


### PR DESCRIPTION
fixes #2557

Signed-off-by: Randy Barlow <randy@electronsweatshop.com>