### PR TITLE
Move insert_in_repo() to metadata.py.

### DIFF
--- a/bodhi/tests/server/base.py
+++ b/bodhi/tests/server/base.py
@@ -27,7 +27,8 @@ from sqlalchemy import event
 import createrepo_c
 import mock
 
-from bodhi.server import bugs, buildsys, models, initialize_db, Session, config, main, webapp, util
+from bodhi.server import (bugs, buildsys, models, initialize_db, Session, config, main, metadata,
+                          webapp)
 from bodhi.tests.server import create_update, populate
 
 
@@ -406,5 +407,5 @@ def mkmetadatadir(path, updateinfo=None, comps=None):
                            '--quiet',
                            path])
     if updateinfo is not False:
-        util.insert_in_repo(createrepo_c.XZ, os.path.join(path, 'repodata'), 'updateinfo', 'xml',
-                            os.path.join(path, 'updateinfo.xml'))
+        metadata.insert_in_repo(createrepo_c.XZ, os.path.join(path, 'repodata'), 'updateinfo',
+                                'xml', os.path.join(path, 'updateinfo.xml'))


### PR DESCRIPTION
insert_in_repo() is only used by bodhi.server.metadata, but it had
been in bodhi.server.util. This added an unnecessary dependency on
createrepo_c to the web server. By moving it into metadata.py, this
dependency is avoided.

fixes #2565

Signed-off-by: Randy Barlow <randy@electronsweatshop.com>