### PR TITLE
[WIP] Rely on Greenwave to resolve test results from update id.

### DIFF
--- a/bodhi/server/models.py
+++ b/bodhi/server/models.py
@@ -1967,13 +1967,7 @@ class Update(Base):
             list: A list of dictionaries that are appropriate to be passed to the Greenwave API
                 subject field for a decision about this Update.
         """
-        # See discussion on https://pagure.io/greenwave/issue/34 for why we use these subjects.
-        subject = [{'item': build.nvr, 'type': 'koji_build'} for build in self.builds]
-        # Additionally add some subject entries for "CI"
-        # https://pagure.io/greenwave/issue/61
-        subject.extend([{'original_spec_nvr': build.nvr} for build in self.builds])
-        subject.append({'item': self.alias, 'type': 'bodhi_update'})
-        return subject
+        return [{'item': self.alias, 'type': 'bodhi_update'}]
 
     @property
     def greenwave_subject_json(self):


### PR DESCRIPTION
Greenwave's API docs[0] state that we can hand Greenwave only the
update ID and it will find test results for the Koji builds. Prior
to this commit we had been handing Greenwave the update ID, Koji
builds, and original_nvr fields, which were redundant.

[0] https://docs.pagure.org/greenwave/policies.html#subject-types

Signed-off-by: Randy Barlow <randy@electronsweatshop.com>