### PR TITLE
s/autodoc_default_flags/autodoc_default_options/

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -37,7 +37,7 @@ extensions = [
     'sphinx.ext.todo',
     'sphinx.ext.viewcode']
 
-autodoc_default_flags = ['members', 'show-inheritance', 'special-members']
+autodoc_default_options = {'members': None, 'show-inheritance': None, 'special-members': None}
 autosummary_generate = True
 
 # Add any paths that contain templates here, relative to this directory.


### PR DESCRIPTION
This fixes a docs build failure that emitted this message:

Warning, treated as error:
autodoc_default_flags is now deprecated. Please use
autodoc_default_options instead.

Signed-off-by: Randy Barlow <randy@electronsweatshop.com>