### PR TITLE
Tell the CI job template to use github hooks

### DIFF
--- a/devel/ci/githubprb-project.yml
+++ b/devel/ci/githubprb-project.yml
@@ -55,7 +55,8 @@
         - git-scm:
             git_url: https://github.com/{git_username}/{git_repo}.git
     triggers:
-        - githubprb
+        - githubprb:
+            github-hooks: true
     publishers:
         - junit:
             results: 'test_results/**/nosetests.xml'


### PR DESCRIPTION
Signed-off-by: Randy Barlow <randy@electronsweatshop.com>