### PR TITLE
Allow multiple users filtering for comments, updates and overrides.

### DIFF
--- a/bodhi/server/schemas.py
+++ b/bodhi/server/schemas.py
@@ -90,6 +90,12 @@ class Packages(colander.SequenceSchema):
     package = colander.SchemaNode(colander.String())
 
 
+class Users(colander.SequenceSchema):
+    """A SequenceSchema to validate a list of User objects."""
+
+    user = colander.SchemaNode(colander.String())
+
+
 class Releases(colander.SequenceSchema):
     """A SequenceSchema to validate a list of Release objects."""
 
@@ -653,10 +659,11 @@ class ListUpdateSchema(PaginatedSchema, SearchableSchema, Cosmetics):
         validator=colander.OneOf(list(ContentType.values())),
     )
 
-    user = colander.SchemaNode(
-        colander.String(),
+    user = Users(
+        colander.Sequence(accept_scalar=True),
         location="querystring",
         missing=None,
+        preparer=[util.splitter],
     )
 
     updateid = Builds(
@@ -734,22 +741,25 @@ class ListCommentSchema(PaginatedSchema, SearchableSchema):
         preparer=[util.splitter],
     )
 
-    user = colander.SchemaNode(
-        colander.String(),
+    user = Users(
+        colander.Sequence(accept_scalar=True),
         location="querystring",
         missing=None,
+        preparer=[util.splitter],
     )
 
-    update_owner = colander.SchemaNode(
-        colander.String(),
+    update_owner = Users(
+        colander.Sequence(accept_scalar=True),
         location="querystring",
         missing=None,
+        preparer=[util.splitter],
     )
 
-    ignore_user = colander.SchemaNode(
-        colander.String(),
+    ignore_user = Users(
+        colander.Sequence(accept_scalar=True),
         location="querystring",
         missing=None,
+        preparer=[util.splitter],
     )
 
     anonymous = colander.SchemaNode(
@@ -795,10 +805,11 @@ class ListOverrideSchema(PaginatedSchema, SearchableSchema, Cosmetics):
         preparer=[util.splitter],
     )
 
-    user = colander.SchemaNode(
-        colander.String(),
+    user = Users(
+        colander.Sequence(accept_scalar=True),
         location="querystring",
         missing=None,
+        preparer=[util.splitter],
     )
 
 

--- a/bodhi/server/services/comments.py
+++ b/bodhi/server/services/comments.py
@@ -24,7 +24,7 @@ from cornice import Service
 from cornice.validators import colander_body_validator, colander_querystring_validator
 from pyramid.httpexceptions import HTTPBadRequest
 from sqlalchemy import func, distinct
-from sqlalchemy.sql import or_
+from sqlalchemy.sql import or_, and_
 
 from bodhi.server import log
 from bodhi.server.models import Comment, Build, Update
@@ -155,15 +155,15 @@ def query_comments(request):
     update_owner = data.get('update_owner')
     if update_owner is not None:
         query = query.join(Comment.update)
-        query = query.filter(Update.user == update_owner)
+        query = query.filter(or_(*[Update.user == u for u in update_owner]))
 
     ignore_user = data.get('ignore_user')
     if ignore_user is not None:
-        query = query.filter(Comment.user != ignore_user)
+        query = query.filter(and_(*[Comment.user != u for u in ignore_user]))
 
     user = data.get('user')
     if user is not None:
-        query = query.filter(Comment.user == user)
+        query = query.filter(or_(*[Comment.user == u for u in user]))
 
     query = query.order_by(Comment.timestamp.desc())
 

--- a/bodhi/server/services/overrides.py
+++ b/bodhi/server/services/overrides.py
@@ -182,7 +182,7 @@ def query_overrides(request):
 
     submitter = data.get('user')
     if submitter is not None:
-        query = query.filter(BuildrootOverride.submitter == submitter)
+        query = query.filter(or_(*[BuildrootOverride.submitter == s for s in submitter]))
 
     query = query.order_by(BuildrootOverride.submission_date.desc())
 

--- a/bodhi/server/services/updates.py
+++ b/bodhi/server/services/updates.py
@@ -380,7 +380,7 @@ def query_updates(request):
 
     user = data.get('user')
     if user is not None:
-        query = query.filter(Update.user == user)
+        query = query.filter(or_(*[Update.user == u for u in user]))
 
     updateid = data.get('updateid')
     if updateid is not None:

--- a/docs/user/man_pages/bodhi.rst
+++ b/docs/user/man_pages/bodhi.rst
@@ -103,7 +103,7 @@ The ``overrides`` command allows users to manage build overrides.
 
     ``--user <username>``
 
-        Filter for overrides by the given username.
+        Filter for overrides by a list of usernames, given as a comma-separated list.
 
 
 ``bodhi overrides save [options] <nvr>``
@@ -360,7 +360,7 @@ The ``updates`` command allows users to interact with bodhi updates.
 
     ``--user <username>``
 
-        Filter for updates by the given username.
+        Filter for updates by a list of usernames, given as a comma-separated list.
 
 ``bodhi updates request [options] <update> <state>``
 


### PR DESCRIPTION
This will allow multiple users filtering when searching for comments, updates or overrides:
```
comments/?ignore_user=bolowfeggs,mattia
comments/?user=bolowfeggs,mattia
comments/?update_owner=bolowfeggs,mattia
updates/?user=bolowfeggs,mattia
overrides/?user=bolowfeggs,mattia
```
I did not changed the input parameter name to plural (`user` --> `users`) because I think it's better to keep backward compatibility. Is it ok?

Fixes #2489 
Signed-off-by: Mattia Verga <mattia.verga@tiscali.it>