### PR TITLE
Add the {pyver} variable to the JJB unit test job template.

### DIFF
--- a/devel/ci/githubprb-project.yml
+++ b/devel/ci/githubprb-project.yml
@@ -122,7 +122,7 @@
     <<: *job_template_defaults
 
 - job-template:
-    name: '{ci_project}-{git_repo}-unit-{release}'
+    name: '{ci_project}-{git_repo}-unit-{release}-{pyver}'
     publishers:
       - junit:
           results: 'test_results/**/nosetests.xml'
@@ -165,7 +165,7 @@
       - pip
       - rawhide
     jobs:
-        - '{ci_project}-{git_repo}-unit-{release}':
+        - '{ci_project}-{git_repo}-unit-{release}-{pyver}':
             git_organization: fedora-infra
             git_username: fedora-infra
             git_repo: bodhi


### PR DESCRIPTION
A recent change to the JJB template split the unit test jobs into
two, one for testing Python 2 and one for Python 3. Unfortunately,
I forgot to include the {pyver} variable in the JJB unit test
template and the jobs ended up getting names like "unit tests
(f27-python[2, 3])" instead of "unit tests (f27-python2)", which
is what Mergify expects to find. This commit should fix that.

Signed-off-by: Randy Barlow <randy@electronsweatshop.com>