### PR TITLE
Do not marked Duffy nodes as failed.

### DIFF
--- a/devel/ci/githubprb-project.yml
+++ b/devel/ci/githubprb-project.yml
@@ -98,17 +98,15 @@
             rtn_code=$?
             # Copy the archive results back to the master
             rsync -e "ssh $sshopts" -Ha $CICO_hostname:payload/test_results $(pwd)/
+            cico node done $CICO_ssid;
             if [ $rtn_code -eq 0 ]; then
-                cico node done $CICO_ssid
+                echo "BUILD SUCCEEDED";
             else
                 if [[ $rtn_code -eq 124 ]]; then
-                   echo "BUILD TIMEOUT";
-                   cico node done $CICO_ssid;
-                   exit 1;
+                    echo "BUILD TIMEOUT";
+                    exit 1;
                 else
-                    # fail mode gives us 12 hrs to debug the machine
-                    set +x
-                    curl "http://admin.ci.centos.org:8080/Node/fail?key=$CICO_API_KEY&ssid=$CICO_ssid";
+                    echo "BUILD FAILED";
                     exit 1
                 fi
             fi


### PR DESCRIPTION
In recent weeks, Bodhi started using far more test jobs per pull
request in order to give more granular test reporting. When jobs
failed, Bodhi's CI system would mark the nodes used as failed,
which gave use 12 hours to log into those systems to poke around.
This was a nice feature, but now that we run 20 tests per pull
requests, I've been informed that we are now causing large numbers
of systems in CentOS CI to wait around for 12 hours in case we want
to debug on them. I rarely use that feature (though it is nice), so
this pull requests adjusts the script such that we always return
the node as successful so we don't exhaust the pool of workers.

Signed-off-by: Randy Barlow <randy@electronsweatshop.com>