### PR TITLE
Call the recent unit JJB job bodhi instead of bodhi-unit.

### DIFF
--- a/devel/ci/githubprb-project.yml
+++ b/devel/ci/githubprb-project.yml
@@ -154,7 +154,7 @@
             timeout: '128m'
 
 - project:
-    name: bodhi-unit
+    name: bodhi
     pyver:
       - 2
       - 3


### PR DESCRIPTION
Examining a job created by the current JJB template shows an error
about how there are no nodes labeled bodhi-unit. I believe this is
due to calling the new CI project bodhi-unit instead of bodhi. This
commit corrects that label.

[0] https://ci.centos.org/job/bodhi-unit-bodhi-unit-f27-2/

Signed-off-by: Randy Barlow <randy@electronsweatshop.com>