### PR TITLE
Explicitly use the bodhi node in CI jobs.

### DIFF
--- a/devel/ci/githubprb-project.yml
+++ b/devel/ci/githubprb-project.yml
@@ -47,7 +47,7 @@
     description: |
         Managed by Jenkins Job Builder, do not edit manually!
     concurrent: true
-    node: "{ci_project}"
+    node: bodhi
     properties:
         - github:
             url: https://github.com/{git_username}/{git_repo}/
@@ -154,7 +154,7 @@
             timeout: '128m'
 
 - project:
-    name: bodhi
+    name: bodhi-unit
     pyver:
       - 2
       - 3


### PR DESCRIPTION
Signed-off-by: Randy Barlow <randy@electronsweatshop.com>