### PR TITLE
Increase the size of the Vagrant guest.

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -56,11 +56,11 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
     bodhi.vm.provider :libvirt do |domain|
         # Season to taste
-        domain.cpus = 4
+        domain.cpus = 8
         domain.cpu_mode = "host-passthrough"
         domain.graphics_type = "spice"
         # The unit tests use a lot of RAM.
-        domain.memory = 2048
+        domain.memory = 4096
         domain.video_type = "qxl"
 
         # Uncomment the following line if you would like to enable libvirt's unsafe cache


### PR DESCRIPTION
With the recent addition of the bci alias, the Vagrant guest would
benefit from having more RAM and virtual CPUs. bci all will fail
with the current allocation of RAM, and due to the large number of
parallel processes it is beneficial to give the guest more virtual
cores as well.

Signed-off-by: Randy Barlow <randy@electronsweatshop.com>