### PR TITLE
Temporarily disable JJB CI.

### DIFF
--- a/devel/ci/githubprb-project.yml
+++ b/devel/ci/githubprb-project.yml
@@ -48,6 +48,7 @@
         Managed by Jenkins Job Builder, do not edit manually!
     concurrent: true
     node: bodhi
+    disabled: true
     properties:
         - github:
             url: https://github.com/{git_username}/{git_repo}/


### PR DESCRIPTION
I am working on adding a Jenkinsfile[0] to test Bodhi with the
Jenkins Pipeline plugin, and it is difficult to test the new script
when the existing JJB tasks are taking up all the available
workers. This commit temporarily disables the JJB jobs so I can
iterate more rapidly on replacing them.

[0] https://github.com/fedora-infra/bodhi/pull/2609

Signed-off-by: Randy Barlow <randy@electronsweatshop.com>