### PR TITLE
Rename the bodhi-ci stages to match their GitHub contexts.

### DIFF
--- a/devel/ci/cico.pipeline
+++ b/devel/ci/cico.pipeline
@@ -77,7 +77,7 @@ def bodhi_ci = { String release, String command, String context, String args ->
     githubNotify context: release + '-' + context, status: 'PENDING'
 
     try {
-        stage(release + ' ' + command) {
+        stage(release + '-' + context) {
             timeout(time: 16, unit: 'MINUTES') {
                 onmyduffynode 'cd payload && ./devel/ci/bodhi-ci ' + command + ' -r ' + release + ' ' + args
             }


### PR DESCRIPTION
The primary goal here is to get the Python 2 unit and Python 3
unit stages to have different names, but it was easy to just use
the same name we use for the GitHub context.

Signed-off-by: Randy Barlow <randy@electronsweatshop.com>