### PR TITLE
Correct an incorrect example in the bodhi CLI's helptext.

### DIFF
--- a/bodhi/client/__init__.py
+++ b/bodhi/client/__init__.py
@@ -156,7 +156,7 @@ release_options = [
     click.option('--pending-stable-tag',
                  help='Koji pending tag (eg: f20-updates-pending)'),
     click.option('--pending-testing-tag',
-                 help='Koji pending testing tag (eg: f20-updates-testing-testing)'),
+                 help='Koji pending testing tag (eg: f20-updates-pending-testing)'),
     click.option('--pending-signing-tag',
                  help='Koji pending signing tag (eg: f20-updates-pending-signing)'),
     click.option('--override-tag', help='Koji override tag (eg: f20-override)'),


### PR DESCRIPTION
The Bodhi CLI incorrectly referenced the pending-testing-tag as
f20-updates-testing-testing instead of f20-updates-pending-testing.

Signed-off-by: Randy Barlow <randy@electronsweatshop.com>