### PR TITLE
Correct a man page example for the f29-updates-pending-testing tag.

### DIFF
--- a/docs/user/man_pages/bodhi.rst
+++ b/docs/user/man_pages/bodhi.rst
@@ -461,7 +461,7 @@ The ``releases`` command allows users to manage update releases.
 
     ``--pending-testing-tag TEXT``
 
-        The Koji tag to use on updates that are pending testing (e.g., f29-updates-testing-pending).
+        The Koji tag to use on updates that are pending testing (e.g., f29-updates-pending-testing).
 
     ``--stable-tag TEXT``
 


### PR DESCRIPTION
The man page incorrectly referenced f29-updates-testing-pending
instead of f29-updates-pending-testing.

Signed-off-by: Randy Barlow <randy@electronsweatshop.com>