### PR TITLE
Refine javascript code in New Update form

### DIFF
--- a/bodhi/server/static/js/update_form.js
+++ b/bodhi/server/static/js/update_form.js
@@ -70,6 +70,17 @@ $(document).ready(function() {
         },
     });
 
+    // Do not submit form when pressing enter while typing packages
+    // Instead select the first typeahead suggestion if only one result is given
+    $('#packages-search .typeahead').keydown(function(event) {
+        if(event.keyCode == 13) {
+            event.preventDefault();
+            if ($(".tt-selectable").length == 1) {
+                $(".tt-selectable").first().click();
+            }
+        }
+    });
+
     // Callback to remove a checkbox when it is unchecked.
     // https://github.com/fedora-infra/bodhi/issues/260
     var remove_unchecked = function() {

--- a/bodhi/server/static/js/update_form.js
+++ b/bodhi/server/static/js/update_form.js
@@ -70,23 +70,6 @@ $(document).ready(function() {
         },
     });
 
-    // candidate_error and bug_error are just two handy utilities for reporting
-    // errors when stuff in the code blocks below this goes wrong.
-    var candidate_error = function(package) {
-        $("#candidate-checkboxes .spinner").remove();
-        messenger.post({
-            message: 'No candidate builds found for ' + package,
-            type: 'error',
-        });
-    }
-    var bugs_error = function(package) {
-        $("#bugs-checkboxes .spinner").remove();
-        messenger.post({
-            message: 'No bugs found for ' + package,
-            type: 'error',
-        });
-    }
-
     // Callback to remove a checkbox when it is unchecked.
     // https://github.com/fedora-infra/bodhi/issues/260
     var remove_unchecked = function() {
@@ -180,7 +163,12 @@ $(document).ready(function() {
             success: function(builds) {
                 $("#candidate-checkboxes .spinner").remove();
                 $("#candidate-checkboxes input:checkbox:not(:checked)").parents("div.checkbox").remove();
-                if (builds.length == 0) {return candidate_error(datum.name);}
+                if (builds.length == 0) {
+                    return messenger.post({
+                        message: 'No candidate builds found for ' + datum.name,
+                        type: 'info',
+                    });
+                }
                 $.each(builds, function(i, build) {
                     // Insert the checkbox only if this ID is not already listed
                     if ($.inArray(build.id, checked_candidate_ids) == -1) {
@@ -188,7 +176,12 @@ $(document).ready(function() {
                     }
                 });
             },
-            error: function() {candidate_error(datum.name);},
+            error: function() {
+                messenger.post({
+                        message: 'Unable to retrieve builds list for ' + datum.name,
+                        type: 'error',
+                    });
+            },
         });
         var base = 'https://apps.fedoraproject.org/packages/fcomm_connector';
         var prefix = '/bugzilla/query/query_bugs/%7B%22filters%22:%7B%22package%22:%22';
@@ -199,7 +192,12 @@ $(document).ready(function() {
                 $("#bugs-checkboxes .spinner").remove();
                 $("#bugs-checkboxes input:checkbox:not(:checked)").parents("div.checkbox").remove();
                 data = JSON.parse(data);
-                if (data.rows.length == 0) {return bugs_error(datum.name);}
+                if (data.rows.length == 0) {
+                    return messenger.post({
+                        message: 'No bugs found for ' + datum.name,
+                        type: 'info',
+                    });
+                }
                 $.each(data.rows, function(i, bug) {
                     // Insert the checkbox only if this ID is not already listed
                     if ($.inArray(bug.id, checked_bug_ids) == -1) {
@@ -208,7 +206,12 @@ $(document).ready(function() {
                 });
                 // TODO -- tack on 'And 200 more bugs..'
             },
-            error: function() {bugs_error(datum.name);},
+            error: function() {
+                messenger.post({
+                        message: 'Unable to retrieve bugs list for ' + datum.name,
+                        type: 'error',
+                    });
+            },
         });
     });
 

--- a/bodhi/server/static/js/update_form.js
+++ b/bodhi/server/static/js/update_form.js
@@ -200,6 +200,7 @@ $(document).ready(function() {
         // Get the candidate builds
         $.ajax({
             url: 'latest_candidates',
+            timeout: 10000,
             data: $.param({package: datum.name}),
             success: function(builds) {
                 if (builds.length == 0) {
@@ -215,11 +216,19 @@ $(document).ready(function() {
                     }
                 });
             },
-            error: function() {
-                messenger.post({
+            error: function(jqXHR, textStatus) {
+                if (textStatus == 'timeout') {
+                    messenger.post({
+                        message: 'Reached timeout while retrieving builds list for ' + datum.name,
+                        type: 'error',
+                    });
+                }
+                else {
+                    messenger.post({
                         message: 'Unable to retrieve builds list for ' + datum.name,
                         type: 'error',
                     });
+                }
             },
             complete: function() {
                 $("#candidate-checkboxes .spinner").remove();
@@ -234,6 +243,7 @@ $(document).ready(function() {
         var suffix = '%22,%22version%22:%22%22%7D,%22rows_per_page%22:8,%22start_row%22:0%7D';
         $.ajax({
             url: base + prefix + datum.name + suffix,
+            timeout: 10000,
             success: function(data) {
                 data = JSON.parse(data);
                 if (data.rows.length == 0) {
@@ -255,11 +265,19 @@ $(document).ready(function() {
                 });
                 // TODO -- tack on 'And 200 more bugs..'
             },
-            error: function() {
-                messenger.post({
+            error: function(jqXHR, textStatus) {
+                if (textStatus == 'timeout') {
+                    messenger.post({
+                        message: 'Reached timeout while retrieving bugs list for ' + datum.name,
+                        type: 'error',
+                    });
+                }
+                else {
+                    messenger.post({
                         message: 'Unable to retrieve bugs list for ' + datum.name,
                         type: 'error',
                     });
+                }
             },
             complete: function() {
                 $("#bugs-checkboxes .spinner").remove();


### PR DESCRIPTION
I've reworked the javascript code that runs the form in the New Update submission page. This is the list of what I want to achieve with this PR:

- Builds and bugs lists are refreshed every time a new package is selected in the input field. Before, the bugs and builds retrieved were appended to the existing list, which caused duplicated entries if the user selected the same package twice.
- Manual added bugs and builds are not added to the lists if they are already present after having been retrieved from package selection.
- When an error in ajax query occurs it is now displayed as an error message, while before it was displayed as a info message.
- Added a timeout to ajax queries (10 sec)
- Avoid form submit when pressing Enter while entering text in the package text input field

While testing this PR be advised that I noticed a couple of bugs unrelated to these changes (they're already hitting production now): latest_candidates list from bodhi seems to not be working and apps.fedoraproject.org API seems to report packages twice.

Signed-off-by: Mattia Verga <mattia.verga@tiscali.it>