### PR TITLE
Waiver Dialog and Button UI tweaks

### DIFF
--- a/bodhi/server/templates/update.html
+++ b/bodhi/server/templates/update.html
@@ -66,7 +66,7 @@ ${update.type} update for ${update.beautify_title(amp=True) | n}
             if ($.inArray(requirement.testcase, requirements) == -1) {
                 requirements.push(requirement.testcase);
             }
-            $('#failed_requirements').append('<li class="list-group-item">' + requirement.item + '</li>');
+            $('#failed_requirements').append('<li class="list-group-item">' + requirement.testcase + '</li>');
         });
         % if request.registry.settings.get("test_gating.required") is True:
             if (data['policies_satisfied']) {

--- a/bodhi/server/templates/update.html
+++ b/bodhi/server/templates/update.html
@@ -67,6 +67,9 @@ ${update.type} update for ${update.beautify_title(amp=True) | n}
                 requirements.push(requirement.testcase);
             }
             $('#failed_requirements').append('<li class="list-group-item">' + requirement.testcase + '</li>');
+            
+            // there is at least one unsatisfied requirement, so show the button to be able to waive.
+            $('#waive').show();
         });
         % if request.registry.settings.get("test_gating.required") is True:
             if (data['policies_satisfied']) {
@@ -570,7 +573,7 @@ $(document).ready(function(){
             <a id='unpush' class="btn btn-sm btn-danger"><span class="fa fa-fw fa-arrow-circle-left"></span> Unpush</a>
           % endif
           % if self.util.can_waive_test_results(update):
-            <a id='waive' class="btn btn-sm btn-primary" data-toggle="modal" data-target="#waive_test_results">Waive Test Results</a>
+            <a id='waive' class="btn btn-sm btn-primary hidden" data-toggle="modal" data-target="#waive_test_results">Waive Test Results</a>
           % endif
           </div>
         % else:


### PR DESCRIPTION
This PR fixes two issues with the waiving of unsatsfied requirements from greenwave:

1. Previously, the waiver dialog was showing "Object object"
for each unsatified requirement that was returned by
greenwave. This was because it was showing the entire
javascriptt object, woth .item, rather than a useful
property. This commit updates this to show the testcase
name. Fixes #2571

2. This updates the "Waive Test Results" button so
it is hidden at page load, and is subsequently
displayed if there are unsatisfied requirements
returned from greenwave. Fixes #2545