### PR TITLE
Use Koji metadata to get registry repository for images

### DIFF
--- a/bodhi/tests/server/consumers/test_masher.py
+++ b/bodhi/tests/server/consumers/test_masher.py
@@ -2294,14 +2294,16 @@ class TestContainerComposerThread__compose_updates(ComposerThreadBaseTestCase):
         package2 = Package(name=u'testcontainer2',
                            type=ContentType.container)
         self.db.add(package2)
-        build1 = ContainerBuild(nvr=u'testcontainer1-2.0.1-71.fc28', release=release, signed=True,
+        build1 = ContainerBuild(nvr=u'testcontainer1-2.0.1-71.fc28container',
+                                release=release, signed=True,
                                 package=package1)
         self.db.add(build1)
-        build2 = ContainerBuild(nvr=u'testcontainer2-1.0.1-1.fc28', release=release, signed=True,
+        build2 = ContainerBuild(nvr=u'testcontainer2-1.0.1-1.fc28container',
+                                release=release, signed=True,
                                 package=package2)
         self.db.add(build2)
         update = Update(
-            title=u'testcontainer1-2.0.1-71.fc28, testcontainer2-1.0.1-1.fc28',
+            title=u'testcontainer1-2.0.1-71.fc28container, testcontainer2-1.0.1-1.fc28container',
             builds=[build1, build2], user=user,
             status=UpdateStatus.pending,
             request=UpdateRequest.testing,
@@ -2328,7 +2330,8 @@ class TestContainerComposerThread__compose_updates(ComposerThreadBaseTestCase):
         # Popen should have been called three times per build, once for each of the destination
         # tags. With two builds that is a total of 6 calls to Popen.
         expected_mock_calls = []
-        for source in ('testcontainer1:2.0.1-71.fc28', 'testcontainer2:1.0.1-1.fc28'):
+        for source in ('testcontainer1:2.0.1-71.fc28container',
+                       'testcontainer2:1.0.1-1.fc28container'):
             for dtag in [source.split(':')[1], source.split(':')[1].split('-')[0], 'testing']:
                 mock_call = mock.call(
                     [config['skopeo.cmd'], 'copy',
@@ -2356,7 +2359,8 @@ class TestContainerComposerThread__compose_updates(ComposerThreadBaseTestCase):
         # Popen should have been called three times per build, once for each of the destination
         # tags. With two builds that is a total of 6 calls to Popen.
         expected_mock_calls = []
-        for source in ('testcontainer1:2.0.1-71.fc28', 'testcontainer2:1.0.1-1.fc28'):
+        for source in ('testcontainer1:2.0.1-71.fc28container',
+                       'testcontainer2:1.0.1-1.fc28container'):
             for dtag in [source.split(':')[1], source.split(':')[1].split('-')[0], 'latest']:
                 mock_call = mock.call(
                     [config['skopeo.cmd'], 'copy',
@@ -2385,9 +2389,9 @@ class TestContainerComposerThread__compose_updates(ComposerThreadBaseTestCase):
         # Popen should have been called once.
         skopeo_cmd = [
             config['skopeo.cmd'], 'copy',
-            'docker://{}/f28/testcontainer1:2.0.1-71.fc28'.format(
+            'docker://{}/f28/testcontainer1:2.0.1-71.fc28container'.format(
                 config['container.source_registry']),
-            'docker://{}/f28/testcontainer1:2.0.1-71.fc28'.format(
+            'docker://{}/f28/testcontainer1:2.0.1-71.fc28container'.format(
                 config['container.destination_registry'])]
         Popen.assert_called_once_with(skopeo_cmd, shell=False, stderr=-1, stdout=-1, cwd=None)
         self.assertEqual(str(exc.exception),
@@ -2409,7 +2413,8 @@ class TestContainerComposerThread__compose_updates(ComposerThreadBaseTestCase):
         # Popen should have been called three times per build, once for each of the destination
         # tags. With two builds that is a total of 6 calls to Popen.
         expected_mock_calls = []
-        for source in ('testcontainer1:2.0.1-71.fc28', 'testcontainer2:1.0.1-1.fc28'):
+        for source in ('testcontainer1:2.0.1-71.fc28container',
+                       'testcontainer2:1.0.1-1.fc28container'):
             for dtag in [source.split(':')[1], source.split(':')[1].split('-')[0], 'testing']:
                 mock_call = mock.call(
                     [config['skopeo.cmd'], 'copy', '--dest-tls-verify=false',
@@ -2455,14 +2460,16 @@ class TestFlatpakComposerThread__compose_updates(ComposerThreadBaseTestCase):
         package2 = Package(name=u'testflatpak2',
                            type=ContentType.flatpak)
         self.db.add(package2)
-        build1 = FlatpakBuild(nvr=u'testflatpak1-2.0.1-71.fc28', release=release, signed=True,
+        build1 = FlatpakBuild(nvr=u'testflatpak1-2.0.1-71.fc28flatpak',
+                              release=release, signed=True,
                               package=package1)
         self.db.add(build1)
-        build2 = FlatpakBuild(nvr=u'testflatpak2-1.0.1-1.fc28', release=release, signed=True,
+        build2 = FlatpakBuild(nvr=u'testflatpak2-1.0.1-1.fc28flatpak',
+                              release=release, signed=True,
                               package=package2)
         self.db.add(build2)
         update = Update(
-            title=u'testflatpak1-2.0.1-71.fc28, testflatpak2-1.0.1-1.fc28',
+            title=u'testflatpak1-2.0.1-71.fc28flatpak, testflatpak2-1.0.1-1.fc28flatpak',
             builds=[build1, build2], user=user,
             status=UpdateStatus.pending,
             request=UpdateRequest.testing,
@@ -2494,13 +2501,13 @@ class TestFlatpakComposerThread__compose_updates(ComposerThreadBaseTestCase):
         # Popen should have been called three times per build, once for each of the destination
         # tags. With two builds that is a total of 6 calls to Popen.
         expected_mock_calls = []
-        for source in ('testflatpak1:2.0.1-71.fc28', 'testflatpak2:1.0.1-1.fc28'):
+        for source in ('testflatpak1:2.0.1-71.fc28flatpak', 'testflatpak2:1.0.1-1.fc28flatpak'):
             for dtag in [source.split(':')[1], source.split(':')[1].split('-')[0], 'testing']:
                 mock_call = mock.call(
                     [config['skopeo.cmd'], 'copy',
-                     'docker://{}/f28/{}'.format(config['container.source_registry'], source),
-                     'docker://{}/f28/{}:{}'.format(config['container.destination_registry'],
-                                                    source.split(':')[0], dtag)],
+                     'docker://{}/{}'.format(config['container.source_registry'], source),
+                     'docker://{}/{}:{}'.format(config['container.destination_registry'],
+                                                source.split(':')[0], dtag)],
                     shell=False, stderr=-1, stdout=-1, cwd=None)
                 expected_mock_calls.append(mock_call)
                 expected_mock_calls.append(mock.call().communicate())


### PR DESCRIPTION
Instead of hardcoding that a registry image is at <release>/<name>,
look it up via the registry metadata that OSBS writes.

Fixes #2658