### PR TITLE
Be technically correct when logging about pungi calls

### DIFF
--- a/bodhi/server/consumers/masher.py
+++ b/bodhi/server/consumers/masher.py
@@ -1218,9 +1218,9 @@ class PungiComposerThread(ComposerThread):
         """
         self.save_state(ComposeState.punging)
         if pungi_process is None:
-            self.log.info('Not waiting for pungi thread, as there was no pungi')
+            self.log.info('Not waiting for pungi process, as there was no pungi')
             return
-        self.log.info('Waiting for pungi thread to finish')
+        self.log.info('Waiting for pungi process to finish')
         out, err = pungi_process.communicate()
         self.devnull.close()
         if pungi_process.returncode != 0:

--- a/bodhi/tests/server/consumers/test_masher.py
+++ b/bodhi/tests/server/consumers/test_masher.py
@@ -3511,5 +3511,5 @@ class TestPungiComposerThread__wait_for_pungi(ComposerThreadBaseTestCase):
         self.assertEqual(
             t.log.info.mock_calls,
             [mock.call('Compose object updated.'),
-             mock.call('Not waiting for pungi thread, as there was no pungi')])
+             mock.call('Not waiting for pungi process, as there was no pungi')])
         self.assertEqual(t.compose.state, ComposeState.punging)


### PR DESCRIPTION
We actually call pungi as a subprocess rather than a thread, so this
will make the logs technically correct: the Best Kind of Correct(R).

Signed-off-by: Patrick Uiterwijk <patrick@puiterwijk.org>