### PR TITLE
Use a longer timeout for Jenkies tests.

### DIFF
--- a/devel/ci/cico.pipeline
+++ b/devel/ci/cico.pipeline
@@ -82,7 +82,7 @@ def bodhi_ci = { String release, String command, String context, String args ->
 
     try {
         stage(release + '-' + context) {
-            timeout(time: 16, unit: 'MINUTES') {
+            timeout(time: 32, unit: 'MINUTES') {
                 onmyduffynode 'cd payload && python36 ./devel/ci/bodhi-ci ' + command + ' --no-tty -r ' + release + ' ' + args
             }
         }


### PR DESCRIPTION
CI had occasionally been hitting a timeout on some pull requests.
This commit doubles the timeout to reduce the frequency of that
happening.

Signed-off-by: Randy Barlow <randy@electronsweatshop.com>