### PR TITLE
Gracefully handle private bugs

### DIFF
--- a/bodhi/server/bugs.py
+++ b/bodhi/server/bugs.py
@@ -147,6 +147,9 @@ class Bugzilla(BugTracker):
             if len(comment) > 65535:
                 raise InvalidComment("Comment is too long: %s" % comment)
             bug = self.bz.getbug(bug_id)
+            if bug.private:
+                log.info('Unable to comment on private bug #%d' % bug_id)
+                return
             attempts = 0
             while attempts < 5:
                 try:
@@ -179,6 +182,9 @@ class Bugzilla(BugTracker):
         """
         try:
             bug = self.bz.getbug(bug_id)
+            if bug.private:
+                log.info('Unable to modify status of private bug #%d' % bug_id)
+                return
             if bug.product not in config.get('bz_products'):
                 log.info("Skipping set on_qa on {0!r} bug #{1}".format(bug.product, bug_id))
                 return
@@ -206,6 +212,9 @@ class Bugzilla(BugTracker):
         args = {'comment': comment}
         try:
             bug = self.bz.getbug(bug_id)
+            if bug.private:
+                log.info('Unable to modify status of private bug #%d' % bug_id)
+                return
             if bug.product not in config.get('bz_products'):
                 log.info("Skipping set closed on {0!r} bug #{1}".format(bug.product, bug_id))
                 return
@@ -248,10 +257,15 @@ class Bugzilla(BugTracker):
         if not bug:
             try:
                 bug = self.bz.getbug(bug_entity.bug_id)
-            except xmlrpc_client.Fault as e:
-                bug_entity.title = 'Invalid bug number'
-                log.error("Got fault from Bugzilla: fault code: %d, fault string: %s" % (
-                    e.faultCode, e.faultString))
+            except xmlrpc_client.Fault as err:
+                if err.faultCode == 102:
+                    bug_entity.title = 'Private bug'
+                    bug_entity.private = True
+                    log.info("Marked bug #" + str(bug_entity.bug_id) + " as private.")
+                else:
+                    bug_entity.title = 'Invalid bug number'
+                    log.error("Got fault from Bugzilla: fault code: %d, fault string: %s" % (
+                        err.faultCode, err.faultString))
                 return
             except Exception:
                 log.exception("Unknown exception from Bugzilla")
@@ -281,6 +295,9 @@ class Bugzilla(BugTracker):
         """
         try:
             bug = self.bz.getbug(bug_id)
+            if bug.private:
+                log.info('Unable to modify status of private bug #%d' % bug_id)
+                return
             if bug.product not in config.get('bz_products'):
                 log.info("Skipping set modified on {0!r} bug #{1}".format(bug.product, bug_id))
                 return

--- a/bodhi/server/consumers/updates.py
+++ b/bodhi/server/consumers/updates.py
@@ -162,6 +162,9 @@ class UpdatesHandler(fedmsg.consumers.FedmsgConsumer):
         details from Bugzilla, comment on the bug to let watchers know about the update, and mark
         the bug as MODIFIED. If the bug is a security issue, mark the update as a security update.
 
+        If the bug is private, Bodhi can't retrieve any information, comment on it, or modify
+        it, so we just associate the bug id with the update and mark it to be private.
+
         If handle_bugs is not True, return and do nothing.
 
         Args:
@@ -181,6 +184,10 @@ class UpdatesHandler(fedmsg.consumers.FedmsgConsumer):
 
                 log.info("Updating our details for %r" % bug.bug_id)
                 bug.update_details(rhbz_bug)
+                if bug.private:
+                    # Bodhi can't retrieve any information so just continue with the next bug
+                    log.info("  Skipping bug %r because it is private" % (bug.bug_id))
+                    continue
                 log.info("  Got title %r for %r" % (bug.title, bug.bug_id))
 
                 # If you set the type of your update to 'enhancement' but you

--- a/bodhi/server/mail.py
+++ b/bodhi/server/mail.py
@@ -325,9 +325,9 @@ def get_template(update, use_template='fedora_errata_template'):
                     if parent and not bug.parent:
                         log.debug("Skipping tracker bug %s" % bug)
                         continue
-                title = (
-                    bug.title != 'Unable to fetch title' and bug.title != 'Invalid bug number') \
-                    and ' - %s' % bug.title or ''
+                title = (bug.title != 'Unable to fetch title'
+                         and bug.title != 'Invalid bug number'
+                         and not bug.private) and ' - %s' % bug.title or ''
                 info['references'] += u"  [ %d ] Bug #%d%s\n        %s\n" % \
                                       (i, bug.bug_id, title, bug.url)
                 i += 1

--- a/bodhi/server/migrations/versions/3a14c47250fb_add_a_private_flag_to_bugs.py
+++ b/bodhi/server/migrations/versions/3a14c47250fb_add_a_private_flag_to_bugs.py
@@ -1,0 +1,43 @@
+# Copyright (c) 2018 Mattia Verga
+#
+# This file is part of Bodhi.
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+"""
+Add a private flag to bugs.
+
+Revision ID: 3a14c47250fb
+Revises: 68f9ccb1f388
+Create Date: 2018-11-04 14:55:57.939008
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '3a14c47250fb'
+down_revision = '68f9ccb1f388'
+
+
+def upgrade():
+    """Add a new Bool column to bugs table, set default to False."""
+    op.add_column('bugs', sa.Column('private', sa.Boolean(), nullable=True))
+    op.execute("""UPDATE bugs SET private = FALSE""")
+    op.alter_column('bugs', 'private', nullable=False)
+
+
+def downgrade():
+    """Just remove the new column."""
+    op.drop_column('bugs', 'private')

--- a/bodhi/server/models.py
+++ b/bodhi/server/models.py
@@ -4155,6 +4155,9 @@ class Bug(Base):
     # List of Mitre CVE's associated with this bug
     cves = relationship(CVE, secondary=bug_cve_table, backref='bugs')
 
+    # Is it public or private
+    private = Column(Boolean, default=False)
+
     @property
     def url(self):
         """
@@ -4210,6 +4213,9 @@ class Bug(Base):
             comment (basestring or None): The comment to add to the bug. If None, a default message
                 is added to the bug. Defaults to None.
         """
+        if self.private:
+            log.debug('Not commenting on private bug %s', self.bug_id)
+            return
         if update.type is UpdateType.security and self.parent \
                 and update.status is not UpdateStatus.stable:
             log.debug('Not commenting on parent security bug %s', self.bug_id)
@@ -4229,6 +4235,9 @@ class Bug(Base):
         Args:
             update (Update): The update associated with the bug.
         """
+        if self.private:
+            log.debug('Not modifying private bug %s', self.bug_id)
+            return
         # Skip modifying Security Response bugs for testing updates
         if update.type is UpdateType.security and self.parent:
             log.debug('Not modifying parent security bug %s', self.bug_id)
@@ -4243,6 +4252,9 @@ class Bug(Base):
         Args:
             update (Update): The update associated with the bug.
         """
+        if self.private:
+            log.debug('Not modifying private bug %s', self.bug_id)
+            return
         # Build a mapping of package names to build versions
         # so that .close() can figure out which build version fixes which bug.
         versions = dict([
@@ -4259,6 +4271,9 @@ class Bug(Base):
         Args:
             update (Update): The update that is associated with this bug.
         """
+        if self.private:
+            log.debug('Not modifying private bug %s', self.bug_id)
+            return
         if update.type is UpdateType.security and self.parent:
             log.debug('Not modifying parent security bug %s', self.bug_id)
         else:

--- a/bodhi/server/util.py
+++ b/bodhi/server/util.py
@@ -911,9 +911,12 @@ def bug_link(context, bug, short=False):
     link = "<a target='_blank' href='%s'>%s</a>" % (url, display)
     if not short:
         if bug.title:
-            # We're good, but we do need to clean the bug title in case it contains malicious
-            # tags. See CVE-2017-1002152: https://github.com/fedora-infra/bodhi/issues/1740
-            link = link + " " + bleach.clean(bug.title, tags=[], attributes=[])
+            if bug.private:
+                link = link + " <span class='label label-danger'>Private bug</span>"
+            else:
+                # We're good, but we do need to clean the bug title in case it contains malicious
+                # tags. See CVE-2017-1002152: https://github.com/fedora-infra/bodhi/issues/1740
+                link = link + " " + bleach.clean(bug.title, tags=[], attributes=[])
         else:
             # Otherwise, the backend is async grabbing the title from rhbz, so
             link = link + " <img class='spinner' src='static/img/spinner.gif'>"

--- a/bodhi/tests/server/test_bugs.py
+++ b/bodhi/tests/server/test_bugs.py
@@ -94,6 +94,7 @@ class TestBugzilla(unittest.TestCase):
         """Assert that an xmlrpc Fault is caught and logged by close()."""
         bz = bugs.Bugzilla()
         bz._bz = mock.MagicMock()
+        bz._bz.getbug.return_value.private = False
         bz._bz.getbug.return_value.product = 'aproduct'
         bz._bz.getbug.return_value.close.side_effect = xmlrpc_client.Fault(
             410, 'You must log in before using this part of Red Hat Bugzilla.')
@@ -111,6 +112,7 @@ class TestBugzilla(unittest.TestCase):
         """Test the close() method with a success case."""
         bz = bugs.Bugzilla()
         bz._bz = mock.MagicMock()
+        bz._bz.getbug.return_value.private = False
         bz._bz.getbug.return_value.component = 'bodhi'
         bz._bz.getbug.return_value.product = 'aproduct'
 
@@ -126,10 +128,28 @@ class TestBugzilla(unittest.TestCase):
 
     @mock.patch('bodhi.server.bugs.log.info')
     @mock.patch.dict('bodhi.server.bugs.config', {'bz_products': 'aproduct'})
+    def test_close_private_bug(self, info):
+        """Test the close() method with a bug flagged as private."""
+        bz = bugs.Bugzilla()
+        bz._bz = mock.MagicMock()
+        bz._bz.getbug.return_value.private = True
+        bz._bz.getbug.return_value.component = 'bodhi'
+        bz._bz.getbug.return_value.product = 'aproduct'
+
+        bz.close(12345, {'bodhi': 'bodhi-3.1.0-1.fc27'},
+                 'Fixed. Closing bug and adding version to fixed_in field.')
+
+        bz._bz.getbug.assert_called_once_with(12345)
+        bz._bz.getbug.return_value.close.assert_not_called()
+        info.assert_called_once_with('Unable to modify status of private bug #12345')
+
+    @mock.patch('bodhi.server.bugs.log.info')
+    @mock.patch.dict('bodhi.server.bugs.config', {'bz_products': 'aproduct'})
     def test_close_fixedin_maxlength(self, info):
         """Test the close() method when fixed_in field may go over 255 chars."""
         bz = bugs.Bugzilla()
         bz._bz = mock.MagicMock()
+        bz._bz.getbug.return_value.private = False
         bz._bz.getbug.return_value.component = 'bodhi'
         bz._bz.getbug.return_value.product = 'aproduct'
         fill_text = ' '.join([u'exactly-10', ] * 23)
@@ -150,6 +170,7 @@ class TestBugzilla(unittest.TestCase):
         """Test the close() method at the edge of the allowed size of the fixedin field (254)."""
         bz = bugs.Bugzilla()
         bz._bz = mock.MagicMock()
+        bz._bz.getbug.return_value.private = False
         bz._bz.getbug.return_value.component = 'bodhi'
         bz._bz.getbug.return_value.product = 'aproduct'
         fill_text = ' '.join([u'exactly-10', ] * 21)
@@ -172,6 +193,7 @@ class TestBugzilla(unittest.TestCase):
         """Test the close() method when the bug's product is not in the bz_products config."""
         bz = bugs.Bugzilla()
         bz._bz = mock.MagicMock()
+        bz._bz.getbug.return_value.private = False
         bz._bz.getbug.return_value.product = 'not fedora!'
 
         bz.close(12345, {'bodhi': 'bodhi-35.103.109-1.fc27'},
@@ -186,6 +208,7 @@ class TestBugzilla(unittest.TestCase):
         """Test the comment() method with a success case."""
         bz = bugs.Bugzilla()
         bz._bz = mock.MagicMock()
+        bz._bz.getbug.return_value.private = False
 
         bz.comment(1411188, 'A nice message.')
 
@@ -194,11 +217,25 @@ class TestBugzilla(unittest.TestCase):
         # No exceptions should have been logged
         self.assertEqual(info.call_count, 0)
 
+    @mock.patch('bodhi.server.bugs.log.info')
+    def test_comment_private_bug(self, info):
+        """Test the comment() method on a bug flagged as private."""
+        bz = bugs.Bugzilla()
+        bz._bz = mock.MagicMock()
+        bz._bz.getbug.return_value.private = True
+
+        bz.comment(1411188, 'A nice message.')
+
+        bz._bz.getbug.assert_called_once_with(1411188)
+        bz._bz.getbug.return_value.addcomment.assert_not_called()
+        info.assert_called_once_with('Unable to comment on private bug #1411188')
+
     @mock.patch('bodhi.server.bugs.log.error')
     def test_comment_too_long(self, error):
         """Assert that the comment() method gets angry if the comment is too long."""
         bz = bugs.Bugzilla()
         bz._bz = mock.MagicMock()
+        bz._bz.getbug.return_value.private = False
         oh_my = u'All work aind no play makes bowlofeggs a dull… something something… '
         long_comment = oh_my * (65535 // len(oh_my) + 1)
 
@@ -214,6 +251,7 @@ class TestBugzilla(unittest.TestCase):
         """Assert that only 5 attempts are made to comment before giving up."""
         bz = bugs.Bugzilla()
         bz._bz = mock.MagicMock()
+        bz._bz.getbug.return_value.private = False
         bz._bz.getbug.return_value.addcomment.side_effect = \
             xmlrpc_client.Fault(
                 42,
@@ -236,6 +274,7 @@ class TestBugzilla(unittest.TestCase):
         """Test the comment() method with an unexpected Exception."""
         bz = bugs.Bugzilla()
         bz._bz = mock.MagicMock()
+        bz._bz.getbug.return_value.private = False
         bz._bz.getbug.return_value.addcomment.side_effect = Exception(
             'Ran out of internet fluid, please refill.')
 
@@ -273,6 +312,7 @@ class TestBugzilla(unittest.TestCase):
         """Ensure correct execution of the modified() method."""
         bz = bugs.Bugzilla()
         bz._bz = mock.MagicMock()
+        bz._bz.getbug.return_value.private = False
         bz._bz.getbug.return_value.product = 'aproduct'
         bz._bz.getbug.return_value.bug_status = 'NEW'
 
@@ -283,11 +323,28 @@ class TestBugzilla(unittest.TestCase):
         bz._bz.getbug.return_value.setstatus.assert_called_once_with('MODIFIED',
                                                                      comment='A mean message.')
 
+    @mock.patch('bodhi.server.bugs.log.info')
+    @mock.patch.dict('bodhi.server.bugs.config', {'bz_products': 'aproduct'})
+    def test_modified_private_bug(self, info):
+        """Test the modified() method when the bug is flagged as private."""
+        bz = bugs.Bugzilla()
+        bz._bz = mock.MagicMock()
+        bz._bz.getbug.return_value.private = True
+        bz._bz.getbug.return_value.product = 'aproduct'
+        bz._bz.getbug.return_value.bug_status = 'NEW'
+
+        bz.modified(1411188, 'A mean message.')
+
+        bz._bz.getbug.assert_called_once_with(1411188)
+        info.assert_called_once_with("Unable to modify status of private bug #1411188")
+        bz._bz.getbug.return_value.setstatus.assert_not_called()
+
     @mock.patch.dict('bodhi.server.bugs.config', {'bz_products': 'aproduct'})
     def test_modified_after_verified(self):
         """Test the modified() method when the status of bug is VERIFIED."""
         bz = bugs.Bugzilla()
         bz._bz = mock.MagicMock()
+        bz._bz.getbug.return_value.private = False
         bz._bz.getbug.return_value.product = 'aproduct'
         bz._bz.getbug.return_value.bug_status = 'VERIFIED'
 
@@ -301,6 +358,7 @@ class TestBugzilla(unittest.TestCase):
         """Test the modified() method when the bug's product is not in the bz_products config."""
         bz = bugs.Bugzilla()
         bz._bz = mock.MagicMock()
+        bz._bz.getbug.return_value.private = False
         bz._bz.getbug.return_value.product = 'not fedora!'
 
         bz.modified(1411188, 'A mean message.')
@@ -375,6 +433,22 @@ class TestBugzilla(unittest.TestCase):
         error.assert_called_once_with(
             'Got fault from Bugzilla: fault code: 42, fault string: You found the meaning.')
 
+    @mock.patch('bodhi.server.bugs.log.info')
+    def test_update_details_xmlrpc_fault_bug_is_private(self, info):
+        """Test we set the bug as private and log the info"""
+        bz = bugs.Bugzilla()
+        bz._bz = mock.MagicMock()
+        bz._bz.getbug.side_effect = xmlrpc_client.Fault(102, 'The bug is private.')
+        bug = mock.MagicMock()
+        bug.bug_id = 123
+
+        bz.update_details(0, bug)
+
+        self.assertEqual(bug.title, 'Private bug')
+        self.assertEqual(bug.private, True)
+        bz._bz.getbug.assert_called_once_with(123)
+        info.assert_called_once_with('Marked bug #123 as private.')
+
     @mock.patch('bodhi.server.bugs.log.exception')
     @mock.patch.dict('bodhi.server.bugs.config', {'bz_products': 'aproduct'})
     def test_on_qa_failure(self, exception):
@@ -383,6 +457,7 @@ class TestBugzilla(unittest.TestCase):
         """
         bz = bugs.Bugzilla()
         bz._bz = mock.MagicMock()
+        bz._bz.getbug.return_value.private = False
         bz._bz.getbug.return_value.product = 'aproduct'
         bz._bz.getbug.return_value.setstatus.side_effect = Exception(
             'You forgot to pay your oxygen bill. Your air supply will promptly be severed.')
@@ -402,6 +477,7 @@ class TestBugzilla(unittest.TestCase):
         """
         bz = bugs.Bugzilla()
         bz._bz = mock.MagicMock()
+        bz._bz.getbug.return_value.private = False
         bz._bz.getbug.return_value.product = 'aproduct'
 
         bz.on_qa(1411188, 'A message.')
@@ -412,6 +488,24 @@ class TestBugzilla(unittest.TestCase):
 
     @mock.patch('bodhi.server.bugs.log.info')
     @mock.patch.dict('bodhi.server.bugs.config', {'bz_products': 'aproduct'})
+    def test_on_qa_private_bug(self, info):
+        """
+        Test the on_qa() method with a private bug.
+        """
+        bz = bugs.Bugzilla()
+        bz._bz = mock.MagicMock()
+        bz._bz.getbug.return_value.private = True
+        bz._bz.getbug.return_value.product = 'aproduct'
+
+        bz.on_qa(1411188, 'A message.')
+
+        bz._bz.getbug.assert_called_once_with(1411188)
+        bz._bz.getbug.return_value.setstatus.assert_not_called()
+        bz._bz.getbug.return_value.addcomment.assert_not_called()
+        info.assert_called_once_with('Unable to modify status of private bug #1411188')
+
+    @mock.patch('bodhi.server.bugs.log.info')
+    @mock.patch.dict('bodhi.server.bugs.config', {'bz_products': 'aproduct'})
     def test_on_qa_skipped_because_closed(self, info):
         """
         Test the on_qa() method when the bug is already CLOSED.
@@ -419,6 +513,7 @@ class TestBugzilla(unittest.TestCase):
         """
         bz = bugs.Bugzilla()
         bz._bz = mock.MagicMock()
+        bz._bz.getbug.return_value.private = False
         bz._bz.getbug.return_value.product = 'aproduct'
         bz._bz.getbug.return_value.bug_status = 'CLOSED'
 
@@ -438,6 +533,7 @@ class TestBugzilla(unittest.TestCase):
         """
         bz = bugs.Bugzilla()
         bz._bz = mock.MagicMock()
+        bz._bz.getbug.return_value.private = False
         bz._bz.getbug.return_value.product = 'aproduct'
         bz._bz.getbug.return_value.bug_status = 'VERIFIED'
 
@@ -457,6 +553,7 @@ class TestBugzilla(unittest.TestCase):
         """
         bz = bugs.Bugzilla()
         bz._bz = mock.MagicMock()
+        bz._bz.getbug.return_value.private = False
         bz._bz.getbug.return_value.product = 'aproduct'
         bz._bz.getbug.return_value.bug_status = 'ON_QA'
 
@@ -472,6 +569,7 @@ class TestBugzilla(unittest.TestCase):
         """Test the on_qa() method when the bug's product is not in the bz_products config."""
         bz = bugs.Bugzilla()
         bz._bz = mock.MagicMock()
+        bz._bz.getbug.return_value.private = False
         bz._bz.getbug.return_value.product = 'not fedora!'
 
         bz.on_qa(1411188, 'A message.')

--- a/bodhi/tests/server/test_models.py
+++ b/bodhi/tests/server/test_models.py
@@ -253,6 +253,20 @@ class TestBugAddComment(BaseTestCase):
         debug.assert_called_once_with('Not commenting on parent security bug %s', bug.bug_id)
         self.assertEqual(comment.call_count, 0)
 
+    @mock.patch('bodhi.server.models.bugs.bugtracker.comment')
+    @mock.patch('bodhi.server.models.log.debug')
+    def test_private_bug(self, debug, comment):
+        """The method should not comment if a bug is flagged as private."""
+        update = model.Update.query.first()
+        update.type = model.UpdateType.security
+        bug = model.Bug.query.first()
+        bug.private = True
+
+        bug.add_comment(update)
+
+        debug.assert_called_once_with('Not commenting on private bug %s', bug.bug_id)
+        self.assertEqual(comment.call_count, 0)
+
 
 class TestBugDefaultMessage(BaseTestCase):
     """Test Bug.default_mesage()."""
@@ -311,6 +325,20 @@ class TestBugModified(BaseTestCase):
         debug.assert_called_once_with('Not modifying parent security bug %s', bug.bug_id)
         self.assertEqual(modified.call_count, 0)
 
+    @mock.patch('bodhi.server.models.bugs.bugtracker.modified')
+    @mock.patch('bodhi.server.models.log.debug')
+    def test_private_bug(self, debug, modified):
+        """The method should not act on a bug flagged as private."""
+        update = model.Update.query.first()
+        update.type = model.UpdateType.security
+        bug = model.Bug.query.first()
+        bug.private = True
+
+        bug.modified(update, 'this should not be used')
+
+        debug.assert_called_once_with('Not modifying private bug %s', bug.bug_id)
+        self.assertEqual(modified.call_count, 0)
+
 
 class TestBugTesting(BaseTestCase):
     """Test Bug.testing()."""
@@ -328,6 +356,38 @@ class TestBugTesting(BaseTestCase):
 
         debug.assert_called_once_with('Not modifying parent security bug %s', bug.bug_id)
         self.assertEqual(on_qa.call_count, 0)
+
+    @mock.patch('bodhi.server.models.bugs.bugtracker.on_qa')
+    @mock.patch('bodhi.server.models.log.debug')
+    def test_private_bug(self, debug, on_qa):
+        """The method should not act on a bug flagged as private."""
+        update = model.Update.query.first()
+        update.type = model.UpdateType.security
+        bug = model.Bug.query.first()
+        bug.private = True
+
+        bug.testing(update)
+
+        debug.assert_called_once_with('Not modifying private bug %s', bug.bug_id)
+        self.assertEqual(on_qa.call_count, 0)
+
+
+class TestBugClose(BaseTestCase):
+    """Test Bug.close()."""
+
+    @mock.patch('bodhi.server.models.bugs.bugtracker.close')
+    @mock.patch('bodhi.server.models.log.debug')
+    def test_private_bug(self, debug, close):
+        """The method should not act on a bug flagged as private."""
+        update = model.Update.query.first()
+        update.type = model.UpdateType.security
+        bug = model.Bug.query.first()
+        bug.private = True
+
+        bug.close_bug(update)
+
+        debug.assert_called_once_with('Not modifying private bug %s', bug.bug_id)
+        self.assertEqual(close.call_count, 0)
 
 
 class TestQueryProperty(BaseTestCase):

--- a/bodhi/tests/server/test_util.py
+++ b/bodhi/tests/server/test_util.py
@@ -97,6 +97,7 @@ class TestBugLink(base.BaseTestCase):
         bug = mock.MagicMock()
         bug.bug_id = 1234567
         bug.title = "Lucky bug number"
+        bug.private = False
 
         link = util.bug_link(None, bug)
 
@@ -104,6 +105,20 @@ class TestBugLink(base.BaseTestCase):
             link,
             ("<a target='_blank' href='https://bugzilla.redhat.com/show_bug.cgi?id=1234567'>"
              "#1234567</a> Lucky bug number"))
+
+    def test_short_false_with_title_but_private(self):
+        """Test a call to bug_link() with short=False on a Bug that is private."""
+        bug = mock.MagicMock()
+        bug.bug_id = 1234567
+        bug.title = "Lucky bug number"
+        bug.private = True
+
+        link = util.bug_link(None, bug)
+
+        self.assertEqual(
+            link,
+            ("<a target='_blank' href='https://bugzilla.redhat.com/show_bug.cgi?id=1234567'>"
+             "#1234567</a> <span class='label label-danger'>Private bug</span>"))
 
     def test_short_false_with_title_sanitizes_safe_tags(self):
         """
@@ -113,6 +128,7 @@ class TestBugLink(base.BaseTestCase):
         bug = mock.MagicMock()
         bug.bug_id = 1234567
         bug.title = 'Check <b>this</b> out'
+        bug.private = False
 
         link = util.bug_link(None, bug)
 
@@ -129,6 +145,7 @@ class TestBugLink(base.BaseTestCase):
         bug = mock.MagicMock()
         bug.bug_id = 1473091
         bug.title = '<disk> <driver name="..."> should be optional'
+        bug.private = False
 
         link = util.bug_link(None, bug)
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,7 +15,7 @@ width = 80
 show-source = True
 max-line-length = 100
 exclude = .git,.tox,dist,*egg,build,tools
-ignore = E712
+ignore = E712,W503
 
 [init_catalog]
 domain = bodhi


### PR DESCRIPTION
The PR adds a new column to bugs table to flag as private those bugs which are not publicly accessible in RH BZ.
Bodhi will avoid to comment or change status of those bugs, since it doesn't have permission to do so. Those bugs can still be attached to updates as reference for maintainer and to allow the reporter to give feedback. In the GUI they will be displayed with a "Private bug" label, and the same string will be used for title (as Bodhi can't fetch the real title).

This comes with all relevant tests, but I couldn't test in real, because in the vagrant box all users are granted only the 'guest' permissions.

This PR involves change in database schema.
Fixes #344 

Signed-off-by: Mattia Verga <mattia.verga@tiscali.it>