### PR TITLE
Allow user in devel environment to get ACL rights.

### DIFF
--- a/bodhi/server/config.py
+++ b/bodhi/server/config.py
@@ -284,6 +284,9 @@ class BodhiConfig(dict):
         'acl_system': {
             'value': 'dummy',
             'validator': six.text_type},
+        'acl_dummy_committer': {
+            'value': None,
+            'validator': _validate_none_or(six.text_type)},
         'admin_groups': {
             'value': ['proventesters', 'security_respons', 'bodhiadmin', 'sysadmin-main'],
             'validator': _generate_list_validator()},

--- a/bodhi/server/validators.py
+++ b/bodhi/server/validators.py
@@ -488,9 +488,11 @@ def validate_acls(request, **kwargs):
                 request.errors.add('body', 'builds', error_msg)
                 return
         elif acl_system == 'dummy':
-            people = (['ralph', 'bowlofeggs', 'guest'], ['guest'])
-            groups = (['ralph', 'bowlofeggs', 'guest'], ['guest'])
-            committers, watchers = people
+            committers = ['ralph', 'bowlofeggs', 'guest']
+            if config['acl_dummy_committer']:
+                committers.append(config['acl_dummy_committer'])
+            groups = ['guest']
+            people = committers
         else:
             log.warning('No acl_system configured')
             people = None

--- a/bodhi/tests/server/test_validators.py
+++ b/bodhi/tests/server/test_validators.py
@@ -299,6 +299,19 @@ class TestValidateAcls(BaseTestCase):
         validators.validate_acls(mock_request)
         assert len(mock_request.errors) == 0, mock_request.errors
 
+    @mock.patch.dict('bodhi.server.validators.config',
+                     {'acl_system': 'dummy', 'acl_dummy_committer': 'mattia'})
+    def test_validate_acls_dummy_committer(self):
+        """ Test validate_acls when the acl system is dummy and a user
+        adds himself to the committers list by the development.ini file.
+        """
+        user = self.db.query(models.User).filter_by(id=1).one()
+        user.name = 'mattia'
+        self.db.flush()
+        mock_request = self.get_mock_request()
+        validators.validate_acls(mock_request)
+        assert len(mock_request.errors) == 0, mock_request.errors
+
     @mock.patch.dict('bodhi.server.validators.config', {'acl_system': 'nonexistent'})
     def test_validate_acls_invalid_acl_system(self):
         """ Test validate_acls when the acl system is invalid.

--- a/devel/development.ini.example
+++ b/devel/development.ini.example
@@ -43,6 +43,9 @@ cache.second.expire = 1
 cache.short_term.expire = 60
 cache.default_term.expire = 300
 cache.long_term.expire = 3600
+# Uncomment this line and add your username here to enable ACL rights in the development environment
+# acl_dummy_committer = mattia
+
 # If you want to test composing containers in development, it can be handy to run your own container
 # registry locally. To do that, you can run a container registry like this:
 # 

--- a/production.ini
+++ b/production.ini
@@ -347,6 +347,10 @@ use = egg:bodhi-server
 ##
 # acl_system = dummy
 
+# Add your username here to enable ACL rights in the development environment. Only has an effect if
+# you are using the dummy acl_system.
+# acl_dummy_committer =
+
 ##
 ## Package DB
 ##


### PR DESCRIPTION
This PR allow a user to add himself to the committers list in devel environment by editing a row in the `development.ini` file.
Also, the `watcher` list variable is not used anywhere in the code and has been removed and the `groups` variable should be a list, not a tuple of lists.

Signed-off-by: Mattia Verga <mattia.verga@tiscali.it>