### PR TITLE
Add integration testing to bodhi-ci

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+devel/ci/integration/dumps/*

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -29,6 +29,7 @@ pull_request_rules:
   - status-success=pip-python2-diff-cover
   - status-success=pip-python3-unit
   - status-success=pip-python3-diff-cover
+  - status-success=f29-python2-integration
   name: default
 - actions:
     merge:

--- a/devel/ansible/roles/bodhi/tasks/main.yml
+++ b/devel/ansible/roles/bodhi/tasks/main.yml
@@ -68,6 +68,7 @@
       - python3-bleach
       - python3-click
       - python3-colander
+      - python3-conu
       - python3-cornice
       - python3-cornice-sphinx
       - python3-createrepo_c

--- a/devel/ci/Dockerfile-f28
+++ b/devel/ci/Dockerfile-f28
@@ -1,5 +1,5 @@
 FROM registry.fedoraproject.org/fedora:28
-MAINTAINER "Randy Barlow" <bowlofeggs@fedoraproject.org>
+LABEL maintainer="Randy Barlow <bowlofeggs@fedoraproject.org>"
 
 # Work around a severe dnf/libsolv/glibc issue: https://pagure.io/releng/issue/7125
 # This was suggested in a BZ comment: https://bugzilla.redhat.com/show_bug.cgi?id=1483553#c78

--- a/devel/ci/Dockerfile-f29
+++ b/devel/ci/Dockerfile-f29
@@ -1,5 +1,5 @@
 FROM registry.fedoraproject.org/fedora:29
-MAINTAINER "Randy Barlow" <bowlofeggs@fedoraproject.org>
+LABEL maintainer="Randy Barlow <bowlofeggs@fedoraproject.org>"
 
 # Work around a severe dnf/libsolv/glibc issue: https://pagure.io/releng/issue/7125
 # This was suggested in a BZ comment: https://bugzilla.redhat.com/show_bug.cgi?id=1483553#c78

--- a/devel/ci/Dockerfile-pip
+++ b/devel/ci/Dockerfile-pip
@@ -1,5 +1,5 @@
 FROM registry.fedoraproject.org/fedora:29
-MAINTAINER "Randy Barlow" <bowlofeggs@fedoraproject.org>
+LABEL maintainer="Randy Barlow <bowlofeggs@fedoraproject.org>"
 
 # Work around a severe dnf/libsolv/glibc issue: https://pagure.io/releng/issue/7125
 # This was suggested in a BZ comment: https://bugzilla.redhat.com/show_bug.cgi?id=1483553#c78

--- a/devel/ci/Dockerfile-rawhide
+++ b/devel/ci/Dockerfile-rawhide
@@ -1,5 +1,5 @@
 FROM registry.fedoraproject.org/fedora:rawhide
-MAINTAINER "Randy Barlow" <bowlofeggs@fedoraproject.org>
+LABEL maintainer="Randy Barlow <bowlofeggs@fedoraproject.org>"
 
 RUN dnf upgrade -y
 RUN dnf install --disablerepo rawhide-modular -y \

--- a/devel/ci/bodhi-ci
+++ b/devel/ci/bodhi-ci
@@ -260,6 +260,24 @@ def unit(archive, concurrency, container_runtime, no_build, failfast, init, pyve
                                archive_path=archive_path))
 
 
+@cli.command()
+@archive_option
+@concurrency_option
+@container_runtime_option
+@failfast_option
+@init_option
+@no_build_option
+@pyver_option
+@releases_option
+@archive_path_option
+@tty_option
+def integration(archive, concurrency, container_runtime, no_build, failfast, init, pyver, release,
+                archive_path, tty):
+    """Run the integration tests."""
+    _run_jobs(_build_jobs_list('integration', concurrency, release, pyvers=pyver, archive=archive,
+                               archive_path=archive_path))
+
+
 class Job(object):
     """
     Represent a CI job.
@@ -388,7 +406,7 @@ class Job(object):
                 error.result = self
                 raise error
 
-        except asyncio.CancelledError as e:
+        except asyncio.CancelledError:
             self.cancelled = True
         finally:
             # If the job's been cancelled or successful, let's go ahead and print its output now.
@@ -705,9 +723,9 @@ class UnitJob(Job):
 
         self.pyver = pyver
         self._label = '{}-py{}'.format(self._label, pyver)
-        pytest_flags = ''
+        pytest_flags = '--junit-xml=nosetests.xml bodhi/tests'
         if failfast:
-            pytest_flags = '-x'
+            pytest_flags += ' -x'
 
         test_command = ('({} setup.py develop && {} {} || (cp *.xml /results && exit 1)) '
                         '&& cp *.xml /results')
@@ -755,6 +773,70 @@ class UnitJob(Job):
         return self
 
 
+class IntegrationBuildJob(BuildJob):
+    """
+    Define a Job for building container images for integration testing.
+
+    See the Job superclass's docblock for details about its attributes.
+    """
+
+    def __init__(self, app_name, *args, **kwargs):
+        """
+        Initialize the IntegrationBuildJob.
+
+        See the superclass's docblock for details about accepted parameters.
+        """
+        super(IntegrationBuildJob, self).__init__(*args, **kwargs)
+
+        self._label = 'integration-build-{}'.format(app_name)
+        self._container_image = '{}-integration-{}'.format(CONTAINER_NAME, app_name)
+        dockerfile = os.path.join(PROJECT_PATH, 'devel', 'ci', 'integration', app_name, 'Dockerfile')
+        self._command = [container_runtime, 'build', '--pull', '-t', self._container_image,
+                         '-f', dockerfile, '.']
+
+
+class IntegrationJob(Job):
+    """
+    Define a Job for running the integration tests.
+
+    See the Job superclass's docblock for details about its attributes.
+
+    Attributes:
+        pyver (int): The Python version we are testing.
+    """
+
+    _label = 'integration'
+
+    def __init__(self, archive, archive_path, pyver, *args, **kwargs):
+        """
+        Initialize the IntegrationJob.
+
+        See the superclass's docblock for details about additional accepted parameters.
+
+        Args:
+            archive (bool): If True, set up the volume mount so we can retrieve the test results
+                from the container.
+            archive_path (str): A path on the host to share as a volume into the container for
+                its /results path.
+            pyver (int): Which major version of Python we are testing with.
+        """
+        super(IntegrationJob, self).__init__(*args, **kwargs)
+
+        self.pyver = pyver
+        self._command = [sys.executable, '-m', 'pytest', '--no-cov', 'devel/ci/integration/tests/']
+        bodhi_container_image = '{}-integration-bodhi'.format(CONTAINER_NAME)
+        self._popen_kwargs["env"] = os.environ.copy()
+        self._popen_kwargs["env"]["BODHI_INTEGRATION_IMAGE"] = bodhi_container_image
+        if failfast:
+            self._command.append('-x')
+        if archive:
+            self._command.append(
+                '--junit-xml={}/{}/nosetests.xml'.format(
+                    archive_path, self._label
+                )
+            )
+
+
 def _build_jobs_list(
         command: str, concurrency: int, releases: typing.Iterable[str],
         pyvers: typing.Iterable[int] = None, archive: bool = False,
@@ -780,34 +862,46 @@ def _build_jobs_list(
         buffer_output = concurrency != 1 and len(releases) != 1
     jobs = []
     for release in releases:
-        build_job = BuildJob(release, buffer_output=buffer_output)
-        jobs.append(build_job)
-        if command != 'build':
-            if command in ('all', 'docs'):
-                docs_job = DocsJob(release, depends_on=build_job, buffer_output=buffer_output)
-                jobs.append(docs_job)
-            if command in ('all', 'flake8'):
-                flake8_job = Flake8Job(release, depends_on=build_job, buffer_output=buffer_output)
-                jobs.append(flake8_job)
-            if command in ('all', 'pydocstyle'):
-                pydocstyle_job = PydocstyleJob(release, depends_on=build_job,
-                                               buffer_output=buffer_output)
-                jobs.append(pydocstyle_job)
-            if command in ('all', 'diff_cover', 'unit'):
-                for pyver in pyvers:
-                    unit_job = UnitJob(
-                        archive=archive, archive_path=archive_path, pyver=pyver, release=release,
-                        depends_on=build_job, buffer_output=buffer_output)
-                    jobs.append(unit_job)
-                    if command in ('all', 'diff_cover'):
-                        if pyver == 2 and release not in ('f27', 'f28', 'f29', 'pip'):
-                            # We don't support Python 2 on the server for Fedora >= 30, so don't
-                            # enforce coverage there.
-                            continue
-                        diff_cover_job = DiffCoverJob(
-                            archive=archive, archive_path=archive_path, pyver=pyver,
-                            release=release, depends_on=unit_job, buffer_output=buffer_output)
-                        jobs.append(diff_cover_job)
+        if command in ('all', 'build', 'docs', 'flake8', 'pydocstyle', 'diff_cover', 'unit'):
+            build_job = BuildJob(release, buffer_output=buffer_output)
+            jobs.append(build_job)
+        if command in ('all', 'docs'):
+            docs_job = DocsJob(release, depends_on=build_job, buffer_output=buffer_output)
+            jobs.append(docs_job)
+        if command in ('all', 'flake8'):
+            flake8_job = Flake8Job(release, depends_on=build_job, buffer_output=buffer_output)
+            jobs.append(flake8_job)
+        if command in ('all', 'pydocstyle'):
+            pydocstyle_job = PydocstyleJob(release, depends_on=build_job,
+                                           buffer_output=buffer_output)
+            jobs.append(pydocstyle_job)
+        if command in ('all', 'diff_cover', 'unit'):
+            for pyver in pyvers:
+                unit_job = UnitJob(
+                    archive=archive, archive_path=archive_path, pyver=pyver, release=release,
+                    depends_on=build_job, buffer_output=buffer_output)
+                jobs.append(unit_job)
+                if command in ('all', 'diff_cover'):
+                    if pyver == 2 and release not in ('f27', 'f28', 'f29', 'pip'):
+                        # We don't support Python 2 on the server for Fedora >= 30, so don't
+                        # enforce coverage there.
+                        continue
+                    diff_cover_job = DiffCoverJob(
+                        archive=archive, archive_path=archive_path, pyver=pyver,
+                        release=release, depends_on=unit_job, buffer_output=buffer_output)
+                    jobs.append(diff_cover_job)
+    if command in ('all', 'integration') and 3 in pyvers and "f29" in releases:
+        build_jobs = [
+            IntegrationBuildJob(app_name="resultsdb", release="f29", buffer_output=buffer_output),
+            IntegrationBuildJob(app_name="waiverdb", release="f29", buffer_output=buffer_output),
+            IntegrationBuildJob(app_name="greenwave", release="f29", buffer_output=buffer_output),
+            IntegrationBuildJob(app_name="bodhi", release="f29", buffer_output=buffer_output),
+        ]
+        jobs.extend(build_jobs)
+        integration_job = IntegrationJob(
+            archive=archive, archive_path=archive_path, pyver=3, release="f29",
+            depends_on=build_jobs, buffer_output=buffer_output)
+        jobs.append(integration_job)
 
     return jobs
 
@@ -889,6 +983,10 @@ def _run_jobs(jobs):
     Args:
         jobs (list): A list of Jobs to run.
     """
+    if not jobs:
+        click.echo("No jobs!")
+        sys.exit(3)
+
     loop = asyncio.get_event_loop()
 
     processes = [j.run() for j in jobs]

--- a/devel/ci/bodhi-ci
+++ b/devel/ci/bodhi-ci
@@ -271,8 +271,8 @@ class Job(object):
         archive_dir (str): A path where this job's test results is on the host. Only set if an
             archive is used (not used on all jobs).
         release (str): The release this job is testing.
-        depends_on (Job or None): If not None, this Job will wait for the depends_on job's complete
-            Event to start.
+        depends_on (list of Job): This Job will wait for all the jobs' complete Event in the list
+            to start.
         cancelled (bool): True if this Job has been cancelled, False otherwise.
         complete (asyncio.Event): An Event that allows other Jobs to wait for this Job to complete.
             complete.set() is called at the end of run().
@@ -287,13 +287,17 @@ class Job(object):
 
         Args:
             release (str): The release this Job pertains to.
-            depends_on (Job): Another Job that this Job should wait to complete before starting.
+            depends_on (list of Job): A list of Job that this Job should wait to complete before
+                starting. It is also possible to provide a Job instance if there is a single
+                dependency.
             buffer_output (bool): If True, this Job will buffer its stdout and stderr into its
                 output property. If False, child processes will send their output straign to stdout
                 and stderr.
         """
         self.release = release
-        self.depends_on = depends_on
+        self.depends_on = depends_on or []
+        if not isinstance(self.depends_on, list):
+            self.depends_on = [self.depends_on]
 
         self.cancelled = False
         # Used to block dependent processes until this Job is done.
@@ -342,9 +346,9 @@ class Job(object):
             Job: Returns self.
         """
         try:
-            if self.depends_on:
-                await self.depends_on.complete.wait()
-                if self.depends_on.returncode != 0 and not self.depends_on.skipped:
+            for job in self.depends_on:
+                await job.complete.wait()
+                if job.returncode != 0 and not job.skipped:
                     # If the Job we depend on failed, we should cancel.
                     raise asyncio.CancelledError()
 
@@ -569,7 +573,7 @@ class DiffCoverJob(Job):
         """
         if not os.path.exists(self.archive_dir):
             os.makedirs(self.archive_dir)
-        shutil.copy(os.path.join(self.depends_on.archive_dir, 'coverage.xml'),
+        shutil.copy(os.path.join(self.depends_on[0].archive_dir, 'coverage.xml'),
                     os.path.join(self.archive_dir, 'coverage.xml'))
 
         super(DiffCoverJob, self)._pre_start_hook()

--- a/devel/ci/cico.pipeline
+++ b/devel/ci/cico.pipeline
@@ -43,10 +43,13 @@ def synctoduffynode(rsyncpath) {
  */
 def configure_node = {
     onmyduffynode 'yum -y install epel-release'
-    onmyduffynode 'yum install -y docker python36-click rsync'
+    onmyduffynode 'yum install -y docker python36-click python36-requests rsync'
     // Workaround https://bugzilla.redhat.com/show_bug.cgi?id=1655214
     onmyduffynode 'yum downgrade -y docker-1.13.1-75.git8633870.el7.centos.x86_64 docker-client-1.13.1-75.git8633870.el7.centos.x86_64 docker-common-1.13.1-75.git8633870.el7.centos.x86_64'
     onmyduffynode 'systemctl start docker'
+    // To run the integration testsuite
+    onmyduffynode 'python3.6 -m ensurepip'
+    onmyduffynode 'python3.6 -m pip install \'pytest<4.0\' pytest-cov conu munch psycopg2'
 }
 
 
@@ -150,7 +153,10 @@ node('bodhi') {
             f28: {test_release('f28')},
             f29: {test_release('f29')},
             pip: {test_release('pip')},
-            rawhide: {test_release('rawhide')}
+            rawhide: {test_release('rawhide')},
+            integration: {
+                bodhi_ci('f29', 'integration', 'python3-integration', '--no-build --no-init -p 3')
+            }
         )
     } catch (e) {
         currentBuild.result = "FAILURE"

--- a/devel/ci/cico.pipeline
+++ b/devel/ci/cico.pipeline
@@ -44,6 +44,8 @@ def synctoduffynode(rsyncpath) {
 def configure_node = {
     onmyduffynode 'yum -y install epel-release'
     onmyduffynode 'yum install -y docker python36-click rsync'
+    // Workaround https://bugzilla.redhat.com/show_bug.cgi?id=1655214
+    onmyduffynode 'yum downgrade -y docker-1.13.1-75.git8633870.el7.centos.x86_64 docker-client-1.13.1-75.git8633870.el7.centos.x86_64 docker-common-1.13.1-75.git8633870.el7.centos.x86_64'
     onmyduffynode 'systemctl start docker'
 }
 

--- a/devel/ci/integration/bodhi/Dockerfile
+++ b/devel/ci/integration/bodhi/Dockerfile
@@ -1,0 +1,108 @@
+FROM registry.fedoraproject.org/fedora:29
+LABEL \
+  name="bodhi-web" \
+  vendor="Fedora Infrastructure" \
+  maintainer="Aurelien Bompard <abompard@fedoraproject.org>" \
+  license="MIT"
+
+RUN curl -o /etc/yum.repos.d/infra-tags.repo https://infrastructure.fedoraproject.org/cgit/ansible.git/plain/files/common/fedora-infra-tags.repo
+
+# While dnf has a --nodocs, it doesen't have a --docs...
+RUN sed -i '/nodocs/d' /etc/dnf/dnf.conf
+
+# Install Bodhi deps
+# 1. bodhi-server
+# 2. bodhi-composer
+# 3. python3-bodhi-client
+RUN dnf install -y \
+    \
+    httpd \
+    intltool \
+    liberation-mono-fonts \
+    python3-dogpile-cache \
+    python3-koji \
+    python3-librepo \
+    python3-mod_wsgi \
+    python3-pillow \
+    "python3dist(alembic)" \
+    "python3dist(arrow)" \
+    "python3dist(bleach)" \
+    "python3dist(click)" \
+    "python3dist(colander)" \
+    "python3dist(cornice)" \
+    "python3dist(cryptography)" \
+    "python3dist(fedmsg)" \
+    "python3dist(feedgen)" \
+    "python3dist(jinja2)" \
+    "python3dist(kitchen)" \
+    "python3dist(markdown)" \
+    "python3dist(psycopg2)" \
+    "python3dist(pylibravatar)" \
+    "python3dist(pyramid)" \
+    "python3dist(pyramid-fas-openid)" \
+    "python3dist(pyramid-mako)" \
+    "python3dist(python-bugzilla)" \
+    "python3dist(python-fedora)" \
+    "python3dist(python3-openid)" \
+    "python3dist(simplemediawiki)" \
+    "python3dist(six)" \
+    "python3dist(sqlalchemy)" \
+    "python3dist(waitress)" \
+    \
+    python3-createrepo_c \
+    python3-hawkey \
+    skopeo \
+    \
+    /usr/bin/koji \
+    python3-dnf \
+    python3-koji \
+    "python3dist(click)" \
+    "python3dist(iniparse)" \
+    "python3dist(kitchen)" \
+    "python3dist(python-fedora)" \
+    "python3dist(six)" \
+    \
+    fedmsg \
+    fedmsg-base \
+    git
+
+# Create bodhi user
+RUN groupadd -r bodhi && \
+    useradd  -r -s /sbin/nologin -d /home/bodhi/ -m -c 'Bodhi Server' -g bodhi bodhi
+
+# Copy source
+WORKDIR /bodhi
+COPY . /bodhi
+
+# Install it
+RUN sed -i -e '/pyramid_debugtoolbar/d' setup.py devel/development.ini.example
+RUN python3 setup.py build && pip3 install .
+
+# Configuration
+RUN mkdir -p /etc/bodhi
+COPY production.ini /etc/bodhi/production.ini
+
+COPY devel/ci/integration/bodhi/start.sh /etc/bodhi/start.sh
+COPY devel/ci/integration/bodhi/httpd.conf /etc/bodhi/httpd.conf
+COPY apache/bodhi.wsgi /etc/bodhi/bodhi.wsgi
+RUN sed -i -e 's,/var/www,/httpdir,g' /etc/bodhi/bodhi.wsgi
+# Put the fedmsg config in place. Let's name it starting with zz so it sorts last.
+COPY devel/ci/integration/bodhi/fedmsg.py /etc/fedmsg.d/zzbodhi.py
+
+RUN \
+# Put the fedmsg cert and key in place
+    mkdir -p /etc/pki/fedmsg/ && \
+    ln -sf /etc/pki/fedmsg/key/fedmsg-bodhi.key /etc/pki/fedmsg/bodhi.key && \
+    ln -sf /etc/pki/fedmsg/crt/fedmsg-bodhi.crt /etc/pki/fedmsg/bodhi.crt && \
+# Set up krb5
+    rm -f /etc/krb5.conf && \
+    ln -sf /etc/bodhi/krb5.conf /etc/krb5.conf && \
+    ln -sf /etc/keytabs/koji-keytab /etc/krb5.bodhi_bodhi.fedoraproject.org.keytab
+
+# Apache
+RUN mkdir -p /httpdir && chown bodhi:bodhi /httpdir
+
+EXPOSE 8080
+USER bodhi
+ENV USER=bodhi
+CMD ["bash", "/etc/bodhi/start.sh"]

--- a/devel/ci/integration/bodhi/fedmsg.py
+++ b/devel/ci/integration/bodhi/fedmsg.py
@@ -1,0 +1,11 @@
+config = {
+    'sign_messages': False,
+    'active': True,
+    # TODO: setup a container for the fedmsg relay
+    'relay_inbound': ['tcp://fedmsg:9941'],
+    # 'bodhi': ['tcp://busgateway.fedoraproject.org:9941'],
+    'environment': 'testing',
+    'endpoints': {
+        'prod_gateway': ['tcp://fedoraproject.org:9940']
+    }
+}

--- a/devel/ci/integration/bodhi/httpd.conf
+++ b/devel/ci/integration/bodhi/httpd.conf
@@ -1,0 +1,66 @@
+Listen 0.0.0.0:8080
+ServerRoot "/httpdir"
+PidFile "/httpdir/httpd.pid"
+LoadModule authn_file_module modules/mod_authn_file.so
+LoadModule authn_anon_module modules/mod_authn_anon.so
+LoadModule authz_user_module modules/mod_authz_user.so
+LoadModule authz_host_module modules/mod_authz_host.so
+LoadModule include_module modules/mod_include.so
+LoadModule log_config_module modules/mod_log_config.so
+LoadModule env_module modules/mod_env.so
+LoadModule ext_filter_module modules/mod_ext_filter.so
+LoadModule expires_module modules/mod_expires.so
+LoadModule headers_module modules/mod_headers.so
+LoadModule mime_module modules/mod_mime.so
+LoadModule status_module modules/mod_status.so
+LoadModule negotiation_module modules/mod_negotiation.so
+LoadModule dir_module modules/mod_dir.so
+LoadModule alias_module modules/mod_alias.so
+LoadModule rewrite_module modules/mod_rewrite.so
+LoadModule version_module modules/mod_version.so
+LoadModule wsgi_module modules/mod_wsgi_python3.so
+LoadModule authn_core_module modules/mod_authn_core.so
+LoadModule authz_core_module modules/mod_authz_core.so
+LoadModule unixd_module modules/mod_unixd.so
+LoadModule mpm_event_module modules/mod_mpm_event.so
+StartServers  20
+ServerLimit   100
+MaxRequestsPerChild 2000
+MaxRequestWorkers 100
+<Directory "/usr/share/doc/bodhi-docs/html/">
+    AllowOverride None
+    Require all granted
+</Directory>
+<Directory "/usr/lib/python3.7/site-packages/bodhi/server/static/">
+    AllowOverride None
+    Require all granted
+</Directory>
+<Location />
+    Require all granted
+</Location>
+<Location /docs/>
+    Header set Cache-Control public
+    ExpiresDefault "access plus 1 month"
+    Header unset ETag
+</Location>
+<Location /static/>
+    Header set Cache-Control public
+    ExpiresDefault "access plus 1 month"
+    Header unset ETag
+</Location>
+LogFormat "%h %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\"" combined
+    CustomLog /httpdir/accesslog combined
+ErrorLog /httpdir/errorlog
+LogLevel info
+TypesConfig /etc/mime.types
+AddDefaultCharset UTF-8
+CoreDumpDirectory /tmp
+Alias /docs /usr/share/doc/bodhi-docs/html/
+Alias /static /usr/lib/python3.7/site-packages/bodhi/server/static/
+WSGIDaemonProcess bodhi display-name=bodhi processes=2 threads=2 maximum-requests=1000 home=/httpdir
+WSGIApplicationGroup %{GLOBAL}
+WSGISocketPrefix run/wsgi
+WSGIRestrictStdout Off
+WSGIRestrictSignal Off
+WSGIPythonOptimize 1
+WSGIScriptAlias / /etc/bodhi/bodhi.wsgi

--- a/devel/ci/integration/bodhi/start.sh
+++ b/devel/ci/integration/bodhi/start.sh
@@ -1,0 +1,5 @@
+mkdir /httpdir/run
+ln -s /etc/httpd/modules /httpdir/modules
+truncate --size=0 /httpdir/accesslog /httpdir/errorlog
+tail -qf /httpdir/accesslog /httpdir/errorlog &
+exec httpd -f /etc/bodhi/httpd.conf -DFOREGROUND -DNO_DETACH

--- a/devel/ci/integration/dumps/.gitignore
+++ b/devel/ci/integration/dumps/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/devel/ci/integration/greenwave/Dockerfile
+++ b/devel/ci/integration/greenwave/Dockerfile
@@ -1,0 +1,25 @@
+FROM quay.io/factory2/greenwave:prod
+LABEL \
+  name="greenwave" \
+  vendor="Fedora Infrastructure" \
+  maintainer="Aurelien Bompard <abompard@fedoraproject.org>" \
+  license="MIT"
+
+# fedmsg needs a username.
+ENV USER=greenwave
+
+# Become root during build to chmod
+USER 0
+
+# Make sure fedmsg can write its CRL.
+RUN chmod 777 /var/run/fedmsg/
+
+RUN mkdir -p /etc/greenwave
+COPY devel/ci/integration/greenwave/fedmsg.py /etc/fedmsg.d/zz_greenwave.py
+COPY devel/ci/integration/greenwave/settings.py /etc/greenwave/settings.py
+COPY devel/ci/integration/greenwave/policy.yaml /etc/greenwave/fedora.yaml
+
+# Become non-root again
+USER 1001
+
+ENTRYPOINT ["/bin/sh", "-c", "gunicorn-3 --workers 8 --bind 0.0.0.0:8080 --access-logfile=- --error-logfile=- --enable-stdio-inheritance greenwave.wsgi:app"]

--- a/devel/ci/integration/greenwave/fedmsg.py
+++ b/devel/ci/integration/greenwave/fedmsg.py
@@ -1,0 +1,13 @@
+config = dict(
+    sign_messages=False,
+    active=True,
+    greenwave_cache={},
+    environment='testing',
+    relay_inbound=["tcp://fedmsg:9941"],
+    greenwave_api_url='https://greenwave/api/v1.0',
+    endpoints=dict(
+        prod_gateway=[
+            'tcp://stg.fedoraproject.org:9940',
+        ],
+    ),
+)

--- a/devel/ci/integration/greenwave/policy.yaml
+++ b/devel/ci/integration/greenwave/policy.yaml
@@ -1,0 +1,146 @@
+--- !Policy
+id: "openqa_important_stuff_for_rawhide"
+product_versions:
+  - fedora-rawhide
+decision_context: rawhide_compose_sync_to_mirrors
+subject_type: compose
+blacklist: []
+rules:
+  - !PassingTestCaseRule {test_case_name: compose.cloud.all}
+  - !PassingTestCaseRule {test_case_name: compose.base_system_logging, scenario: "fedora.KDE-live-iso.x86_64.64bit"}
+  - !PassingTestCaseRule {test_case_name: compose.base_system_logging, scenario: "fedora.Server-dvd-iso.x86_64.64bit"}
+  - !PassingTestCaseRule {test_case_name: compose.base_system_logging, scenario: "fedora.Workstation-live-iso.x86_64.64bit"}
+  - !PassingTestCaseRule {test_case_name: compose.base_update_cli, scenario: "fedora.KDE-live-iso.x86_64.64bit"}
+  - !PassingTestCaseRule {test_case_name: compose.base_update_cli, scenario: "fedora.Server-dvd-iso.x86_64.64bit"}
+  - !PassingTestCaseRule {test_case_name: compose.base_update_cli, scenario: "fedora.Workstation-live-iso.x86_64.64bit"}
+  - !PassingTestCaseRule {test_case_name: compose.desktop_browser, scenario: "fedora.KDE-live-iso.x86_64.64bit"}
+  - !PassingTestCaseRule {test_case_name: compose.desktop_browser, scenario: "fedora.Workstation-live-iso.x86_64.64bit"}
+  - !PassingTestCaseRule {test_case_name: compose.desktop_terminal, scenario: "fedora.KDE-live-iso.x86_64.64bit"}
+  - !PassingTestCaseRule {test_case_name: compose.desktop_terminal, scenario: "fedora.Workstation-live-iso.x86_64.64bit"}
+  - !PassingTestCaseRule {test_case_name: compose.install_anaconda_text, scenario: "fedora.universal.x86_64.64bit"}
+  - !PassingTestCaseRule {test_case_name: compose.install_arm_image_deployment_upload, scenario: "fedora.Minimal-raw_xz-raw.xz.arm.ARM"}
+  - !PassingTestCaseRule {test_case_name: compose.install_default, scenario: "fedora.Everything-boot-iso.x86_64.64bit"}
+  - !PassingTestCaseRule {test_case_name: compose.install_default, scenario: "fedora.Everything-boot-iso.x86_64.uefi"}
+  - !PassingTestCaseRule {test_case_name: compose.install_default, scenario: "fedora.KDE-live-iso.x86_64.uefi"}
+  - !PassingTestCaseRule {test_case_name: compose.install_default, scenario: "fedora.Server-boot-iso.x86_64.64bit"}
+  - !PassingTestCaseRule {test_case_name: compose.install_default, scenario: "fedora.Server-boot-iso.x86_64.uefi"}
+  - !PassingTestCaseRule {test_case_name: compose.install_default, scenario: "fedora.Server-dvd-iso.x86_64.uefi"}
+  - !PassingTestCaseRule {test_case_name: compose.install_default, scenario: "fedora.Workstation-boot-iso.x86_64.64bit"}
+  - !PassingTestCaseRule {test_case_name: compose.install_default, scenario: "fedora.Workstation-boot-iso.x86_64.uefi"}
+  - !PassingTestCaseRule {test_case_name: compose.install_default, scenario: "fedora.Workstation-live-iso.x86_64.uefi"}
+  - !PassingTestCaseRule {test_case_name: compose.install_default_upload, scenario: "fedora.KDE-live-iso.x86_64.64bit"}
+  - !PassingTestCaseRule {test_case_name: compose.install_default_upload, scenario: "fedora.Server-dvd-iso.x86_64.64bit"}
+  - !PassingTestCaseRule {test_case_name: compose.install_default_upload, scenario: "fedora.Workstation-live-iso.x86_64.64bit"}
+  - !PassingTestCaseRule {test_case_name: compose.install_delete_pata, scenario: "fedora.universal.x86_64.64bit"}
+  - !PassingTestCaseRule {test_case_name: compose.install_delete_pata, scenario: "fedora.universal.x86_64.uefi"}
+  - !PassingTestCaseRule {test_case_name: compose.install_kickstart_firewall_configured, scenario: "fedora.universal.x86_64.64bit"}
+  - !PassingTestCaseRule {test_case_name: compose.install_kickstart_firewall_disabled, scenario: "fedora.universal.x86_64.64bit"}
+  - !PassingTestCaseRule {test_case_name: compose.install_kickstart_user_creation, scenario: "fedora.universal.x86_64.64bit"}
+  - !PassingTestCaseRule {test_case_name: compose.install_mirrorlist_graphical, scenario: "fedora.universal.x86_64.64bit"}
+  - !PassingTestCaseRule {test_case_name: compose.install_multi, scenario: "fedora.universal.x86_64.64bit"}
+  - !PassingTestCaseRule {test_case_name: compose.install_multi, scenario: "fedora.universal.x86_64.uefi"}
+  - !PassingTestCaseRule {test_case_name: compose.install_no_user, scenario: "fedora.KDE-live-iso.x86_64.64bit"}
+  - !PassingTestCaseRule {test_case_name: compose.install_no_user, scenario: "fedora.Workstation-live-iso.x86_64.64bit"}
+  - !PassingTestCaseRule {test_case_name: compose.install_repository_http_graphical, scenario: "fedora.universal.i386.64bit"}
+  - !PassingTestCaseRule {test_case_name: compose.install_repository_http_graphical, scenario: "fedora.universal.x86_64.64bit"}
+  - !PassingTestCaseRule {test_case_name: compose.install_repository_http_variation, scenario: "fedora.universal.x86_64.64bit"}
+  - !PassingTestCaseRule {test_case_name: compose.install_sata, scenario: "fedora.universal.x86_64.64bit"}
+  - !PassingTestCaseRule {test_case_name: compose.install_sata, scenario: "fedora.universal.x86_64.uefi"}
+  - !PassingTestCaseRule {test_case_name: compose.install_scsi_updates_img, scenario: "fedora.universal.i386.64bit"}
+  - !PassingTestCaseRule {test_case_name: compose.install_scsi_updates_img, scenario: "fedora.universal.x86_64.64bit"}
+  - !PassingTestCaseRule {test_case_name: compose.realmd_join_sssd, scenario: "fedora.Server-dvd-iso.x86_64.64bit"}
+  - !PassingTestCaseRule {test_case_name: compose.server_cockpit_default, scenario: "fedora.Server-dvd-iso.x86_64.64bit"}
+  - !PassingTestCaseRule {test_case_name: compose.server_database_client, scenario: "fedora.Server-dvd-iso.x86_64.64bit"}
+  - !PassingTestCaseRule {test_case_name: compose.server_firewall_default, scenario: "fedora.Server-dvd-iso.x86_64.64bit"}
+  - !PassingTestCaseRule {test_case_name: compose.server_realmd_join_kickstart, scenario: "fedora.Server-dvd-iso.x86_64.64bit"}
+  - !PassingTestCaseRule {test_case_name: compose.server_role_deploy_database_server, scenario: "fedora.Server-dvd-iso.x86_64.64bit"}
+  - !PassingTestCaseRule {test_case_name: compose.server_role_deploy_domain_controller, scenario: "fedora.Server-dvd-iso.x86_64.64bit"}
+
+--- !Policy
+id: "taskotron_release_critical_tasks_for_testing"
+product_versions:
+  - fedora-29
+  - fedora-28
+  - fedora-27
+  - fedora-26
+decision_context: bodhi_update_push_testing
+blacklist: []
+subject_type: koji_build
+relevance_value: koji_build
+rules:
+  - !PassingTestCaseRule {test_case_name: dist.rpmdeplint}
+  - !RemoteRule {}
+--- !Policy
+id: "taskotron_release_critical_tasks_for_stable"
+product_versions:
+  - fedora-29
+  - fedora-28
+  - fedora-27
+  - fedora-26
+decision_context: bodhi_update_push_stable
+blacklist: []
+subject_type: koji_build
+relevance_value: koji_build
+rules:
+  - !PassingTestCaseRule {test_case_name: dist.rpmdeplint}
+  - !RemoteRule {}
+--- !Policy
+id: "no_requirements_testing"
+product_versions:
+  - fedora-29-modular
+  - fedora-29-containers
+  - fedora-28-modular
+  - fedora-28-containers
+  - fedora-epel-7
+  - fedora-epel-6
+decision_context: bodhi_update_push_testing
+blacklist: []
+subject_type: koji_build
+relevance_value: koji_build
+rules: []
+--- !Policy
+id: "no_requirements_for_stable"
+product_versions:
+  - fedora-29-modular
+  - fedora-29-containers
+  - fedora-28-modular
+  - fedora-28-containers
+  - fedora-epel-7
+  - fedora-epel-6
+decision_context: bodhi_update_push_stable
+blacklist: []
+subject_type: koji_build
+relevance_value: koji_build
+rules: []
+--- !Policy
+# Fedora Atomic CI pipeline
+# http://fedoraproject.org/wiki/CI
+id: "atomic_ci_pipeline_results"
+product_versions:
+  - fedora-29
+  - fedora-28
+  - fedora-27
+  - fedora-26
+decision_context: bodhi_update_push_testing
+blacklist: []
+subject_type: koji_build
+relevance_key: original_spec_nvr
+rules:
+  # List taken from https://github.com/CentOS-PaaS-SIG/ci-pipeline/blob/master/config/package_list
+      - !FedoraAtomicCi { test_case_name: org.centos.prod.ci.pipeline.complete, repos: ['acl', 'atk', 'atomic', 'atomic-devmode', 'attr', 'audit', 'audit-libs', 'authconfig', 'avahi', 'basesystem', 'bash', 'bash-completion', 'bind', 'bind99', 'biosdevname', 'boost', 'bridge-utils', 'bwidget', 'bzip2', 'ca-certificates', 'cairo', 'c-ares', 'ceph', 'checkpolicy', 'chkconfig', 'chrony', 'cloud-init', 'cloud-utils', 'cockpit', 'conntrack-tools', 'container-selinux', 'coreutils', 'cpio', 'cracklib', 'criu', 'crypto-policies', 'cryptsetup', 'cups', 'curl', 'cyrus-sasl', 'dbus', 'dbus-glib', 'dbus-python', 'dejavu-fonts', 'deltarpm', 'device-mapper-libs', 'device-mapper-multipath', 'device-mapper-persistent-data', 'dhcp', 'diffutils', 'ding-libs', 'dmidecode', 'dnf', 'dnsmasq', 'docker', 'dracut', 'dracut-network', 'e2fsprogs', 'efibootmgr', 'efivar', 'elfutils', 'emacs', 'etcd', 'ethtool', 'euca2ools', 'expat', 'fedora-logos', 'fedora-release', 'fedora-repos', 'file', 'filesystem', 'findutils', 'fipscheck', 'fipscheck-lib', 'flannel', 'fontconfig', 'fontpackages', 'freetype', 'fuse', 'gawk', 'gc', 'gcc', 'gdbm', 'gdisk', 'gdk-pixbuf2', 'GeoIP', 'GeoIP-GeoLite-data', 'gettext', 'glib2', 'glibc', 'glib-networking', 'glusterfs', 'gmp', 'gnupg', 'gnupg2', 'gnutls', 'gobject-introspection', 'gomtree', 'gperftools', 'gpgme', 'gpm', 'gpm-libs', 'graphite2', 'grep', 'grub2', 'gsettings-desktop-schemas', 'gssproxy', 'guile', 'gzip', 'harfbuzz', 'hawkey', 'hdparm', 'hicolor-icon-theme', 'hostname', 'http-parser', 'hwdata', 'initscripts', 'ipcalc', 'iproute', 'iptables', 'iputils', 'irqbalance', 'iscsi-initiator-utils', 'jansson', 'jasper', 'jbigkit', 'json-glib', 'kernel', 'kexec-tools', 'keyutils', 'keyutils-libs', 'kmod', 'krb5', 'krb5-libs', 'kubernetes', 'less', 'libacl', 'libaio', 'libarchive', 'libassuan', 'libatomic_ops', 'libblkid', 'libbsd', 'libcap', 'libcap-ng', 'libcgroup', 'libcom_err', 'libcomps', 'libcroco', 'libdatrie', 'libdb', 'libdrm', 'libedit', 'liberation-fonts', 'libev', 'libevent', 'libffi', 'libgcrypt', 'libglade2', 'libglvnd', 'libgpg-error', 'libgudev', 'libICE', 'libidn', 'libidn2', 'libiscsi', 'libjpeg-turbo', 'libksba', 'libldb', 'libmetalink', 'libmnl', 'libmodman', 'libmount', 'libndp', 'libnet', 'libnetfilter_conntrack', 'libnetfilter_cthelper', 'libnetfilter_cttimeout', 'libnetfilter_queue', 'libnfnetlink', 'libnfs', 'libnfsidmap', 'libnl3', 'libpcap', 'libpciaccess', 'libpng', 'libproxy', 'libpsl', 'libpwquality', 'librepo', 'libreport', 'libseccomp', 'libselinux', 'libsemanage', 'libsepol', 'libsigsegv', 'libSM', 'libsolv', 'libsoup', 'libssh2', 'libtalloc', 'libtasn1', 'libtdb', 'libtevent', 'libthai', 'libtiff', 'libtirpc', 'libtomcrypt', 'libtommath', 'libtool', 'libunistring', 'libunwind', 'libusb', 'libusbx', 'libuser', 'libutempter', 'libverto', 'libX11', 'libXau', 'libxcb', 'libXcomposite', 'libXcursor', 'libXdamage', 'libXext', 'libXfixes', 'libXft', 'libXi', 'libXinerama', 'libxml2', 'libXmu', 'libXrandr', 'libXrender', 'libxshmfence', 'libxslt', 'libXt', 'libXxf86misc', 'libXxf86vm', 'libyaml', 'linux-firmware', 'logrotate', 'lttng-ust', 'lua', 'lvm2', 'lz4', 'lzo', 'make', 'mcpp', 'mdadm', 'mesa', 'mokutil', 'mozjs17', 'mpfr', 'nano', 'ncurses', 'nettle', 'net-tools', 'NetworkManager', 'newt', 'nfs-utils', 'nghttp2', 'nmap', 'npth', 'nspr', 'nss', 'nss-pem', 'nss-softokn', 'nss-util', 'numactl', 'openldap', 'openssh', 'openssl', 'os-prober', 'ostree', 'p11-kit', 'pam', 'pango', 'passwd', 'pciutils', 'pcre', 'perl', 'perl-libs', 'pixman', 'policycoreutils', 'polkit', 'polkit-pkla-compat', 'popt', 'ppp', 'procps-ng', 'protobuf-c', 'publicsuffix-list', 'pygobject3', 'pyliblzma', 'pyserial', 'python', 'python3', 'python-beautifulsoup4', 'python-cffi', 'python-chardet', 'python-configobj', 'python-crypto', 'python-cryptography', 'python-cssselect', 'python-dateutil', 'python-decorator', 'python-dmidecode', 'python-docker-py', 'python-docker-pycreds', 'python-enum34', 'python-ethtool', 'python-html5lib', 'python-idna', 'python-iniparse', 'python-ipaddress', 'python-IPy', 'python-jinja2', 'python-jsonpatch', 'python-jsonpointer', 'python-lxml', 'python-markupsafe', 'python-oauthlib', 'python-paramiko', 'python-pip', 'python-ply', 'python-prettytable', 'python-progressbar', 'python-pyasn1', 'python-pycparser', 'python-pycurl', 'python-pygpgme', 'python-pysocks', 'python-pyudev', 'python-requestbuilder', 'python-requests', 'python-rhsm', 'python-setuptools', 'python-six', 'python-slip', 'python-urlgrabber', 'python-urllib3', 'python-websocket-client', 'pyxattr', 'PyYAML', 'qemu', 'qrencode', 'quota', 'readline', 'rpcbind', 'rpm', 'rpm-ostree', 'rsync', 'runc', 'samba', 'sed', 'selinux-policy', 'setools', 'setup', 'sgml-common', 'shadow-utils', 'shared-mime-info', 'shim-signed', 'skopeo', 'skopeo-containers', 'slang', 'snappy', 'socat', 'sqlite', 'sssd', 'subscription-manager', 'sudo', 'systemd', 'tar', 'tcl', 'tcp_wrappers', 'tcp_wrappers-libs', 'texinfo', 'tk', 'tmux', 'tuned', 'tzdata', 'usermode', 'userspace-rcu', 'ustr', 'util-linux', 'vim', 'virt-what', 'wayland', 'which', 'xfsprogs', 'xorg-x11-server-utils', 'xorg-x11-xauth', 'xorg-x11-xinit', 'xz', 'yum', 'yum-metadata-parser', 'zlib'] }
+--- !Policy
+# Fedora Atomic CI pipeline
+# http://fedoraproject.org/wiki/CI
+id: "atomic_ci_pipeline_results_stable"
+product_versions:
+  - fedora-29
+  - fedora-28
+  - fedora-27
+  - fedora-26
+decision_context: bodhi_update_push_stable
+blacklist: []
+subject_type: koji_build
+relevance_key: original_spec_nvr
+rules:
+  # List taken from https://github.com/CentOS-PaaS-SIG/ci-pipeline/blob/master/config/package_list
+      - !FedoraAtomicCi { test_case_name: org.centos.prod.ci.pipeline.complete, repos: ['acl', 'atk', 'atomic', 'atomic-devmode', 'attr', 'audit', 'audit-libs', 'authconfig', 'avahi', 'basesystem', 'bash', 'bash-completion', 'bind', 'bind99', 'biosdevname', 'boost', 'bridge-utils', 'bwidget', 'bzip2', 'ca-certificates', 'cairo', 'c-ares', 'ceph', 'checkpolicy', 'chkconfig', 'chrony', 'cloud-init', 'cloud-utils', 'cockpit', 'conntrack-tools', 'container-selinux', 'coreutils', 'cpio', 'cracklib', 'criu', 'crypto-policies', 'cryptsetup', 'cups', 'curl', 'cyrus-sasl', 'dbus', 'dbus-glib', 'dbus-python', 'dejavu-fonts', 'deltarpm', 'device-mapper-libs', 'device-mapper-multipath', 'device-mapper-persistent-data', 'dhcp', 'diffutils', 'ding-libs', 'dmidecode', 'dnf', 'dnsmasq', 'docker', 'dracut', 'dracut-network', 'e2fsprogs', 'efibootmgr', 'efivar', 'elfutils', 'emacs', 'etcd', 'ethtool', 'euca2ools', 'expat', 'fedora-logos', 'fedora-release', 'fedora-repos', 'file', 'filesystem', 'findutils', 'fipscheck', 'fipscheck-lib', 'flannel', 'fontconfig', 'fontpackages', 'freetype', 'fuse', 'gawk', 'gc', 'gcc', 'gdbm', 'gdisk', 'gdk-pixbuf2', 'GeoIP', 'GeoIP-GeoLite-data', 'gettext', 'glib2', 'glibc', 'glib-networking', 'glusterfs', 'gmp', 'gnupg', 'gnupg2', 'gnutls', 'gobject-introspection', 'gomtree', 'gperftools', 'gpgme', 'gpm', 'gpm-libs', 'graphite2', 'grep', 'grub2', 'gsettings-desktop-schemas', 'gssproxy', 'guile', 'gzip', 'harfbuzz', 'hawkey', 'hdparm', 'hicolor-icon-theme', 'hostname', 'http-parser', 'hwdata', 'initscripts', 'ipcalc', 'iproute', 'iptables', 'iputils', 'irqbalance', 'iscsi-initiator-utils', 'jansson', 'jasper', 'jbigkit', 'json-glib', 'kernel', 'kexec-tools', 'keyutils', 'keyutils-libs', 'kmod', 'krb5', 'krb5-libs', 'kubernetes', 'less', 'libacl', 'libaio', 'libarchive', 'libassuan', 'libatomic_ops', 'libblkid', 'libbsd', 'libcap', 'libcap-ng', 'libcgroup', 'libcom_err', 'libcomps', 'libcroco', 'libdatrie', 'libdb', 'libdrm', 'libedit', 'liberation-fonts', 'libev', 'libevent', 'libffi', 'libgcrypt', 'libglade2', 'libglvnd', 'libgpg-error', 'libgudev', 'libICE', 'libidn', 'libidn2', 'libiscsi', 'libjpeg-turbo', 'libksba', 'libldb', 'libmetalink', 'libmnl', 'libmodman', 'libmount', 'libndp', 'libnet', 'libnetfilter_conntrack', 'libnetfilter_cthelper', 'libnetfilter_cttimeout', 'libnetfilter_queue', 'libnfnetlink', 'libnfs', 'libnfsidmap', 'libnl3', 'libpcap', 'libpciaccess', 'libpng', 'libproxy', 'libpsl', 'libpwquality', 'librepo', 'libreport', 'libseccomp', 'libselinux', 'libsemanage', 'libsepol', 'libsigsegv', 'libSM', 'libsolv', 'libsoup', 'libssh2', 'libtalloc', 'libtasn1', 'libtdb', 'libtevent', 'libthai', 'libtiff', 'libtirpc', 'libtomcrypt', 'libtommath', 'libtool', 'libunistring', 'libunwind', 'libusb', 'libusbx', 'libuser', 'libutempter', 'libverto', 'libX11', 'libXau', 'libxcb', 'libXcomposite', 'libXcursor', 'libXdamage', 'libXext', 'libXfixes', 'libXft', 'libXi', 'libXinerama', 'libxml2', 'libXmu', 'libXrandr', 'libXrender', 'libxshmfence', 'libxslt', 'libXt', 'libXxf86misc', 'libXxf86vm', 'libyaml', 'linux-firmware', 'logrotate', 'lttng-ust', 'lua', 'lvm2', 'lz4', 'lzo', 'make', 'mcpp', 'mdadm', 'mesa', 'mokutil', 'mozjs17', 'mpfr', 'nano', 'ncurses', 'nettle', 'net-tools', 'NetworkManager', 'newt', 'nfs-utils', 'nghttp2', 'nmap', 'npth', 'nspr', 'nss', 'nss-pem', 'nss-softokn', 'nss-util', 'numactl', 'openldap', 'openssh', 'openssl', 'os-prober', 'ostree', 'p11-kit', 'pam', 'pango', 'passwd', 'pciutils', 'pcre', 'perl', 'perl-libs', 'pixman', 'policycoreutils', 'polkit', 'polkit-pkla-compat', 'popt', 'ppp', 'procps-ng', 'protobuf-c', 'publicsuffix-list', 'pygobject3', 'pyliblzma', 'pyserial', 'python', 'python3', 'python-beautifulsoup4', 'python-cffi', 'python-chardet', 'python-configobj', 'python-crypto', 'python-cryptography', 'python-cssselect', 'python-dateutil', 'python-decorator', 'python-dmidecode', 'python-docker-py', 'python-docker-pycreds', 'python-enum34', 'python-ethtool', 'python-html5lib', 'python-idna', 'python-iniparse', 'python-ipaddress', 'python-IPy', 'python-jinja2', 'python-jsonpatch', 'python-jsonpointer', 'python-lxml', 'python-markupsafe', 'python-oauthlib', 'python-paramiko', 'python-pip', 'python-ply', 'python-prettytable', 'python-progressbar', 'python-pyasn1', 'python-pycparser', 'python-pycurl', 'python-pygpgme', 'python-pysocks', 'python-pyudev', 'python-requestbuilder', 'python-requests', 'python-rhsm', 'python-setuptools', 'python-six', 'python-slip', 'python-urlgrabber', 'python-urllib3', 'python-websocket-client', 'pyxattr', 'PyYAML', 'qemu', 'qrencode', 'quota', 'readline', 'rpcbind', 'rpm', 'rpm-ostree', 'rsync', 'runc', 'samba', 'sed', 'selinux-policy', 'setools', 'setup', 'sgml-common', 'shadow-utils', 'shared-mime-info', 'shim-signed', 'skopeo', 'skopeo-containers', 'slang', 'snappy', 'socat', 'sqlite', 'sssd', 'subscription-manager', 'sudo', 'systemd', 'tar', 'tcl', 'tcp_wrappers', 'tcp_wrappers-libs', 'texinfo', 'tk', 'tmux', 'tuned', 'tzdata', 'usermode', 'userspace-rcu', 'ustr', 'util-linux', 'vim', 'virt-what', 'wayland', 'which', 'xfsprogs', 'xorg-x11-server-utils', 'xorg-x11-xauth', 'xorg-x11-xinit', 'xz', 'yum', 'yum-metadata-parser', 'zlib'] }

--- a/devel/ci/integration/greenwave/settings.py
+++ b/devel/ci/integration/greenwave/settings.py
@@ -1,0 +1,16 @@
+HOST = '0.0.0.0'
+PORT = 8080
+DEBUG = False
+POLICIES_DIR = '/etc/greenwave/'
+DIST_GIT_BASE_URL = 'https://src.fedoraproject.org'
+DIST_GIT_URL_TEMPLATE = '{DIST_GIT_BASE_URL}/{pkg_namespace}/{pkg_name}/raw/{rev}/f/gating.yaml'
+KOJI_BASE_URL = 'https://koji.fedoraproject.org/kojihub'
+BODHI_URL = 'https://bodhi/'
+
+SECRET_KEY = 'this-is-only-for-integration-testing'
+WAIVERDB_API_URL = 'http://waiverdb:8080/api/v1.0'
+RESULTSDB_API_URL = 'http://resultsdb/resultsdb/api/v2.0'
+CORS_URL = 'https://bodhi'
+CACHE = {
+    "backend": "dogpile.cache.memory_pickle",
+}

--- a/devel/ci/integration/resultsdb/Dockerfile
+++ b/devel/ci/integration/resultsdb/Dockerfile
@@ -1,0 +1,26 @@
+FROM centos:7
+LABEL \
+  name="resultsdb" \
+  vendor="Fedora Infrastructure" \
+  maintainer="Aurelien Bompard <abompard@fedoraproject.org>" \
+  license="MIT"
+
+RUN yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
+
+# The echo works around https://bugzilla.redhat.com/show_bug.cgi?id=1483553 and any other future yum
+# upgrade bugs.
+RUN yum upgrade -y || echo "We are not trying to test dnf upgrade, so ignoring dnf failure."
+
+# Install deps
+RUN yum install -y \
+    httpd \
+    mod_wsgi \
+    resultsdb \
+    python-psycopg2
+
+# Configuration
+COPY devel/ci/integration/resultsdb/settings.py /etc/resultsdb/settings.py
+COPY devel/ci/integration/resultsdb/httpd.conf /etc/httpd/conf.d/resultsdb.conf
+
+EXPOSE 80
+CMD ["/usr/sbin/httpd", "-DFOREGROUND"]

--- a/devel/ci/integration/resultsdb/httpd.conf
+++ b/devel/ci/integration/resultsdb/httpd.conf
@@ -1,0 +1,13 @@
+WSGIDaemonProcess resultsdb user=apache group=apache threads=5
+WSGIScriptAlias /resultsdb /usr/share/resultsdb/resultsdb.wsgi
+WSGISocketPrefix run/wsgi
+
+<Directory /usr/share/resultsdb>
+    WSGIProcessGroup resultsdb
+    WSGIApplicationGroup %{GLOBAL}
+    WSGIScriptReloading On
+
+    AllowOverride None
+    Require all granted
+
+</Directory>

--- a/devel/ci/integration/resultsdb/settings.py
+++ b/devel/ci/integration/resultsdb/settings.py
@@ -1,0 +1,15 @@
+SECRET_KEY = 'this-is-only-for-integration-testing'
+SQLALCHEMY_DATABASE_URI = 'postgresql+psycopg2://resultsdb@db/resultsdb'
+FILE_LOGGING = False
+LOGFILE = '/var/log/resultsdb/resultsdb.log'
+SYSLOG_LOGGING = False
+STREAM_LOGGING = True
+
+MESSAGE_BUS_PUBLISH = False
+MESSAGE_BUS_PUBLISH_TASKOTRON = False
+# TODO: integration testing of published fedmsgs?
+# MESSAGE_BUS_PUBLISH = True
+# MESSAGE_BUS_PUBLISH_TASKOTRON = True
+
+MESSAGE_BUS_PLUGIN = 'fedmsg'
+MESSAGE_BUS_KWARGS = {'modname': 'resultsdb'}

--- a/devel/ci/integration/tests/conftest.py
+++ b/devel/ci/integration/tests/conftest.py
@@ -1,0 +1,26 @@
+# Copyright © 2018 Red Hat, Inc.
+#
+# This file is part of Bodhi.
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+# flake8: noqa
+
+from .fixtures.backend import docker_backend, docker_network
+from .fixtures.db import db_container
+from .fixtures.resultsdb import resultsdb_container
+from .fixtures.waiverdb import waiverdb_container
+from .fixtures.greenwave import greenwave_container
+from .fixtures.bodhi import bodhi_container

--- a/devel/ci/integration/tests/fixtures/backend.py
+++ b/devel/ci/integration/tests/fixtures/backend.py
@@ -1,0 +1,51 @@
+# Copyright © 2018 Red Hat, Inc.
+#
+# This file is part of Bodhi.
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+from __future__ import absolute_import, unicode_literals
+
+import logging
+
+import pytest
+from conu import DockerBackend
+
+
+@pytest.fixture(scope="session")
+def docker_backend():
+    """Fixture yielding a Conu Docker backend.
+
+    Yields:
+        conu.DockerBackend: The Docker backend.
+    """
+    # Redefined to set the scope
+    with DockerBackend(logging_level=logging.DEBUG) as backend:
+        yield backend
+
+
+@pytest.fixture(scope="session")
+def docker_network(docker_backend):
+    """Fixture yielding a Docker network to attach all containers to.
+
+    Args:
+        conu.DockerBackend: The Docker backend fixture.
+
+    Yields:
+        str: The Docker network ID.
+    """
+    network = docker_backend.d.create_network("bodhi_test", driver="bridge")
+    yield network
+    docker_backend.d.remove_network(network["Id"])

--- a/devel/ci/integration/tests/fixtures/bodhi.py
+++ b/devel/ci/integration/tests/fixtures/bodhi.py
@@ -1,0 +1,126 @@
+# Copyright © 2018 Red Hat, Inc.
+#
+# This file is part of Bodhi.
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+import os
+from uuid import uuid4
+
+import pytest
+from conu.backend.docker.container_parameters import DockerContainerParameters
+from six.moves.configparser import ConfigParser
+
+from ..utils import make_db_and_user, edit_file
+
+
+@pytest.fixture(scope="session")
+def bodhi_container(
+    docker_backend, docker_network, db_container, resultsdb_container,
+    waiverdb_container, greenwave_container
+):
+    """Fixture preparing and yielding a Bodhi container to test against.
+
+    Args:
+        docker_backend (conu.DockerBackend): The Docker backend (fixture).
+        docker_network (str): The Docker network ID (fixture).
+        db_container (conu.DockerContainer): The PostgreSQL container (fixture).
+        resultsdb_container (conu.DockerContainer): The ResultsDB container
+            (fixture).
+        waiverdb_container (conu.DockerContainer): The WaiverDB container
+            (fixture).
+        greenwave_container (conu.DockerContainer): The Greenwave container
+            (fixture).
+
+    Yields:
+        conu.DockerContainer: The Bodhi container.
+    """
+    # Prepare the database
+    make_db_and_user(
+        db_container, "bodhi2",
+        "https://infrastructure.fedoraproject.org/infra/db-dumps/bodhi2.dump.xz"
+    )
+    image = docker_backend.ImageClass(
+        os.environ.get("BODHI_INTEGRATION_IMAGE", "bodhi-ci-integration-bodhi")
+    )
+    container = image.run_via_api(DockerContainerParameters(name="bodhi"))
+    config_override = {
+        "base_address": "https://bodhi.fedoraproject.org/",
+        "sqlalchemy.url": "postgresql://bodhi2@db/bodhi2",
+        "pungi.cmd": "/bin/true",
+        "dogpile.cache.backend": "dogpile.cache.memory_pickle",
+        "captcha.secret": "VNaWm-coV1VfG_7ZopF7O4Osjsu5DlLZSHkRDB_eMF0=",
+        "legal_link": "https://fedoraproject.org/wiki/Legal:Main",
+        "privacy_link": "https://fedoraproject.org/wiki/Legal:PrivacyPolicy",
+        "datagrepper_url": "https://apps.fedoraproject.org/datagrepper",
+        "authtkt.secret": uuid4().hex,
+        "session.secret": uuid4().hex,
+        "query_wiki_test_cases": "True",
+        "wiki_url": "https://fedoraproject.org/w/api.php",
+        "test_case_base_url": "https://fedoraproject.org/wiki/",
+        "resultsdb_url": "http://resultsdb/resultsdb/",
+        "test_gating.required": "True",
+        "greenwave_api_url": "http://greenwave:8080/api/v1.0",
+        "waiverdb_api_url": "http://waiverdb:8080/api/v1.0",
+        "default_email_domain": "fedoraproject.org",
+        "releng_fedmsg_certname": "bodhi",
+        # Only on bodhi-backend
+        # "mash_dir": "/mnt/koji/compose/updates/",
+        # "mash_stage_dir": "/mnt/koji/compose/updates/",
+        "max_concurrent_mashes": "3",
+        "clean_old_composes": "false",
+        "pungi.conf.rpm": "pungi.rpm.conf.j2",
+        "pungi.conf.module": "pungi.module.conf.j2",
+        "pungi.extracmdline":
+            "--notification-script=/usr/bin/pungi-fedmsg-notification "
+            "--notification-script=pungi-wait-for-signed-ostree-handler",
+        "max_update_length_for_ui": "70",
+        "top_testers_timeframe": "900",
+        "buildsystem": "koji",
+        "fedmenu.url": "https://apps.fedoraproject.org/fedmenu",
+        "fedmenu.data_url": "https://apps.fedoraproject.org/js/data.js",
+        "acl_system": "pagure",
+        "bugtracker": "bugzilla",
+        "bz_products": "Fedora,Fedora EPEL",
+        "reboot_pkgs": "kernel kernel-smp kernel-PAE glibc hal dbus",
+        "critpath.type": "pdc",
+        "critpath.num_admin_approvals": "0",
+        "fedora_modular.mandatory_days_in_testing": "7",
+        "buildroot_overrides.expire_after": "1",
+        "pyramid.reload_templates": "false",
+        "pyramid.debug_authorization": "false",
+        "pyramid.debug_notfound": "false",
+        "pyramid.debug_routematch": "false",
+        "authtkt.secure": "true",
+        "authtkt.timeout": "1209600",
+    }
+    with edit_file(container, "/etc/bodhi/production.ini") as config_path:
+        config = ConfigParser()
+        config.read(config_path)
+        for key, value in config_override.items():
+            config.set("app:main", key, value)
+
+        with open(config_path, "w") as config_file:
+            config.write(config_file)
+
+    container.start()
+    docker_backend.d.connect_container_to_network(container.name, docker_network["Id"])
+    # Update the database schema
+    container.execute(["alembic-3", "-c", "/bodhi/alembic.ini", "upgrade", "head"])
+    # we need to wait for the webserver to start serving
+    container.wait_for_port(8080, timeout=-1)
+    yield container
+    container.kill()
+    container.delete()

--- a/devel/ci/integration/tests/fixtures/db.py
+++ b/devel/ci/integration/tests/fixtures/db.py
@@ -1,0 +1,49 @@
+# Copyright © 2018 Red Hat, Inc.
+#
+# This file is part of Bodhi.
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+import os
+import pytest
+from conu.backend.docker.container_parameters import DockerContainerParameters
+
+
+@pytest.fixture(scope="session")
+def db_container(docker_backend, docker_network):
+    """Fixture preparing and yielding a PostgreSQL container.
+
+    This container can be used by other apps to store data.
+
+    Args:
+        docker_backend (conu.DockerBackend): The Docker backend (fixture).
+        docker_network (str): The Docker network ID (fixture).
+
+    Yields:
+        conu.DockerContainer: The PostgreSQL container.
+    """
+    image = docker_backend.ImageClass(
+        os.environ.get("BODHI_INTEGRATION_POSTGRESQL_IMAGE", "postgres"),
+        tag="latest"
+    )
+    container = image.run_via_api(
+        DockerContainerParameters(name="db")
+    )
+    container.start()
+    docker_backend.d.connect_container_to_network(container.name, docker_network["Id"])
+    container.wait_for_port(5432, timeout=-1)
+    yield container
+    container.kill()
+    container.delete()

--- a/devel/ci/integration/tests/fixtures/greenwave.py
+++ b/devel/ci/integration/tests/fixtures/greenwave.py
@@ -1,0 +1,51 @@
+# Copyright © 2018 Red Hat, Inc.
+#
+# This file is part of Bodhi.
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+import pytest
+from conu.backend.docker.container_parameters import DockerContainerParameters
+
+from ..utils import make_db_and_user
+
+
+@pytest.fixture(scope="session")
+def greenwave_container(docker_backend, docker_network, db_container):
+    """Fixture preparing and yielding a Greenwave container.
+
+    Args:
+        docker_backend (conu.DockerBackend): The Docker backend (fixture).
+        docker_network (str): The Docker network ID (fixture).
+        db_container(conu.DockerContainer): The PostgreSQL container (fixture).
+
+    Yields:
+        conu.DockerContainer: The Greenwave container.
+    """
+    # Prepare the database
+    make_db_and_user(db_container, "greenwave")
+    # Define the container and start it
+    image_name = "bodhi-ci-integration-greenwave"
+    image = docker_backend.ImageClass(image_name)
+    container = image.run_via_api(
+        DockerContainerParameters(name="greenwave")
+    )
+    container.start()
+    docker_backend.d.connect_container_to_network(container.name, docker_network["Id"])
+    # we need to wait for the webserver to start serving
+    container.wait_for_port(8080, timeout=-1)
+    yield container
+    container.kill()
+    container.delete()

--- a/devel/ci/integration/tests/fixtures/resultsdb.py
+++ b/devel/ci/integration/tests/fixtures/resultsdb.py
@@ -1,0 +1,53 @@
+# Copyright © 2018 Red Hat, Inc.
+#
+# This file is part of Bodhi.
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+import pytest
+from conu.backend.docker.container_parameters import DockerContainerParameters
+
+from ..utils import make_db_and_user
+
+
+@pytest.fixture(scope="session")
+def resultsdb_container(docker_backend, docker_network, db_container):
+    """Fixture preparing and yielding a ResultsDB container.
+
+    Args:
+        docker_backend (conu.DockerBackend): The Docker backend (fixture).
+        docker_network (str): The Docker network ID (fixture).
+        db_container(conu.DockerContainer): The PostgreSQL container (fixture).
+
+    Yields:
+        conu.DockerContainer: The ResultsDB container.
+    """
+    # Prepare the database
+    make_db_and_user(db_container, "resultsdb")
+    # Define the container and start it
+    image_name = "bodhi-ci-integration-resultsdb"
+    image = docker_backend.ImageClass(image_name)
+    container = image.run_via_api(
+        DockerContainerParameters(name="resultsdb")
+    )
+    container.start()
+    docker_backend.d.connect_container_to_network(container.name, docker_network["Id"])
+    # Add sample data in the database
+    container.execute(["resultsdb", "init_db"])
+    # we need to wait for the webserver to start serving
+    container.wait_for_port(80, timeout=-1)
+    yield container
+    container.kill()
+    container.delete()

--- a/devel/ci/integration/tests/fixtures/waiverdb.py
+++ b/devel/ci/integration/tests/fixtures/waiverdb.py
@@ -1,0 +1,56 @@
+# Copyright © 2018 Red Hat, Inc.
+#
+# This file is part of Bodhi.
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+import pytest
+from conu.backend.docker.container_parameters import DockerContainerParameters
+
+from ..utils import make_db_and_user
+
+
+@pytest.fixture(scope="session")
+def waiverdb_container(docker_backend, docker_network, db_container):
+    """Fixture preparing and yielding a WaiverDB container.
+
+    Args:
+        docker_backend (conu.DockerBackend): The Docker backend (fixture).
+        docker_network (str): The Docker network ID (fixture).
+        db_container(conu.DockerContainer): The PostgreSQL container (fixture).
+
+    Yields:
+        conu.DockerContainer: The WaiverDB container.
+    """
+    # Prepare the database
+    make_db_and_user(
+        db_container, "waiverdb",
+        "https://infrastructure.fedoraproject.org/infra/db-dumps/waiverdb.dump.xz"
+    )
+    # Define the container and start it
+    image_name = "bodhi-ci-integration-waiverdb"
+    image = docker_backend.ImageClass(image_name)
+    container = image.run_via_api(
+        DockerContainerParameters(name="waiverdb")
+    )
+    container.start()
+    docker_backend.d.connect_container_to_network(container.name, docker_network["Id"])
+    # Add sample data in the database
+    container.execute(["waiverdb", "db", "upgrade"])
+    # we need to wait for the webserver to start serving
+    container.wait_for_port(8080, timeout=-1)
+    yield container
+    container.kill()
+    container.delete()

--- a/devel/ci/integration/tests/test_bodhi.py
+++ b/devel/ci/integration/tests/test_bodhi.py
@@ -1,0 +1,34 @@
+# Copyright © 2018 Red Hat, Inc.
+#
+# This file is part of Bodhi.
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+from tests.utils import read_file
+
+
+def test_get_root(bodhi_container):
+    # GET on /
+    # this is standard `requests.Response`
+    http_response = bodhi_container.http_request(path="/", port=8080)
+    try:
+        assert http_response.ok
+        assert "Fedora Update System" in http_response.text
+    except AssertionError:
+        print(http_response)
+        print(http_response.text)
+        with read_file(bodhi_container, "/httpdir/errorlog") as log:
+            print(log.read())
+        raise

--- a/devel/ci/integration/tests/test_bodhi_cli.py
+++ b/devel/ci/integration/tests/test_bodhi_cli.py
@@ -1,0 +1,316 @@
+# Copyright © 2018 Red Hat, Inc.
+#
+# This file is part of Bodhi.
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+import itertools
+import json
+import re
+import textwrap
+
+import psycopg2
+import requests
+
+from conu import ConuException
+from munch import Munch
+
+from .utils import replace_file
+
+
+def _run_cli(bodhi_container, args, **kwargs):
+    """Run the Bodhi CLI in the Bodhi container
+
+    Args:
+        bodhi_container (conu.DockerContainer): The Bodhi container to use.
+        args (list): The CLI arguments
+        kwargs (dict): The kwargs to use for the ``DockerContainer.execute()``
+            method.
+    Returns:
+        Munch: Execution result as an object with an ``exit_code`` property
+            (``int``) and an ``output`` property (``str``).
+    """
+    try:
+        output = bodhi_container.execute(
+            ["bodhi"] + args + ["--url", "http://localhost:8080"],
+            **kwargs
+        )
+    except ConuException as e:
+        return Munch(exit_code=1, output=str(e))
+    return Munch(exit_code=0, output="".join(line.decode("utf-8") for line in output))
+
+
+def _db_record_to_munch(cursor, record):
+    """Convert a database record to a Munch object.
+
+    Args:
+        cursor (psycopg2.extensions.cursor): The database cursor.
+        record (tuple): The record to convert.
+    Returns:
+        Munch: An object with column names as attributes and record values as
+            values.
+    """
+    return Munch(dict([
+        (cursor.description[i].name, record[i])
+        for i in range(len(record))
+    ]))
+
+
+def test_composes_list(bodhi_container, db_container):
+    """Test ``bodhi composes list``"""
+    result = _run_cli(bodhi_container, ["composes", "list"])
+    assert result.exit_code == 0
+    # Parse command output
+    updates_by_compose = {}
+    output_parser = re.compile(r"[\*\s]?([\w-]+)\s+:\s+(\d+) updates \((\w+)\)")
+    for line in result.output.splitlines():
+        match = output_parser.match(line)
+        assert match is not None
+        updates_by_compose[match.group(1)] = (int(match.group(2)), match.group(3))
+    # Look in the DB for what is expected
+    expected = {}
+    query = """SELECT
+    r.name, c.request, COUNT(u.id), c.state
+    FROM composes c
+    JOIN releases r ON r.id = c.release_id
+    JOIN updates u ON u.release_id = r.id AND u.request = c.request
+    WHERE r.state = 'current' AND u.locked = TRUE
+    GROUP BY r.name, c.request, c.state
+    """
+    db_ip = db_container.get_IPv4s()[0]
+    conn = psycopg2.connect("dbname=bodhi2 user=postgres host={}".format(db_ip))
+    with conn:
+        with conn.cursor() as curs:
+            curs.execute(query)
+            for record in curs:
+                compose = "{}-{}".format(record[0], record[1])
+                expected[compose] = (record[2], record[3])
+    conn.close()
+    assert updates_by_compose == expected
+
+
+def test_releases_info(bodhi_container, db_container):
+    """Test ``bodhi releases info``"""
+    # Fetch the available releases from the DB
+    db_ip = db_container.get_IPv4s()[0]
+    query = "SELECT * FROM releases"
+    releases = []
+    conn = psycopg2.connect("dbname=bodhi2 user=postgres host={}".format(db_ip))
+    with conn:
+        with conn.cursor() as curs:
+            curs.execute(query)
+            for record in curs:
+                releases.append(_db_record_to_munch(curs, record))
+    conn.close()
+    for release in releases:
+        # Run the command for each release
+        result = _run_cli(bodhi_container, ["releases", "info", release["name"]])
+        assert result.exit_code == 0
+        expected = """Release:
+  Name:                {name}
+  Long Name:           {long_name}
+  Version:             {version}
+  Branch:              {branch}
+  ID Prefix:           {id_prefix}
+  Dist Tag:            {dist_tag}
+  Stable Tag:          {stable_tag}
+  Testing Tag:         {testing_tag}
+  Candidate Tag:       {candidate_tag}
+  Pending Signing Tag: {pending_signing_tag}
+  Pending Testing Tag: {pending_testing_tag}
+  Pending Stable Tag:  {pending_stable_tag}
+  Override Tag:        {override_tag}
+  State:               {state}
+  Email Template:      {mail_template}
+""".format(**release)
+        assert result.output == expected
+
+
+def test_overrides_query(bodhi_container, db_container):
+    """Test ``bodhi overrides query``"""
+    # Fetch the number of overrides from the DB
+    db_ip = db_container.get_IPv4s()[0]
+    query = "SELECT COUNT(*) FROM buildroot_overrides"
+    conn = psycopg2.connect("dbname=bodhi2 user=postgres host={}".format(db_ip))
+    with conn:
+        with conn.cursor() as curs:
+            curs.execute(query)
+            total = curs.fetchone()[0]
+    conn.close()
+    # Run the command
+    result = _run_cli(bodhi_container, ["overrides", "query"])
+    assert result.exit_code == 0
+    last_line = result.output.split("\n")[-2]
+    assert last_line == "{} overrides found (20 shown)".format(total)
+
+
+def test_updates_query_total(bodhi_container, db_container):
+    """Test listing the updates with ``bodhi updates query``"""
+    # Fetch the number of updates from the DB
+    db_ip = db_container.get_IPv4s()[0]
+    query = "SELECT COUNT(*) FROM updates"
+    conn = psycopg2.connect("dbname=bodhi2 user=postgres host={}".format(db_ip))
+    with conn:
+        with conn.cursor() as curs:
+            curs.execute(query)
+            total = curs.fetchone()[0]
+    conn.close()
+    # Run the command
+    result = _run_cli(bodhi_container, ["updates", "query"])
+    assert result.exit_code == 0
+    last_line = result.output.split("\n")[-2]
+    assert last_line == "{} updates found (20 shown)".format(total)
+
+
+def test_updates_query_details(bodhi_container, db_container, greenwave_container):
+    """Test getting an update's details with ``bodhi updates query``"""
+    # Fetch the last update from the DB
+    db_ip = db_container.get_IPv4s()[0]
+    query_update = (
+        "SELECT "
+        "  users.name as username, "
+        "  releases.long_name as release, "
+        "  updates.* "
+        "FROM updates "
+        "JOIN users ON updates.user_id = users.id "
+        "JOIN releases ON updates.release_id = releases.id "
+        "ORDER BY date_submitted DESC LIMIT 1"
+    )
+    query_comments = (
+        "SELECT u.name as username, c.timestamp, c.karma, c.text FROM comments c "
+        "JOIN users u ON c.user_id = u.id "
+        "WHERE update_id = %s ORDER BY c.timestamp"
+    )
+    query_karma = (
+        "SELECT SUM(comments.karma) as karma FROM comments "
+        "JOIN updates ON comments.update_id = updates.id "
+        "WHERE update_id = %s"
+    )
+    query_ct = (
+        "SELECT builds.type FROM builds "
+        "JOIN updates ON builds.update_id = updates.id "
+        "WHERE update_id = %s LIMIT 1"
+    )
+    query_builds = "SELECT nvr FROM builds WHERE update_id = %s ORDER BY nvr"
+    conn = psycopg2.connect("dbname=bodhi2 user=postgres host={}".format(db_ip))
+    with conn:
+        with conn.cursor() as curs:
+            curs.execute(query_update)
+            update = _db_record_to_munch(curs, curs.fetchone())
+            update.comments = []
+            curs.execute(query_comments, (update.id, ))
+            for record in curs:
+                update.comments.append(_db_record_to_munch(curs, record))
+            curs.execute(query_karma, (update.id, ))
+            update.karma = _db_record_to_munch(curs, curs.fetchone()).karma
+            curs.execute(query_ct, (update.id, ))
+            update.content_type = _db_record_to_munch(curs, curs.fetchone()).type
+            curs.execute(query_builds, (update.id, ))
+            update.builds = [r[0] for r in curs]
+    conn.close()
+    # Run the command
+    result = _run_cli(bodhi_container, ["updates", "query", "--updateid", update.alias])
+    assert result.exit_code == 0
+    assert "Update ID: {}".format(update.alias) in result.output
+    assert "Content Type: {}".format(update.content_type) in result.output
+    assert "Release: {}".format(update.release) in result.output
+    assert "Status: {}".format(update.status) in result.output
+    assert "Type: {}".format(update.type) in result.output
+    assert "Severity: {}".format(update.severity) in result.output
+    assert "Karma: {}".format(update.karma) in result.output
+    expected_autokarma = (
+        "Autokarma: {u.autokarma}  [{u.unstable_karma}, {u.stable_karma}]"
+    ).format(u=update)
+    assert expected_autokarma in result.output
+    assert "Request: {}".format(update.request) in result.output
+    # Notes are formatted
+    formatted_notes = list(itertools.chain(*[
+        textwrap.wrap(line, width=66)
+        for line in update.notes.splitlines()
+    ]))
+    for index, notes_line in enumerate(formatted_notes):
+        if index == 0:
+            assert "Notes: {}".format(notes_line) in result.output
+        else:
+            assert "     : {}".format(notes_line) in result.output
+    assert "Submitter: {}".format(update.username) in result.output
+    expected_submitted = "Submitted: {}".format(
+        update.date_submitted.strftime("%Y-%m-%d %H:%M:%S")
+    )
+    assert expected_submitted in result.output
+    for comment in update.comments:
+        assert "{user} - {date} (karma {karma})".format(
+            user=comment.username,
+            date=comment.timestamp.strftime("%Y-%m-%d %H:%M:%S"),
+            karma=comment.karma,
+        ) in result.output
+        assert comment.text.strip() in result.output
+    assert "1 updates found (1 shown)" in result.output
+    # CI Status
+    gw_ip = greenwave_container.get_IPv4s()[0]
+    greenwave_result = requests.post(
+        "http://{}:8080/api/v1.0/decision".format(gw_ip),
+        headers={"content-type": "application/json"},
+        data=json.dumps({
+            "product_version": update.release.lower().replace(' ', '-'),
+            "decision_context": (
+                "bodhi_update_push_stable" if update.status == "stable"
+                else "bodhi_update_push_testing"
+            ),
+            "subject": [
+                {"item": b, "type": "koji_build"}
+                for b in update.builds
+            ] + [
+                {"original_spec_nvr": b}
+                for b in update.builds
+            ] + [
+                {"item": update.alias, "type": "bodhi_update"}
+            ]
+        }),
+    ).json()
+    assert "summary" in greenwave_result
+    assert "CI Status: {}".format(greenwave_result["summary"]) in result.output
+
+
+def test_updates_download(bodhi_container, db_container):
+    """Test ``bodhi updates download``"""
+    # Fetch the last updates from the DB
+    builds = []
+    db_ip = db_container.get_IPv4s()[0]
+    query_updates = "SELECT id, alias FROM updates ORDER BY date_submitted DESC LIMIT 3"
+    query_builds = "SELECT nvr FROM builds WHERE update_id = %s ORDER BY nvr"
+    conn = psycopg2.connect("dbname=bodhi2 user=postgres host={}".format(db_ip))
+    with conn:
+        with conn.cursor() as curs:
+            curs.execute(query_updates)
+            updates = [_db_record_to_munch(curs, record) for record in curs]
+            for update in updates:
+                curs.execute(query_builds, (update.id, ))
+                builds.extend([r[0] for r in curs])
+    conn.close()
+    # Prepare the command to run
+    cmd = [
+        "updates", "download", "--arch", "all",
+        "--updateid", ",".join([u.alias for u in updates]),
+    ]
+    # The bodhi CLI will execute the koji CLI. Replace that executable with
+    # something we can track.
+    koji_mock = "#!/bin/sh\necho TESTING CALL $0 $@\n"
+    with replace_file(bodhi_container, "/usr/bin/koji", koji_mock):
+        result = _run_cli(bodhi_container, cmd)
+    assert result.exit_code == 0
+    for build_id in builds:
+        assert "Downloading packages from {}".format(build_id) in result.output
+        assert "TESTING CALL /usr/bin/koji download-build {}".format(build_id) in result.output

--- a/devel/ci/integration/tests/utils.py
+++ b/devel/ci/integration/tests/utils.py
@@ -1,0 +1,146 @@
+# Copyright © 2018 Red Hat, Inc.
+#
+# This file is part of Bodhi.
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+import os
+import shutil
+import subprocess
+import tempfile
+from contextlib import contextmanager
+
+import requests
+
+
+def get_db_dump(url):
+    """Get an app's database dump in the Fedora infrastructure.
+
+    The database dump will be uncompressed and store locally. If the local file
+    exists, it will used and not re-downloaded.
+
+    Args:
+        url (str): The URL to download the dump from.
+
+    Returns:
+        str: The local file path of the dump.
+    """
+    filename = os.path.basename(url)
+    if filename.endswith(".xz"):
+        filename = filename[:-3]
+    filepath = os.path.join("devel", "ci", "integration", "dumps", filename)
+    if os.path.exists(filepath):
+        return filepath
+    response = requests.get(url)
+    if url.endswith(".xz"):
+        compressed_filepath = "{}.xz".format(filepath)
+        with open(compressed_filepath, "wb") as fd:
+            for chunk in response.iter_content(chunk_size=128):
+                fd.write(chunk)
+        subprocess.call(["xz", "-d", compressed_filepath])
+    return filepath
+
+
+def make_db_and_user(db_container, name, dump_url=None):
+    """Create a database and a user in PostgreSQL.
+
+    Args:
+        db_container (conu.DockerContainer): The PostgreSQL container.
+        name (str): the database and use names to create.
+        dump_url (str): the URL of the database dump to preload the new
+            database with.
+    """
+    # Prepare the database
+    db_container.execute(
+        ["/usr/bin/psql", "-q", "-U", "postgres", "-c", "CREATE USER {} CREATEDB;".format(name)]
+    )
+    db_container.execute(
+        [
+            "/usr/bin/psql", "-q", "-U", "postgres", "-c",
+            (
+                "CREATE DATABASE {} WITH TEMPLATE = template0 ENCODING = 'UTF8' "
+                "LC_COLLATE = 'en_US.UTF-8' LC_CTYPE = 'en_US.UTF-8';"
+            ).format(name),
+        ]
+    )
+    if dump_url:
+        db_dump = get_db_dump(dump_url)
+        db_container.copy_to(db_dump, "/tmp/database.dump")
+        db_container.execute(["/usr/bin/psql", "-q", "-U", name, "-f", "/tmp/database.dump"])
+        db_container.execute(["rm", "/tmp/database.dump"])
+
+
+@contextmanager
+def read_file(container, path, binary=False):
+    """Read a file in a container.
+
+    Args:
+        container (conu.DockerContainer): The container where the file is.
+        path (str): The file path in the container.
+        binary (bool): Whether the file should be opened in binary mode.
+
+    Yields:
+        file: The opened file object.
+    """
+    with tempfile.TemporaryDirectory() as tempdir:
+        destfile = os.path.join(tempdir, "file")
+        container.copy_from(path, destfile)
+        mode = "rb" if binary else "r"
+        with open(destfile, mode) as fh:
+            yield fh
+
+
+@contextmanager
+def edit_file(container, path):
+    """Edit a file in a container.
+
+    Args:
+        container (conu.DockerContainer): The container where the file is.
+        path (str): The file path in the container.
+
+    Yields:
+        str: A path to a local file that will be synced back to the container.
+    """
+    with tempfile.TemporaryDirectory() as tempdir:
+        destfile = os.path.join(tempdir, "file")
+        container.copy_from(path, destfile)
+        yield destfile
+        container.copy_to(destfile, path)
+
+
+@contextmanager
+def replace_file(container, path, contents):
+    """Temporarily replace a file with the provided content in a container.
+
+    Args:
+        container (conu.DockerContainer): The container where the file is.
+        path (str): The file path in the container.
+        contents (str): The temporary content for the file.
+
+    Yields:
+        str: A path to a local file that will be synced back to the container.
+    """
+    with tempfile.TemporaryDirectory() as tempdir:
+        backupfile = os.path.join(tempdir, "original")
+        container.copy_from(path, backupfile)
+        newfile = os.path.join(tempdir, "replacement")
+        with open(newfile, "w") as f:
+            f.write(contents)
+        shutil.copymode(backupfile, newfile)
+        container.copy_to(newfile, path)
+        try:
+            yield
+        finally:
+            container.copy_to(backupfile, path)

--- a/devel/ci/integration/waiverdb/Dockerfile
+++ b/devel/ci/integration/waiverdb/Dockerfile
@@ -1,0 +1,22 @@
+FROM quay.io/factory2/waiverdb:prod
+LABEL \
+  name="waiverdb" \
+  vendor="Fedora Infrastructure" \
+  maintainer="Aurelien Bompard <abompard@fedoraproject.org>" \
+  license="MIT"
+
+# fedmsg needs a username.
+ENV USER=waiverdb
+
+# Become root during build to copy files
+USER 0
+
+# Make sure fedmsg can write its CRL.
+RUN chmod 777 /var/run/fedmsg/
+
+RUN mkdir -p /etc/waiverdb
+COPY devel/ci/integration/waiverdb/fedmsg.py /etc/fedmsg.d/zz_waiverdb.py
+COPY devel/ci/integration/waiverdb/settings.py /etc/waiverdb/settings.py
+
+# Become non-root again
+USER 1001

--- a/devel/ci/integration/waiverdb/fedmsg.py
+++ b/devel/ci/integration/waiverdb/fedmsg.py
@@ -1,0 +1,7 @@
+config = dict(
+    sign_messages=False,
+    active=True,
+    endpoints={},
+    environment='testing',
+    relay_inbound=["tcp://fedmsg:9941"],
+)

--- a/devel/ci/integration/waiverdb/settings.py
+++ b/devel/ci/integration/waiverdb/settings.py
@@ -1,0 +1,12 @@
+DATABASE_URI = 'postgresql+psycopg2://waiverdb@db:5432/waiverdb'
+SECRET_KEY = 'this-is-only-for-integration-testing'
+RESULTSDB_API_URL = 'https://resultsdb:8080/api/v2.0'
+CORS_URL = 'https://bodhi'
+
+# TODO: integration testing of published fedmsgs?
+# MESSAGE_BUS_PUBLISH = True
+MESSAGE_BUS_PUBLISH = False
+
+AUTH_METHOD = 'dummy'
+SUPERUSERS = ['bodhi@service']
+PORT = 8080

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,7 +27,7 @@ inherit = true
 add-ignore = D413
 
 [tool:pytest]
-addopts = --junit-xml=nosetests.xml --cov-config .coveragerc --cov=bodhi --cov-report term --cov-report xml --cov-report html
+addopts = --cov-config .coveragerc --cov=bodhi --cov-report term --cov-report xml --cov-report html
 
 [update_catalog]
 domain = bodhi

--- a/setup.py
+++ b/setup.py
@@ -88,6 +88,11 @@ setup(
         'pyyaml',
         'webtest',
         'mock',
+        'six',
+        'conu >= 0.5.0',
+        'munch',
+        'psycopg2',
+        'requests',
     ],
 )
 


### PR DESCRIPTION
It currently only works for F27 and Python 2 (which is what we currently
have in prod) but it should be possible to expand that in the future if
there's a need.

The created container is different from the currently created bodhi
containers because it tries to be as close as possible to the production
setup: bodhi is running behind apache, with the production.ini
configuration file, etc.

The integration test suite executes on the host running bodhi-ci via
pytest, but will start and test containers running the components
(currently only Bodhi and PostgreSQL). It only tests a successful GET on
/ for now, it should be easy to add more tests.

Signed-off-by: Aurélien Bompard <aurelien@bompard.org>