### PR TITLE
Do not require pyramid_tm.

### DIFF
--- a/devel/development.ini.example
+++ b/devel/development.ini.example
@@ -26,7 +26,6 @@ pyramid.debug_routematch = true
 pyramid.default_locale_name = en
 pyramid.includes =
     pyramid_debugtoolbar
-    pyramid_tm
 debugtoolbar.hosts = 127.0.0.1 ::1
 sqlalchemy.url = sqlite:///%(here)s/bodhi.db
 authtkt.secret = changethisinproduction!

--- a/docs/user/release_notes.rst
+++ b/docs/user/release_notes.rst
@@ -10,6 +10,7 @@ Dependency changes
 
 * Bodhi now fully supports Python 3.
 * Bodhi now works with markdown 3 and click 7.
+* Bodhi no longer requires pyramid_tm.
 
 
 Server upgrade instructions

--- a/production.ini
+++ b/production.ini
@@ -526,9 +526,6 @@ pyramid.debug_notfound = true
 pyramid.debug_routematch = true
 pyramid.default_locale_name = en
 
-pyramid.includes =
-    pyramid_tm
-
 debugtoolbar.hosts = 127.0.0.1 ::1
 
 ##

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,6 @@ pylibravatar
 pyramid~=1.7
 pyramid_fas_openid
 pyramid_mako
-pyramid_tm
 python-bugzilla
 python-fedora
 simplemediawiki


### PR DESCRIPTION
Bodhi didn't actually use pyramid_tm anymore, and including it in
the pyramid_include setting recently started to cause several
tests to fail as pyramid_tm is not compatible with the latest
version of transaction.

fixes #1616

Signed-off-by: Randy Barlow <randy@electronsweatshop.com>