### PR TITLE
Convert subprocess.communicate()'s output to str in the composer.

### DIFF
--- a/bodhi/server/consumers/masher.py
+++ b/bodhi/server/consumers/masher.py
@@ -1222,6 +1222,8 @@ class PungiComposerThread(ComposerThread):
             return
         self.log.info('Waiting for pungi process to finish')
         out, err = pungi_process.communicate()
+        out = out.decode()
+        err = err.decode()
         self.devnull.close()
         if pungi_process.returncode != 0:
             self.log.error('Pungi exited with exit code %d', pungi_process.returncode)

--- a/bodhi/tests/server/consumers/test_masher.py
+++ b/bodhi/tests/server/consumers/test_masher.py
@@ -268,7 +268,7 @@ Compose dir: %s
 That was the actual one''' % mash_dir
 
             fake_popen = mock.MagicMock()
-            fake_popen.communicate = lambda: (fake_stdout, 'hello')
+            fake_popen.communicate = lambda: (fake_stdout.encode(), b'hello')
             fake_popen.poll.return_value = None
             fake_popen.returncode = 0
             return fake_popen
@@ -630,11 +630,11 @@ References:
             t.release = session.query(Release).filter_by(name=u'F17').one()
             try:
                 fake_popen = mock.MagicMock()
-                fake_stdout = '''Some output
+                fake_stdout = b'''Some output
 Some more output ...... This is not a Compose dir: ....
 Compose dir: /tmp/nonsensical_directory
 That was the actual one'''
-                fake_popen.communicate = lambda: (fake_stdout, 'hello')
+                fake_popen.communicate = lambda: (fake_stdout, b'hello')
                 fake_popen.poll.return_value = None
                 fake_popen.returncode = 0
                 t._startyear = datetime.datetime.utcnow().year
@@ -660,10 +660,10 @@ That was the actual one'''
             t.release = session.query(Release).filter_by(name=u'F17').one()
             try:
                 fake_popen = mock.MagicMock()
-                fake_stdout = '''Some output
+                fake_stdout = b'''Some output
     Some more output ...... This is not a Compose dir: ....
     That was the actual one'''
-                fake_popen.communicate = lambda: (fake_stdout, 'hello')
+                fake_popen.communicate = lambda: (fake_stdout, b'hello')
                 fake_popen.poll.return_value = None
                 fake_popen.returncode = 0
                 t._startyear = datetime.datetime.utcnow().year


### PR DESCRIPTION
subprocess returns bytes in Python 3, and so we need to convert
the output to a str before using it.

fixes #2738

Signed-off-by: Randy Barlow <randy@electronsweatshop.com>