### PR TITLE
Properly parse container pull specs from koji metadata

### DIFF
--- a/bodhi/server/buildsys.py
+++ b/bodhi/server/buildsys.py
@@ -277,9 +277,9 @@ class DevBuildsys(Buildsystem):
                     'container_koji_task_id': 19708268,
                     'image': {
                         'index': {
-                            'pull': ['{registry}/{repository}:{hash}'
+                            'pull': ['{registry}/{repository}@sha256:{hash}'
                                      .format(**format_data),
-                                     '{registry}/{repository}:{version}:{release}'
+                                     '{registry}/{repository}:{version}-{release}'
                                      .format(**format_data)],
                         }
                     },

--- a/bodhi/server/util.py
+++ b/bodhi/server/util.py
@@ -25,6 +25,7 @@ import hashlib
 import json
 import os
 import pkg_resources
+import re
 import socket
 import subprocess
 import tempfile
@@ -1428,11 +1429,11 @@ class no_autoflush(object):
 
 def _get_build_repository(build):
     """
-    Return the registry repository name for the given Build.
+    Return the registry repository name for the given Build from the container's pull string.
 
-    For example, if the Build's container pull string is:
-
-    'candidate-registry.fedoraproject.org/f29/cockpit:176-5.fc28', this will return 'f29/cockpit'.
+    Examples -
+    'candidate-registry.fedoraproject.org/f29/cockpit:176-5.fc28' => 'f29/cockpit'.
+    'candidate-registry.fedoraproject.org/myrepo@sha256:<hash>' => 'myrepo'.
 
     Args:
         build (bodhi.server.models.Build): A Build representing a container or flatpak.
@@ -1443,9 +1444,8 @@ def _get_build_repository(build):
     koji_build = koji.getBuild(build.nvr)
 
     pull_specs = koji_build['extra']['image']['index']['pull']
-    # Specs are of the form 'candidate-registry.fedoraproject.org/f29/cockpit:176-5.fc28'
     # All the pull specs should have the same repository, so which one we use is arbitrary
-    base, tag = pull_specs[0].split(':', 1)
+    base, tag = re.compile(r'[:@]').split(pull_specs[0], 1)
     server, repository = base.split('/', 1)
 
     return repository

--- a/bodhi/tests/server/test_util.py
+++ b/bodhi/tests/server/test_util.py
@@ -1458,6 +1458,30 @@ class TestCMDFunctions(base.BaseTestCase):
         mock_error.assert_not_called()
         mock_debug.assert_called_with('output\nerror')
 
+    @mock.patch('bodhi.server.buildsys.get_session')
+    def test__get_build_repository(self, session):
+        session.return_value = mock.Mock()
+        session.return_value.getBuild.side_effect = [
+            {
+                'extra': {
+                    'image': {
+                        'index': {
+                            'pull': [pullspec]
+                        }
+                    }
+                }
+            }
+            for pullspec in [
+                'candidate-registry.fedoraproject.org/f29/cockpit:176-5.fc28',
+                'candidate-registry.fedoraproject.org/myrepo@sha256:abcdefg123456'
+            ]
+        ]
+        build = mock.Mock()
+        build.nvr = 'cockpit-167-5'
+        self.assertEqual(util._get_build_repository(build), 'f29/cockpit')
+        self.assertEqual(util._get_build_repository(build), 'myrepo')
+        session.return_value.getBuild.assert_called_with('cockpit-167-5')
+
 
 class TestTransactionalSessionMaker(base.BaseTestCase):
     """This class contains tests on the TransactionalSessionMaker class."""


### PR DESCRIPTION
The test for extracting container pull specs  did not match the actual
metadata atomic-reactor saves, so we weren't properly handling pull
specs of the form <repo>@sha256:<hash>.

Fixes #2742