### PR TITLE
Don't try to encode() byte arrays.

### DIFF
--- a/bodhi/server/consumers/masher.py
+++ b/bodhi/server/consumers/masher.py
@@ -1324,7 +1324,7 @@ class PungiComposerThread(ComposerThread):
                 self.log.exception('Error fetching repomd.xml')
                 time.sleep(200)
                 continue
-            newsum = hashlib.sha1(masterrepomd.read().encode('utf-8')).hexdigest()
+            newsum = hashlib.sha1(masterrepomd.read()).hexdigest()
             if newsum == checksum:
                 self.log.info("master repomd.xml matches!")
                 notifications.publish(


### PR DESCRIPTION
byte arrays don't have an encode() method, and in Python 2 it
doesn't make sense to call encode() on a str either. The mocks on
this function were returning incorrect types in Python 3 (a str
instead of a byte).

This commit fixes the mocks to return correct types in both Python
versions, and fixes the composer so that it does not try to call
encode() on those responses.

fixes #2746

Signed-off-by: Randy Barlow <randy@electronsweatshop.com>