### PR TITLE
Remove some cruft that was needed to run on EL 7.

### DIFF
--- a/apache/bodhi.wsgi
+++ b/apache/bodhi.wsgi
@@ -1,7 +1,3 @@
-import __main__
-__requires__ = __main__.__requires__ = 'WebOb>=1.4.1'  # Force forward-compat packages on epel7
-import pkg_resources
-
 import sys
 sys.stdout = sys.stderr
 

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,3 @@
-import __main__
-__requires__ = __main__.__requires__ = 'WebOb>=1.4.1'
-import pkg_resources  # noqa
-
 # The following two imports are required to shut up an
 # atexit error when running tests with python 2.7
 from setuptools import setup, find_packages  # noqa


### PR DESCRIPTION
EPEL 7 had an old verion of WebOb and so there were some Python
hacks to get Bodhi to use a newer WebOb from EPEL. Bodhi hasn't
supported EPEL in a long time, so we do not need these hacks
anymore, and they present a problem in Rawhide where we want to
ship the Python 2 version of the client but not the server.

Signed-off-by: Randy Barlow <randy@electronsweatshop.com>