### PR TITLE
Convert Bodhi to publish messages via AMQP

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -20,6 +20,10 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
  # if you have other services listening on your host's port 80.
  config.vm.network "forwarded_port", guest: 6543, host: 6543
 
+ # Forward traffic on the host to the RabbitMQ management UI on the guest.
+ # This allows developers to view message queues at http://localhost:15672/
+ config.vm.network "forwarded_port", guest: 15672, host: 15672
+
  # This is an optional plugin that, if installed, updates the host's /etc/hosts
  # file with the hostname of the guest VM. In Fedora it is packaged as
  # ``vagrant-hostmanager``

--- a/bodhi/server/notifications.py
+++ b/bodhi/server/notifications.py
@@ -23,6 +23,7 @@ import logging
 import socket
 
 from sqlalchemy import event
+from fedora_messaging import api, exceptions as fml_exceptions
 import fedmsg
 import fedmsg.config
 import fedmsg.encoding
@@ -97,7 +98,68 @@ def send_fedmsgs_after_commit(session):
             session.info['fedmsg'][topic] = []
 
 
+@event.listens_for(Session, 'after_commit')
+def send_messages_after_commit(session):
+    """
+    Send messages via AMQP after a database commit occurs.
+
+    Args:
+        session (sqlalchemy.orm.session.Session): The session that was committed.
+    """
+    if 'messages' in session.info:
+        for m in session.info['messages']:
+            try:
+                api.publish(m)
+            except fml_exceptions.BaseException:
+                # In the future we should handle errors more gracefully
+                _log.exception("An error occurred publishing %r after a database commit", m)
+        session.info['messages'] = []
+
+
 def publish(topic, msg, force=False):
+    """
+    Send a message via AMQP or fedmsg.
+
+    This is used to send a message to fedmsg if "fedmsg_enabled" is true in the
+    application configuration, otherwise it will use AMQP.
+
+    Args:
+        topic (str): The topic suffix. The "bodhi" prefix is applied, along with
+            the "topic_prefix" and "environment" settings from fedmsg.
+        msg (dict): The message body to send.
+        force (bool): If False (the default), the message is only sent after the
+            currently active database transaction successfully commits. If true,
+            the messages is sent immediately.
+    """
+    if bodhi.server.config.config.get('fedmsg_enabled'):
+        _fedmsg_publish(topic, msg, force)
+        return
+
+    # Dirty, nasty hack that I feel shame for: fedmsg modifies messages quietly
+    # if they have objects with __json__ methods on them. For now, copy that
+    # behavior. In the future, callers should pass fedora_messaging.api.Message
+    # sub-classes or this whole API should go away.
+    body = fedmsg.encoding.loads(fedmsg.encoding.dumps(msg))
+
+    # Dirty, nasty hack #2: fedmsg mangles the topic in various ways. Duplicate
+    # that behavior here for now. In the future callers should pass proper topics.
+    fedmsg_conf = fedmsg.config.load_config()
+    topic = "{prefix}.{env}.bodhi.{t}".format(
+        prefix=fedmsg_conf["topic_prefix"], env=fedmsg_conf["environment"], t=topic)
+
+    message = api.Message(topic=topic, body=body)
+    if force:
+        api.publish(message)
+        return
+
+    session = Session()
+    if 'messages' not in session.info:
+        session.info['messages'] = []
+    session.info['messages'].append(message)
+    _log.debug('Queuing message %r for delivery on session commit', message.id)
+
+
+def _fedmsg_publish(topic, msg, force):
     """Publish a message to fedmsg.
 
     By default, messages are not sent immediately, but are queued in a
@@ -114,10 +176,6 @@ def publish(topic, msg, force=False):
         force (bool): If True, send the message immediately. Else, queue the message to be sent
             after the current database transaction is committed.
     """
-    if not bodhi.server.config.config.get('fedmsg_enabled'):
-        _log.warning("fedmsg disabled.  not sending %r" % topic)
-        return
-
     # Initialize right before we try to publish, but only if we haven't
     # initialized for this thread already.
     if not fedmsg_is_initialized():

--- a/bodhi/tests/server/consumers/test_masher.py
+++ b/bodhi/tests/server/consumers/test_masher.py
@@ -32,6 +32,8 @@ except ImportError:
     IncompleteRead = None
 
 from click import testing
+from fedora_messaging import api
+from fedora_messaging.testing import mock_sends
 import mock
 import six
 import six.moves.urllib.parse as urlparse
@@ -2666,7 +2668,8 @@ class TestComposerThread_perform_gating(ComposerThreadBaseTestCase):
         t.db = self.db
         t.id = getattr(self.db.query(Release).one(), '{}_tag'.format('stable'))
 
-        t.perform_gating()
+        with mock_sends(api.Message):
+            t.perform_gating()
 
         # Without the call to self.db.expire() at the end of perform_gating(), there would be 1
         # update here.

--- a/bodhi/tests/server/functional/test_stacks.py
+++ b/bodhi/tests/server/functional/test_stacks.py
@@ -21,6 +21,7 @@ import copy
 
 import mock
 import webtest
+from fedora_messaging import api, testing as fml_testing
 
 from bodhi.server import main
 from bodhi.server.models import Group, RpmPackage, Stack, User
@@ -117,7 +118,8 @@ class TestStacksService(base.BaseTestCase):
         self.db.commit()
         attrs = {'name': u'KDE', 'packages': 'kde-filesystem kdegames',
                  'csrf_token': self.get_csrf_token()}
-        res = self.app.post("/stacks/", attrs, status=200)
+        with fml_testing.mock_sends(api.Message):
+            res = self.app.post("/stacks/", attrs, status=200)
         body = res.json_body['stack']
         self.assertEqual(body['name'], 'KDE')
         r = self.db.query(Stack).filter(Stack.name == attrs["name"]).one()
@@ -149,7 +151,8 @@ class TestStacksService(base.BaseTestCase):
         attrs = {"name": u"Hackey", "packages": "nethack",
                  "requirements": u"rpmlint",
                  "csrf_token": self.get_csrf_token()}
-        res = self.app.post("/stacks/", attrs)
+        with fml_testing.mock_sends(api.Message):
+            res = self.app.post("/stacks/", attrs)
         body = res.json_body['stack']
         self.assertEqual(body['name'], 'Hackey')
         r = self.db.query(Stack).filter(Stack.name == attrs["name"]).one()
@@ -164,7 +167,8 @@ class TestStacksService(base.BaseTestCase):
         attrs = {'name': 'GNOME', 'packages': 'gnome-music gnome-shell',
                  'description': 'foo', 'requirements': 'upgradepath',
                  'csrf_token': self.get_csrf_token()}
-        res = self.app.post("/stacks/", attrs, status=200)
+        with fml_testing.mock_sends(api.Message):
+            res = self.app.post("/stacks/", attrs, status=200)
         body = res.json_body['stack']
         self.assertEqual(body['name'], 'GNOME')
         self.assertEqual(len(body['packages']), 2)
@@ -181,7 +185,8 @@ class TestStacksService(base.BaseTestCase):
         self.assertEqual(package.requirements, None)
 
     def test_delete_stack(self):
-        res = self.app.delete("/stacks/GNOME")
+        with fml_testing.mock_sends(api.Message):
+            res = self.app.delete("/stacks/GNOME")
         self.assertEqual(res.json_body['status'], 'success')
         self.assertEqual(self.db.query(Stack).count(), 0)
 
@@ -191,7 +196,8 @@ class TestStacksService(base.BaseTestCase):
         self.db.commit()
         attrs = {'name': 'GNOME', 'packages': 'gnome-music',
                  'csrf_token': self.get_csrf_token()}
-        res = self.app.post("/stacks/", attrs, status=200)
+        with fml_testing.mock_sends(api.Message):
+            res = self.app.post("/stacks/", attrs, status=200)
         body = res.json_body['stack']
         self.assertEqual(body['name'], 'GNOME')
         self.assertEqual(len(body['packages']), 1)
@@ -237,7 +243,8 @@ class TestStacksService(base.BaseTestCase):
         self.db.commit()
         attrs = {'name': 'GNOME', 'packages': 'gnome-music gnome-shell',
                  'csrf_token': self.get_csrf_token()}
-        res = self.app.post("/stacks/", attrs, status=200)
+        with fml_testing.mock_sends(api.Message):
+            res = self.app.post("/stacks/", attrs, status=200)
         body = res.json_body['stack']
         self.assertEqual(body['name'], 'GNOME')
         self.assertEqual(len(body['packages']), 2)
@@ -255,7 +262,8 @@ class TestStacksService(base.BaseTestCase):
         self.db.commit()
         attrs = {'name': 'GNOME', 'packages': 'gnome-music gnome-shell',
                  'csrf_token': self.get_csrf_token()}
-        res = self.app.post("/stacks/", attrs, status=200)
+        with fml_testing.mock_sends(api.Message):
+            res = self.app.post("/stacks/", attrs, status=200)
         body = res.json_body['stack']
         self.assertEqual(body['name'], 'GNOME')
         self.assertEqual(len(body['packages']), 2)

--- a/bodhi/tests/server/scripts/test_approve_testing.py
+++ b/bodhi/tests/server/scripts/test_approve_testing.py
@@ -21,6 +21,7 @@ This module contains tests for the bodhi.server.scripts.approve_testing module.
 """
 from datetime import datetime, timedelta
 
+from fedora_messaging import api, testing as fml_testing
 from mock import patch
 from six import StringIO
 
@@ -169,7 +170,8 @@ class TestMain(BaseTestCase):
 
         with patch('bodhi.server.scripts.approve_testing.initialize_db'):
             with patch('bodhi.server.scripts.approve_testing.get_appsettings', return_value=''):
-                approve_testing.main(['nosetests', 'some_config.ini'])
+                with fml_testing.mock_sends(api.Message):
+                    approve_testing.main(['nosetests', 'some_config.ini'])
 
                 # Now we will run main() again, but this time we expect Bodhi not to add any
                 # further comments.
@@ -201,7 +203,8 @@ class TestMain(BaseTestCase):
 
         with patch('bodhi.server.scripts.approve_testing.initialize_db'):
             with patch('bodhi.server.scripts.approve_testing.get_appsettings', return_value=''):
-                approve_testing.main(['nosetests', 'some_config.ini'])
+                with fml_testing.mock_sends(api.Message):
+                    approve_testing.main(['nosetests', 'some_config.ini'])
 
                 # Now we will run main() again, but this time we expect Bodhi not to add any
                 # further comments.
@@ -235,7 +238,8 @@ class TestMain(BaseTestCase):
 
         with patch('bodhi.server.scripts.approve_testing.initialize_db'):
             with patch('bodhi.server.scripts.approve_testing.get_appsettings', return_value=''):
-                approve_testing.main(['nosetests', 'some_config.ini'])
+                with fml_testing.mock_sends(api.Message):
+                    approve_testing.main(['nosetests', 'some_config.ini'])
 
                 # Now we will run main() again, but this time we expect Bodhi not to add any
                 # further comments.
@@ -266,7 +270,8 @@ class TestMain(BaseTestCase):
 
         with patch('bodhi.server.scripts.approve_testing.initialize_db'):
             with patch('bodhi.server.scripts.approve_testing.get_appsettings', return_value=''):
-                approve_testing.main(['nosetests', 'some_config.ini'])
+                with fml_testing.mock_sends(api.Message):
+                    approve_testing.main(['nosetests', 'some_config.ini'])
 
                 # Now we will run main() again, but this time we expect Bodhi not to add any
                 # further comments.
@@ -298,7 +303,8 @@ class TestMain(BaseTestCase):
 
         with patch('bodhi.server.scripts.approve_testing.initialize_db'):
             with patch('bodhi.server.scripts.approve_testing.get_appsettings', return_value=''):
-                approve_testing.main(['nosetests', 'some_config.ini'])
+                with fml_testing.mock_sends(api.Message):
+                    approve_testing.main(['nosetests', 'some_config.ini'])
 
         # The bodhi user shouldn't exist, since it shouldn't have made any comments
         self.assertEqual(self.db.query(models.User).filter_by(name=u'bodhi').count(), 0)
@@ -322,7 +328,8 @@ class TestMain(BaseTestCase):
 
         with patch('bodhi.server.scripts.approve_testing.initialize_db'):
             with patch('bodhi.server.scripts.approve_testing.get_appsettings', return_value=''):
-                approve_testing.main(['nosetests', 'some_config.ini'])
+                with fml_testing.mock_sends(api.Message):
+                    approve_testing.main(['nosetests', 'some_config.ini'])
 
         # The bodhi user shouldn't exist, since it shouldn't have made any comments
         self.assertEqual(self.db.query(models.User).filter_by(name=u'bodhi').count(), 0)
@@ -346,7 +353,8 @@ class TestMain(BaseTestCase):
 
         with patch('bodhi.server.scripts.approve_testing.initialize_db'):
             with patch('bodhi.server.scripts.approve_testing.get_appsettings', return_value=''):
-                approve_testing.main(['nosetests', 'some_config.ini'])
+                with fml_testing.mock_sends(api.Message):
+                    approve_testing.main(['nosetests', 'some_config.ini'])
 
         # The bodhi user shouldn't exist, since it shouldn't have made any comments
         self.assertEqual(self.db.query(models.User).filter_by(name=u'bodhi').count(), 0)
@@ -374,7 +382,8 @@ class TestMain(BaseTestCase):
 
         with patch('bodhi.server.scripts.approve_testing.initialize_db'):
             with patch('bodhi.server.scripts.approve_testing.get_appsettings', return_value=''):
-                approve_testing.main(['nosetests', 'some_config.ini'])
+                with fml_testing.mock_sends(api.Message, api.Message):
+                    approve_testing.main(['nosetests', 'some_config.ini'])
 
         bodhi = self.db.query(models.User).filter_by(name=u'bodhi').one()
         comment_q = self.db.query(models.Comment).filter_by(update_id=update.id, user_id=bodhi.id)
@@ -396,7 +405,8 @@ class TestMain(BaseTestCase):
         update.stable_karma = 1
         update.status = models.UpdateStatus.testing
         update.comment(self.db, u'testing', author=u'hunter2', anonymous=False, karma=1)
-        self.db.commit()
+        with fml_testing.mock_sends(api.Message):
+            self.db.commit()
 
         with patch('bodhi.server.scripts.approve_testing.initialize_db'):
             with patch('bodhi.server.scripts.approve_testing.get_appsettings', return_value=''):
@@ -428,9 +438,11 @@ class TestMain(BaseTestCase):
 
         with patch('bodhi.server.scripts.approve_testing.initialize_db'):
             with patch('bodhi.server.scripts.approve_testing.get_appsettings', return_value=''):
-                approve_testing.main(['nosetests', 'some_config.ini'])
+                with fml_testing.mock_sends(api.Message):
+                    approve_testing.main(['nosetests', 'some_config.ini'])
                 update.comment(self.db, u"Removed build", 0, u'bodhi')
-                approve_testing.main(['nosetests', 'some_config.ini'])
+                with fml_testing.mock_sends(api.Message):
+                    approve_testing.main(['nosetests', 'some_config.ini'])
 
         bodhi = self.db.query(models.User).filter_by(name=u'bodhi').one()
         cmnts = self.db.query(models.Comment).filter_by(update_id=update.id, user_id=bodhi.id)

--- a/bodhi/tests/server/scripts/test_dequeue_stable.py
+++ b/bodhi/tests/server/scripts/test_dequeue_stable.py
@@ -22,6 +22,7 @@ This module contains tests for the bodhi.server.scripts.dequeue_stable module.
 from datetime import datetime, timedelta
 
 from click import testing
+from fedora_messaging import api, testing as fml_testing
 import mock
 
 from bodhi.server import config, models
@@ -54,7 +55,8 @@ class TestDequeueStable(BaseTestCase):
         self.db.add(update_2)
         self.db.commit()
 
-        result = runner.invoke(dequeue_stable.dequeue_stable, [])
+        with fml_testing.mock_sends(api.Message):
+            result = runner.invoke(dequeue_stable.dequeue_stable, [])
 
         self.assertEqual(result.exit_code, 0)
         self.assertTrue(config.config['not_yet_tested_msg'] in result.output)
@@ -84,7 +86,8 @@ class TestDequeueStable(BaseTestCase):
         update.date_testing = datetime.utcnow() - timedelta(days=7)
         self.db.commit()
 
-        result = runner.invoke(dequeue_stable.dequeue_stable, [])
+        with fml_testing.mock_sends(api.Message):
+            result = runner.invoke(dequeue_stable.dequeue_stable, [])
         self.assertEqual(result.exit_code, 0)
 
         update = self.db.query(models.Update).all()[0]

--- a/bodhi/tests/server/scripts/test_expire_overrides.py
+++ b/bodhi/tests/server/scripts/test_expire_overrides.py
@@ -18,6 +18,7 @@ import unittest
 from datetime import timedelta
 
 import mock
+from fedora_messaging import api, testing as fml_testing
 from six import StringIO
 
 from bodhi.server import models
@@ -100,10 +101,11 @@ class TestMain(BaseTestCase):
             with mock.patch('bodhi.server.scripts.expire_overrides.get_appsettings',
                             return_value=''):
                 with mock.patch('bodhi.server.scripts.expire_overrides.setup_logging'):
-                    expire_overrides.main(['expire_overrides', 'some_config.ini'])
+                    with fml_testing.mock_sends(api.Message):
+                        expire_overrides.main(['expire_overrides', 'some_config.ini'])
 
         log_info.assert_has_calls([mock.call('Expiring %d buildroot overrides...', 1),
-                                   mock.call(u'Expired bodhi-2.0-1.fc17')])
+                                   mock.call(u'Expired bodhi-2.0-1.fc17')], any_order=True)
         self.assertNotEqual(buildrootoverride.expired_date, None)
 
     @mock.patch('sys.exit')

--- a/bodhi/tests/server/services/test_overrides.py
+++ b/bodhi/tests/server/services/test_overrides.py
@@ -20,6 +20,7 @@
 from datetime import datetime, timedelta
 import copy
 
+from fedora_messaging import api, testing as fml_testing
 import mock
 import webtest
 
@@ -781,7 +782,8 @@ class TestOverridesWebViews(base.BaseTestCase):
                 'edited': 'bodhi-2.0-1.fc17', 'expired': True,
                 'csrf_token': self.get_csrf_token()}
 
-        self.app.post('/overrides/', data)
+        with fml_testing.mock_sends(api.Message):
+            self.app.post('/overrides/', data)
         resp = self.app.get('/overrides/bodhi-2.0-1.fc17',
                             status=200, headers={'Accept': 'text/html'})
 

--- a/bodhi/tests/server/test_models.py
+++ b/bodhi/tests/server/test_models.py
@@ -1542,6 +1542,7 @@ class TestUpdateEdit(BaseTestCase):
             build.nvr: {
                 'nvr': build._get_n_v_r(), 'info': buildsys.get_session().getBuild(build.nvr)}}
         request.db = self.db
+        request.user.name = 'tester'
         update.release.pending_signing_tag = ''
         self.db.flush()
 

--- a/bodhi/tests/server/test_validators.py
+++ b/bodhi/tests/server/test_validators.py
@@ -22,6 +22,7 @@ import unittest
 
 import mock
 from cornice.errors import Errors
+from fedora_messaging import api, testing as fml_testing
 from pyramid import exceptions
 
 from bodhi.tests.server.base import BaseTestCase
@@ -56,7 +57,8 @@ class TestValidateCSRFToken(BaseTestCase):
                    'csrf_token': self.get_csrf_token()}
 
         # This should not cause any error.
-        self.app.post_json('/comments/', comment, status=200)
+        with fml_testing.mock_sends(api.Message):
+            self.app.post_json('/comments/', comment, status=200)
 
 
 class TestGetValidRequirements(unittest.TestCase):

--- a/devel/ansible/roles/bodhi/defaults/main.yml
+++ b/devel/ansible/roles/bodhi/defaults/main.yml
@@ -1,0 +1,1 @@
+rabbitmq_cluster_file_limit: 500000

--- a/devel/ansible/roles/bodhi/files/print-messages.service
+++ b/devel/ansible/roles/bodhi/files/print-messages.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Print messages sent to the amq.topic exchange
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+User=vagrant
+ExecStart=/usr/bin/fedora-messaging consume --callback="fedora_messaging.example:printer"
+
+[Install]
+WantedBy=multi-user.target

--- a/devel/ansible/roles/bodhi/handlers/main.yml
+++ b/devel/ansible/roles/bodhi/handlers/main.yml
@@ -1,0 +1,5 @@
+- name: reload rabbitmq
+  systemd:
+    name: rabbitmq-server
+    state: restarted
+    daemon_reload: yes

--- a/devel/ansible/roles/bodhi/tasks/main.yml
+++ b/devel/ansible/roles/bodhi/tasks/main.yml
@@ -7,6 +7,7 @@
       - docker
       - fedmsg-hub
       - fedmsg-relay
+      - fedora-messaging
       - freetype-devel
       - gcc
       - git

--- a/devel/ansible/roles/bodhi/tasks/main.yml
+++ b/devel/ansible/roles/bodhi/tasks/main.yml
@@ -208,6 +208,7 @@
   with_items:
       - bodhi.service
       - fedmsg-tail.service
+      - print-messages.service
 
 - name: Install the .bashrc
   copy:
@@ -231,6 +232,9 @@
       dest: /etc/motd
       mode: 0644
 
+- name: Set up the RabbitMQ broker
+  import_tasks: rabbitmq.yml
+
 - name: Remove default fedmsg endpoints
   file: path=/etc/fedmsg.d/endpoints.py state=absent
 
@@ -252,6 +256,12 @@
 - name: Start and enable the docker service
   service:
       name: docker
+      state: started
+      enabled: yes
+
+- name: Start and enable the fedora-messaging print service
+  service:
+      name: print-messages
       state: started
       enabled: yes
 

--- a/devel/ansible/roles/bodhi/tasks/rabbitmq.yml
+++ b/devel/ansible/roles/bodhi/tasks/rabbitmq.yml
@@ -1,0 +1,49 @@
+---
+- name: Install RabbitMQ packages
+  package:
+      name: "{{ item }}"
+      state: present
+  with_items:
+      - rabbitmq-server
+
+- name: Create RabbitMQ systemd override directory
+  file:
+    path: /etc/systemd/system/rabbitmq-server.service.d/
+    state: directory
+
+- name: Override file limit on rabbitmq
+  copy:
+    content: "[Service]\nLimitNOFILE={{rabbitmq_cluster_file_limit}}\n"
+    dest: /etc/systemd/system/rabbitmq-server.service.d/override.conf
+  notify:
+    - reload rabbitmq
+
+- name: Enables the rabbitmq management and SSL authentication plugins
+  rabbitmq_plugin:
+    names: rabbitmq_management,rabbitmq_auth_mechanism_ssl
+  notify:
+    - reload rabbitmq
+
+- name: start rabbitmq
+  service: name=rabbitmq-server state=started enabled=yes
+
+- name: Ensure default vhost exists
+  rabbitmq_vhost:
+    name: /
+    state: present
+
+- name: Create a guest user in RabbitMQ
+  rabbitmq_user:
+    user: guest
+    password: guest
+    tags: administrator
+    permissions:
+      - vhost: /
+        configure_priv: .*
+        read_priv: .*
+        write_priv: .*
+      - vhost: /
+        configure_priv: .*
+        read_priv: .*
+        write_priv: .*
+    state: present

--- a/devel/ci/Dockerfile-f28
+++ b/devel/ci/Dockerfile-f28
@@ -78,7 +78,9 @@ RUN dnf install --disablerepo rawhide-modular -y \
     python2-libcomps
 
 # sqlalchemy_schemadisplay is not packaged for Python 3 in Fedora < 30
-RUN pip-3 install sqlalchemy_schemadisplay
+# fedora_messaging isn't packaged for Fedora 28
+RUN pip-3 install sqlalchemy_schemadisplay fedora_messaging
+RUN pip install fedora_messaging
 
 # Fake pungi being installed so we can avoid it and all its dependencies
 RUN ln -s /usr/bin/true /usr/bin/pungi-koji

--- a/devel/ci/Dockerfile-f29
+++ b/devel/ci/Dockerfile-f29
@@ -9,6 +9,7 @@ RUN dnf upgrade -y libsolv || echo "We are not trying to test dnf upgrade, so ig
 RUN dnf upgrade -y || echo "We are not trying to test dnf upgrade, so ignoring dnf failure."
 RUN dnf install --disablerepo rawhide-modular -y \
     createrepo_c \
+    fedora-messaging \
     findutils \
     git \
     liberation-mono-fonts \
@@ -79,6 +80,8 @@ RUN dnf install --disablerepo rawhide-modular -y \
 
 # sqlalchemy_schemadisplay is not packaged for Python 3 in Fedora < 30
 RUN pip-3 install sqlalchemy_schemadisplay
+# fedora_messaging isn't packaged for Python 2 in Fedora
+RUN pip install fedora_messaging
 
 # Fake pungi being installed so we can avoid it and all its dependencies
 RUN ln -s /usr/bin/true /usr/bin/pungi-koji

--- a/devel/ci/Dockerfile-rawhide
+++ b/devel/ci/Dockerfile-rawhide
@@ -4,6 +4,7 @@ LABEL maintainer="Randy Barlow <bowlofeggs@fedoraproject.org>"
 RUN dnf upgrade -y
 RUN dnf install --disablerepo rawhide-modular -y \
     createrepo_c \
+    fedora-messaging \
     findutils \
     git \
     liberation-mono-fonts \

--- a/devel/ci/integration/bodhi/Dockerfile
+++ b/devel/ci/integration/bodhi/Dockerfile
@@ -16,6 +16,7 @@ RUN sed -i '/nodocs/d' /etc/dnf/dnf.conf
 # 3. python3-bodhi-client
 RUN dnf install -y \
     \
+    fedora-messaging \
     httpd \
     intltool \
     liberation-mono-fonts \

--- a/docs/developer/vagrant.rst
+++ b/docs/developer/vagrant.rst
@@ -22,6 +22,12 @@ guest's port 6543, so you can now visit http://localhost:6543 with your browser 
 development instance if your browser is on the same host as the Vagrant host. If not, you will need
 to connect to port 6543 on your Vagrant host, which is an exercise left for the reader.
 
+The ``Vagrantfile`` also sets up a port forward from the host machine's port
+15672 to the Vagrant guest's port 15672. The Vagrant guest runs an AMQP message
+broker (RabbitMQ) which has a web interface for monitoring and administration
+at http://localhost:15672. The default username is "guest" and the password is
+"guest".
+
 
 .. _Vagrant: https://www.vagrantup.com
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,8 @@ cornice>=3.1.0
 cryptography
 dogpile.cache
 fedmsg[consumers]
+pyasn1-modules  # Due to an unfortunate dash in its name, installs break if pyasn1 is installed first
+fedora_messaging
 feedgen
 jinja2
 kitchen


### PR DESCRIPTION
This converts Bodhi to use fedora-messaging to publish to an AMQP message broker. It also sets up a RabbitMQ message broker in the Vagrant environment.

This pull request does the minimal amount necessary to publish via AMQP. It does not define message schema, nor does it attempt to convert the existing fedmsg consumers to the fedora-messaging consumer API. These will be done in follow-up pull requests.