### PR TITLE
Do not install pyramid_tm in Vagrant or CI.

### DIFF
--- a/devel/ansible/roles/bodhi/tasks/main.yml
+++ b/devel/ansible/roles/bodhi/tasks/main.yml
@@ -56,7 +56,6 @@
       - python2-pyramid
       - python2-pyramid-fas-openid
       - python2-pyramid-mako
-      - python2-pyramid-tm
       - python2-pytest-cov
       - python2-responses
       - python2-simplemediawiki

--- a/devel/ci/Dockerfile-f28
+++ b/devel/ci/Dockerfile-f28
@@ -35,7 +35,6 @@ RUN dnf install --disablerepo rawhide-modular -y \
     python2-mock \
     python2-pillow \
     python2-pyramid-mako \
-    python2-pyramid-tm \
     python2-pytest-cov \
     python2-responses \
     python2-sqlalchemy \
@@ -59,7 +58,6 @@ RUN dnf install --disablerepo rawhide-modular -y \
     python3-pydocstyle \
     python3-pylibravatar \
     python3-pyramid-mako \
-    python3-pyramid-tm \
     python3-pytest \
     python3-pytest-cov \
     python3-responses \

--- a/devel/ci/Dockerfile-f29
+++ b/devel/ci/Dockerfile-f29
@@ -35,7 +35,6 @@ RUN dnf install --disablerepo rawhide-modular -y \
     python2-mock \
     python2-pillow \
     python2-pyramid-mako \
-    python2-pyramid-tm \
     python2-pytest-cov \
     python2-responses \
     python2-sqlalchemy \
@@ -59,7 +58,6 @@ RUN dnf install --disablerepo rawhide-modular -y \
     python3-pydocstyle \
     python3-pylibravatar \
     python3-pyramid-mako \
-    python3-pyramid-tm \
     python3-pytest \
     python3-pytest-cov \
     python3-responses \

--- a/devel/ci/Dockerfile-rawhide
+++ b/devel/ci/Dockerfile-rawhide
@@ -47,7 +47,6 @@ RUN dnf install --disablerepo rawhide-modular -y \
     python3-pylibravatar \
     python3-pyramid-fas-openid \
     python3-pyramid-mako \
-    python3-pyramid-tm \
     python3-pytest \
     python3-pytest-cov \
     python3-responses \


### PR DESCRIPTION
Bodhi no longer uses pyramid_tm.

Signed-off-by: Randy Barlow <randy@electronsweatshop.com>