### PR TITLE
Use strs instead of bytes for smtplib.SMTP.sendmail().

### DIFF
--- a/bodhi/server/mail.py
+++ b/bodhi/server/mail.py
@@ -403,8 +403,8 @@ def send_mail(from_addr, to_addr, subject, body_text, headers=None):
     Send an e-mail.
 
     Args:
-        from_addr (basestring): The address to use in the From: header.
-        to_addr (basestring): The address to send the e-mail to.
+        from_addr (str): The address to use in the From: header.
+        to_addr (str): The address to send the e-mail to.
         subject (basestring): The subject of the e-mail.
         body_text (basestring): The body of the e-mail to be sent.
         headers (dict or None): A mapping of header fields to values to be included in the e-mail,
@@ -418,12 +418,10 @@ def send_mail(from_addr, to_addr, subject, body_text, headers=None):
     if to_addr in config.get('exclude_mail'):
         return
 
-    from_addr = to_bytes(from_addr)
-    to_addr = to_bytes(to_addr)
     subject = to_bytes(subject)
     body_text = to_bytes(body_text)
 
-    msg = [b'From: %s' % from_addr, b'To: %s' % to_addr]
+    msg = [b'From: %s' % to_bytes(from_addr), b'To: %s' % to_bytes(to_addr)]
     if headers:
         for key, value in headers.items():
             msg.append(b'%s: %s' % (to_bytes(key), to_bytes(value)))
@@ -440,11 +438,11 @@ def send(to, msg_type, update, sender=None, agent=None):
     Send an update notification email to a given recipient.
 
     Args:
-        to (iterable): An iterable of e-mail addresses to send an update e-mail to.
+        to (iterable): An iterable strs of e-mail addresses to send an update e-mail to.
         msg_type (basestring): The message template to use. Should be one of the keys in the
             MESSAGES template.
         update (bodhi.server.models.Update): The Update we are mailing people about.
-        sender (basestring or None): The address to use in the From: header. If None, the
+        sender (str or None): The address to use in the From: header. If None, the
             "bodhi_email" setting will be used as the From: header.
         agent (basestring): The username that performed the action that generated this e-mail.
     """

--- a/bodhi/tests/server/consumers/test_masher.py
+++ b/bodhi/tests/server/consumers/test_masher.py
@@ -28,7 +28,6 @@ import unittest
 
 from click import testing
 import mock
-from kitchen.text.converters import to_bytes
 import six
 import six.moves.urllib.parse as urlparse
 from six.moves.urllib.error import HTTPError, URLError
@@ -596,8 +595,8 @@ References:
 
 """ % time.strftime('%Y'))
 
-        mail.assert_called_with(to_bytes(config.get('bodhi_email')),
-                                to_bytes(config.get('fedora_test_announce_list')),
+        mail.assert_called_with(config.get('bodhi_email'),
+                                config.get('fedora_test_announce_list'),
                                 mock.ANY)
         assert len(mail.mock_calls) == 2, len(mail.mock_calls)
         body = mail.mock_calls[1][1][2]
@@ -3287,9 +3286,8 @@ class TestComposerThread_send_testing_digest(ComposerThreadBaseTestCase):
         sendmail = SMTP.return_value.sendmail
         self.assertEqual(sendmail.call_count, 1)
         args = sendmail.mock_calls[0][1]
-        self.assertEqual(args[0].decode('utf-8'), config['bodhi_email'])
-        self.assertEqual([c.decode('utf-8') for c in args[1]],
-                         [config['fedora_test_announce_list']])
+        self.assertEqual(args[0], config['bodhi_email'])
+        self.assertEqual(args[1], [config['fedora_test_announce_list']])
         self.assertTrue(
             'The following Fedora 17 Critical Path updates have yet to be approved:\n Age URL\n'
             in args[2].decode('utf-8'))
@@ -3319,9 +3317,8 @@ class TestComposerThread_send_testing_digest(ComposerThreadBaseTestCase):
         sendmail = SMTP.return_value.sendmail
         self.assertEqual(sendmail.call_count, 1)
         args = sendmail.mock_calls[0][1]
-        self.assertEqual(args[0].decode('utf-8'), config['bodhi_email'])
-        self.assertEqual([c.decode('utf-8') for c in args[1]],
-                         [config['fedora_test_announce_list']])
+        self.assertEqual(args[0], config['bodhi_email'])
+        self.assertEqual(args[1], [config['fedora_test_announce_list']])
         self.assertTrue(
             'The following Fedora 17 Security updates need testing:\n Age  URL\n'
             in args[2].decode('utf-8'))

--- a/bodhi/tests/server/test_mail.py
+++ b/bodhi/tests/server/test_mail.py
@@ -210,11 +210,12 @@ class TestSend(base.BaseTestCase):
         self.assertEqual(sendmail.call_count, 1)
         sendmail = sendmail.mock_calls[0]
         self.assertEqual(len(sendmail[1]), 3)
-        self.assertEqual(sendmail[1][0], b'updates@fedoraproject.org')
-        self.assertEqual(sendmail[1][1], [b'bowlofeggs@example.com'])
-        self.assertTrue('Message-ID: <bodhi-update-{}-{}-{}@{}>'.format(
+        self.assertEqual(sendmail[1][0], 'updates@fedoraproject.org')
+        self.assertEqual(sendmail[1][1], ['bowlofeggs@example.com'])
+        expected_body = 'Message-ID: <bodhi-update-{}-{}-{}@{}>'.format(
             update.id, update.user.name, update.release.name,
-            config.config.get('message_id_email_domain')) in str(sendmail[1][2]))
+            config.config.get('message_id_email_domain'))
+        self.assertTrue(expected_body.encode('utf-8') in sendmail[1][2])
 
     @mock.patch.dict('bodhi.server.mail.config', {'smtp_server': 'smtp.example.com'})
     @mock.patch('bodhi.server.mail.smtplib.SMTP')
@@ -227,8 +228,8 @@ class TestSend(base.BaseTestCase):
         SMTP.assert_called_once_with('smtp.example.com')
         sendmail = SMTP.return_value.sendmail
         self.assertEqual(sendmail.call_count, 1)
-        self.assertEqual(sendmail.mock_calls[0][1][0], b'updates@fedoraproject.org')
-        self.assertEqual(sendmail.mock_calls[0][1][1], [b'fake@news.com'])
+        self.assertEqual(sendmail.mock_calls[0][1][0], 'updates@fedoraproject.org')
+        self.assertEqual(sendmail.mock_calls[0][1][1], ['fake@news.com'])
         self.assertTrue(b'X-Bodhi-Update-Title: bodhi-2.0-1.fc17' in sendmail.mock_calls[0][1][2])
         self.assertTrue(
             b'Subject: [Fedora Update] [comment] bodhi-2.0-1.fc17' in sendmail.mock_calls[0][1][2])
@@ -271,7 +272,7 @@ class TestSendMail(unittest.TestCase):
 
         SMTP.assert_called_once_with('smtp.fp.o')
         smtp.sendmail.assert_called_once_with(
-            b'bodhi@example.com', [b'bowlofeggs@example.com'],
+            'bodhi@example.com', ['bowlofeggs@example.com'],
             (b'From: bodhi@example.com\r\nTo: bowlofeggs@example.com\r\nBodhi-Is: Great\r\n'
              b'X-Bodhi: fedoraproject.org\r\nSubject: R013X\r\n\r\nWant a c00l w@tch?'))
 
@@ -297,7 +298,7 @@ class TestSendMail(unittest.TestCase):
 
         SMTP.assert_called_once_with('smtp.fp.o')
         smtp.sendmail.assert_called_once_with(
-            b'bodhi@example.com', [b'bowlofeggs@example.com'],
+            'bodhi@example.com', ['bowlofeggs@example.com'],
             (b'From: bodhi@example.com\r\nTo: bowlofeggs@example.com\r\n'
              b'X-Bodhi: fedoraproject.org\r\nSubject: R013X\r\n\r\nWant a c00l w@tch?'))
 
@@ -315,8 +316,8 @@ class TestSendReleng(unittest.TestCase):
 
         SMTP.assert_called_once_with('smtp.fp.o')
         smtp.sendmail.assert_called_once_with(
-            config.config.get('bodhi_email').encode('utf-8'),
-            [config.config.get('release_team_address').encode('utf-8')],
+            config.config.get('bodhi_email'),
+            [config.config.get('release_team_address')],
             ('From: {}\r\nTo: {}\r\nX-Bodhi: fedoraproject.org\r\nSubject: sup\r\n\r\nr u '
              'ready 2 upd8').format(
                 config.config.get('bodhi_email'), config.config.get('release_team_address')).encode(

--- a/bodhi/tests/server/test_models.py
+++ b/bodhi/tests/server/test_models.py
@@ -3402,8 +3402,8 @@ class TestUpdate(ModelTest):
             config['bodhi_email'], config['{}_test_announce_list'.format(release_name)],
             config['default_email_domain'], self.obj.builds[0].nvr, body)
         SMTP.return_value.sendmail.assert_called_once_with(
-            config['bodhi_email'].encode('utf-8'),
-            [config['{}_test_announce_list'.format(release_name)].encode('utf-8')],
+            config['bodhi_email'],
+            [config['{}_test_announce_list'.format(release_name)]],
             msg.encode('utf-8'))
 
     def test_check_requirements_empty(self):


### PR DESCRIPTION
Under Python 3, a TypeError is raised if the from address or to
addresses are passed as bytes objects instead of str objects. We
had mistakenly been converting them as part of the Python 3
readiness effort. This commit fixes the code so we pass str
objects instead.

fixes #2756

Signed-off-by: Randy Barlow <randy@electronsweatshop.com>