### PR TITLE
Run diff-cover with just develop instead of origin/develop.

### DIFF
--- a/devel/ci/bodhi-ci
+++ b/devel/ci/bodhi-ci
@@ -559,7 +559,7 @@ class DiffCoverJob(Job):
         self.archive_path = archive_path
 
         self._command = ['/usr/bin/diff-cover', '/results/coverage.xml',
-                         '--compare-branch=origin/develop', '--fail-under=100']
+                         '--compare-branch=develop', '--fail-under=100']
         self._label = '{}-py{}'.format(self._label, pyver)
         self._convert_command_for_container(archive=archive, archive_path=archive_path)
 

--- a/devel/ci/cico.pipeline
+++ b/devel/ci/cico.pipeline
@@ -115,7 +115,12 @@ def test_release = { String release ->
 
 
 node('bodhi') {
-    checkout scm
+    commit_hash = checkout(scm).GIT_COMMIT
+    // diff-cover sometimes fails to identify origin/develop, so let's check out the develop branch
+    // and then switch back to the commit hash we are testing so there is a develop branch available
+    // for diff-cover to use later. See https://github.com/Bachmann1234/diff-cover/issues/55
+    sh 'git checkout develop'
+    sh 'git checkout ' + commit_hash
 
     stage('Allocate Duffy node') {
         env.CICO_API_KEY = readFile("${env.HOME}/duffy.key").trim()


### PR DESCRIPTION
It's better not to assume that all users of bodhi-ci call the
central remote origin.

Signed-off-by: Randy Barlow <randy@electronsweatshop.com>