### PR TITLE
Fix ordering of suggestions to have "unspecified" first

### DIFF
--- a/bodhi/server/services/updates.py
+++ b/bodhi/server/services/updates.py
@@ -152,7 +152,7 @@ def get_update_for_editing(request):
         types=reversed(list(bodhi.server.models.UpdateType.values())),
         severities=sorted(
             list(bodhi.server.models.UpdateSeverity.values()), key=bodhi.server.util.sort_severity),
-        suggestions=reversed(list(bodhi.server.models.UpdateSuggestion.values())),
+        suggestions=list(bodhi.server.models.UpdateSuggestion.values()),
     )
 
 


### PR DESCRIPTION
Previously there was no ordering, but since 4c7829ff5e741162ba16b5517cd2d9b3bc1f7d90,
that is no longer true.
Let's use the ordering as passed by that.

Signed-off-by: Patrick Uiterwijk <patrick@puiterwijk.org>