### PR TITLE
Drop dependency on iniparse

### DIFF
--- a/bodhi/client/bindings.py
+++ b/bodhi/client/bindings.py
@@ -35,7 +35,6 @@ import os
 import re
 import textwrap
 
-from iniparse.compat import ConfigParser
 from six.moves import configparser
 from six.moves import input
 try:
@@ -913,7 +912,7 @@ class BodhiClient(OpenIdBaseClient):
         Returns:
             koji.ClientSession: An intialized authenticated koji client.
         """
-        config = ConfigParser()
+        config = configparser.ConfigParser()
         if os.path.exists(os.path.join(os.path.expanduser('~'), '.koji', 'config')):
             config.readfp(open(os.path.join(os.path.expanduser('~'), '.koji', 'config')))
         else:

--- a/bodhi/tests/client/test_bindings.py
+++ b/bodhi/tests/client/test_bindings.py
@@ -1738,12 +1738,12 @@ class TestGetKojiSession(unittest.TestCase):
     This class tests the get_koji_session method.
     """
     @mock.patch('{}.open'.format(builtin_module_name), create=True)
-    @mock.patch('bodhi.client.bindings.ConfigParser.readfp')
+    @mock.patch('bodhi.client.bindings.configparser.ConfigParser.readfp')
     @mock.patch("os.path.exists")
     @mock.patch("os.path.expanduser", return_value="/home/dudemcpants/")
     @mock.patch('bodhi.client.bindings.BodhiClient._load_cookies')
     @mock.patch('bodhi.client.bindings.koji.ClientSession')
-    @mock.patch('bodhi.client.bindings.ConfigParser.get')
+    @mock.patch('bodhi.client.bindings.configparser.ConfigParser.get')
     def test_koji_conf_in_home_directory(self, get, koji, cookies,
                                          expanduser, exists, readfp, mock_open):
         """Test that if ~/.koji/config exists, we read the config from there first"""
@@ -1756,12 +1756,12 @@ class TestGetKojiSession(unittest.TestCase):
         mock_open.assert_called_once_with("/home/dudemcpants/.koji/config")
 
     @mock.patch('{}.open'.format(builtin_module_name), create=True)
-    @mock.patch('bodhi.client.bindings.ConfigParser.readfp')
+    @mock.patch('bodhi.client.bindings.configparser.ConfigParser.readfp')
     @mock.patch("os.path.exists")
     @mock.patch("os.path.expanduser", return_value="/home/dudemcpants/")
     @mock.patch('bodhi.client.bindings.BodhiClient._load_cookies')
     @mock.patch('bodhi.client.bindings.koji.ClientSession')
-    @mock.patch('bodhi.client.bindings.ConfigParser.get')
+    @mock.patch('bodhi.client.bindings.configparser.ConfigParser.get')
     def test_koji_conf_not_in_home_directory(self, get, koji, cookies,
                                              expanduser, exists, readfp, mock_open):
         """Test that if ~/.koji.config doesn't exist, we read config from /etc/koji.conf"""

--- a/bootstrap.py
+++ b/bootstrap.py
@@ -113,7 +113,7 @@ def link_system_libs():
                 '_sqlitecache', 'psycopg2', 'krbVmodule', 'deltarpm',
                 '_deltarpmmodule', 'fedora_cert', 'libxml2', 'libxml2mod',
                 'librepo', 'createrepo_c', 'dnf', 'gpg', 'gpgme', 'lzma',
-                'iniparse', 'hawkey', 'yum'):
+                'hawkey', 'yum'):
         _link_system_lib(mod)
 
 

--- a/devel/ci/Dockerfile-f28
+++ b/devel/ci/Dockerfile-f28
@@ -29,7 +29,6 @@ RUN dnf install --disablerepo rawhide-modular -y \
     python2-dogpile-cache \
     python2-fedmsg \
     python2-feedgen \
-    python2-iniparse \
     python2-kitchen \
     python2-markdown \
     python2-mock \

--- a/devel/ci/Dockerfile-f29
+++ b/devel/ci/Dockerfile-f29
@@ -29,7 +29,6 @@ RUN dnf install --disablerepo rawhide-modular -y \
     python2-dogpile-cache \
     python2-fedmsg \
     python2-feedgen \
-    python2-iniparse \
     python2-kitchen \
     python2-markdown \
     python2-mock \

--- a/devel/ci/Dockerfile-rawhide
+++ b/devel/ci/Dockerfile-rawhide
@@ -15,7 +15,6 @@ RUN dnf install --disablerepo rawhide-modular -y \
     make \
     python2-click \
     python2-fedora \
-    python2-iniparse \
     python2-koji \
     python2-mock \
     python2-munch \

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,6 @@ cryptography
 dogpile.cache
 fedmsg[consumers]
 feedgen
-iniparse
 jinja2
 kitchen
 markdown

--- a/setup.py
+++ b/setup.py
@@ -110,7 +110,7 @@ setup(
     packages=['bodhi.client'],
     include_package_data=False,
     zip_safe=False,
-    install_requires=['click', 'iniparse', 'python-fedora >= 0.9.0', 'six'],
+    install_requires=['click', 'python-fedora >= 0.9.0', 'six'],
     entry_points="""\
     [console_scripts]
     bodhi = bodhi.client:cli


### PR DESCRIPTION
The iniparse library is python2-only (the python3 patches are unreleased) and I haven't found any places where stdlib's configparser isn't sufficient.