### PR TITLE
Fix formatting issue in the client

### DIFF
--- a/bodhi/client/bindings.py
+++ b/bodhi/client/bindings.py
@@ -849,7 +849,7 @@ class BodhiClient(OpenIdBaseClient):
 
         if update['notes']:
             notes_lines = list(itertools.chain(
-                *[wrap_line(update['notes'])]
+                *[wrap_line(line) for line in update['notes'].splitlines()]
             ))
             indent_lines = ['Notes'] + [' '] * (len(notes_lines) - 1)
             for indent, line in six.moves.zip(indent_lines, notes_lines):

--- a/bodhi/tests/client/test_bindings.py
+++ b/bodhi/tests/client/test_bindings.py
@@ -1336,6 +1336,19 @@ class TestBodhiClient_update_str(unittest.TestCase):
 
         self.assertIn('CI Status: no tests required\n', text)
 
+    @mock.patch.dict(
+        client_test_data.EXAMPLE_UPDATE_MUNCH,
+        {'notes': 'This note contains:\n* multiline formatting\n* bullet points\n\n'})
+    def test_notes_multiline(self):
+        """Test that severity is rendered."""
+        client = bindings.BodhiClient()
+        client.base_url = 'http://example.com/tests/'
+        text = client.update_str(client_test_data.EXAMPLE_UPDATE_MUNCH)
+
+        self.assertIn('Notes: This note contains:\n', text)
+        self.assertIn('     : * multiline formatting\n', text)
+        self.assertIn('     : * bullet points\n', text)
+
 
 class TestErrorhandled(unittest.TestCase):
     """


### PR DESCRIPTION
Lines in `Notes` were joined before being wrapped, issue introduced by changeset 7b94d3008.