### PR TITLE
Do not reverse the logout/reboot choices in Python 3.

### DIFF
--- a/bodhi/server/services/updates.py
+++ b/bodhi/server/services/updates.py
@@ -26,6 +26,7 @@ from cornice.validators import colander_body_validator, colander_querystring_val
 from sqlalchemy import func, distinct
 from sqlalchemy.sql import or_
 from requests import RequestException, Timeout as RequestsTimeout
+import six
 
 from bodhi.server import log, security
 from bodhi.server.exceptions import BodhiException, LockedUpdateException
@@ -147,12 +148,15 @@ def get_update_for_editing(request):
             severities: The possible values for update severity.
             suggestions: The possible values for update suggestion.
     """
+    suggestions = list(bodhi.server.models.UpdateSuggestion.values())
+    if six.PY2:  # pragma: no cover
+        suggestions = reversed(suggestions)
     return dict(
         update=request.validated['update'],
         types=reversed(list(bodhi.server.models.UpdateType.values())),
         severities=sorted(
             list(bodhi.server.models.UpdateSeverity.values()), key=bodhi.server.util.sort_severity),
-        suggestions=reversed(list(bodhi.server.models.UpdateSuggestion.values())),
+        suggestions=suggestions,
     )
 
 

--- a/bodhi/server/views/generic.py
+++ b/bodhi/server/views/generic.py
@@ -241,12 +241,15 @@ def new_update(request):
     user = request.authenticated_userid
     if not user:
         raise HTTPForbidden("You must be logged in.")
+    suggestions = list(models.UpdateSuggestion.values())
+    if six.PY2:  # pragma: no cover
+        suggestions = reversed(suggestions)
     return dict(
         update=None,
         types=reversed(list(models.UpdateType.values())),
         severities=sorted(list(models.UpdateSeverity.values()),
                           key=bodhi.server.util.sort_severity),
-        suggestions=reversed(list(models.UpdateSuggestion.values())),
+        suggestions=suggestions,
     )
 
 

--- a/bodhi/tests/server/services/test_updates.py
+++ b/bodhi/tests/server/services/test_updates.py
@@ -19,6 +19,7 @@
 """This module contains tests for bodhi.server.services.updates."""
 from datetime import datetime, timedelta
 import copy
+import re
 import textwrap
 import time
 
@@ -829,6 +830,11 @@ class TestEditUpdateForm(BaseTestCase):
             '/updates/FEDORA-{}-a3bbe1a8f2/edit'.format(datetime.utcnow().year),
             headers={'accept': 'text/html'})
         self.assertIn('Editing an update requires JavaScript', resp)
+        # Make sure that unspecified comes first, as it should be the default.
+        regex = r''
+        for value in ('unspecified', 'reboot', 'logout'):
+            regex = regex + r'name="suggest" value="{}".*'.format(value)
+        self.assertTrue(re.search(regex, resp.body.decode('utf8').replace('\n', ' ')))
 
     def test_edit_without_permission(self):
         """

--- a/bodhi/tests/server/views/test_generic.py
+++ b/bodhi/tests/server/views/test_generic.py
@@ -19,6 +19,7 @@
 
 from datetime import datetime
 import copy
+import re
 
 import mock
 import webtest
@@ -393,6 +394,11 @@ class TestGenericViews(base.BaseTestCase):
         # Test that a logged in user sees the New Update form
         res = self.app.get('/updates/new')
         self.assertIn('Creating a new update requires JavaScript', res)
+        # Make sure that unspecified comes first, as it should be the default.
+        regex = r''
+        for value in ('unspecified', 'reboot', 'logout'):
+            regex = regex + r'name="suggest" value="{}".*'.format(value)
+        self.assertTrue(re.search(regex, res.body.decode('utf8').replace('\n', ' ')))
 
         # Test that the unlogged in user cannot see the New Update form
         anonymous_settings = copy.copy(self.app_settings)

--- a/docs/user/release_notes.rst
+++ b/docs/user/release_notes.rst
@@ -22,6 +22,7 @@ Bug fixes
 * Allow ``EnumSymbols`` to be sorted (:issue:`2757`).
 * Catch ``http.client.IncompleteRead`` while Composing and retry (:issue:`2758`).
 * Correctly handle timestamps from Koji (:issue:`2768`).
+* Do not reverse the logout/reboot options in the web UI on Python 3 (:issue:`2778`).
 
 
 Contributors
@@ -29,6 +30,7 @@ Contributors
 
 The following developers contributed to Bodhi 3.11.1:
 
+* Patrick Uiterwijk
 * Randy Barlow
 
 


### PR DESCRIPTION
fixes #2778 

This patch is based on a patch by @puiterwijk in #2777.

Signed-off-by: Randy Barlow <randy@electronsweatshop.com>