### PR TITLE
Show dnf command for installing the selected update.

### DIFF
--- a/bodhi/server/templates/update.html
+++ b/bodhi/server/templates/update.html
@@ -521,6 +521,41 @@ $(document).ready(function(){
 });
 </script>
 
+<script type="text/javascript">
+$(document).ready(function(){
+    var button = document.getElementById('copybutton')
+
+    button.addEventListener('click', function(event) {
+        if (document.selection) { 
+            document.selection.empty();
+            var range = document.body.createTextRange();
+            range.moveToElementText(document.getElementById('commandtext'));
+            range.select().createTextRange();
+            try {
+                document.execCommand('copy');
+            } catch (err) {
+                console.log('Oops, unable to copy');
+            }
+
+        } else if (window.getSelection) {
+            if (window.getSelection().empty) {  // Chrome
+                window.getSelection().empty();
+            } else if (window.getSelection().removeAllRanges) {  // Firefox
+                window.getSelection().removeAllRanges();
+            }
+            var range = document.createRange();
+            range.selectNode(document.getElementById('commandtext'));
+            window.getSelection().addRange(range);
+            try {
+                document.execCommand('copy');
+            } catch (err) {
+                console.log('Oops, unable to copy');
+            }
+        }
+    });
+});
+</script>
+
 <div class="subheader p-t-2">
 <div class="container">
 <div class="row">
@@ -641,7 +676,9 @@ $(document).ready(function(){
         <div class="col-md-9">
           % if update.notes:
           ${self.util.markup(update.notes) | n}
+          ${update.content_type}
           % endif
+
           % if not 'unspecified' in update.suggest:
           <div class="alert alert-info">
             % if 'logout' in update.suggest:
@@ -656,6 +693,15 @@ $(document).ready(function(){
             properly.
             % endif
           </div>
+          % endif
+
+          % if update.content_type:
+          % if update.content_type.description == 'RPM' and ('testing' in update.status or 'stable' in update.status):
+          <div class="p-t-1">
+          <h4>How to install</h4>
+            <pre style="position: relative;"><span class="label label-default" id="copybutton" style="position: absolute; top: 0px; right: 0px; cursor: pointer;" title="Copy to clipboard"><i class="fa fa-copy"></i></span><code id="commandtext">${self.util.update_install_command(update)}</code></pre>
+          </div>
+          % endif
           % endif
 
           <div class="p-t-3">

--- a/bodhi/server/util.py
+++ b/bodhi/server/util.py
@@ -1523,3 +1523,28 @@ def get_absolute_path(location):
     module, final = location.split(':')
     base = os.path.dirname(__import__(module).__file__)
     return base + "/" + final
+
+
+def update_install_command(context, update):
+    """
+    Return the dnf command for installing the Update.
+
+    Args:
+        context (mako.runtime.Context): Unused.
+        update (bodhi.server.models.Update): The Update you want to install.
+    Returns:
+        basestring: The dnf command to install the Update.
+    """
+    status = six.text_type(update.status)
+    alias = update.alias
+    update_type = six.text_type(update.type)
+
+    if status != 'stable' and status != 'testing':
+        raise ValueError('Only updates in stable or testing can be installed!')
+
+    command = 'sudo dnf {}{} --advisory={}{}'.format(
+        'install' if update_type == 'newpackage' else 'upgrade',
+        ' --enablerepo=updates-testing' if status == 'testing' else '',
+        alias,
+        r' \*' if update_type == 'newpackage' else '')
+    return command

--- a/bodhi/tests/server/test_util.py
+++ b/bodhi/tests/server/test_util.py
@@ -30,7 +30,7 @@ import six
 from bodhi.server import util, models
 from bodhi.server.config import config
 from bodhi.server.models import (ComposeState, TestGatingStatus, Update, UpdateRequest,
-                                 UpdateSeverity)
+                                 UpdateSeverity, UpdateStatus, UpdateType)
 from bodhi.tests.server import base
 
 if six.PY2:
@@ -1571,3 +1571,68 @@ class TestTransactionalSessionMaker(base.BaseTestCase):
         Session.return_value.commit.assert_called_once_with()
         Session.return_value.close.assert_called_once_with()
         Session.remove.assert_called_once_with()
+
+
+class TestUpdateInstallCommand(base.BaseTestCase):
+    """Test the update_install_command() function."""
+
+    def test_upgrade_in_testing(self):
+        """Update is an enhancement, a security or a bugfix and is in testing."""
+        context = {'request': mock.MagicMock()}
+        update = models.Update.query.first()
+        update.status = UpdateStatus.testing
+        update.type = UpdateType.bugfix
+
+        command = util.update_install_command(context, update)
+
+        self.assertEqual(
+            command,
+            'sudo dnf upgrade --enablerepo=updates-testing --advisory={}'.format(update.alias))
+
+    def test_upgrade_in_stable(self):
+        """Update is an enhancement, a security or a bugfix and is in stable."""
+        context = {'request': mock.MagicMock()}
+        update = models.Update.query.first()
+        update.status = UpdateStatus.stable
+        update.type = UpdateType.bugfix
+
+        command = util.update_install_command(context, update)
+
+        self.assertEqual(
+            command,
+            'sudo dnf upgrade --advisory={}'.format(update.alias))
+
+    def test_newpackage_in_testing(self):
+        """Update is a newpackage and is in testing."""
+        context = {'request': mock.MagicMock()}
+        update = models.Update.query.first()
+        update.status = UpdateStatus.testing
+        update.type = UpdateType.newpackage
+
+        command = util.update_install_command(context, update)
+
+        self.assertEqual(
+            command,
+            r'sudo dnf install --enablerepo=updates-testing --advisory={} \*'.format(update.alias))
+
+    def test_newpackage_in_stable(self):
+        """Update is a newpackage and is in stable."""
+        context = {'request': mock.MagicMock()}
+        update = models.Update.query.first()
+        update.status = UpdateStatus.stable
+        update.type = UpdateType.newpackage
+
+        command = util.update_install_command(context, update)
+
+        self.assertEqual(
+            command,
+            r'sudo dnf install --advisory={} \*'.format(update.alias))
+
+    def test_cannot_install(self):
+        """Update is out of stable or testing repositories."""
+        context = {'request': mock.MagicMock()}
+        update = models.Update.query.first()
+        update.status = UpdateStatus.obsolete
+
+        with self.assertRaises(ValueError):
+            util.update_install_command(context, update)


### PR DESCRIPTION
This will add a "How to install" section after update notes on the update page.
The dnf command string is built in utils, so that the same function can be used to add installation instructions to CLI or in email.

I've also added a javascript button to copy the dnf command to system's clipboard, it should be cross-browser compatible, please test it.

fixes #2261 

Signed-off-by: Mattia Verga <mattia.verga@tiscali.it>