### PR TITLE
Remove side_tag_merging from the side tag migration docblock.

### DIFF
--- a/bodhi/server/migrations/versions/22858ba91115_add_new_side_tag_update_states.py
+++ b/bodhi/server/migrations/versions/22858ba91115_add_new_side_tag_update_states.py
@@ -35,8 +35,7 @@ def upgrade():
     """
     Add side tag enums to the update_status enum.
 
-    Side tags add three new enums to the update_status enum: side_tag_active, side_tag_merging, and
-    side_tag_expired.
+    Side tags add three new enums to the update_status enum: side_tag_active and side_tag_expired.
     """
     op.execute('COMMIT')  # See https://bitbucket.org/zzzeek/alembic/issue/123
     try:


### PR DESCRIPTION
There had likely been a side_tag_merging state when I was
developing the patch that introduced this comment, but I ultimately
didn't include it so we should correct the docblock.

Signed-off-by: Randy Barlow <randy@electronsweatshop.com>