### PR TITLE
Do run the unittests on rawhide for python 3

### DIFF
--- a/devel/ci/bodhi-ci
+++ b/devel/ci/bodhi-ci
@@ -708,7 +708,7 @@ class UnitJob(Job):
         test_command = ('({} setup.py develop && {} {} || (cp *.xml /results && exit 1)) '
                         '&& cp *.xml /results')
 
-        if self.release not in ('f28', 'f29', 'pip'):
+        if pyver == 2 and self.release not in ('f28', 'f29', 'pip'):
             # We do not support the server on Fedora >= 30:
             test_command = (
                 'rm requirements.txt && touch requirements.txt && rm .coveragerc && '


### PR DESCRIPTION
Changeset 64ff87102 disabled the unittests on Rawhide for any version of Python, but it's only unsupported on Python 2. As a results, the `diff_cover` check fails because no tests were run on Rawhide & Python 3.