### PR TITLE
Allow CLI users to override the OpenID API.

### DIFF
--- a/bodhi/client/bindings.py
+++ b/bodhi/client/bindings.py
@@ -174,7 +174,8 @@ def _days_since(data_str):
 class BodhiClient(OpenIdBaseClient):
     """Python bindings to the Bodhi server REST API."""
 
-    def __init__(self, base_url=BASE_URL, username=None, password=None, staging=False, **kwargs):
+    def __init__(self, base_url=BASE_URL, username=None, password=None, staging=False,
+                 openid_api=None, **kwargs):
         """
         Initialize the Bodhi client.
 
@@ -184,9 +185,14 @@ class BodhiClient(OpenIdBaseClient):
             username (basestring): The username to use to authenticate with the server.
             password (basestring): The password to use to authenticate with the server.
             staging (bool): If True, use the staging server. If False, use base_url.
+            opennid_api (str or None): If not None, the URL to an OpenID API to use to authenticate
+                to Bodhi. Ignored if staging is True.
             kwargs (dict): Other keyword arguments to pass on to
                            :class:`fedora.client.OpenIdBaseClient`
         """
+        if openid_api:
+            fedora.client.openidproxyclient.FEDORA_OPENID_API = openid_api
+
         if staging:
             fedora.client.openidproxyclient.FEDORA_OPENID_API = STG_OPENID_API
             base_url = STG_BASE_URL

--- a/bodhi/tests/client/test___init__.py
+++ b/bodhi/tests/client/test___init__.py
@@ -1118,6 +1118,7 @@ class TestQueryBuildrootOverrides(unittest.TestCase):
             params={'page': 5})
 
 
+@mock.patch.dict(os.environ, {'BODHI_OPENID_API': 'https://id.example.com/api/v1/'})
 class TestRequest(unittest.TestCase):
     """
     This class tests the request() function.
@@ -1154,8 +1155,9 @@ class TestRequest(unittest.TestCase):
             )
         ]
         self.assertEqual(send_request.mock_calls, calls)
-        __init__.assert_called_once_with(base_url=EXPECTED_DEFAULT_BASE_URL, username='some_user',
-                                         password='s3kr3t', staging=False)
+        __init__.assert_called_once_with(
+            base_url=EXPECTED_DEFAULT_BASE_URL, username='some_user', password='s3kr3t',
+            staging=False, openid_api='https://id.example.com/api/v1/')
 
     @mock.patch('bodhi.client.bindings.BodhiClient.__init__', return_value=None)
     @mock.patch('bodhi.client.bindings.BodhiClient.csrf',
@@ -1183,8 +1185,9 @@ class TestRequest(unittest.TestCase):
             'updates/bodhi-2.2.4-99.el7/request', verb='POST', auth=True,
             data={'csrf_token': 'a_csrf_token', 'request': u'revoke',
                   'update': u'bodhi-2.2.4-99.el7'})
-        __init__.assert_called_once_with(base_url=EXPECTED_DEFAULT_BASE_URL, username='some_user',
-                                         password='s3kr3t', staging=False)
+        __init__.assert_called_once_with(
+            base_url=EXPECTED_DEFAULT_BASE_URL, username='some_user', password='s3kr3t',
+            staging=False, openid_api='https://id.example.com/api/v1/')
 
     @mock.patch('bodhi.client.bindings.BodhiClient.csrf',
                 mock.MagicMock(return_value='a_csrf_token'))

--- a/bodhi/tests/client/test_bindings.py
+++ b/bodhi/tests/client/test_bindings.py
@@ -33,6 +33,7 @@ from bodhi.tests.utils import compare_output
 builtin_module_name = 'builtins' if six.PY3 else '__builtin__'
 
 
+@mock.patch('fedora.client.openidproxyclient.FEDORA_OPENID_API', 'default')
 class TestBodhiClient___init__(unittest.TestCase):
     """
     This class contains tests for the BodhiClient.__init__() method.
@@ -44,6 +45,22 @@ class TestBodhiClient___init__(unittest.TestCase):
         client = bindings.BodhiClient(base_url='http://localhost:6543')
 
         self.assertEqual(client.base_url, 'http://localhost:6543/')
+        self.assertEqual(fedora.client.openidproxyclient.FEDORA_OPENID_API, 'default')
+
+    def test_openid_api(self):
+        """Test the openid_api parameter."""
+        client = bindings.BodhiClient(
+            base_url='http://example.com/bodhi/', username='some_user', password='s3kr3t',
+            staging=False, timeout=60, openid_api='https://example.com/api/v1/')
+
+        self.assertEqual(client.base_url, 'http://example.com/bodhi/')
+        self.assertEqual(client.login_url, 'http://example.com/bodhi/login')
+        self.assertEqual(client.username, 'some_user')
+        self.assertEqual(client.timeout, 60)
+        self.assertEqual(client._password, 's3kr3t')
+        self.assertEqual(client.csrf_token, None)
+        self.assertEqual(fedora.client.openidproxyclient.FEDORA_OPENID_API,
+                         'https://example.com/api/v1/')
 
     def test_staging_false(self):
         """
@@ -58,13 +75,15 @@ class TestBodhiClient___init__(unittest.TestCase):
         self.assertEqual(client.timeout, 60)
         self.assertEqual(client._password, 's3kr3t')
         self.assertEqual(client.csrf_token, None)
+        self.assertEqual(fedora.client.openidproxyclient.FEDORA_OPENID_API, 'default')
 
     def test_staging_true(self):
         """
         Test with staging set to True.
         """
-        client = bindings.BodhiClient(base_url='http://example.com/bodhi/', username='some_user',
-                                      password='s3kr3t', staging=True, retries=5)
+        client = bindings.BodhiClient(
+            base_url='http://example.com/bodhi/', username='some_user', password='s3kr3t',
+            staging=True, retries=5, openid_api='ignored')
 
         self.assertEqual(client.base_url, bindings.STG_BASE_URL)
         self.assertEqual(client.login_url, bindings.STG_BASE_URL + 'login')
@@ -73,6 +92,7 @@ class TestBodhiClient___init__(unittest.TestCase):
         self.assertEqual(client.retries, 5)
         self.assertEqual(client._password, 's3kr3t')
         self.assertEqual(client.csrf_token, None)
+        self.assertEqual(fedora.client.openidproxyclient.FEDORA_OPENID_API, bindings.STG_OPENID_API)
 
 
 class TestBodhiClient_comment(unittest.TestCase):

--- a/devel/ansible/roles/bodhi/files/.bashrc
+++ b/devel/ansible/roles/bodhi/files/.bashrc
@@ -38,6 +38,7 @@ function btest {
 }
 
 export BODHI_URL="http://localhost:6543/"
+export BODHI_OPENID_API="https://id.stg.fedoraproject.org/api/v1/"
 export PYTHONWARNINGS="once"
 export BODHI_CI_ARCHIVE_PATH="/home/vagrant/bodhi-ci-test_results/"
 

--- a/devel/development.ini.example
+++ b/devel/development.ini.example
@@ -54,6 +54,9 @@ cache.long_term.expire = 3600
 # The following settings should work with a local container registry as described above:
 container.destination_registry = localhost:5000
 skopeo.extra_copy_flags = --dest-tls-verify=false
+openid.provider = https://id.stg.fedoraproject.org/openid/
+openid.url = https://id.stg.fedoraproject.org/
+openid_template = {username}.id.stg.fedoraproject.org
 
 
 [server:main]

--- a/docs/developer/vagrant.rst
+++ b/docs/developer/vagrant.rst
@@ -93,3 +93,13 @@ the host::
 
 If you wish to use a custom ``Vagrantfile``, you can set the environment variable
 ``VAGRANT_VAGRANTFILE`` as a path to a script.
+
+
+Authentication
+^^^^^^^^^^^^^^
+
+The Vagrant environment will configure Bodhi server and Bodhi's CLI to use Fedora's staging Ipsilon
+server for authentication. This means you will need to ensure you have an account on Fedora's
+staging account system. If you need to make an account, you can do so
+`here <https://admin.stg.fedoraproject.org/accounts/>`_. This is done to prevent accidental changes
+to Fedora's production instance during development.


### PR DESCRIPTION
It has long bothered me that Bodhi development uses Fedora's
production authentication server instead of some other
authentication, because this adds a risk that actions in
development might alter production Bodhi (particular with the CLI).

This commit makes it possible for CLI users to override the OpenID
API used by the CLI, and configures the defaults in Vagrant to use
Fedora's staging identity server instead of production.

I did consider giving the server an API to provide settings like
the OpenID provider, but that would cause another request on every
command and so I opted for allowing the user to specify an OpenID
API.

Signed-off-by: Randy Barlow <randy@electronsweatshop.com>