### PR TITLE
Show more bugs information in the update page

### DIFF
--- a/bodhi/server/config.py
+++ b/bodhi/server/config.py
@@ -271,7 +271,7 @@ class BodhiConfig(dict):
             'value': 'dev',
             'validator': str},
         'bz_products': {
-            'value': [],
+            'value': ['Fedora', 'Fedora EPEL', 'Fedora Modules'],
             'validator': _generate_list_validator(',')},
         'bz_server': {
             'value': 'https://bugzilla.redhat.com/xmlrpc.cgi',

--- a/bodhi/server/static/css/site.css
+++ b/bodhi/server/static/css/site.css
@@ -297,3 +297,7 @@ padding-bottom: 2em;
 .notblue{
   color:inherit;
 }
+
+.bug-container{
+  padding-top: 0.5rem;
+}

--- a/bodhi/server/static/js/update_form.js
+++ b/bodhi/server/static/js/update_form.js
@@ -357,7 +357,8 @@ $(document).ready(function() {
                             return;
                         }
                         // Check Bug product
-                        if (data.result.bugs[0].product !== "Fedora" && data.result.bugs[0].product !== "Fedora EPEL") {
+                        var product = data.result.bugs[0].product;
+                        if (product !== "Fedora" && product !== "Fedora EPEL" && product !== "Fedora Modules") {
                             var r = confirm('Bug #' + item + ' doesn\'t seem to refer to Fedora or Fedora EPEL.\nAre you sure you want to reference it in this update?');
                             if (r === false) { return; }
                         }
@@ -366,7 +367,10 @@ $(document).ready(function() {
                             var r = confirm('Bug #' + item + ' is already in CLOSED state.\nAre you sure you want to reference it in this update?');
                             if (r === false) { return; }
                         }
-                        var release = data.result.bugs[0].product + ' ' + data.result.bugs[0].version[0];
+                        var release = product
+                        if (data.result.bugs[0].version[0] !== 'unspecified') {
+                            release += ' ' + data.result.bugs[0].version[0];
+                        }
                         add_bug_checkbox(item, data.result.bugs[0].summary, release, true, true);
                     },
                     error: function(jqXHR, textStatus) {

--- a/bodhi/server/static/js/update_form.js
+++ b/bodhi/server/static/js/update_form.js
@@ -329,12 +329,23 @@ $(document).ready(function() {
                     timeout: 10000,
                     dataType: 'jsonp',
                     success: function(data) {
-                        // Received error response e.g. bug doesn't exist
+                        // Received error response
                         if (data.error) {
-                            messenger.post({
-                                message: data.error.message,
-                                type: 'error',
-                            });
+                            // Error 102 is due to bug being private
+                            // Bodhi can't handle private bugs, we should avoid
+                            // attaching them to updates
+                            if (data.error.code == 102) {
+                                messenger.post({
+                                    message: 'Bodhi can\'t manage private bugs! (#' + item + ')',
+                                    type: 'error',
+                                });
+                            }
+                            else {
+                                messenger.post({
+                                    message: data.error.message,
+                                    type: 'error',
+                                });
+                            }
                             return;
                         }
                         // There should be only one

--- a/bodhi/server/static/js/update_form.js
+++ b/bodhi/server/static/js/update_form.js
@@ -370,17 +370,25 @@ $(document).ready(function() {
 
     // If you press "enter", make it count
     $("#bugs-adder input").keypress(function (e) {
-        if (e.which == 13) { return add_bugs(); }
+        if (e.which == 13 && $("#bugs-adder input").val() != '') { return add_bugs(); }
     });
     $("#builds-adder input").keypress(function (e) {
-        if (e.which == 13) { return add_builds(); }
+        if (e.which == 13 && $("#builds-adder input").val() != '') { return add_builds(); }
     });
     // If you "tab" away from the input, make it count.
-    $("#bugs-adder input").focusout(function(e) { return add_bugs(); });
-    $("#builds-adder input").focusout(function(e) { return add_builds(); });
+    $("#bugs-adder input").focusout(function(e) {
+        if ($("#bugs-adder input").val() != '') { return add_bugs(); }
+    });
+    $("#builds-adder input").focusout(function(e) {
+        if ($("#builds-adder input").val() != '') { return add_builds(); }
+    });
     // Or, if you click the "+" button, make it count
-    $("#bugs-adder button").click(function(e) { return add_bugs(); });
-    $("#builds-adder button").click(function(e) { return add_builds(); });
+    $("#bugs-adder button").click(function(e) {
+        if ($("#bugs-adder input").val() != '') { return add_bugs(); }
+    });
+    $("#builds-adder button").click(function(e) {
+        if ($("#builds-adder input").val() != '') { return add_builds(); }
+    });
 
     // Wire up the submit button
     $("#submit").click(function (e) {

--- a/bodhi/server/static/js/update_form.js
+++ b/bodhi/server/static/js/update_form.js
@@ -299,11 +299,21 @@ $(document).ready(function() {
     // field or the 'bugs' field, those things get added to the list of
     // possibilities.
     var add_bugs = function() {
+        $("#bugs-checkboxes").prepend("<img class='spinner' src='static/img/spinner.gif'>\n");
         var value = $("#bugs-adder input").val().trim();
+        var count_done = 0;
+        var count_todo = 0;
         $.each(value.split(","), function(i, intermediary) {
-            $.each(intermediary.trim().split(" "), function(j, item) {
+            bug_list = intermediary.trim().split(" ");
+            count_todo += bug_list.length;
+            $.each(bug_list, function(j, item) {
                 item = item.trim()
                 if (item[0] == '#') { item = item.substring(1); }
+                // Prevent empty item e.g. double space in input
+                if (item == '') {
+                    count_done += 1;
+                    return;
+                }
                 $.ajax({
                     url: "https://bugzilla.redhat.com/jsonrpc.cgi?method=Bug.get&params=%5B%7B%22ids%22:" + item + "%7D%5D",
                     timeout: 10000,
@@ -350,6 +360,10 @@ $(document).ready(function() {
                                 type: 'error',
                             });
                         }
+                    },
+                    complete: function() {
+                        count_done += 1;
+                        if (count_done == count_todo) { $("#bugs-checkboxes .spinner").remove(); }
                     },
                 });
             });

--- a/bodhi/server/static/js/update_form.js
+++ b/bodhi/server/static/js/update_form.js
@@ -358,8 +358,8 @@ $(document).ready(function() {
                         }
                         // Check Bug product
                         var product = data.result.bugs[0].product;
-                        if (product !== "Fedora" && product !== "Fedora EPEL" && product !== "Fedora Modules") {
-                            var r = confirm('Bug #' + item + ' doesn\'t seem to refer to Fedora or Fedora EPEL.\nAre you sure you want to reference it in this update?');
+                        if (settings.bz_products.indexOf(product) == -1) {
+                            var r = confirm('Bug #' + item + ' doesn\'t seem to refer to Fedora or Fedora EPEL.\nAre you sure you want to reference it in this update? Bodhi will not be able to operate on this bug!');
                             if (r === false) { return; }
                         }
                         // Alert user if bug is already closed

--- a/bodhi/server/templates/master.html
+++ b/bodhi/server/templates/master.html
@@ -40,6 +40,11 @@
     <link href="${request.static_url('bodhi:server/static/css/panel.css') }" rel="stylesheet" />
     <script src="${request.static_url('bodhi:server/static/js/jquery-1.10.2.min.js')}"></script>
     <script src="${request.static_url('bodhi:server/static/js/Chart-0.2.0.min.js')}"></script>
+    <script type="text/javascript">
+        var settings = {
+            bz_products: ["${ '","'.join(config['bz_products']) | n }"]
+        };
+    </script>
   </head>
 
   <body>


### PR DESCRIPTION
This change will change how bugs are added and displayed on the new update page.
Each bug will be displayed on two rows along with a badge with the release-product information. This should reduce the risk to reference by mistake an EPEL bug to a Fedora update or vice versa.

Moreover, information about manually entered bugs will be retrieved from RH Bugzilla and a series of checks will be performed:

- if the bug is private, user will not be able to add it to the update
- if the bug is not related to Fedora, Fedora EPEL or Fedora Modules, user will be prompted to confirm they're sure to reference the bug to the update
- if the bug is already in CLOSED state, again user is prompted to confirm their action

The final result looks like this:
![screenshot_20181206_195138](https://user-images.githubusercontent.com/17218209/49635002-9c0e6a80-f9fe-11e8-9827-26eb120e6e69.png)

Signed-off-by: Mattia Verga <mattia.verga@tiscali.it>