### PR TITLE
Require python3 on the integration tests, not python 2.

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -29,7 +29,7 @@ pull_request_rules:
   - status-success=pip-python2-diff-cover
   - status-success=pip-python3-unit
   - status-success=pip-python3-diff-cover
-  - status-success=f29-python2-integration
+  - status-success=f29-python3-integration
   name: default
 - actions:
     merge:


### PR DESCRIPTION
Signed-off-by: Randy Barlow <randy@electronsweatshop.com>