### PR TITLE
Add the bodhi_messages Python package

### DIFF
--- a/bodhi/__init__.py
+++ b/bodhi/__init__.py
@@ -17,3 +17,6 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 """Fedora's update manager."""
+
+# This is a regular expression used to match username mentions in comments.
+MENTION_RE = r'(?<!\S)(@\w+)'

--- a/bodhi/messages/__init__.py
+++ b/bodhi/messages/__init__.py
@@ -1,0 +1,16 @@
+# Copyright (C) 2018  Red Hat, Inc.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+"""This package defines Bodhi's messages."""

--- a/bodhi/messages/schemas/__init__.py
+++ b/bodhi/messages/schemas/__init__.py
@@ -1,0 +1,16 @@
+# Copyright (C) 2019 Red Hat, Inc.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+"""This package defines Bodhi's message schemas."""

--- a/bodhi/messages/schemas/base.py
+++ b/bodhi/messages/schemas/base.py
@@ -1,0 +1,234 @@
+# Copyright (C) 2018-2019 Red Hat, Inc.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+"""
+Message schema for Bodhi.
+
+Each message is defined as a Python class. For details, see `fedora-messaging
+<https://fedora-messaging.readthedocs.io/en/stable/>`_ documentation on
+messages.
+"""
+
+import re
+import typing
+
+from fedora_messaging import message
+from fedora_messaging.schema_utils import user_avatar_url
+
+from bodhi import MENTION_RE
+
+
+SCHEMA_URL = 'https://bodhi.fedoraproject.org/message-schemas'
+
+
+class BodhiMessage(message.Message):
+    """A base class for Bodhi messages."""
+
+    @property
+    def app_icon(self) -> str:
+        """
+        Return a URL that points to the application's icon.
+
+        This is used when displaying the message to users.
+
+        Returns:
+            A URL for Bodhi's app icon.
+        """
+        return "https://apps.fedoraproject.org/img/icons/bodhi.png"
+
+    @property
+    def agent(self) -> typing.Union[str, None]:
+        """Return the agent's username for this message.
+
+        Returns:
+            The agent's username, or None if the body has no agent key.
+        """
+        return self.body.get('agent', None)
+
+    @property
+    def agent_avatar(self) -> typing.Union[None, str]:
+        """
+        Return a URL to the avatar of the user who caused the action.
+
+        Returns:
+            The URL to the user's avatar, or None if username is None.
+        """
+        username = self.agent
+        if username is None:
+            return None
+        return user_avatar_url(username)
+
+    @property
+    def usernames(self) -> typing.List[str]:
+        """
+        List of users affected by the action that generated this message.
+
+        Returns:
+            A list of affected usernames.
+        """
+        users = []
+        if self.agent is not None:
+            users.append(self.agent)
+
+        if 'comment' in self.body:
+            text = self.body['comment']['text']
+            mentions = re.findall(MENTION_RE, text)
+            for mention in mentions:
+                users.append(mention[1:])
+
+        users = list(set(users))
+        users.sort()
+        return users
+
+    @property
+    def containers(self) -> typing.Iterable[str]:
+        """
+        List of containers affected by the action that generated this message.
+
+        Returns:
+            A list of affected container names.
+        """
+        return []
+
+    @property
+    def modules(self) -> typing.Iterable[str]:
+        """
+        List of modules affected by the action that generated this message.
+
+        Returns:
+            A list of affected module names.
+        """
+        return []
+
+    @property
+    def flatpaks(self) -> typing.Iterable[str]:
+        """
+        List of flatpaks affected by the action that generated this message.
+
+        Returns:
+            A list of affected flatpaks names.
+        """
+        return []
+
+
+class BuildV1(typing.NamedTuple):
+    """
+    A model for referencing a Build.
+
+    Attributes:
+        nvr: The koji id of the build.
+    """
+
+    nvr: str
+
+    @property
+    def package(self) -> str:
+        """Return the name of the package that this build is associated with."""
+        return self.nvr.rsplit('-', 2)[0]
+
+    @staticmethod
+    def schema() -> dict:
+        """Return a schema snippet for a Build."""
+        return {
+            'type': 'object',
+            'description': 'A build',
+            'properties': {
+                'nvr': {
+                    'type': 'string',
+                    'description': 'The nvr the identifies the build in koji'
+                },
+            },
+            'required': ['nvr']
+        }
+
+
+class UpdateV1(typing.NamedTuple):
+    """
+    A model for referencing an Update object.
+
+    Attributes:
+        alias: The alias of the update.
+        builds: A list of builds associated with the update.
+        submitter: The id of the user who submitted the update.
+    """
+
+    alias: str
+    builds: typing.Iterable[BuildV1]
+    user: 'UserV1'
+    status: str
+    request: typing.Union[None, str]
+
+    @property
+    def packages(self) -> typing.Iterable[str]:
+        """Return a list of package names included in this update."""
+        return [b.package for b in self.builds]
+
+    @staticmethod
+    def schema() -> dict:
+        """Return a schema snippet for an Update."""
+        return {
+            'type': 'object',
+            'description': 'An update',
+            'properties': {
+                'alias': {
+                    'type': 'string',
+                    'description': 'The alias of the update'
+                },
+                'builds': {
+                    'type': 'array',
+                    'description': 'A list of builds included in this update',
+                    'items': {'$ref': '#/definitions/build'}
+                },
+                'request': {
+                    'type': ['null', 'string'],
+                    'description': 'The request of the update, if any',
+                    'enum': [None, 'testing', 'obsolete', 'unpush', 'revoke', 'stable']
+                },
+                'status': {
+                    'type': 'string',
+                    'description': 'The current status of the update',
+                    'enum': [None, 'pending', 'testing', 'stable', 'unpushed', 'obsolete',
+                             'side_tag_active', 'side_tag_expired']
+                },
+                'user': UserV1.schema(),
+            },
+            'required': ['alias', 'builds', 'request', 'status', 'user']
+        }
+
+
+class UserV1(typing.NamedTuple):
+    """
+    A model for referencing a User object.
+
+    Attributes:
+        name: The User's account name
+    """
+
+    name: str
+
+    @staticmethod
+    def schema() -> dict:
+        """Return a schema snippet for a User."""
+        return {
+            'type': 'object',
+            'description': 'The user that submitted the override',
+            'properties': {
+                'name': {
+                    'type': 'string',
+                    'description': "The user's account name"
+                },
+            },
+            'required': ['name']
+        }

--- a/bodhi/messages/schemas/buildroot_override.py
+++ b/bodhi/messages/schemas/buildroot_override.py
@@ -1,0 +1,144 @@
+# Copyright (C) 2018-2019 Red Hat, Inc.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+"""
+Message schema for Bodhi.
+
+Each message is defined as a Python class. For details, see `fedora-messaging
+<https://fedora-messaging.readthedocs.io/en/stable/>`_ documentation on
+messages.
+"""
+
+import typing
+
+from .base import BodhiMessage, BuildV1, SCHEMA_URL, UserV1
+
+
+class BuildrootOverrideMessage(BodhiMessage):
+    """Base class for the buildroot_override messages."""
+
+    @property
+    def build(self) -> BuildV1:
+        """Return the build that was overridden."""
+        return BuildV1(self.body['override']['nvr'])
+
+    @property
+    def submitter(self) -> UserV1:
+        """Return the name of the submitter for the override."""
+        return UserV1(self.body['override']['submitter']['name'])
+
+    @property
+    def summary(self) -> str:
+        """
+        Return a short, human-readable representation of this message.
+
+        This should provide a short summary of the message, much like the subject line
+        of an email.
+        """
+        return self._summary_tmpl.format(submitter=self.submitter.name, build=self.build.nvr)
+
+    @property
+    def url(self) -> str:
+        """
+        Return a URL to the action that caused this message to be emitted.
+
+        Returns:
+            A relevant URL.
+        """
+        return "https://bodhi.fedoraproject.org/overrides/{nvr}".format(nvr=self.build.nvr)
+
+    @property
+    def packages(self) -> typing.Iterable[str]:
+        """List of packages affected by the action that generated this message.
+
+        Returns:
+            A list of affected package names.
+        """
+        return [self.build.package]
+
+    @property
+    def agent(self) -> str:
+        """Return the agent's username for this message.
+
+        Returns:
+            The agent's username.
+        """
+        return self.submitter.name
+
+    @property
+    def usernames(self) -> typing.List[str]:
+        """
+        List of users affected by the action that generated this message.
+
+        Returns:
+            A list of affected usernames.
+        """
+        return [self.agent]
+
+
+class BuildrootOverrideTagV1(BuildrootOverrideMessage):
+    """Sent when a buildroot override is added and tagged into the build root."""
+
+    body_schema = {
+        'id': f'{SCHEMA_URL}/v1/bodhi.buildroot_override.tag#',
+        '$schema': 'http://json-schema.org/draft-04/schema#',
+        'description': 'Schema for message sent when buildroot overrides are tagged',
+        'type': 'object',
+        'properties': {
+            'override': {
+                'type': 'object',
+                'properties': {
+                    'nvr': {
+                        'type': 'string',
+                        'description': 'The NVR of the build that was overridden'
+                    },
+                    'submitter': UserV1.schema(),
+                },
+                'required': ['nvr', 'submitter']
+            }
+        },
+        'required': ['override'],
+    }
+
+    topic = "bodhi.buildroot_override.tag"
+    _summary_tmpl = "{submitter} submitted a buildroot override for {build}"
+
+
+class BuildrootOverrideUntagV1(BuildrootOverrideMessage):
+    """Sent when a buildroot override is untagged from the build root."""
+
+    body_schema = {
+        'id': f'{SCHEMA_URL}/v1/bodhi.buildroot_override.untag#',
+        '$schema': 'http://json-schema.org/draft-04/schema#',
+        'description': 'Schema for message sent when buildroot overrides are untagged',
+        'type': 'object',
+        'properties': {
+            'override': {
+                'type': 'object',
+                'properties': {
+                    'nvr': {
+                        'type': 'string',
+                        'description': 'The NVR of the build that had been overridden'
+                    },
+                    'submitter': UserV1.schema(),
+                },
+                'required': ['nvr', 'submitter']
+            }
+        },
+        'required': ['override'],
+    }
+
+    topic = "bodhi.buildroot_override.untag"
+    _summary_tmpl = "{submitter} expired a buildroot override for {build}"

--- a/bodhi/messages/schemas/compose.py
+++ b/bodhi/messages/schemas/compose.py
@@ -1,0 +1,238 @@
+# Copyright (C) 2018-2019  Red Hat, Inc.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+"""
+Message schema for Bodhi.
+
+Each message is defined as a Python class. For details, see `fedora-messaging
+<https://fedora-messaging.readthedocs.io/en/stable/>`_ documentation on
+messages.
+"""
+
+from .base import BodhiMessage, SCHEMA_URL
+
+
+class ComposeCompleteV1(BodhiMessage):
+    """Sent when a compose task completes."""
+
+    body_schema = {
+        'id': f'{SCHEMA_URL}/v1/bodhi.compose.complete#',
+        '$schema': 'http://json-schema.org/draft-04/schema#',
+        'description': 'Schema for message sent when composes finish',
+        'type': 'object',
+        'properties': {
+            'agent': {
+                'type': 'string',
+                'description': 'The name of the user who started this compose.'
+            },
+            'repo': {
+                'type': 'string',
+                'description': 'The name of the repository being composed.'
+            },
+            'success': {
+                'type': 'boolean',
+                'description': 'true if the compose was successful, false otherwise.'
+            }
+        },
+        'required': ['agent', 'repo', 'success'],
+    }
+
+    topic = "bodhi.compose.complete"
+
+    @property
+    def repo(self) -> str:
+        """Return the name of the repository being composed."""
+        return self.body.get('repo')
+
+    @property
+    def success(self) -> bool:
+        """Return the name of the repository being composed."""
+        return self.body.get('success')
+
+    @property
+    def summary(self) -> str:
+        """
+        Return a short, human-readable representation of this message.
+
+        This should provide a short summary of the message, much like the subject line
+        of an email.
+
+        Returns:
+            The message summary.
+        """
+        if self.success:
+            return f"bodhi composer successfully composed {self.repo}"
+        else:
+            return f"bodhi composer failed to compose {self.repo}"
+
+
+class ComposeComposingV1(BodhiMessage):
+    """Sent when the compose task composees."""
+
+    body_schema = {
+        'id': f'{SCHEMA_URL}/v1/bodhi.compose.composing#',
+        '$schema': 'http://json-schema.org/draft-04/schema#',
+        'description': 'Schema for message sent when composes start',
+        'type': 'object',
+        'properties': {
+            'agent': {
+                'type': 'string',
+                'description': 'The name of the user who started this compose.'
+            },
+            'repo': {
+                'type': 'string',
+                'description': 'The name of the repository being composed.'
+            },
+        },
+        'required': ['agent', 'repo'],
+    }
+
+    topic = "bodhi.compose.composing"
+
+    @property
+    def repo(self) -> str:
+        """Return the name of the repository being composed."""
+        return self.body.get('repo')
+
+    @property
+    def summary(self) -> str:
+        """
+        Return a short, human-readable representation of this message.
+
+        This should provide a short summary of the message, much like the subject line
+        of an email.
+
+        Returns:
+            A summary for this message.
+        """
+        return f"bodhi composer started composing {self.repo}"
+
+
+class ComposeStartV1(BodhiMessage):
+    """Sent when a compose task starts."""
+
+    body_schema = {
+        'id': f'{SCHEMA_URL}/v1/bodhi.compose.start#',
+        '$schema': 'http://json-schema.org/draft-04/schema#',
+        'description': 'Schema for message sent when composes start',
+        'type': 'object',
+        'properties': {
+            'agent': {
+                'type': 'string',
+                'description': 'The name of the user who started this compose.'
+            },
+        },
+        'required': ['agent'],
+    }
+
+    topic = "bodhi.compose.start"
+
+    @property
+    def summary(self) -> str:
+        """
+        Return a short, human-readable representation of this message.
+
+        This should provide a short summary of the message, much like the subject line
+        of an email.
+
+        Returns:
+            A summary for this message.
+        """
+        return "bodhi composer started a push"
+
+
+class ComposeSyncDoneV1(BodhiMessage):
+    """Sent when a compose task sync is done."""
+
+    body_schema = {
+        'id': f'{SCHEMA_URL}/v1/bodhi.compose.sync.done#',
+        '$schema': 'http://json-schema.org/draft-04/schema#',
+        'description': ('Schema for message sent when the composer is done waiting to sync to '
+                        'mirrors'),
+        'type': 'object',
+        'properties': {
+            'agent': {
+                'type': 'string',
+                'description': 'The name of the user who started this compose.'
+            },
+            'repo': {
+                'type': 'string',
+                'description': 'The name of the repository being composed.'
+            },
+        },
+        'required': ['agent', 'repo'],
+    }
+
+    topic = "bodhi.compose.sync.done"
+
+    @property
+    def repo(self) -> str:
+        """Return the name of the repository being composed."""
+        return self.body.get('repo')
+
+    @property
+    def summary(self) -> str:
+        """
+        Return a short, human-readable representation of this message.
+
+        This should provide a short summary of the message, much like the subject line
+        of an email.
+
+        Returns:
+            A summary for this message.
+        """
+        return f"bodhi composer finished waiting for {self.repo} to hit the master mirror"
+
+
+class ComposeSyncWaitV1(BodhiMessage):
+    """Sent when a compose task sync is waiting."""
+
+    body_schema = {
+        'id': f'{SCHEMA_URL}/v1/bodhi.compose.sync.wait#',
+        '$schema': 'http://json-schema.org/draft-04/schema#',
+        'description': 'Schema for message sent when the composer is waiting to sync to mirrors',
+        'type': 'object',
+        'properties': {
+            'agent': {
+                'type': 'string',
+                'description': 'The name of the user who started this compose.'
+            },
+            'repo': {
+                'type': 'string',
+                'description': 'The name of the repository being composed.'
+            },
+        },
+        'required': ['agent', 'repo'],
+    }
+
+    topic = "bodhi.compose.sync.wait"
+
+    @property
+    def repo(self) -> str:
+        """Return the name of the repository being composed."""
+        return self.body.get('repo')
+
+    @property
+    def summary(self) -> str:
+        """
+        Return a short, human-readable representation of this message.
+
+        This should provide a short summary of the message, much like the subject line
+        of an email.
+
+        Returns:
+            A summary for this message.
+        """
+        return f"bodhi composer is waiting for {self.repo} to hit the master mirror"

--- a/bodhi/messages/schemas/composer.py
+++ b/bodhi/messages/schemas/composer.py
@@ -1,0 +1,123 @@
+# Copyright (C) 2018-2019  Red Hat, Inc.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+"""
+Message schema for Bodhi.
+
+Each message is defined as a Python class. For details, see `fedora-messaging
+<https://fedora-messaging.readthedocs.io/en/stable/>`_ documentation on
+messages.
+"""
+
+import typing
+
+from .base import BodhiMessage, SCHEMA_URL
+
+
+class ComposeV1(typing.NamedTuple):
+    """
+    A model for referencing a Compose object.
+
+    Attributes:
+        security: True if this compose contains security updates.
+        release_id: The database id of the release we are composing.
+        request: The request of the release we are composing.
+        content_type: The content type of the builds in this compose.
+    """
+
+    release_id: int
+    request: str
+    content_type: str
+    security: bool
+
+    @staticmethod
+    def schema() -> dict:
+        """Return a schema snippet for a Compose object."""
+        return {
+            'type': 'object',
+            'description': 'A compose being requested',
+            'properties': {
+                'content_type': {
+                    'type': 'string',
+                    'description': 'The content type of this compose'
+                },
+                'release_id': {
+                    'type': 'integer',
+                    'description': 'The database ID for the release being requested'
+                },
+                'request': {
+                    'type': 'string',
+                    'description': 'The request being requested'
+                },
+                'security': {
+                    'type': 'boolean',
+                    'description': 'true if this compose contains security updates'
+                },
+            },
+            'required': ['content_type', 'release_id', 'request', 'security']
+        }
+
+
+class ComposerStartV1(BodhiMessage):
+    """Sent when a compose begins."""
+
+    body_schema = {
+        'id': f'{SCHEMA_URL}/v1/bodhi.composer.start#',
+        '$schema': 'http://json-schema.org/draft-04/schema#',
+        'description': 'Schema for message sent when a compose is requested to start',
+        'type': 'object',
+        'properties': {
+            'agent': {
+                'type': 'string',
+                'description': 'The name of the user who started this compose.'
+            },
+            'composes': {
+                'type': 'array',
+                'description': 'A list of composes included in this compose job',
+                'items': {'$ref': '#/definitions/compose'}
+            },
+            'resume': {
+                'type': 'boolean',
+                'description': 'true if this is a request to resume the given composes'
+            }
+        },
+        'required': ['agent', 'composes', 'resume'],
+        'definitions': {
+            'compose': ComposeV1.schema(),
+        }
+    }
+
+    topic = "bodhi.composer.start"
+
+    @property
+    def composes(self) -> typing.List[ComposeV1]:
+        """Return a list of the composes included in this request."""
+        return [ComposeV1(c['release_id'], c['request'], c['content_type'], c['security'])
+                for c in self.body['composes']]
+
+    @property
+    def resume(self) -> bool:
+        """Return True if this is a request to resume the composes."""
+        return self.body['resume']
+
+    @property
+    def summary(self) -> str:
+        """
+        Return a short, human-readable representation of this message.
+
+        This should provide a short summary of the message, much like the subject line
+        of an email.
+        """
+        return f"{self.agent} requested a compose of {len(self.composes)} repositories"

--- a/bodhi/messages/schemas/errata.py
+++ b/bodhi/messages/schemas/errata.py
@@ -1,0 +1,113 @@
+# Copyright (C) 2018-2019 Red Hat, Inc.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+"""
+Message schema for Bodhi.
+
+Each message is defined as a Python class. For details, see `fedora-messaging
+<https://fedora-messaging.readthedocs.io/en/stable/>`_ documentation on
+messages.
+"""
+
+import typing
+
+from .base import BodhiMessage, BuildV1, SCHEMA_URL, UpdateV1, UserV1
+
+
+class ErrataPublishV1(BodhiMessage):
+    """Sent when an errata is published."""
+
+    body_schema = {
+        'id': f'{SCHEMA_URL}/v1/bodhi.errata.publish#',
+        '$schema': 'http://json-schema.org/draft-04/schema#',
+        'description': 'Schema for message sent when an update is pushed to stable',
+        'type': 'object',
+        'properties': {
+            'body': {
+                'type': 'string',
+                'description': 'The body of an human readable message about the update',
+            },
+            'subject': {
+                'type': 'string',
+                'description': 'A short summary of the update'
+            },
+            'update': UpdateV1.schema(),
+        },
+        'required': ['body', 'subject', 'update'],
+        'definitions': {
+            'build': BuildV1.schema(),
+        }
+    }
+
+    topic = "bodhi.errata.publish"
+
+    def __str__(self) -> str:
+        """
+        Return a human-readable representation of this message.
+
+        This should provide a detailed representation of the message, much like the body
+        of an email.
+        """
+        return self.body['body']
+
+    @property
+    def agent(self) -> str:
+        """Return the agent's username for this message.
+
+        Returns:
+            The agent's username.
+        """
+        return self.update.user.name
+
+    @property
+    def packages(self) -> typing.Iterable[str]:
+        """List of package names affected by the action that generated this message.
+
+        Returns:
+            A list of affected package names.
+        """
+        return self.update.packages
+
+    @property
+    def summary(self) -> str:
+        """
+        Return a short, human-readable representation of this message.
+
+        This should provide a short summary of the message, much like the subject line
+        of an email.
+        """
+        return self.body['subject']
+
+    @property
+    def url(self) -> str:
+        """
+        Return a URL to the action that caused this message to be emitted.
+
+        Returns:
+            A relevant URL.
+        """
+        return f'https://bodhi.fedoraproject.org/updates/{self.update.alias}'
+
+    @property
+    def update(self) -> UpdateV1:
+        """Return the Update from this errata."""
+        if not hasattr(self, '_update'):
+            # Let's cache the Update since a few different methods use it.
+            self._update = UpdateV1(
+                self.body['update']['alias'],
+                [BuildV1(b['nvr']) for b in self.body['update']['builds']],
+                UserV1(self.body['update']['user']['name']), self.body['update']['status'],
+                self.body['update']['request'])
+        return self._update

--- a/bodhi/messages/schemas/update.py
+++ b/bodhi/messages/schemas/update.py
@@ -1,0 +1,517 @@
+# Copyright (C) 2018-2019 Red Hat, Inc.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+"""
+Message schema for Bodhi.
+
+Each message is defined as a Python class. For details, see `fedora-messaging
+<https://fedora-messaging.readthedocs.io/en/stable/>`_ documentation on
+messages.
+"""
+
+import typing
+
+from .base import BodhiMessage, BuildV1, SCHEMA_URL, UpdateV1, UserV1
+from ..utils import truncate
+
+
+class UpdateMessage(BodhiMessage):
+    """Base class for update messages."""
+
+    @property
+    def url(self) -> str:
+        """
+        Return a URL to the action that caused this message to be emitted.
+
+        Returns:
+            A relevant URL.
+        """
+        return f"https://bodhi.fedoraproject.org/updates/{self.update.alias}"
+
+    @property
+    def update(self) -> UpdateV1:
+        """Return the Update referenced by this message."""
+        # Many things use this object, so let's cache it so we don't construct it repeatedly.
+        if not hasattr(self, '_update_obj'):
+            self._update_obj = UpdateV1(
+                self._update['alias'], [BuildV1(b['nvr']) for b in self._update['builds']],
+                UserV1(self._update['user']['name']), self._update['status'],
+                self._update['request'])
+        return self._update_obj
+
+    @property
+    def usernames(self) -> typing.List[str]:
+        """
+        List of users affected by the action that generated this message.
+
+        Returns:
+            A list of affected usernames.
+        """
+        usernames = super(UpdateMessage, self).usernames
+        # Add the submitter if there is one
+        if self.update.user.name not in usernames:
+            usernames.append(self.update.user.name)
+        usernames.sort()
+        return usernames
+
+    @property
+    def packages(self) -> typing.Iterable[str]:
+        """
+        List of names of packages affected by the action that generated this message.
+
+        Returns:
+            A list of affected package names.
+        """
+        return self.update.packages
+
+    @property
+    def _update(self) -> dict:
+        """Return a dictionary from the body representing an update."""
+        return self.body['update']
+
+
+class UpdateCommentV1(UpdateMessage):
+    """Sent when a comment is made on an update."""
+
+    body_schema = {
+        'id': f'{SCHEMA_URL}/v1/bodhi.update.comment#',
+        '$schema': 'http://json-schema.org/draft-04/schema#',
+        'description': 'Schema for message sent when a comment is added to an update',
+        'type': 'object',
+        'properties': {
+            'comment': {
+                'type': 'object',
+                'description': 'The comment added to an update',
+                'properties': {
+                    'karma': {
+                        'type': 'integer',
+                        'description': 'The karma associated with the comment',
+                    },
+                    'text': {
+                        'type': 'string',
+                        'description': 'The text of the comment',
+                    },
+                    'timestamp': {
+                        'type': 'string',
+                        'description': 'The timestamp that the comment was left on.'
+                    },
+                    'update': UpdateV1.schema(),
+                    'user': UserV1.schema(),
+                },
+                'required': ['karma', 'text', 'timestamp', 'update', 'user'],
+            },
+        },
+        'required': ['comment'],
+        'definitions': {
+            'build': BuildV1.schema(),
+        }
+    }
+
+    topic = "bodhi.update.comment"
+
+    def __str__(self) -> str:
+        """
+        Return a human-readable representation of this message.
+
+        This should provide a detailed representation of the message, much like the body
+        of an email.
+
+        Returns:
+            A human readable representation of this message.
+        """
+        return self.body['comment']['text']
+
+    @property
+    def karma(self) -> int:
+        """Return the karma from this comment."""
+        return self.body['comment']['karma']
+
+    @property
+    def summary(self) -> str:
+        """
+        Return a short, human-readable representation of this message.
+
+        This should provide a short summary of the message, much like the subject line
+        of an email.
+
+        Returns:
+            A summary for this message.
+        """
+        return (f"{self.user.name} commented on bodhi update {self.update.alias} "
+                f"(karma: {self.karma})")
+
+    @property
+    def agent(self) -> str:
+        """
+        Return the agent's username for this message.
+
+        Returns:
+            The agent's username.
+        """
+        return self.user.name
+
+    @property
+    def user(self) -> UserV1:
+        """Return the user who wrote this comment."""
+        return UserV1(self.body['comment']['user']['name'])
+
+    @property
+    def _update(self) -> dict:
+        """Return a dictionary from the body representing an update."""
+        return self.body['comment']['update']
+
+
+class UpdateCompleteTestingV1(UpdateMessage):
+    """Sent when an update is available in the testing repository."""
+
+    body_schema = {
+        'id': f'{SCHEMA_URL}/v1/bodhi.update.complete.testing#',
+        '$schema': 'http://json-schema.org/draft-04/schema#',
+        'description': 'Schema for message sent when an update is pushed to testing',
+        'type': 'object',
+        'properties': {
+            'update': UpdateV1.schema(),
+        },
+        'required': ['update'],
+        'definitions': {
+            'build': BuildV1.schema(),
+        }
+    }
+
+    topic = "bodhi.update.complete.testing"
+
+    @property
+    def summary(self) -> str:
+        """
+        Return a short, human-readable representation of this message.
+
+        This should provide a short summary of the message, much like the subject line
+        of an email.
+
+        Returns:
+            A summary for this message.
+        """
+        return (
+            f"{self.update.user.name}'s {truncate(' '.join([b.nvr for b in self.update.builds]))} "
+            f"bodhi update completed push to {self.update.status}")
+
+
+class UpdateEditV1(UpdateMessage):
+    """Sent when an update is edited."""
+
+    body_schema = {
+        'id': f'{SCHEMA_URL}/v1/bodhi.update.edit#',
+        '$schema': 'http://json-schema.org/draft-04/schema#',
+        'description': 'Schema for message sent when an update is edited',
+        'type': 'object',
+        'properties': {
+            'agent': {
+                'type': 'string',
+                'description': 'The user who edited the update',
+            },
+            'update': UpdateV1.schema(),
+        },
+        'required': ['agent', 'update'],
+        'definitions': {
+            'build': BuildV1.schema(),
+        }
+    }
+
+    topic = "bodhi.update.edit"
+
+    @property
+    def summary(self) -> str:
+        """
+        Return a short, human-readable representation of this message.
+
+        This should provide a short summary of the message, much like the subject line
+        of an email.
+
+        Returns:
+            A summary for this message.
+        """
+        return f"{self.agent} edited {self.update.alias}"
+
+
+class UpdateEjectV1(UpdateMessage):
+    """Sent when an update is ejected from the push."""
+
+    body_schema = {
+        'id': f'{SCHEMA_URL}/v1/bodhi.update.eject#',
+        '$schema': 'http://json-schema.org/draft-04/schema#',
+        'description': 'Schema for message sent when an update is ejected from a compose',
+        'type': 'object',
+        'properties': {
+            'reason': {
+                'type': 'string',
+                'description': 'The reason the update was ejected',
+            },
+            'repo': {
+                'type': 'string',
+                'description': 'The name of the repo that the update is associated with'
+            },
+            'update': UpdateV1.schema(),
+        },
+        'required': ['reason', 'repo', 'update'],
+        'definitions': {
+            'build': BuildV1.schema(),
+        }
+    }
+
+    topic = "bodhi.update.eject"
+
+    @property
+    def reason(self) -> str:
+        """Return the reason this update was ejected from the compose."""
+        return self.body['reason']
+
+    @property
+    def repo(self) -> str:
+        """Return the name of the repository that this update is associated with."""
+        return self.body['repo']
+
+    @property
+    def summary(self) -> str:
+        """
+        Return a short, human-readable representation of this message.
+
+        This should provide a short summary of the message, much like the subject line
+        of an email.
+
+        Returns:
+            A summary for this message.
+        """
+        return (
+            f"{self.update.user.name}'s {truncate(' '.join([b.nvr for b in self.update.builds]))} "
+            f"bodhi update was ejected from the {self.repo} mash. Reason: \"{self.reason}\"")
+
+
+class UpdateKarmaThresholdV1(UpdateMessage):
+    """Sent when an update reaches its karma threshold."""
+
+    body_schema = {
+        'id': f'{SCHEMA_URL}/v1/bodhi.update.karma.threshold.reach#',
+        '$schema': 'http://json-schema.org/draft-04/schema#',
+        'description': 'Schema for message sent when an update reaches its karma threshold',
+        'type': 'object',
+        'properties': {
+            'status': {
+                'type': 'string',
+                'description': 'Which karma threshold was reached',
+                'enum': ['stable', 'unstable']
+            },
+            'update': UpdateV1.schema(),
+        },
+        'required': ['status', 'update'],
+        'definitions': {
+            'build': BuildV1.schema(),
+        }
+    }
+
+    topic = "bodhi.update.karma.threshold.reach"
+
+    @property
+    def status(self) -> str:
+        """Return the threshold that was reached."""
+        return self.body['status']
+
+    @property
+    def summary(self) -> str:
+        """
+        Return a short, human-readable representation of this message.
+
+        This should provide a short summary of the message, much like the subject line
+        of an email.
+
+        Returns:
+            A summary for this message.
+        """
+        return f"{self.update.alias} reached the {self.status} karma threshold"
+
+
+class UpdateRequestMessage(UpdateMessage):
+    """Sent when an update's request is changed."""
+
+    @property
+    def summary(self) -> str:
+        """
+        Return a short, human-readable representation of this message.
+
+        This should provide a short summary of the message, much like the subject line
+        of an email.
+
+        Returns:
+            A summary for this message.
+        """
+        status = self.topic.split('.')[-1]
+        if status in ('unpush', 'obsolete', 'revoke'):
+            # make our status past-tense
+            status = status + (status[-1] == 'e' and 'd' or 'ed')
+            return f"{self.agent} {status} {self.update.alias}"
+        else:
+            return f"{self.agent} submitted {self.update.alias} to {status}"
+
+
+class UpdateRequestRevokeV1(UpdateRequestMessage):
+    """Sent when an update is revoked."""
+
+    body_schema = {
+        'id': f'{SCHEMA_URL}/v1/bodhi.update.request.revoke#',
+        '$schema': 'http://json-schema.org/draft-04/schema#',
+        'description': 'Schema for message sent when an update is revoked',
+        'type': 'object',
+        'properties': {
+            'agent': {
+                'type': 'string',
+                'description': 'The user who requested the update to be revoked',
+            },
+            'update': UpdateV1.schema(),
+        },
+        'required': ['agent', 'update'],
+        'definitions': {
+            'build': BuildV1.schema(),
+        }
+    }
+
+    topic = "bodhi.update.request.revoke"
+
+
+class UpdateRequestStableV1(UpdateRequestMessage):
+    """Sent when an update is submitted as a stable candidate."""
+
+    body_schema = {
+        'id': f'{SCHEMA_URL}/v1/bodhi.update.request.stable#',
+        '$schema': 'http://json-schema.org/draft-04/schema#',
+        'description': 'Schema for message sent when an update is requested stable',
+        'type': 'object',
+        'properties': {
+            'agent': {
+                'type': 'string',
+                'description': 'The user who requested the update to be stable',
+            },
+            'update': UpdateV1.schema(),
+        },
+        'required': ['agent', 'update'],
+        'definitions': {
+            'build': BuildV1.schema(),
+        }
+    }
+
+    topic = "bodhi.update.request.stable"
+
+
+class UpdateRequestTestingV1(UpdateRequestMessage):
+    """Sent when an update is submitted as a testing candidate."""
+
+    body_schema = {
+        'id': f'{SCHEMA_URL}/v1/bodhi.update.request.testing#',
+        '$schema': 'http://json-schema.org/draft-04/schema#',
+        'description': 'Schema for message sent when an update is requested testing',
+        'type': 'object',
+        'properties': {
+            'agent': {
+                'type': 'string',
+                'description': 'The user who requested the update to be tested',
+            },
+            'update': UpdateV1.schema(),
+        },
+        'required': ['agent', 'update'],
+        'definitions': {
+            'build': BuildV1.schema(),
+        }
+    }
+
+    topic = "bodhi.update.request.testing"
+
+
+class UpdateRequestUnpushV1(UpdateRequestMessage):
+    """Sent when an update is requested to be unpushed."""
+
+    body_schema = {
+        'id': f'{SCHEMA_URL}/v1/bodhi.update.request.unpush#',
+        '$schema': 'http://json-schema.org/draft-04/schema#',
+        'description': 'Schema for message sent when an update is unpushed',
+        'type': 'object',
+        'properties': {
+            'agent': {
+                'type': 'string',
+                'description': 'The user who requested the update to be unpushed',
+            },
+            'update': UpdateV1.schema(),
+        },
+        'required': ['agent', 'update'],
+        'definitions': {
+            'build': BuildV1.schema(),
+        }
+    }
+
+    topic = "bodhi.update.request.unpush"
+
+
+class UpdateRequestObsoleteV1(UpdateRequestMessage):
+    """Sent when an update is requested to be obsoleted."""
+
+    body_schema = {
+        'id': f'{SCHEMA_URL}/v1/bodhi.update.request.obsolete#',
+        '$schema': 'http://json-schema.org/draft-04/schema#',
+        'description': 'Schema for message sent when an update is obsoleted',
+        'type': 'object',
+        'properties': {
+            'agent': {
+                'type': 'string',
+                'description': 'The user who requested the update to be obsoleted',
+            },
+            'update': UpdateV1.schema(),
+        },
+        'required': ['agent', 'update'],
+        'definitions': {
+            'build': BuildV1.schema(),
+        }
+    }
+
+    topic = "bodhi.update.request.obsolete"
+
+
+class UpdateRequirementsMetStableV1(UpdateMessage):
+    """Sent when all the update requirements are meant for stable."""
+
+    body_schema = {
+        'id': f'{SCHEMA_URL}/v1/bodhi.update.requirements_met.stable#',
+        '$schema': 'http://json-schema.org/draft-04/schema#',
+        'description': 'Schema for message sent when an update meets stable requirements',
+        'type': 'object',
+        'properties': {
+            'update': UpdateV1.schema(),
+        },
+        'required': ['update'],
+        'definitions': {
+            'build': BuildV1.schema(),
+        }
+    }
+
+    topic = "bodhi.update.requirements_met.stable"
+
+    @property
+    def summary(self) -> str:
+        """
+        Return a short, human-readable representation of this message.
+
+        This should provide a short summary of the message, much like the subject line
+        of an email.
+
+        Returns:
+            A summary for this message.
+        """
+        return f'{self.update.alias} has met stable testing requirements'

--- a/bodhi/messages/utils.py
+++ b/bodhi/messages/utils.py
@@ -1,0 +1,30 @@
+# Copyright (C) 2018-2019 Red Hat, Inc.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+"""Utilities for Bodhi's message schemas."""
+
+
+def truncate(title: str) -> str:
+    """
+    Truncate the string to 40 characters and adds ellipsis.
+
+    Args:
+        title: The string you wish to truncate.
+    Returns:
+        The truncated string.
+    """
+    if len(title) >= 40:
+        title = title[:40] + "…"
+    return title

--- a/bodhi/server/ffmarkdown.py
+++ b/bodhi/server/ffmarkdown.py
@@ -1,4 +1,4 @@
-# Copyright © 2014-2018 Red Hat, Inc. and others.
+# Copyright © 2014-2019 Red Hat, Inc. and others.
 #
 # This file is part of Bodhi.
 #
@@ -28,8 +28,9 @@ import markdown.postprocessors
 import markdown.util
 import pyramid.threadlocal
 
+from bodhi import MENTION_RE
 
-MENTION_RE = r'(?<!\S)(@\w+)'
+
 BUGZILLA_RE = r'([a-zA-Z]+)(#[0-9]{5,})'
 
 

--- a/bodhi/tests/messages/__init__.py
+++ b/bodhi/tests/messages/__init__.py
@@ -1,0 +1,16 @@
+# Copyright (C) 2018-2019 Red Hat, Inc.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+"""Test the bodhi.messages package."""

--- a/bodhi/tests/messages/schemas/__init__.py
+++ b/bodhi/tests/messages/schemas/__init__.py
@@ -1,0 +1,16 @@
+# Copyright (C) 2019 Red Hat, Inc.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+"""Test the bodhi.messages.schemas package."""

--- a/bodhi/tests/messages/schemas/test_buildroot_override.py
+++ b/bodhi/tests/messages/schemas/test_buildroot_override.py
@@ -1,0 +1,81 @@
+# Copyright (C) 2018-2019 Red Hat, Inc.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+"""Unit tests for the buildroot_override message schemas."""
+
+import unittest
+
+from bodhi.messages.schemas import base
+from bodhi.messages.schemas.buildroot_override import (BuildrootOverrideTagV1,
+                                                       BuildrootOverrideUntagV1)
+from bodhi.tests.messages.utils import check_message
+
+
+class BuildrootOverrideMessageTests(unittest.TestCase):
+    """A set of unit tests for classes in :py:mod:`bodhi_messages.schemas.buildroot_override`"""
+
+    def test_tag_v1(self):
+        expected = {
+            "topic": "bodhi.buildroot_override.tag",
+            "summary": "lmacken submitted a buildroot override for libxcrypt-4.4.4-2.fc28",
+            "app_icon": "https://apps.fedoraproject.org/img/icons/bodhi.png",
+            "url": "https://bodhi.fedoraproject.org/overrides/libxcrypt-4.4.4-2.fc28",
+            "agent_avatar": (
+                "https://seccdn.libravatar.org/avatar/"
+                "203f6cb95b44b5d38aa21425b066dd522d3e19d8919cf4b339f29e0ea7f03e9b"
+                "?s=64&d=retro"
+            ),
+            "usernames": ["lmacken"],
+            "packages": ["libxcrypt"],
+            'build': base.BuildV1('libxcrypt-4.4.4-2.fc28'),
+            'submitter': base.UserV1('lmacken'),
+            'agent': 'lmacken'
+        }
+        msg = BuildrootOverrideTagV1(
+            body={
+                "override": {
+                    "nvr": "libxcrypt-4.4.4-2.fc28",
+                    "submitter": {'name': 'lmacken'},
+                }
+            }
+        )
+        check_message(msg, expected)
+
+    def test_untag_v1(self):
+        expected = {
+            "topic": "bodhi.buildroot_override.untag",
+            "summary": "lmacken expired a buildroot override for libxcrypt-4.4.4-2.fc28",
+            "app_icon": "https://apps.fedoraproject.org/img/icons/bodhi.png",
+            "url": "https://bodhi.fedoraproject.org/overrides/libxcrypt-4.4.4-2.fc28",
+            "agent_avatar": (
+                "https://seccdn.libravatar.org/avatar/"
+                "203f6cb95b44b5d38aa21425b066dd522d3e19d8919cf4b339f29e0ea7f03e9b"
+                "?s=64&d=retro"
+            ),
+            "usernames": ["lmacken"],
+            "packages": ["libxcrypt"],
+            'build': base.BuildV1('libxcrypt-4.4.4-2.fc28'),
+            'submitter': base.UserV1('lmacken'),
+            'agent': 'lmacken'
+        }
+        msg = BuildrootOverrideUntagV1(
+            body={
+                "override": {
+                    "nvr": "libxcrypt-4.4.4-2.fc28",
+                    "submitter": {"name": "lmacken"},
+                }
+            }
+        )
+        check_message(msg, expected)

--- a/bodhi/tests/messages/schemas/test_compose.py
+++ b/bodhi/tests/messages/schemas/test_compose.py
@@ -1,0 +1,146 @@
+# Copyright (C) 2018-2019 Red Hat, Inc.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+"""Unit tests for the compose message schemas."""
+
+import unittest
+
+from bodhi.messages.schemas.compose import (
+    ComposeComposingV1,
+    ComposeStartV1,
+    ComposeCompleteV1,
+    ComposeSyncWaitV1,
+    ComposeSyncDoneV1,
+)
+from bodhi.tests.messages.utils import check_message
+
+
+class ComposeMessageTests(unittest.TestCase):
+    """A set of unit tests for classes in :py:mod:`bodhi_messages.schemas.compose`"""
+
+    def test_composing_v1(self):
+        expected = {
+            "topic": "bodhi.compose.composing",
+            "summary": "bodhi composer started composing test_repo",
+            "app_icon": "https://apps.fedoraproject.org/img/icons/bodhi.png",
+            "url": None,
+            "usernames": ['mohanboddu'],
+            "packages": [],
+            'repo': 'test_repo',
+            'agent': 'mohanboddu'
+        }
+        msg = ComposeComposingV1(
+            body={
+                'agent': 'mohanboddu',
+                'repo': 'test_repo',
+                'updates': ['monitorix-3.11.0-1.el6'],
+            }
+        )
+        check_message(msg, expected)
+
+    def test_start_v1(self):
+        expected = {
+            "topic": "bodhi.compose.start",
+            "summary": "bodhi composer started a push",
+            "app_icon": "https://apps.fedoraproject.org/img/icons/bodhi.png",
+            "url": None,
+            "usernames": ['mohanboddu'],
+            "packages": [],
+            'agent': 'mohanboddu'
+        }
+        msg = ComposeStartV1(body={'agent': 'mohanboddu'})
+        check_message(msg, expected)
+
+    def test_complete_v1_failed(self):
+        """Test the ComposeCompleteV1 Message with a failed compose."""
+        expected = {
+            "topic": "bodhi.compose.complete",
+            "summary": "bodhi composer failed to compose test_repo",
+            "app_icon": "https://apps.fedoraproject.org/img/icons/bodhi.png",
+            "url": None,
+            "usernames": ['mohanboddu'],
+            "packages": [],
+            'agent': 'mohanboddu',
+            'repo': 'test_repo',
+            'success': False,
+        }
+        msg = ComposeCompleteV1(
+            body={
+                'agent': 'mohanboddu',
+                'success': False,
+                'repo': 'test_repo',
+            }
+        )
+        check_message(msg, expected)
+
+    def test_complete_v1_success(self):
+        """Test the ComposeCompleteV1 Message with a successful compose."""
+        expected = {
+            "topic": "bodhi.compose.complete",
+            "summary": "bodhi composer successfully composed test_repo",
+            "app_icon": "https://apps.fedoraproject.org/img/icons/bodhi.png",
+            "url": None,
+            "usernames": ['mohanboddu'],
+            "packages": [],
+            'agent': 'mohanboddu',
+            'repo': 'test_repo',
+            'success': True,
+        }
+        msg = ComposeCompleteV1(
+            body={
+                'agent': 'mohanboddu',
+                'success': True,
+                'repo': 'test_repo',
+            }
+        )
+        check_message(msg, expected)
+
+    def test_sync_wait_v1(self):
+        expected = {
+            "topic": "bodhi.compose.sync.wait",
+            "summary": (
+                "bodhi composer is waiting for test_repo "
+                "to hit the master mirror"
+            ),
+            "app_icon": "https://apps.fedoraproject.org/img/icons/bodhi.png",
+            "url": None,
+            "usernames": ['mohanboddu'],
+            "packages": [],
+            'agent': 'mohanboddu',
+            'repo': 'test_repo'
+        }
+        msg = ComposeSyncWaitV1(
+            body={'agent': 'mohanboddu', 'repo': 'test_repo'}
+        )
+        check_message(msg, expected)
+
+    def test_sync_done_v1(self):
+        expected = {
+            "topic": "bodhi.compose.sync.done",
+            "summary": (
+                "bodhi composer finished waiting for test_repo "
+                "to hit the master mirror"
+            ),
+            "app_icon": "https://apps.fedoraproject.org/img/icons/bodhi.png",
+            "url": None,
+            "usernames": ['mohanboddu'],
+            "packages": [],
+            'agent': 'mohanboddu',
+            'repo': 'test_repo'
+        }
+        msg = ComposeSyncDoneV1(
+            body={'agent': 'mohanboddu', 'repo': 'test_repo'}
+        )
+        check_message(msg, expected)

--- a/bodhi/tests/messages/schemas/test_composer.py
+++ b/bodhi/tests/messages/schemas/test_composer.py
@@ -1,0 +1,58 @@
+# Copyright (C) 2018-2019  Red Hat, Inc.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+"""Unit tests for the composer message schemas."""
+
+import unittest
+
+from bodhi.messages.schemas.composer import ComposeV1, ComposerStartV1
+from bodhi.tests.messages.utils import check_message
+
+
+class ComposerMessageTests(unittest.TestCase):
+    """A set of unit tests for classes in :py:mod:`bodhi_messages.schemas.composer`"""
+
+    def test_start_v1(self):
+        expected = {
+            "topic": "bodhi.composer.start",
+            "summary": "mohanboddu requested a compose of 2 repositories",
+            "app_icon": "https://apps.fedoraproject.org/img/icons/bodhi.png",
+            "url": None,
+            "agent_avatar": (
+                "https://seccdn.libravatar.org/avatar/"
+                "20652954adacfd9f6e26536bbcf3b5fbc850dc61f8a2e67c5bfbc6e345032976"
+                "?s=64&d=retro"
+            ),
+            "usernames": ["mohanboddu"],
+            "packages": [],
+            'resume': False,
+            'agent': 'mohanboddu',
+            'composes': [ComposeV1(21, 'stable', 'rpm', True), ComposeV1(23, 'stable', 'rpm', True)]
+        }
+        msg = ComposerStartV1(
+            body={
+                "resume": False,
+                "api_version": 2,
+                "agent": "mohanboddu",
+                "composes": [
+                    {"security": True,
+                     "release_id": 21,
+                     "request": "stable",
+                     "content_type": "rpm"},
+                    {"security": True,
+                     "release_id": 23,
+                     "request": "stable",
+                     "content_type": "rpm"}]})
+        check_message(msg, expected)

--- a/bodhi/tests/messages/schemas/test_errata.py
+++ b/bodhi/tests/messages/schemas/test_errata.py
@@ -1,0 +1,135 @@
+# Copyright (C) 2018-2019 Red Hat, Inc.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+"""Unit tests for the errata message schemas."""
+
+import unittest
+
+from bodhi.messages.schemas.errata import BuildV1, ErrataPublishV1, UpdateV1, UserV1
+from bodhi.tests.messages.utils import check_message
+
+
+class ErrataMessageTests(unittest.TestCase):
+    """A set of unit tests for classes in :py:mod:`bodhi_messages.schemas.errata`"""
+
+    def test_publish_v1(self):
+        """Test an ErrataPublishV1."""
+        expected = {
+            "topic": "bodhi.errata.publish",
+            "summary": "This is the subject of the errata email",
+            "__str__": "This is the body of the errata email",
+            "app_icon": "https://apps.fedoraproject.org/img/icons/bodhi.png",
+            "url": "https://bodhi.fedoraproject.org/updates/FEDORA-2019-4cc36fafbb",
+            "agent_avatar": (
+                'https://seccdn.libravatar.org/avatar/'
+                'a9bfa08eb2cdbfc3f0c22150b53985ea4489d288d9618b53b7d039c44e0f829d?s=64&d=retro'),
+            "usernames": ['test_submitter'],
+            "packages": ["tzdata"],
+            'agent': 'test_submitter',
+            'update': UpdateV1(
+                "FEDORA-2019-4cc36fafbb",
+                [BuildV1('tzdata-2014i-1.fc19')], UserV1('test_submitter'), 'pending', 'testing'),
+        }
+        msg = ErrataPublishV1(
+            body={
+                "subject": "This is the subject of the errata email",
+                "body": "This is the body of the errata email",
+                "update": {
+                    "alias": "FEDORA-2019-4cc36fafbb",
+                    "close_bugs": True,
+                    "old_updateid": None,
+                    "pushed": False,
+                    "require_testcases": True,
+                    "critpath": False,
+                    "stable_karma": 3,
+                    "date_pushed": None,
+                    "severity": "unspecified",
+                    "title": "tzdata-2014i-1.fc19",
+                    "suggest": "unspecified",
+                    "require_bugs": True,
+                    "comments": [
+                        {
+                            "bug_feedback": [],
+                            "user_id": 1681,
+                            "timestamp": "2015-01-28 03:02:44",
+                            "testcase_feedback": [],
+                            "karma_critpath": 0,
+                            "update": 54046,
+                            "update_id": 54046,
+                            "karma": 0,
+                            "anonymous": False,
+                            "text": "ralph edited this update. ",
+                            "id": 484236,
+                            "user": {
+                                "buildroot_overrides": [],
+                                "stacks": [],
+                                "name": "bodhi",
+                                "avatar": None
+                            }
+                        }
+                    ],
+                    "date_approved": None,
+                    "type": "enhancement",
+                    "status": "pending",
+                    "date_submitted": "2014-10-29 20:02:57",
+                    "unstable_karma": -3,
+                    "user": {
+                        "buildroot_overrides": [],
+                        "stacks": [
+                            {
+                                "requirements": "depcheck upgradepath",
+                                "description": "This stack is so hack!",
+                                "name": "Hackey",
+                                "groups": [],
+                                "packages": [],
+                                "users": [
+                                    1711
+                                ]
+                            },
+                        ],
+                        "name": "test_submitter",
+                        "avatar": None
+                    },
+                    "locked": False,
+                    "builds": [
+                        {
+                            "override": None,
+                            "nvr": "tzdata-2014i-1.fc19"
+                        }
+                    ],
+                    "date_modified": "2015-01-28 03:02:55",
+                    "notes": "the update notes go here...",
+                    "request": "testing",
+                    "bugs": [],
+                    "karma": 0,
+                    "release": {
+                        "dist_tag": "f19",
+                        "name": "F19",
+                        "testing_tag": "f19-updates-testing",
+                        "pending_stable_tag": "f19-updates-pending",
+                        "long_name": "Fedora 19",
+                        "state": "disabled",
+                        "version": None,
+                        "override_tag": "f19-override",
+                        "branch": None,
+                        "id_prefix": "FEDORA",
+                        "pending_testing_tag": "f19-updates-testing-pending",
+                        "stable_tag": "f19-updates",
+                        "candidate_tag": "f19-updates-candidate"
+                    }
+                }
+            }
+        )
+        check_message(msg, expected)

--- a/bodhi/tests/messages/schemas/test_update.py
+++ b/bodhi/tests/messages/schemas/test_update.py
@@ -1,0 +1,689 @@
+# Copyright (C) 2018-2019 Red Hat, Inc.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+"""Unit tests for the update message schemas."""
+
+import unittest
+
+from bodhi.messages.schemas.base import BuildV1, UpdateV1, UserV1
+from bodhi.messages.schemas.update import (
+    UpdateCommentV1,
+    UpdateCompleteTestingV1,
+    UpdateEditV1,
+    UpdateEjectV1,
+    UpdateKarmaThresholdV1,
+    UpdateRequestRevokeV1,
+    UpdateRequestStableV1,
+    UpdateRequestTestingV1,
+    UpdateRequestUnpushV1,
+    UpdateRequestObsoleteV1,
+    UpdateRequirementsMetStableV1,
+)
+from bodhi.tests.messages.utils import check_message
+
+
+class UpdateMessageTests(unittest.TestCase):
+    """A set of unit tests for classes in :py:mod:`bodhi_messages.schemas.update`"""
+
+    def test_eject_v1(self):
+        expected = {
+            "topic": "bodhi.update.eject",
+            "summary": (
+                "mbooth's xstream-1.4.11.1-2.fc30 bodhi update "
+                "was ejected from the test_repo mash. Reason: \"some reason\""
+            ),
+            "app_icon": "https://apps.fedoraproject.org/img/icons/bodhi.png",
+            "url": "https://bodhi.fedoraproject.org/updates/FEDORA-2019-2b055f8870",
+            "agent_avatar": (
+                "https://seccdn.libravatar.org/avatar/"
+                "20652954adacfd9f6e26536bbcf3b5fbc850dc61f8a2e67c5bfbc6e345032976"
+                "?s=64&d=retro"
+            ),
+            "usernames": ["mbooth", 'mohanboddu'],
+            "packages": ["xstream"],
+            'repo': 'test_repo',
+            'update': UpdateV1('FEDORA-2019-2b055f8870', [BuildV1('xstream-1.4.11.1-2.fc30')],
+                               UserV1('mbooth'), 'testing', None)
+        }
+        msg = UpdateEjectV1(
+            body={
+                "agent": "mohanboddu",
+                "update": {
+                    "alias": "FEDORA-2019-2b055f8870",
+                    "builds": [{
+                        "release_id": 28, "nvr": "xstream-1.4.11.1-2.fc30", "signed": True,
+                        "epoch": 0, "ci_url": None, "type": "rpm"}],
+                    "locked": True,
+                    "title": "xstream-1.4.11.1-2.fc30",
+                    'request': None,
+                    "status": "testing",
+                    'user': {'name': 'mbooth'}
+                },
+                "reason": "some reason",
+                "release": {
+                    "dist_tag": "fc30",
+                    "long_name": "Fedora 30",
+                    "name": "F30",
+                },
+                "request": "testing",
+                "repo": "test_repo",
+            }
+        )
+        check_message(msg, expected)
+
+    def test_complete_testing_v1(self):
+        expected = {
+            "topic": "bodhi.update.complete.testing",
+            "summary": (
+                "eclipseo's golang-github-SAP-go-hdb-0.14.1-1.fc29 t… bodhi update "
+                "completed push to testing"
+            ),
+            "app_icon": "https://apps.fedoraproject.org/img/icons/bodhi.png",
+            "url": "https://bodhi.fedoraproject.org/updates/FEDORA-2019-d64d0caab3",
+            "agent_avatar": (
+                "https://seccdn.libravatar.org/avatar/"
+                "20652954adacfd9f6e26536bbcf3b5fbc850dc61f8a2e67c5bfbc6e345032976"
+                "?s=64&d=retro"
+            ),
+            "usernames": ["eclipseo", 'mohanboddu'],
+            "packages": ["golang-github-SAP-go-hdb", 'texworks'],
+            'update': UpdateV1(
+                'FEDORA-2019-d64d0caab3',
+                [BuildV1('golang-github-SAP-go-hdb-0.14.1-1.fc29'),
+                 BuildV1('texworks-0.6.3-1.fc29')],
+                UserV1('eclipseo'), 'testing', None)
+        }
+        msg = UpdateCompleteTestingV1(
+            body={
+                "update": {
+                    "alias": "FEDORA-2019-d64d0caab3",
+                    "builds": [{"nvr": "golang-github-SAP-go-hdb-0.14.1-1.fc29"},
+                               {'nvr': 'texworks-0.6.3-1.fc29'}],
+                    "title": "fedmsg-0.2.7-2.el6",
+                    'request': None,
+                    "status": "testing",
+                    "user": {"name": "eclipseo"}
+                },
+                'agent': 'mohanboddu'
+            }
+        )
+        check_message(msg, expected)
+
+    def test_request_testing_v1_multiple(self):
+        expected = {
+            "topic": "bodhi.update.request.testing",
+            "summary": "lmacken submitted FEDORA-2019-f1ca3c00e5 to testing",
+            "app_icon": "https://apps.fedoraproject.org/img/icons/bodhi.png",
+            "url": "https://bodhi.fedoraproject.org/updates/FEDORA-2019-f1ca3c00e5",
+            "agent_avatar": (
+                "https://seccdn.libravatar.org/avatar/"
+                "203f6cb95b44b5d38aa21425b066dd522d3e19d8919cf4b339f29e0ea7f03e9b"
+                "?s=64&d=retro"
+            ),
+            "usernames": ["hadess", "lmacken"],
+            "packages": ["gnome-settings-daemon", "control-center"],
+            'update': UpdateV1(
+                'FEDORA-2019-f1ca3c00e5',
+                [BuildV1('gnome-settings-daemon-3.6.1-1.fc18'),
+                 BuildV1('control-center-3.6.1-1.fc18')],
+                UserV1('hadess'), 'pending', 'testing')
+        }
+        msg = UpdateRequestTestingV1(
+            body={
+                'agent': 'lmacken',
+                "update": {
+                    'alias': 'FEDORA-2019-f1ca3c00e5',
+                    "status": "pending",
+                    "critpath": False,
+                    "stable_karma": 3,
+                    "date_pushed": None,
+                    'user': {'name': 'hadess'},
+                    "title": (
+                        "gnome-settings-daemon-3.6.1-1.fc18,"
+                        "control-center-3.6.1-1.fc18"
+                    ),
+                    "nagged": None,
+                    "comments": [
+                        {
+                            "group": None,
+                            "author": "bodhi",
+                            "text": "This update has been submitted for "
+                            "testing by hadess. ",
+                            "karma": 0,
+                            "anonymous": False,
+                            "timestamp": 1349718539.0,
+                            "update_title": (
+                                "gnome-settings-daemon-3.6.1-1.fc18,"
+                                "control-center-3.6.1-1.fc18"
+                            )
+                        }
+                    ],
+                    "updateid": None,
+                    "type": "bugfix",
+                    "close_bugs": True,
+                    "date_submitted": 1349718534.0,
+                    "unstable_karma": -3,
+                    "release": {
+                        "dist_tag": "f18",
+                        "locked": True,
+                        "long_name": "Fedora 18",
+                        "name": "F18",
+                        "id_prefix": "FEDORA"
+                    },
+                    "approved": None,
+                    "builds": [
+                        {
+                            "nvr": "gnome-settings-daemon-3.6.1-1.fc18",
+                            "package": {
+                                "suggest_reboot": False,
+                                "committers": [
+                                    "hadess",
+                                    "ofourdan",
+                                    "mkasik",
+                                    "cosimoc"
+                                ],
+                                "name": "gnome-settings-daemon"
+                            }
+                        }, {
+                            "nvr": "control-center-3.6.1-1.fc18",
+                            "package": {
+                                "suggest_reboot": False,
+                                "committers": [
+                                    "ctrl-center-team",
+                                    "ofourdan",
+                                    "ssp",
+                                    "ajax",
+                                    "alexl",
+                                    "jrb",
+                                    "mbarnes",
+                                    "caolanm",
+                                    "davidz",
+                                    "mclasen",
+                                    "rhughes",
+                                    "hadess",
+                                    "johnp",
+                                    "caillon",
+                                    "whot",
+                                    "rstrode"
+                                ],
+                                "name": "control-center"
+                            }
+                        }
+                    ],
+                    "date_modified": None,
+                    "notes": (
+                        "This update fixes numerous bugs in the new Input "
+                        "Sources support, the Network panel and adds a help "
+                        "screen accessible via Wacom tablets's buttons."
+                    ),
+                    "request": "testing",
+                    "bugs": [],
+                    "critpath_approved": False,
+                    "karma": 0,
+                }
+            }
+        )
+        check_message(msg, expected)
+
+    def test_request_unpush_v1(self):
+        """Test a request unpush message."""
+        expected = {
+            "topic": "bodhi.update.request.unpush",
+            "summary": "ralph unpushed FEDORA-2019-8da6360454",
+            "app_icon": "https://apps.fedoraproject.org/img/icons/bodhi.png",
+            "url": "https://bodhi.fedoraproject.org/updates/FEDORA-2019-8da6360454",
+            "agent_avatar": (
+                "https://seccdn.libravatar.org/avatar/"
+                "9c9f7784935381befc302fe3c814f9136e7a33953d0318761669b8643f4df55c"
+                "?s=64&d=retro"
+            ),
+            "usernames": ["ralph"],
+            "packages": ["python-operator-courier"],
+            'update': UpdateV1(
+                'FEDORA-2019-8da6360454', [BuildV1('python-operator-courier-1.2.0-1.fc28')],
+                UserV1('ralph'), 'unpushed', None)
+        }
+        msg = UpdateRequestUnpushV1(
+            body={
+                'agent': 'ralph',
+                'update': {
+                    "alias": "FEDORA-2019-8da6360454",
+                    "builds": [{'nvr': 'python-operator-courier-1.2.0-1.fc28'}],
+                    'request': None,
+                    "status": "unpushed",
+                    "user": {"name": "ralph"}
+                },
+            }
+        )
+        check_message(msg, expected)
+
+    def test_request_obsolete_v1(self):
+        expected = {
+            "topic": "bodhi.update.request.obsolete",
+            "summary": "lmacken obsoleted FEDORA-2019-d64d0caab3",
+            "app_icon": "https://apps.fedoraproject.org/img/icons/bodhi.png",
+            "url": "https://bodhi.fedoraproject.org/updates/FEDORA-2019-d64d0caab3",
+            "agent_avatar": (
+                "https://seccdn.libravatar.org/avatar/"
+                "203f6cb95b44b5d38aa21425b066dd522d3e19d8919cf4b339f29e0ea7f03e9b"
+                "?s=64&d=retro"
+            ),
+            "usernames": ['eclipseo', "lmacken"],
+            "packages": ["golang-github-SAP-go-hdb"],
+            'update': UpdateV1(
+                'FEDORA-2019-d64d0caab3', [BuildV1('golang-github-SAP-go-hdb-0.14.1-1.fc29')],
+                UserV1('eclipseo'), 'testing', None)
+        }
+        msg = UpdateRequestObsoleteV1(
+            body={
+                'agent': 'lmacken',
+                'update': {
+                    "alias": "FEDORA-2019-d64d0caab3",
+                    "builds": [{"nvr": "golang-github-SAP-go-hdb-0.14.1-1.fc29"}],
+                    "title": "golang-github-SAP-go-hdb-0.14.1-1.fc29",
+                    'request': None,
+                    "status": "testing",
+                    "user": {"name": "eclipseo"}
+                },
+            }
+        )
+        check_message(msg, expected)
+
+    def test_request_stable_v1(self):
+        expected = {
+            "topic": "bodhi.update.request.stable",
+            "summary": "lmacken submitted FEDORA-2019-d64d0caab3 to stable",
+            "app_icon": "https://apps.fedoraproject.org/img/icons/bodhi.png",
+            "url": "https://bodhi.fedoraproject.org/updates/FEDORA-2019-d64d0caab3",
+            "agent_avatar": (
+                "https://seccdn.libravatar.org/avatar/"
+                "203f6cb95b44b5d38aa21425b066dd522d3e19d8919cf4b339f29e0ea7f03e9b"
+                "?s=64&d=retro"
+            ),
+            "usernames": ['eclipseo', "lmacken"],
+            "packages": ["golang-github-SAP-go-hdb"],
+            'update': UpdateV1(
+                'FEDORA-2019-d64d0caab3', [BuildV1('golang-github-SAP-go-hdb-0.14.1-1.fc29')],
+                UserV1('eclipseo'), 'testing', 'stable')
+        }
+        msg = UpdateRequestStableV1(
+            body={
+                'agent': 'lmacken',
+                'update': {
+                    "alias": "FEDORA-2019-d64d0caab3",
+                    "builds": [{"nvr": "golang-github-SAP-go-hdb-0.14.1-1.fc29"}],
+                    'request': 'stable',
+                    "status": "testing",
+                    "user": {"name": "eclipseo"}
+                },
+            }
+        )
+        check_message(msg, expected)
+
+    def test_request_revoke_v1(self):
+        expected = {
+            "topic": "bodhi.update.request.revoke",
+            "summary": "lmacken revoked FEDORA-2019-d64d0caab3",
+            "app_icon": "https://apps.fedoraproject.org/img/icons/bodhi.png",
+            "url": "https://bodhi.fedoraproject.org/updates/FEDORA-2019-d64d0caab3",
+            "agent_avatar": (
+                "https://seccdn.libravatar.org/avatar/"
+                "203f6cb95b44b5d38aa21425b066dd522d3e19d8919cf4b339f29e0ea7f03e9b"
+                "?s=64&d=retro"
+            ),
+            "usernames": ['eclipseo', "lmacken"],
+            "packages": ["golang-github-SAP-go-hdb"],
+            'update': UpdateV1(
+                'FEDORA-2019-d64d0caab3', [BuildV1('golang-github-SAP-go-hdb-0.14.1-1.fc29')],
+                UserV1('eclipseo'), 'testing', None)
+        }
+        msg = UpdateRequestRevokeV1(
+            body={
+                'agent': 'lmacken',
+                'update': {
+                    "alias": "FEDORA-2019-d64d0caab3",
+                    "builds": [{"nvr": "golang-github-SAP-go-hdb-0.14.1-1.fc29"}],
+                    'request': None,
+                    "status": "testing",
+                    "user": {"name": "eclipseo"}
+                },
+            }
+        )
+        check_message(msg, expected)
+
+    def test_request_testing_v1(self):
+        expected = {
+            "topic": "bodhi.update.request.testing",
+            "summary": "eclipseo submitted FEDORA-2019-f1ca3c00e5 to testing",
+            "app_icon": "https://apps.fedoraproject.org/img/icons/bodhi.png",
+            "url": "https://bodhi.fedoraproject.org/updates/FEDORA-2019-f1ca3c00e5",
+            "agent_avatar": (
+                "https://seccdn.libravatar.org/avatar/"
+                "899e8719059bf1b2d3aba96e3e276f72f24f18a9e1f4fbfa7a331995a628e760"
+                "?s=64&d=retro"
+            ),
+            "usernames": ["eclipseo"],
+            "packages": ["golang-github-Masterminds-semver"],
+            'update': UpdateV1(
+                'FEDORA-2019-f1ca3c00e5',
+                [BuildV1('golang-github-Masterminds-semver-2.0.0-0.1.20190319git3c92f33.fc29')],
+                UserV1('eclipseo'), 'pending', 'testing')
+        }
+        msg = UpdateRequestTestingV1(
+            body={
+                'agent': 'eclipseo',
+                'update': {
+                    "alias": "FEDORA-2019-f1ca3c00e5",
+                    "builds": [{
+                        "nvr": "golang-github-Masterminds-semver-2.0.0-0.1.20190319git3c92f33.fc29"
+                    }],
+                    'request': 'testing',
+                    "status": "pending",
+                    "user": {"name": "eclipseo"}
+                },
+            }
+        )
+        check_message(msg, expected)
+
+    def test_requirements_met_stable_v1(self):
+        expected = {
+            "topic": "bodhi.update.requirements_met.stable",
+            "summary": "FEDORA-2019-f1ca3c00e5 has met stable testing requirements",
+            "app_icon": "https://apps.fedoraproject.org/img/icons/bodhi.png",
+            "url": "https://bodhi.fedoraproject.org/updates/FEDORA-2019-f1ca3c00e5",
+            "agent_avatar": None,
+            "usernames": ["eclipseo"],
+            "packages": ["golang-github-Masterminds-semver"],
+            'update': UpdateV1(
+                'FEDORA-2019-f1ca3c00e5',
+                [BuildV1('golang-github-Masterminds-semver-2.0.0-0.1.20190319git3c92f33.fc29')],
+                UserV1('eclipseo'), 'pending', 'testing')
+        }
+        msg = UpdateRequirementsMetStableV1(
+            body={
+                'update': {
+                    "alias": "FEDORA-2019-f1ca3c00e5",
+                    "builds": [{
+                        "nvr": "golang-github-Masterminds-semver-2.0.0-0.1.20190319git3c92f33.fc29"
+                    }],
+                    'request': 'testing',
+                    "status": "pending",
+                    "user": {"name": "eclipseo"}
+                },
+            }
+        )
+        check_message(msg, expected)
+
+    def test_comment_v1(self):
+        expected = {
+            "topic": "bodhi.update.comment",
+            "summary": "ralph commented on bodhi update FEDORA-EPEL-2019-f2d195dada (karma: -1)",
+            "__str__": (
+                "Can you believe how much testing we're doing? "
+                "/cc @codeblock.\n"
+                "Nothing from this e-mail should match the regex: test@example.com"
+            ),
+            "app_icon": "https://apps.fedoraproject.org/img/icons/bodhi.png",
+            "url": "https://bodhi.fedoraproject.org/updates/FEDORA-EPEL-2019-f2d195dada",
+            "agent_avatar": (
+                "https://seccdn.libravatar.org/avatar/"
+                "9c9f7784935381befc302fe3c814f9136e7a33953d0318761669b8643f4df55c"
+                "?s=64&d=retro"
+            ),
+            "usernames": ["codeblock", "ralph", "tdawson"],
+            "packages": ['abrt-addon-python3', 'asciinema'],
+            'karma': -1,
+            'user': UserV1('ralph'),
+            'update': UpdateV1(
+                'FEDORA-EPEL-2019-f2d195dada',
+                [BuildV1("abrt-addon-python3-2.1.11-50.el7"), BuildV1("asciinema-1.4.0-2.el7")],
+                UserV1('tdawson'), 'pending', 'testing'),
+            'agent': 'ralph',
+        }
+        msg = UpdateCommentV1(
+            body={
+                "comment": {
+                    "karma": -1,
+                    "text": "Can you believe how much testing we're doing?"
+                            " /cc @codeblock.\n"
+                            "Nothing from this e-mail should match the regex: test@example.com",
+                    "timestamp": "2019-03-18 16:54:48",
+                    "update": {
+                        "alias": "FEDORA-EPEL-2019-f2d195dada",
+                        'builds': [{'nvr': 'abrt-addon-python3-2.1.11-50.el7'},
+                                   {'nvr': 'asciinema-1.4.0-2.el7'}],
+                        'status': 'pending',
+                        'request': 'testing',
+                        'user': {"name": "tdawson"}},
+                    'user': {'name': 'ralph'}
+                }
+            }
+        )
+        check_message(msg, expected)
+
+    def test_edit_v1(self):
+        expected = {
+            "topic": "bodhi.update.edit",
+            "summary": "ralph edited FEDORA-2019-7dbbb74a13",
+            "app_icon": "https://apps.fedoraproject.org/img/icons/bodhi.png",
+            "url": "https://bodhi.fedoraproject.org/updates/FEDORA-2019-7dbbb74a13",
+            "agent_avatar": (
+                "https://seccdn.libravatar.org/avatar/"
+                "9c9f7784935381befc302fe3c814f9136e7a33953d0318761669b8643f4df55c"
+                "?s=64&d=retro"
+            ),
+            "usernames": ["ralph"],
+            "packages": ["tzdata"],
+            'update': UpdateV1('FEDORA-2019-7dbbb74a13', [BuildV1('tzdata-2014i-1.fc19')],
+                               UserV1('ralph'), 'pending', 'testing')
+        }
+        msg = UpdateEditV1(
+            body={
+                "update": {
+                    "close_bugs": True,
+                    "old_updateid": None,
+                    "pushed": False,
+                    "require_testcases": True,
+                    "critpath": False,
+                    "cves": [],
+                    "stable_karma": 3,
+                    "date_pushed": None,
+                    "requirements": "rpmlint",
+                    "severity": "unspecified",
+                    "title": "tzdata-2014i-1.fc19",
+                    "suggest": "unspecified",
+                    "require_bugs": True,
+                    "comments": [
+                        {
+                            "bug_feedback": [],
+                            "user_id": 1681,
+                            "timestamp": "2015-01-28 03:02:44",
+                            "testcase_feedback": [],
+                            "karma_critpath": 0,
+                            "update": 54046,
+                            "update_id": 54046,
+                            "karma": 0,
+                            "anonymous": False,
+                            "text": "ralph edited this update. ",
+                            "id": 484236,
+                            "user": {
+                                "buildroot_overrides": [],
+                                "stacks": [],
+                                "name": "bodhi",
+                                "avatar": None
+                            }
+                        }
+                    ],
+                    "date_approved": None,
+                    "type": "enhancement",
+                    "status": "pending",
+                    "date_submitted": "2014-10-29 20:02:57",
+                    "unstable_karma": -3,
+                    "user": {
+                        "buildroot_overrides": [],
+                        "stacks": [
+                            {
+                                "requirements": "depcheck upgradepath",
+                                "description": "This stack is so hack!",
+                                "name": "Hackey",
+                                "groups": [],
+                                "packages": [],
+                                "users": [
+                                    1711
+                                ]
+                            },
+                        ],
+                        "name": "ralph",
+                        "avatar": None
+                    },
+                    "locked": False,
+                    "builds": [
+                        {
+                            "override": None,
+                            "nvr": "tzdata-2014i-1.fc19"
+                        }
+                    ],
+                    "date_modified": "2015-01-28 03:02:55",
+                    "notes": "the update notes go here...",
+                    "request": "testing",
+                    "bugs": [],
+                    "alias": 'FEDORA-2019-7dbbb74a13',
+                    "karma": 0,
+                    "release": {
+                        "dist_tag": "f19",
+                        "name": "F19",
+                        "testing_tag": "f19-updates-testing",
+                        "pending_stable_tag": "f19-updates-pending",
+                        "long_name": "Fedora 19",
+                        "state": "disabled",
+                        "version": None,
+                        "override_tag": "f19-override",
+                        "branch": None,
+                        "id_prefix": "FEDORA",
+                        "pending_testing_tag": "f19-updates-testing-pending",
+                        "stable_tag": "f19-updates",
+                        "candidate_tag": "f19-updates-candidate"
+                    }
+                },
+                "agent": "ralph"
+            }
+        )
+        check_message(msg, expected)
+
+    def test_karma_threshold_v1(self):
+        expected = {
+            "topic": "bodhi.update.karma.threshold.reach",
+            "summary": "FEDORA-EPEL-2015-0238 reached the stable karma threshold",
+            "app_icon": "https://apps.fedoraproject.org/img/icons/bodhi.png",
+            "url": "https://bodhi.fedoraproject.org/updates/FEDORA-EPEL-2015-0238",
+            "agent_avatar": None,
+            "usernames": ['ralph'],
+            "packages": ["tzdata"],
+            'update': UpdateV1('FEDORA-EPEL-2015-0238', [BuildV1('tzdata-2014i-1.fc19')],
+                               UserV1('ralph'), 'pending', 'testing'),
+            'status': 'stable'
+        }
+        msg = UpdateKarmaThresholdV1(
+            body={
+                "status": "stable",
+                "update": {
+                    "close_bugs": True,
+                    "old_updateid": None,
+                    "pushed": False,
+                    "require_testcases": True,
+                    "critpath": False,
+                    "cves": [],
+                    "stable_karma": 3,
+                    "date_pushed": None,
+                    "requirements": "rpmlint",
+                    "severity": "unspecified",
+                    "title": "tzdata-2014i-1.fc19",
+                    "suggest": "unspecified",
+                    "require_bugs": True,
+                    "comments": [
+                        {
+                            "bug_feedback": [],
+                            "user_id": 1681,
+                            "timestamp": "2015-01-28 03:02:44",
+                            "testcase_feedback": [],
+                            "karma_critpath": 0,
+                            "update": 54046,
+                            "update_id": 54046,
+                            "karma": 0,
+                            "anonymous": False,
+                            "text": "ralph edited this update. ",
+                            "id": 484236,
+                            "user": {
+                                "buildroot_overrides": [],
+                                "stacks": [],
+                                "name": "bodhi",
+                                "avatar": None
+                            }
+                        }
+                    ],
+                    "date_approved": None,
+                    "type": "enhancement",
+                    "status": "pending",
+                    "date_submitted": "2014-10-29 20:02:57",
+                    "unstable_karma": -3,
+                    "user": {
+                        "buildroot_overrides": [],
+                        "stacks": [
+                            {
+                                "requirements": "depcheck upgradepath",
+                                "description": "This stack is so hack!",
+                                "name": "Hackey",
+                                "groups": [],
+                                "packages": [],
+                                "users": [
+                                    1711
+                                ]
+                            },
+                        ],
+                        "name": "ralph",
+                        "avatar": None
+                    },
+                    "locked": False,
+                    "builds": [
+                        {
+                            "override": None,
+                            "nvr": "tzdata-2014i-1.fc19"
+                        }
+                    ],
+                    "date_modified": "2015-01-28 03:02:55",
+                    "notes": "the update notes go here...",
+                    "request": "testing",
+                    "bugs": [],
+                    "alias": "FEDORA-EPEL-2015-0238",
+                    "karma": 0,
+                    "release": {
+                        "dist_tag": "f19",
+                        "name": "F19",
+                        "testing_tag": "f19-updates-testing",
+                        "pending_stable_tag": "f19-updates-pending",
+                        "long_name": "Fedora 19",
+                        "state": "disabled",
+                        "version": None,
+                        "override_tag": "f19-override",
+                        "branch": None,
+                        "id_prefix": "FEDORA",
+                        "pending_testing_tag": "f19-updates-testing-pending",
+                        "stable_tag": "f19-updates",
+                        "candidate_tag": "f19-updates-candidate"
+                    }
+                }
+            }
+        )
+        check_message(msg, expected)

--- a/bodhi/tests/messages/utils.py
+++ b/bodhi/tests/messages/utils.py
@@ -1,0 +1,43 @@
+# Copyright (C) 2018-2019 Red Hat, Inc.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+"""Utilities to do unit testing of message schemas."""
+
+import typing
+
+if typing.TYPE_CHECKING:  # pragma: no cover
+    from bodhi.messages.schemas.base import BodhiMessage  # noqa: 401
+
+
+def check_message(msg: 'BodhiMessage', expected: typing.Mapping[str, typing.Any]):
+    """
+    Assert that the given message matches the information described in the expected mapping.
+
+    Args:
+        msg: The message you wish to validate.
+        expected: A dictionary describing the attributes that msg should have. Each key must match
+            the name of an attribute on msg, and will be used to compare the attribute's value to
+            the expected dictionary's value. A special key, __str__, may be used in expected to
+            index a string for how the message should be rendered by str().
+    """
+    # Let's make sure the message matches the expected schema.
+    msg.validate()
+    for prop, expected_value in expected.items():
+        if prop == "__str__":
+            assert str(msg) == expected_value
+        else:
+            assert getattr(msg, prop) == expected_value, (
+                f"key {prop} does not match: msg has {getattr(msg, prop)}, "
+                f"expected is {expected_value}")

--- a/devel/ci/bodhi-ci
+++ b/devel/ci/bodhi-ci
@@ -817,7 +817,7 @@ class MyPyJob(Job):
         """
         super(MyPyJob, self).__init__(*args, **kwargs)
 
-        self._command = ['/usr/local/bin/mypy', '--follow-imports', 'silent',
+        self._command = ['/usr/local/bin/mypy', '--follow-imports', 'silent', 'bodhi/messages',
                          'bodhi/server/bugs.py', 'bodhi/server/buildsys.py', 'devel/ci/bodhi-ci']
         self._convert_command_for_container()
 

--- a/docs/user/release_notes.rst
+++ b/docs/user/release_notes.rst
@@ -51,6 +51,12 @@ Backwards incompatible changes
 * Bug objects no longer include a ``private`` field (:issue:`3016`).
 * The CLI now defaults to the ``--wait`` flag when creating or editing buildroot overrides. The old
   behavior can be achieved with the ``--no-wait`` flag.
+* All of Bodhi's fedmsgs have been changed. A new bodhi.messages packages has been added with new
+  published message schemas. Note that only the fields listed in the documented schemas are
+  supported in Bodhi 4, even though Bodhi still sends messages similar to the messages it sent in
+  the past. Message consumers should not rely on any undocumented fields in these messages. If you
+  need information that is not included in the supported schema, please work with the Bodhi project
+  to get the schema adjusted accordingly.
 
 
 Dependency changes

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,6 +25,9 @@ output_dir = bodhi/server/locale
 [mypy-bugzilla.*]
 ignore_missing_imports = True
 
+[mypy-fedora_messaging.*]
+ignore_missing_imports = True
+
 [mypy-kitchen.*]
 ignore_missing_imports = True
 

--- a/setup.py
+++ b/setup.py
@@ -113,12 +113,81 @@ setup(
     """)
 
 
+setuptools.command.egg_info.manifest_maker.template = 'MESSAGES_MANIFEST.in'
+
+
+setup(
+    name="bodhi-messages",
+    version=VERSION,
+    description="JSON schema for messages sent by Bodhi",
+    long_description=('Bodhi Messages\n==============\n\n This package contains the schema for '
+                      'messages published by Bodhi.'),
+    url="https://github.com/fedora-infra/bodhi/",
+    # Possible options are at https://pypi.python.org/pypi?%3Aaction=list_classifiers
+    classifiers=[
+        "License :: OSI Approved :: GNU General Public License v2 or later (GPLv2+)",
+        "Operating System :: POSIX :: Linux",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+    ],
+    license="GPLv2+",
+    maintainer="Fedora Infrastructure Team",
+    maintainer_email="infrastructure@lists.fedoraproject.org",
+    platforms=["Fedora", "GNU/Linux"],
+    keywords=["fedora", "fedora-messaging"],
+    packages=['bodhi.messages'],
+    include_package_data=True,
+    zip_safe=False,
+    install_requires=["fedora_messaging"],
+    test_suite="bodhi.tests.messages",
+    entry_points={
+        "fedora.messages": [
+            (
+                "bodhi.buildroot_override.tag.v1="
+                "bodhi.messages.schemas.buildroot_override:BuildrootOverrideTagV1"
+            ), (
+                "bodhi.buildroot_override.untag.v1="
+                "bodhi.messages.schemas.buildroot_override:BuildrootOverrideUntagV1"
+            ),
+            "bodhi.errata.publish.v1=bodhi.messages.schemas.errata:ErrataPublishV1",
+            "bodhi.composer.start.v1=bodhi.messages.schemas.composer:ComposerStartV1",
+            "bodhi.compose.complete.v1=bodhi.messages.schemas.compose:ComposeCompleteV1",
+            "bodhi.compose.composing.v1=bodhi.messages.schemas.compose:ComposeComposingV1",
+            "bodhi.compose.start.v1=bodhi.messages.schemas.compose:ComposeStartV1",
+            "bodhi.compose.sync.done.v1=bodhi.messages.schemas.compose:ComposeSyncDoneV1",
+            "bodhi.compose.sync.wait.v1=bodhi.messages.schemas.compose:ComposeSyncWaitV1",
+            "bodhi.update.comment.v1=bodhi.messages.schemas.update:UpdateCommentV1",
+            (
+                "bodhi.update.complete.testing.v1="
+                "bodhi.messages.schemas.update:UpdateCompleteTestingV1"
+            ),
+            "bodhi.update.edit.v1=bodhi.messages.schemas.update:UpdateEditV1",
+            "bodhi.update.eject.v1=bodhi.messages.schemas.update:UpdateEjectV1",
+            "bodhi.update.karma.threshold.v1=bodhi.messages.schemas.update:UpdateKarmaThresholdV1",
+            "bodhi.update.request.revoke.v1=bodhi.messages.schemas.update:UpdateRequestRevokeV1",
+            "bodhi.update.request.stable.v1=bodhi.messages.schemas.update:UpdateRequestStableV1",
+            "bodhi.update.request.testing.v1=bodhi.messages.schemas.update:UpdateRequestTestingV1",
+            "bodhi.update.request.unpush.v1=bodhi.messages.schemas.update:UpdateRequestUnpushV1",
+            (
+                "bodhi.update.request.obsolete.v1="
+                "bodhi.messages.schemas.update:UpdateRequestObsoleteV1"
+            ), (
+                "bodhi.update.requirements_met.stable.v1="
+                "bodhi.messages.schemas.update:UpdateRequirementsMetStableV1"
+            ),
+        ]
+    },
+)
+
+
 setuptools.command.egg_info.manifest_maker.template = 'SERVER_MANIFEST.in'
 # Due to https://github.com/pypa/setuptools/issues/808, we need to include the bodhi superpackage
 # and then remove it if we want find_packages() to find the bodhi.server package and its
 # subpackages without including the bodhi top level package.
 server_packages = find_packages(
-    exclude=['bodhi.client', 'bodhi.client.*', 'bodhi.tests', 'bodhi.tests.*'])
+    exclude=['bodhi.client', 'bodhi.client.*', 'bodhi.messages', 'bodhi.messages.*', 'bodhi.tests',
+             'bodhi.tests.*'])
 server_packages.remove('bodhi')
 
 


### PR DESCRIPTION
fedora-messages uses Python classes to allow authors to define JSON
schema and a Python API to work with their messages. This adds the
basics of a Python package to distribute these schema.

This is similar to fedora_infrastructure_fedmsg_meta, except each
application manages its own schema definitions and how the message is
represented to the user.

Signed-off-by: Jeremy Cline <jcline@redhat.com>

--- 

I had this sitting in a branch and meant to write schema for Bodhi, but I've not found time yet. I thought it best to push what I have (which is just a skeleton package) and have us all chip away and defining schema and changing the code that publishes messages to use them.

I pulled the list of messages from https://fedora-fedmsg.readthedocs.io/en/latest/, but some may not still be sent. Also that list might not actually be complete. I expect as we audit the code we'll alter the list of classes here.