### PR TITLE
Drop support for Python 2 in bodhi.server.

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -12,14 +12,12 @@ pull_request_rules:
   - status-success=f28-flake8
   - status-success=f28-pydocstyle
   - status-success=f28-python2-unit
-  - status-success=f28-python2-diff-cover
   - status-success=f28-python3-unit
   - status-success=f28-python3-diff-cover
   - status-success=f29-docs
   - status-success=f29-flake8
   - status-success=f29-pydocstyle
   - status-success=f29-python2-unit
-  - status-success=f29-python2-diff-cover
   - status-success=f29-python3-unit
   - status-success=f29-python3-diff-cover
   - status-success=pip-docs
@@ -27,7 +25,6 @@ pull_request_rules:
   - status-success=pip-mypy
   - status-success=pip-pydocstyle
   - status-success=pip-python2-unit
-  - status-success=pip-python2-diff-cover
   - status-success=pip-python3-unit
   - status-success=pip-python3-diff-cover
   - status-success=f29-python3-integration
@@ -46,14 +43,12 @@ pull_request_rules:
   - status-success=f28-flake8
   - status-success=f28-pydocstyle
   - status-success=f28-python2-unit
-  - status-success=f28-python2-diff-cover
   - status-success=f28-python3-unit
   - status-success=f28-python3-diff-cover
   - status-success=f29-docs
   - status-success=f29-flake8
   - status-success=f29-pydocstyle
   - status-success=f29-python2-unit
-  - status-success=f29-python2-diff-cover
   - status-success=f29-python3-unit
   - status-success=f29-python3-diff-cover
   - status-success=pip-docs
@@ -61,7 +56,6 @@ pull_request_rules:
   - status-success=pip-mypy
   - status-success=pip-pydocstyle
   - status-success=pip-python2-unit
-  - status-success=pip-python2-diff-cover
   - status-success=pip-python3-unit
   - status-success=pip-python3-diff-cover
   name: default-from-bowlofeggs

--- a/bodhi/server/__init__.py
+++ b/bodhi/server/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright © 2007-2018 Red Hat, Inc. and others.
 #
 # This file is part of Bodhi.
@@ -29,7 +28,6 @@ from pyramid.config import Configurator
 from pyramid.renderers import JSONP
 from sqlalchemy import engine_from_config, event
 from sqlalchemy.orm import scoped_session, sessionmaker
-import six
 
 from bodhi.server import bugs, buildsys
 from bodhi.server.config import config as bodhi_config
@@ -72,7 +70,7 @@ def get_user(request):
     from bodhi.server.models import User
     userid = request.unauthenticated_userid
     if userid is not None:
-        user = request.db.query(User).filter_by(name=six.text_type(userid)).first()
+        user = request.db.query(User).filter_by(name=str(userid)).first()
         # Why munch?  https://github.com/fedora-infra/bodhi/issues/473
         return munchify(user.__json__(request=request))
 

--- a/bodhi/server/bugs.py
+++ b/bodhi/server/bugs.py
@@ -1,5 +1,4 @@
-# -*- coding: utf-8 -*-
-# Copyright © 2013-2017 Red Hat, Inc. and others.
+# Copyright © 2013-2018 Red Hat, Inc. and others.
 #
 # This file is part of Bodhi.
 #
@@ -18,13 +17,12 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 """Defines utilities for accessing Bugzilla."""
 
+from xmlrpc import client as xmlrpc_client
 import logging
 
 from collections import namedtuple
 from kitchen.text.converters import to_unicode
 import bugzilla
-import six
-from six.moves import xmlrpc_client
 
 from bodhi.server.config import config
 
@@ -276,7 +274,7 @@ class Bugzilla(BugTracker):
         if bug.product == 'Security Response':
             bug_entity.parent = True
         bug_entity.title = to_unicode(bug.short_desc)
-        if isinstance(bug.keywords, six.string_types):
+        if isinstance(bug.keywords, str):
             keywords = bug.keywords.split()
         else:  # python-bugzilla 0.8.0+
             keywords = bug.keywords

--- a/bodhi/server/buildsys.py
+++ b/bodhi/server/buildsys.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2007-2018 Red Hat, Inc. and others.
 #
 # This file is part of Bodhi.

--- a/bodhi/server/captcha.py
+++ b/bodhi/server/captcha.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright © 2014-2018 Red Hat, Inc.
 #
 # This file is part of Bodhi.
@@ -21,7 +20,6 @@
 # Authors:  Ralph Bean <rbean@redhat.com>
 """Define utilities and a view pertaining to captcha images for unauthenticated users."""
 
-from __future__ import division
 import base64
 import math
 import random
@@ -31,7 +29,6 @@ from PIL import Image, ImageDraw, ImageFont
 from pyramid.httpexceptions import HTTPGone, HTTPNotFound
 from pyramid.view import view_config
 import cryptography.fernet
-import six
 
 
 def math_generator(plainkey, settings):
@@ -62,7 +59,7 @@ def math_generator(plainkey, settings):
 
     x, y = int(tokens[0]), int(tokens[2])
 
-    value = six.text_type(x + y)
+    value = str(x + y)
     return plainkey, value
 
 
@@ -252,7 +249,7 @@ def decrypt(ciphertext, settings):
     secret = settings['captcha.secret']
     engine = cryptography.fernet.Fernet(secret)
 
-    if isinstance(ciphertext, six.text_type):
+    if isinstance(ciphertext, str):
         ciphertext = ciphertext.encode('utf-8')
 
     try:

--- a/bodhi/server/config.py
+++ b/bodhi/server/config.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright © 2013-2017 Red Hat, Inc. and others.
 #
 # This file is part of Bodhi.
@@ -25,7 +24,6 @@ import binascii
 from pyramid import settings
 from pyramid.paster import get_appsettings
 import cryptography.fernet
-import six
 
 
 log = logging.getLogger('bodhi')
@@ -54,7 +52,7 @@ def get_configfile():
     return configfile
 
 
-def _generate_list_validator(splitter=' ', validator=six.text_type):
+def _generate_list_validator(splitter=' ', validator=str):
     """Return a function that takes a value and interprets it to be a list with the given splitter.
 
     This function generates a function that can take a string and interpret it as a list by
@@ -81,7 +79,7 @@ def _generate_list_validator(splitter=' ', validator=six.text_type):
         Raises:
             ValueError: If validator fails on any of the list's elements.
         """
-        if isinstance(value, six.string_types):
+        if isinstance(value, str):
             value = [idx.strip() for idx in value.split(splitter) if idx.strip()]
 
         if not isinstance(value, list):
@@ -108,7 +106,7 @@ def _validate_bool(value):
     Raises:
         ValueError: If value cannot be interpreted as a boolean.
     """
-    if isinstance(value, six.string_types):
+    if isinstance(value, str):
         # Recent versions of Pyramid define a settings.falsey, but version 1.5.6 does not so its
         # values have been backported here for the False case. Pyramid defines an asbool(), but it
         # will not raise any error for strings that aren't in the truthy or falsey lists, and we
@@ -140,7 +138,7 @@ def _validate_color(value):
     """
     e = ValueError('"{}" is not a valid color expression.'.format(value))
 
-    if not isinstance(value, six.string_types):
+    if not isinstance(value, str):
         raise e
     if not len(value) == 7:
         raise e
@@ -151,7 +149,7 @@ def _validate_color(value):
     except ValueError:
         raise e
 
-    return six.text_type(value)
+    return str(value)
 
 
 def _validate_fernet_key(value):
@@ -170,7 +168,7 @@ def _validate_fernet_key(value):
     """
     _validate_secret(value)
 
-    if isinstance(value, six.text_type):
+    if isinstance(value, str):
         value = value.encode('utf-8')
 
     try:
@@ -219,7 +217,7 @@ def validate_path(value):
     if not os.path.exists(value):
         raise ValueError('"{}" does not exist.'.format(value))
 
-    return six.text_type(value)
+    return str(value)
 
 
 def _validate_rstripped_str(value):
@@ -227,11 +225,11 @@ def _validate_rstripped_str(value):
     Ensure that value is a str that is rstripped of the / character.
 
     Args:
-        value (six.text_type): The value to be validated and rstripped.
+        value (str): The value to be validated and rstripped.
     Returns:
-        six.text_type: The rstripped value.
+        str: The rstripped value.
     """
-    value = six.text_type(value)
+    value = str(value)
     return value.rstrip('/')
 
 
@@ -251,7 +249,7 @@ def _validate_secret(value):
     if value == 'CHANGEME':
         raise ValueError('This setting must be changed from its default value.')
 
-    return six.text_type(value)
+    return str(value)
 
 
 def _validate_tls_url(value):
@@ -264,10 +262,10 @@ def _validate_tls_url(value):
     Raises:
         ValueError: If value is not a string starting with https://.
     """
-    if not isinstance(value, six.string_types) or not value.startswith('https://'):
+    if not isinstance(value, str) or not value.startswith('https://'):
         raise ValueError('This setting must be a URL starting with https://.')
 
-    return six.text_type(value)
+    return str(value)
 
 
 class BodhiConfig(dict):
@@ -283,10 +281,10 @@ class BodhiConfig(dict):
     _defaults = {
         'acl_system': {
             'value': 'dummy',
-            'validator': six.text_type},
+            'validator': str},
         'acl_dummy_committer': {
             'value': None,
-            'validator': _validate_none_or(six.text_type)},
+            'validator': _validate_none_or(str)},
         'admin_groups': {
             'value': ['proventesters', 'security_respons', 'bodhiadmin', 'sysadmin-main'],
             'validator': _generate_list_validator()},
@@ -307,34 +305,34 @@ class BodhiConfig(dict):
             'validator': _generate_list_validator('|')},
         'base_address': {
             'value': 'https://admin.fedoraproject.org/updates/',
-            'validator': six.text_type},
+            'validator': str},
         'bodhi_email': {
             'value': 'updates@fedoraproject.org',
-            'validator': six.text_type},
+            'validator': str},
         'bodhi_password': {
             'value': None,
-            'validator': _validate_none_or(six.text_type)},
+            'validator': _validate_none_or(str)},
         'buglink': {
             'value': 'https://bugzilla.redhat.com/show_bug.cgi?id=%s',
-            'validator': six.text_type},
+            'validator': str},
         'bugtracker': {
             'value': None,
-            'validator': _validate_none_or(six.text_type)},
+            'validator': _validate_none_or(str)},
         'bugzilla_api_key': {
             'value': None,
-            'validator': _validate_none_or(six.text_type)},
+            'validator': _validate_none_or(str)},
         'buildroot_limit': {
             'value': 31,
             'validator': int},
         'buildsystem': {
             'value': 'dev',
-            'validator': six.text_type},
+            'validator': str},
         'bz_products': {
             'value': [],
             'validator': _generate_list_validator(',')},
         'bz_server': {
             'value': 'https://bugzilla.redhat.com/xmlrpc.cgi',
-            'validator': six.text_type},
+            'validator': str},
         'cache_dir': {
             'value': None,
             'validator': _validate_none_or(validate_path)},
@@ -370,19 +368,19 @@ class BodhiConfig(dict):
             'validator': _validate_bool},
         'container.destination_registry': {
             'value': 'registry.fedoraproject.org',
-            'validator': six.text_type},
+            'validator': str},
         'container.source_registry': {
             'value': 'candidate-registry.fedoraproject.org',
-            'validator': six.text_type},
+            'validator': str},
         'cors_connect_src': {
             'value': 'https://*.fedoraproject.org/ wss://hub.fedoraproject.org:9939/',
-            'validator': six.text_type},
+            'validator': str},
         'cors_origins_ro': {
             'value': '*',
-            'validator': six.text_type},
+            'validator': str},
         'cors_origins_rw': {
             'value': 'https://bodhi.fedoraproject.org',
-            'validator': six.text_type},
+            'validator': str},
         'critpath_pkgs': {
             'value': [],
             'validator': _generate_list_validator()},
@@ -397,24 +395,24 @@ class BodhiConfig(dict):
             'validator': int},
         'critpath.type': {
             'value': None,
-            'validator': _validate_none_or(six.text_type)},
+            'validator': _validate_none_or(str)},
         'datagrepper_url': {
             'value': 'https://apps.fedoraproject.org/datagrepper',
-            'validator': six.text_type},
+            'validator': str},
         'default_email_domain': {
             'value': 'fedoraproject.org',
-            'validator': six.text_type},
+            'validator': str},
         'disable_automatic_push_to_stable': {
             'value': (
                 'Bodhi is disabling automatic push to stable due to negative karma. The '
                 'maintainer may push manually if they determine that the issue is not severe.'),
-            'validator': six.text_type},
+            'validator': str},
         'dogpile.cache.arguments.filename': {
             'value': '/var/cache/bodhi-dogpile-cache.dbm',
-            'validator': six.text_type},
+            'validator': str},
         'dogpile.cache.backend': {
             'value': 'dogpile.cache.dbm',
-            'validator': six.text_type},
+            'validator': str},
         'dogpile.cache.expiration_time': {
             'value': 100,
             'validator': int},
@@ -423,26 +421,26 @@ class BodhiConfig(dict):
             'validator': _generate_list_validator()},
         'fedmenu.data_url': {
             'value': 'https://apps.fedoraproject.org/js/data.js',
-            'validator': six.text_type},
+            'validator': str},
         'fedmenu.url': {
             'value': 'https://apps.fedoraproject.org/fedmenu',
-            'validator': six.text_type},
+            'validator': str},
         'fedmsg_enabled': {
             'value': False,
             'validator': _validate_bool},
         'file_url': {
             'value': 'https://download.fedoraproject.org/pub/fedora/linux/updates',
-            'validator': six.text_type},
+            'validator': str},
         'fmn_url': {
             'value': 'https://apps.fedoraproject.org/notifications/',
-            'validator': six.text_type},
+            'validator': str},
         'important_groups': {
             'value': ['proventesters', 'provenpackager,' 'releng', 'security_respons', 'packager',
                       'bodhiadmin'],
             'validator': _generate_list_validator()},
         'initial_bug_msg': {
             'value': '%s has been submitted as an update to %s. %s',
-            'validator': six.text_type},
+            'validator': str},
         'greenwave_api_url': {
             'value': 'https://greenwave-web-greenwave.app.os.fedoraproject.org/api/v1.0',
             'validator': _validate_rstripped_str},
@@ -451,7 +449,7 @@ class BodhiConfig(dict):
             'validator': _validate_rstripped_str},
         'waiverdb.access_token': {
             'value': None,
-            'validator': _validate_none_or(six.text_type)},
+            'validator': _validate_none_or(str)},
         'koji_web_url': {
             'value': 'https://koji.fedoraproject.org/koji/',
             'validator': _validate_tls_url},
@@ -469,7 +467,7 @@ class BodhiConfig(dict):
             'validator': _validate_none_or(str)},
         'legal_link': {
             'value': '',
-            'validator': six.text_type},
+            'validator': str},
         'libravatar_dns': {
             'value': False,
             'validator': _validate_bool},
@@ -478,19 +476,19 @@ class BodhiConfig(dict):
             'validator': _validate_bool},
         'mail.templates_basepath': {
             'value': 'bodhi:server/email/templates/',
-            'validator': six.text_type},
+            'validator': str},
         'mako.directories': {
             'value': 'bodhi:server/templates',
-            'validator': six.text_type},
+            'validator': str},
         'mandatory_packager_groups': {
             'value': ['packager'],
             'validator': _generate_list_validator()},
         'mash_dir': {
             'value': None,
-            'validator': _validate_none_or(six.text_type)},
+            'validator': _validate_none_or(str)},
         'mash_stage_dir': {
             'value': None,
-            'validator': _validate_none_or(six.text_type)},
+            'validator': _validate_none_or(str)},
         'max_concurrent_mashes': {
             'value': 2,
             'validator': int},
@@ -499,103 +497,100 @@ class BodhiConfig(dict):
             'validator': int},
         'message_id_email_domain': {
             'value': 'admin.fedoraproject.org',
-            'validator': six.text_type},
+            'validator': str},
         'not_yet_tested_epel_msg': {
             'value': (
                 'This update has not yet met the minimum testing requirements defined in the '
                 '<a href="https://fedoraproject.org/wiki/EPEL_Updates_Policy">EPEL Update Policy'
                 '</a>'),
-            'validator': six.text_type},
+            'validator': str},
         'not_yet_tested_msg': {
             'value': (
                 'This update has not yet met the minimum testing requirements defined in the '
                 '<a href="https://fedoraproject.org/wiki/Package_update_acceptance_criteria">'
                 'Package Update Acceptance Criteria</a>'),
-            'validator': six.text_type},
+            'validator': str},
         'openid.provider': {
             'value': 'https://id.fedoraproject.org/openid/',
-            'validator': six.text_type},
+            'validator': str},
         'openid.sreg_required': {
             'value': 'email',
-            'validator': six.text_type},
+            'validator': str},
         'openid.success_callback': {
             'value': 'bodhi.server.security:remember_me',
-            'validator': six.text_type},
+            'validator': str},
         'openid.url': {
             'value': 'https://id.fedoraproject.org/',
-            'validator': six.text_type},
+            'validator': str},
         'openid_template': {
             'value': '{username}.id.fedoraproject.org',
-            'validator': six.text_type},
+            'validator': str},
         'pagure_url': {
             'value': 'https://src.fedoraproject.org/pagure/',
             'validator': _validate_tls_url},
         'pdc_url': {
             'value': 'https://pdc.fedoraproject.org/',
             'validator': _validate_tls_url},
-        'pkgdb_url': {
-            'value': 'https://admin.fedoraproject.org/pkgdb',
-            'validator': six.text_type},
         'prefer_ssl': {
             'value': None,
             'validator': _validate_none_or(bool)},
         'privacy_link': {
             'value': '',
-            'validator': six.text_type},
+            'validator': str},
         'pungi.basepath': {
             'value': '/etc/bodhi',
-            'validator': six.text_type},
+            'validator': str},
         'pungi.cmd': {
             'value': '/usr/bin/pungi-koji',
-            'validator': six.text_type},
+            'validator': str},
         'pungi.conf.module': {
             'value': 'pungi.module.conf',
-            'validator': six.text_type},
+            'validator': str},
         'pungi.conf.rpm': {
             'value': 'pungi.rpm.conf',
-            'validator': six.text_type},
+            'validator': str},
         'pungi.extracmdline': {
             'value': [],
             'validator': _generate_list_validator()},
         'pungi.labeltype': {
             'value': 'Update',
-            'validator': six.text_type},
+            'validator': str},
         'query_wiki_test_cases': {
             'value': False,
             'validator': _validate_bool},
         'release_team_address': {
             'value': 'bodhiadmin-members@fedoraproject.org',
-            'validator': six.text_type},
+            'validator': str},
         'resultsdb_api_url': {
             'value': 'https://taskotron.fedoraproject.org/resultsdb_api/',
-            'validator': six.text_type},
+            'validator': str},
         'session.secret': {
             'value': 'CHANGEME',
             'validator': _validate_secret},
         'site_requirements': {
             'value': 'dist.rpmdeplint dist.upgradepath',
-            'validator': six.text_type},
+            'validator': str},
         'skopeo.cmd': {
             'value': '/usr/bin/skopeo',
-            'validator': six.text_type,
+            'validator': str,
         },
         'skopeo.extra_copy_flags': {
             'value': '',
-            'validator': six.text_type,
+            'validator': str,
         },
         'smtp_server': {
             'value': None,
-            'validator': _validate_none_or(six.text_type)},
+            'validator': _validate_none_or(str)},
         'sqlalchemy.url': {
             'value': 'sqlite:////var/cache/bodhi.db',
-            'validator': six.text_type},
+            'validator': str},
         'stable_bug_msg': {
             'value': ('%s has been pushed to the %s repository. If problems still persist, please '
                       'make note of it in this bug report.'),
-            'validator': six.text_type},
+            'validator': str},
         'stable_from_batched_msg': {
             'value': ('This update has been dequeued from batched and is now entering stable.'),
-            'validator': six.text_type},
+            'validator': str},
         'stacks_enabled': {
             'value': False,
             'validator': _validate_bool},
@@ -607,26 +602,26 @@ class BodhiConfig(dict):
             'validator': _generate_list_validator()},
         'test_case_base_url': {
             'value': 'https://fedoraproject.org/wiki/',
-            'validator': six.text_type},
+            'validator': str},
         'testing_approval_msg_based_on_karma': {
             'value': ('This update has reached the stable karma threshold and can be pushed to '
                       'stable now if the maintainer wishes.'),
-            'validator': six.text_type
+            'validator': str
         },
         'testing_approval_msg': {
             'value': ('This update has reached %d days in testing and can be pushed to stable now '
                       'if the maintainer wishes'),
-            'validator': six.text_type},
+            'validator': str},
         'testing_bug_epel_msg': {
             'value': (
                 '\nSee https://fedoraproject.org/wiki/QA:Updates_Testing for\ninstructions on how '
                 'to install test updates.\nYou can provide feedback for this update here: %s'),
-            'validator': six.text_type},
+            'validator': str},
         'testing_bug_msg': {
             'value': (
                 '\nSee https://fedoraproject.org/wiki/QA:Updates_Testing for\ninstructions on how '
                 'to install test updates.\nYou can provide feedback for this update here: %s'),
-            'validator': six.text_type},
+            'validator': str},
         'top_testers_timeframe': {
             'value': 7,
             'validator': int},
@@ -635,16 +630,16 @@ class BodhiConfig(dict):
             'validator': _validate_bool},
         'test_gating.url': {
             'value': '',
-            'validator': six.text_type},
+            'validator': str},
         'updateinfo_rights': {
             'value': 'Copyright (C) {} Red Hat, Inc. and others.'.format(datetime.now().year),
-            'validator': six.text_type},
+            'validator': str},
         'wait_for_repo_sig': {
             'value': False,
             'validator': _validate_bool},
         'wiki_url': {
             'value': 'https://fedoraproject.org/w/api.php',
-            'validator': six.text_type},
+            'validator': str},
     }
 
     def __getitem__(self, *args, **kw):
@@ -700,7 +695,7 @@ class BodhiConfig(dict):
             try:
                 self[k] = self._defaults[k]['validator'](self[k])
             except ValueError as e:
-                errors.append('\t{}: {}'.format(k, six.text_type(e)))
+                errors.append('\t{}: {}'.format(k, str(e)))
 
         if errors:
             raise ValueError(

--- a/bodhi/server/consumers/signed.py
+++ b/bodhi/server/consumers/signed.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright © 2016-2018 Red Hat, Inc.
 #
 # This file is part of Bodhi.

--- a/bodhi/server/consumers/updates.py
+++ b/bodhi/server/consumers/updates.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2015-2018 Red Hat Inc., and others.
 #
 # This file is part of Bodhi.

--- a/bodhi/server/exceptions.py
+++ b/bodhi/server/exceptions.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright © 2007-2017 Red Hat, Inc. and others.
 #
 # This file is part of Bodhi.

--- a/bodhi/server/ffmarkdown.py
+++ b/bodhi/server/ffmarkdown.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright © 2014-2018 Red Hat, Inc. and others.
 #
 # This file is part of Bodhi.

--- a/bodhi/server/mail.py
+++ b/bodhi/server/mail.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2007-2018 Red Hat, Inc. and others.
 #
 # This file is part of Bodhi.
@@ -24,7 +23,6 @@ import smtplib
 
 from kitchen.iterutils import iterate
 from kitchen.text.converters import to_unicode, to_bytes
-import six
 
 from bodhi.server import log
 from bodhi.server.config import config
@@ -43,7 +41,7 @@ MESSAGES = {
         'fields': lambda agent, x: {
             'email': agent,
             'release': x.release.long_name,
-            'updatestr': six.text_type(x)
+            'updatestr': str(x)
         }
     },
 
@@ -55,7 +53,7 @@ MESSAGES = {
             'package': x.title,
             'email': agent,
             'release': '%s %s' % (x.release.long_name, x.status),
-            'updatestr': six.text_type(x)
+            'updatestr': str(x)
         }
     },
 
@@ -67,7 +65,7 @@ MESSAGES = {
             'package': x.title,
             'email': agent,
             'release': '%s %s' % (x.release.long_name, x.status),
-            'updatestr': six.text_type(x)
+            'updatestr': str(x)
         }
     },
 
@@ -78,7 +76,7 @@ MESSAGES = {
         'fields': lambda agent, x: {
             'package': x.title,
             'release': '%s %s' % (x.release.long_name, x.status),
-            'updatestr': six.text_type(x)
+            'updatestr': str(x)
         }
     },
 
@@ -89,7 +87,7 @@ MESSAGES = {
 """,
         'fields': lambda agent, x: {
             'submitter': agent,
-            'updatestr': six.text_type(x)
+            'updatestr': str(x)
         }
     },
 
@@ -100,7 +98,7 @@ MESSAGES = {
 """,
         'fields': lambda agent, x: {
             'submitter': agent,
-            'updatestr': six.text_type(x)
+            'updatestr': str(x)
         }
     },
 
@@ -110,7 +108,7 @@ MESSAGES = {
 """,
         'fields': lambda agent, x: {
             'submitter': agent,
-            'updatestr': six.text_type(x)
+            'updatestr': str(x)
         }
     },
 
@@ -119,7 +117,7 @@ MESSAGES = {
 The following update has been unpushed\n\n%(updatestr)s
 """,
         'fields': lambda agent, x: {
-            'updatestr': six.text_type(x)
+            'updatestr': str(x)
         }
     },
 
@@ -129,7 +127,7 @@ The following update has been unpushed\n\n%(updatestr)s
 """,
         'fields': lambda agent, x: {
             'submitter': agent,
-            'updatestr': six.text_type(x)
+            'updatestr': str(x)
         }
     },
 
@@ -140,7 +138,7 @@ The following update has been unpushed\n\n%(updatestr)s
 """,
         'fields': lambda agent, x: {
             'submitter': agent,
-            'updatestr': six.text_type(x)
+            'updatestr': str(x)
         }
     },
 
@@ -149,7 +147,7 @@ The following update has been unpushed\n\n%(updatestr)s
 The following update has been moved from Testing to Stable:\n\n%(updatestr)s
 """,
         'fields': lambda agent, x: {
-            'updatestr': six.text_type(x)
+            'updatestr': str(x)
         }
     },
 
@@ -161,7 +159,7 @@ automatically marked as stable.\n
 """,
         'fields': lambda agent, x: {
             'karma': x.karma,
-            'updatestr': six.text_type(x)
+            'updatestr': str(x)
         }
     },
 
@@ -174,7 +172,7 @@ repository.\n
 """,
         'fields': lambda agent, x: {
             'karma': x.karma,
-            'updatestr': six.text_type(x)
+            'updatestr': str(x)
         }
     },
 
@@ -191,7 +189,7 @@ To reply to this comment, please visit the URL at the bottom of this mail
         'fields': lambda agent, x: {
             'package': x.title,
             'comment': x.comments[-1],
-            'updatestr': six.text_type(x)
+            'updatestr': str(x)
         }
     },
 
@@ -218,7 +216,7 @@ or by running the following command with the bodhi-client:
         'fields': lambda agent, x: {
             'package': x.title,
             'stablekarma': x.stable_karma,
-            'updatestr': six.text_type(x)
+            'updatestr': str(x)
         }
     },
 
@@ -236,7 +234,7 @@ link below:
         'fields': lambda agent, x: {
             'package': x.title,
             'submitter': agent,
-            'updatestr': six.text_type(x)
+            'updatestr': str(x)
         }
     },
 
@@ -281,7 +279,7 @@ def get_template(update, use_template='fedora_errata_template'):
     """
     from bodhi.server.models import UpdateStatus, UpdateType
     use_template = read_template(use_template)
-    line = six.text_type('-' * 80) + '\n'
+    line = str('-' * 80) + '\n'
     templates = []
 
     for build in update.builds:

--- a/bodhi/server/metadata.py
+++ b/bodhi/server/metadata.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2007-2018 Red Hat, Inc. and others.
 #
 # This file is part of Bodhi.
@@ -26,7 +25,6 @@ import tempfile
 
 from kitchen.text.converters import to_bytes
 import createrepo_c as cr
-import six
 
 from bodhi.server import util
 from bodhi.server.buildsys import get_session
@@ -159,7 +157,7 @@ class UpdateInfoMetadata(object):
         log.debug("%d builds found" % len(kojiBuilds))
         for build in kojiBuilds:
             self.builds[build['nvr']] = build
-            build_obj = self.db.query(Build).filter_by(nvr=six.text_type(build['nvr'])).first()
+            build_obj = self.db.query(Build).filter_by(nvr=str(build['nvr'])).first()
             if build_obj:
                 if build_obj.update:
                     self.updates.add(build_obj.update)

--- a/bodhi/server/migrations/__init__.py
+++ b/bodhi/server/migrations/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright © 2017 Red Hat, Inc.
 #
 # This file is part of Bodhi.

--- a/bodhi/server/migrations/env.py
+++ b/bodhi/server/migrations/env.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright © 2013-2017 Red Hat, Inc. and others.
 #
 # This file is part of Bodhi.

--- a/bodhi/server/migrations/versions/06aa0e8aa5d2_drop_the_update_karma_column.py
+++ b/bodhi/server/migrations/versions/06aa0e8aa5d2_drop_the_update_karma_column.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright © 2016 Red Hat, Inc.
 #
 # This file is part of Bodhi.

--- a/bodhi/server/migrations/versions/2616c86d8ac6_add_indexes_for_status_and_request.py
+++ b/bodhi/server/migrations/versions/2616c86d8ac6_add_indexes_for_status_and_request.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright © 2017 Till Maas
 #
 # This file is part of Bodhi.

--- a/bodhi/server/migrations/versions/2a10629168e4_add_request_for_batched_update.py
+++ b/bodhi/server/migrations/versions/2a10629168e4_add_request_for_batched_update.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright © 2017 Caleigh Runge-Hottman and Red Hat, Inc.
 #
 # This file is part of Bodhi.

--- a/bodhi/server/migrations/versions/33a416e03f50_add_greenwave_fields.py
+++ b/bodhi/server/migrations/versions/33a416e03f50_add_greenwave_fields.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright © 2017 Red Hat, Inc.
 #
 # This file is part of Bodhi.

--- a/bodhi/server/migrations/versions/385acbb51075_add_flatpak_enum.py
+++ b/bodhi/server/migrations/versions/385acbb51075_add_flatpak_enum.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright © 2018 Red Hat, Inc.
 #
 # This file is part of Bodhi.

--- a/bodhi/server/migrations/versions/4b357c65441e_add_ci_status_to_builds.py
+++ b/bodhi/server/migrations/versions/4b357c65441e_add_ci_status_to_builds.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright © 2017 Red Hat, Inc.
 #
 # This file is part of Bodhi.

--- a/bodhi/server/migrations/versions/4f2f825bcf4a_disallow_null_values_in_autokarma.py
+++ b/bodhi/server/migrations/versions/4f2f825bcf4a_disallow_null_values_in_autokarma.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright © 2016 Red Hat, Inc.
 #
 # This file is part of Bodhi.

--- a/bodhi/server/migrations/versions/8eaacb38b036_add_the_ci_url_field_to_builds.py
+++ b/bodhi/server/migrations/versions/8eaacb38b036_add_the_ci_url_field_to_builds.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright © 2017 Red Hat, Inc.
 #
 # This file is part of Bodhi.

--- a/bodhi/server/migrations/versions/95ce24bed77a_remove_the_ci_status_feature.py
+++ b/bodhi/server/migrations/versions/95ce24bed77a_remove_the_ci_status_feature.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright © 2017 Red Hat, Inc.
 #
 # This file is part of Bodhi.

--- a/bodhi/server/migrations/versions/__init__.py
+++ b/bodhi/server/migrations/versions/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright © 2017 Red Hat, Inc. and others.
 #
 # This file is part of Bodhi.

--- a/bodhi/server/migrations/versions/b01a62d98aa4_convert_package_and_build_type_columns_.py
+++ b/bodhi/server/migrations/versions/b01a62d98aa4_convert_package_and_build_type_columns_.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright © 2017 Red Hat, Inc. and others.
 #
 # This file is part of Bodhi.

--- a/bodhi/server/models.py
+++ b/bodhi/server/models.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright © 2011-2018 Red Hat, Inc. and others.
 #
 # This file is part of Bodhi.
@@ -21,6 +20,7 @@
 from collections import defaultdict
 from datetime import datetime
 from textwrap import wrap
+from urllib.parse import quote
 import copy
 import hashlib
 import json
@@ -31,7 +31,6 @@ import time
 import uuid
 
 from simplemediawiki import MediaWiki
-from six.moves.urllib.parse import quote
 from sqlalchemy import (and_, Boolean, Column, DateTime, event, ForeignKey,
                         Integer, or_, Table, Unicode, UnicodeText, UniqueConstraint)
 from sqlalchemy.ext.declarative import declarative_base
@@ -40,7 +39,6 @@ from sqlalchemy.orm.exc import NoResultFound
 from sqlalchemy.orm.properties import RelationshipProperty
 from sqlalchemy.sql import text
 from sqlalchemy.types import SchemaType, TypeDecorator, Enum
-import six
 
 from bodhi.server import bugs, buildsys, log, mail, notifications, Session, util
 from bodhi.server.config import config
@@ -48,9 +46,6 @@ from bodhi.server.exceptions import BodhiException, LockedUpdateException
 from bodhi.server.util import (
     avatar as get_avatar, build_evr, get_critpath_components,
     get_rpm_header, header, tokenize, pagure_api_get)
-
-if six.PY2:
-    from pkgdb2client import PkgDB
 
 
 # http://techspot.zzzeek.org/2011/01/14/the-enum-recipe
@@ -119,7 +114,7 @@ class EnumSymbol(object):
         Returns:
             unicode: A string representation of this EnumSymbol's value.
         """
-        return six.text_type(self.value)
+        return str(self.value)
 
     __str__ = __unicode__
 
@@ -166,7 +161,7 @@ class EnumMeta(type):
         return iter(cls._reg.values())
 
 
-class DeclEnum(six.with_metaclass(EnumMeta, object)):
+class DeclEnum(metaclass=EnumMeta):
     """Declarative enumeration."""
 
     _reg = {}
@@ -414,11 +409,11 @@ class BodhiBase(object):
                 continue
             d[attr] = cls._expand(obj, getattr(obj, attr), seen, request)
 
-        for key, value in six.iteritems(d):
+        for key, value in d.items():
             if isinstance(value, datetime):
                 d[key] = value.strftime('%Y-%m-%d %H:%M:%S')
             if isinstance(value, EnumSymbol):
-                d[key] = six.text_type(value)
+                d[key] = str(value)
 
         # If explicitly asked to, we will overwrite some fields if the
         # corresponding condition of each evaluates to True.
@@ -1049,44 +1044,6 @@ class Package(Base):
             str: The name of this package.
         """
         return self.name
-
-    def get_pkg_pushers(self, branch, settings):  # pragma: no cover
-        """
-        Return users who can commit and are watching a package.
-
-        pragma: no cover is used on this method because pkgdb support is planned to be dropped in
-        Bodhi. See https://github.com/fedora-infra/bodhi/issues/1970
-
-        Return two two-tuples of lists:
-            * The first tuple is for usernames. The second tuple is for groups.
-            * The first list of the tuples is for committers. The second is for
-              watchers.
-        """
-        watchers = []
-        committers = []
-        watchergroups = []
-        committergroups = []
-
-        pkgdb = PkgDB(settings.get('pkgdb_url'))
-        acls = pkgdb.get_package(self.name, branches=branch)
-
-        for package in acls['packages']:
-            for acl in package.get('acls', []):
-                if acl['status'] == 'Approved':
-                    if acl['acl'] == 'watchcommits':
-                        name = acl['fas_name']
-                        if name.startswith('group::'):
-                            watchergroups.append(name.split('::')[1])
-                        else:
-                            watchers.append(name)
-                    elif acl['acl'] == 'commit':
-                        name = acl['fas_name']
-                        if name.startswith('group::'):
-                            committergroups.append(name.split('::')[1])
-                        else:
-                            committers.append(name)
-
-        return (committers, watchers), (committergroups, watchergroups)
 
     def get_pkg_committers_from_pagure(self):
         """
@@ -2551,7 +2508,7 @@ class Update(Base):
         """
         log.debug('Attempting to set request %s' % action)
         notes = []
-        if isinstance(action, six.string_types):
+        if isinstance(action, str):
             action = UpdateRequest.from_string(action)
         if self.status and action.description == self.status.description:
             log.info("%s already %s" % (self.title, action.description))

--- a/bodhi/server/notifications.py
+++ b/bodhi/server/notifications.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2014-2017 Red Hat, Inc.
 #
 # This file is part of Bodhi.

--- a/bodhi/server/push.py
+++ b/bodhi/server/push.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright © 2007-2018 Red Hat, Inc.
 #
 # This file is part of Bodhi.

--- a/bodhi/server/renderers.py
+++ b/bodhi/server/renderers.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright © 2014-2017 Red Hat, Inc.
 #
 # This file is part of Bodhi.

--- a/bodhi/server/schemas.py
+++ b/bodhi/server/schemas.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright © 2013-2017 Red Hat, Inc. and others.
 #
 # This file is part of Bodhi.

--- a/bodhi/server/scripts/approve_testing.py
+++ b/bodhi/server/scripts/approve_testing.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright © 2013-2017 Red Hat, Inc. and others.
 #
 # This file is part of Bodhi.
@@ -28,7 +27,6 @@ import sys
 import logging
 
 from pyramid.paster import get_appsettings
-import six
 
 from ..models import Update, UpdateStatus
 from ..config import config
@@ -101,7 +99,7 @@ def main(argv=sys.argv):
             # not reached the karma threshold.
             if update.meets_testing_requirements:
                 print('%s now meets testing requirements' % update.title)
-                text = six.text_type(
+                text = str(
                     config.get('testing_approval_msg') % update.mandatory_days_in_testing)
                 update.comment(db, text, author=u'bodhi')
 

--- a/bodhi/server/scripts/check_policies.py
+++ b/bodhi/server/scripts/check_policies.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright © 2017 Red Hat, Inc.
 #
 # This file is part of Bodhi.

--- a/bodhi/server/scripts/clean_old_mashes.py
+++ b/bodhi/server/scripts/clean_old_mashes.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright © 2016-2018 Red Hat, Inc.
 #
 # This file is part of Bodhi.

--- a/bodhi/server/scripts/dequeue_stable.py
+++ b/bodhi/server/scripts/dequeue_stable.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright © 2017 Caleigh Runge-Hottman and Red Hat, Inc.
 #
 # This file is part of Bodhi.

--- a/bodhi/server/scripts/manage_releases.py
+++ b/bodhi/server/scripts/manage_releases.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright © 2014-2017 Red Hat, Inc. and others.
 #
 # This file is part of Bodhi.

--- a/bodhi/server/scripts/monitor_composes.py
+++ b/bodhi/server/scripts/monitor_composes.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright © 2017-2018 Red Hat, Inc.
 #
 # This file is part of Bodhi.

--- a/bodhi/server/scripts/skopeo_lite.py
+++ b/bodhi/server/scripts/skopeo_lite.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright © 2018 Red Hat, Inc.
 #
 # This file is part of Bodhi.
@@ -37,6 +36,7 @@ Some other things that aren't implemented (but could be added if necessary):
  - Handling foreign layers
 """
 
+from urllib.parse import urlparse, urlunparse
 import json
 import logging
 import os
@@ -46,7 +46,6 @@ import tempfile
 import click
 import requests
 from requests.exceptions import SSLError, ConnectionError
-from six.moves.urllib.parse import urlparse, urlunparse
 
 
 @click.group()

--- a/bodhi/server/scripts/untag_branched.py
+++ b/bodhi/server/scripts/untag_branched.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright © 2015-2018 Red Hat, Inc. and others.
 #
 # This file is part of Bodhi.

--- a/bodhi/server/security.py
+++ b/bodhi/server/security.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright © 2013-2017 Red Hat, Inc. and others.
 #
 # This file is part of Bodhi.
@@ -23,7 +22,6 @@ from pyramid.security import (Allow, ALL_PERMISSIONS, DENY_ALL)
 from pyramid.security import remember, forget
 from pyramid.httpexceptions import HTTPFound
 from pyramid.threadlocal import get_current_registry
-import six
 
 from . import log
 from .models import User, Group
@@ -145,7 +143,7 @@ def remember_me(context, request, info, *args, **kw):
                               request.registry.settings['openid.provider'])
         return HTTPFound(location=request.route_url('home'))
 
-    username = six.text_type(info['identity_url'].split('http://')[1].split('.')[0])
+    username = str(info['identity_url'].split('http://')[1].split('.')[0])
     email = info['sreg']['email']
     log.debug('remember_me: groups = %s' % info['groups'])
     log.info('%s successfully logged in' % username)

--- a/bodhi/server/services/__init__.py
+++ b/bodhi/server/services/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright © 2017 Red Hat, Inc.
 #
 # This file is part of Bodhi.

--- a/bodhi/server/services/builds.py
+++ b/bodhi/server/services/builds.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright © 2014-2017 Red Hat, Inc. and others.
 #
 # This file is part of Bodhi.

--- a/bodhi/server/services/comments.py
+++ b/bodhi/server/services/comments.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright © 2014-2017 Red Hat, Inc. and others.
 #
 # This file is part of Bodhi.

--- a/bodhi/server/services/composes.py
+++ b/bodhi/server/services/composes.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright © 2017-2018 Red Hat, Inc.
 #
 # This file is part of Bodhi.

--- a/bodhi/server/services/csrf.py
+++ b/bodhi/server/services/csrf.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright © 2007-2017 Red Hat, Inc. and others.
 #
 # This file is part of Bodhi.

--- a/bodhi/server/services/errors.py
+++ b/bodhi/server/services/errors.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright © 2011-2017 Red Hat, Inc. and others.
 #
 # This file is part of Bodhi.

--- a/bodhi/server/services/markdown.py
+++ b/bodhi/server/services/markdown.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright © 2014-2017 Red Hat, Inc. and others.
 #
 # This file is part of Bodhi.

--- a/bodhi/server/services/overrides.py
+++ b/bodhi/server/services/overrides.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright © 2014-2017 Red Hat, Inc. and others.
 #
 # This file is part of Bodhi.

--- a/bodhi/server/services/packages.py
+++ b/bodhi/server/services/packages.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright © 2015-2017 Red Hat, Inc.
 #
 # This file is part of Bodhi.

--- a/bodhi/server/services/releases.py
+++ b/bodhi/server/services/releases.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright © 2014-2018 Red Hat Inc., and others.
 #
 # This file is part of Bodhi.

--- a/bodhi/server/services/stacks.py
+++ b/bodhi/server/services/stacks.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright © 2014-2018 Red Hat, Inc.
 #
 # This file is part of Bodhi.

--- a/bodhi/server/services/updates.py
+++ b/bodhi/server/services/updates.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright © 2014-2017 Red Hat, Inc. and others.
 #
 # This file is part of Bodhi.
@@ -26,7 +25,6 @@ from cornice.validators import colander_body_validator, colander_querystring_val
 from sqlalchemy import func, distinct
 from sqlalchemy.sql import or_
 from requests import RequestException, Timeout as RequestsTimeout
-import six
 
 from bodhi.server import log, security
 from bodhi.server.exceptions import BodhiException, LockedUpdateException
@@ -149,8 +147,6 @@ def get_update_for_editing(request):
             suggestions: The possible values for update suggestion.
     """
     suggestions = list(bodhi.server.models.UpdateSuggestion.values())
-    if six.PY2:  # pragma: no cover
-        suggestions = reversed(suggestions)
     return dict(
         update=request.validated['update'],
         types=reversed(list(bodhi.server.models.UpdateType.values())),

--- a/bodhi/server/services/user.py
+++ b/bodhi/server/services/user.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2014-2018 Red Hat, Inc. and others
 #
 # This file is part of Bodhi.

--- a/bodhi/server/services/zz_redirects.py
+++ b/bodhi/server/services/zz_redirects.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright © 2015-2017 Red Hat, Inc.
 #
 # This file is part of Bodhi.

--- a/bodhi/server/static/__init__.py
+++ b/bodhi/server/static/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright © 2017 Red Hat, Inc.
 #
 # This file is part of Bodhi.

--- a/bodhi/server/templates/update.html
+++ b/bodhi/server/templates/update.html
@@ -2,10 +2,7 @@
 <%namespace name="captcha" module="bodhi.server.captcha"/>
 <%namespace name="json" module="json"/>
 <%
-  try:
-    from urllib.parse import urljoin
-  except ImportError:
-    from urlparse import urljoin
+  from urllib.parse import urljoin
 %>
 
 <%block name="pagetitle">

--- a/bodhi/server/util.py
+++ b/bodhi/server/util.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright © 2007-2018 Red Hat, Inc. and others.
 #
 # This file is part of Bodhi.
@@ -20,6 +19,7 @@
 
 from collections import defaultdict, OrderedDict
 from contextlib import contextmanager
+from urllib.parse import urlencode
 import functools
 import hashlib
 import json
@@ -43,9 +43,6 @@ import librepo
 import markdown
 import requests
 import rpm
-from six.moves import map
-from six.moves.urllib.parse import urlencode
-import six
 
 from bodhi.server import ffmarkdown, log, buildsys, Session
 from bodhi.server.config import config
@@ -216,13 +213,7 @@ def get_critpath_components(collection='master', component_type='rpm', component
         log.warning('The critpath.type of "{0}" does not support searching for'
                     ' non-RPM components'.format(component_type))
 
-    if critpath_type == 'pkgdb':
-        from pkgdb2client import PkgDB
-        pkgdb = PkgDB(config.get('pkgdb_url'))
-        results = pkgdb.get_critpath_packages(branches=collection)
-        if collection in results['pkgs']:
-            critpath_components = results['pkgs'][collection]
-    elif critpath_type == 'pdc':
+    if critpath_type == 'pdc':
         critpath_components = get_critpath_components_from_pdc(
             collection, component_type, components)
     else:
@@ -403,7 +394,7 @@ def splitter(value):
 
     items = []
     for v in iterate(value):
-        if isinstance(v, six.string_types):
+        if isinstance(v, str):
             for item in v.replace(',', ' ').split():
                 items.append(item)
 
@@ -529,7 +520,7 @@ def status2html(context, status):
     Returns:
         basestring: An HTML span tag representing the UpdateStatus.
     """
-    status = six.text_type(status)
+    status = str(status)
     cls = {
         'pending': 'primary',
         'testing': 'warning',
@@ -604,7 +595,7 @@ def state2class(context, state):
         basestring: A string representing the classification of the given ReleaseState. Can return
             'danger', 'warning', 'success', or 'default active'.
     """
-    state = six.text_type(state)
+    state = str(state)
     cls = {
         'disabled': 'default active',
         'pending': 'warning',
@@ -625,7 +616,7 @@ def type2color(context, t):
         basestring: A string in the format rgba(RED, GREEN, BLUE, ALPHA), where RED, GREEN, BLUE,
             and ALPHA are replaced with numerical values to represent a color.
     """
-    t = six.text_type(t)
+    t = str(t)
     cls = {
         'bugfix': 'rgba(150,180,205,0.5)',
         'security': 'rgba(205,150,180,0.5)',
@@ -716,7 +707,7 @@ def type2html(context, kind):
     Returns:
         basestring: An HTML span tag representing the UpdateType.
     """
-    kind = six.text_type(kind)
+    kind = str(kind)
     cls = {
         'security': 'danger',
         'bugfix': 'warning',
@@ -738,7 +729,7 @@ def type2icon(context, kind):
     Returns:
         basestring: An HTML span tag representing the UpdateType.
     """
-    kind = six.text_type(kind)
+    kind = str(kind)
     cls = {
         'security': 'danger',
         'bugfix': 'warning',
@@ -774,7 +765,7 @@ def severity2html(context, severity):
     Returns:
         basestring: An HTML span tag representing the UpdateSeverity.
     """
-    severity = six.text_type(severity)
+    severity = str(severity)
     cls = {
         'urgent': 'danger',
         'high': 'warning',
@@ -796,7 +787,7 @@ def request2html(context, request):
     Returns:
         basestring: An HTML span tag representing the UpdateRequest.
     """
-    request = six.text_type(request)
+    request = str(request)
     cls = {
         'unpush': 'danger',
         'obsolete': 'default',
@@ -1527,9 +1518,9 @@ def update_install_command(context, update):
     Returns:
         basestring: The dnf command to install the Update.
     """
-    status = six.text_type(update.status)
+    status = str(update.status)
     alias = update.alias
-    update_type = six.text_type(update.type)
+    update_type = str(update.type)
 
     if status != 'stable' and status != 'testing':
         raise ValueError('Only updates in stable or testing can be installed!')

--- a/bodhi/server/validators.py
+++ b/bodhi/server/validators.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright © 2007-2018 Red Hat, Inc. and others.
 #
 # This file is part of Bodhi.
@@ -28,8 +27,6 @@ import colander
 import koji
 import pyramid.threadlocal
 import rpm
-from six.moves import map
-import six
 
 from . import captcha
 from . import log
@@ -359,9 +356,7 @@ def validate_acls(request, **kwargs):
         return
     user = User.get(request.user.name)
     committers = []
-    watchers = []
     groups = []
-    notify_groups = []
 
     # There are two different code-paths that could pass through this validator
     # One of them is for submitting something new with a list of builds (a new
@@ -457,20 +452,7 @@ def validate_acls(request, **kwargs):
                 request.errors.add('body', 'builds', error)
                 return
 
-        if acl_system == 'pkgdb':
-            try:
-                people, groups = package.get_pkg_pushers(
-                    release.branch, config)
-                committers, watchers = people
-                groups, notify_groups = groups
-            except Exception as e:
-                log.exception(e)
-                request.errors.add('body', 'builds',
-                                   "Unable to access the Package "
-                                   "Database to check ACLs. Please "
-                                   "try again later.")
-                return
-        elif acl_system == 'pagure':
+        if acl_system == 'pagure':
             try:
                 committers, groups = package.get_pkg_committers_from_pagure()
                 people = committers
@@ -478,7 +460,7 @@ def validate_acls(request, **kwargs):
                 # If it's a RuntimeError, then the error will be logged
                 # and we can return the error to the user as is
                 log.error(error)
-                request.errors.add('body', 'builds', six.text_type(error))
+                request.errors.add('body', 'builds', str(error))
                 return
             except Exception as error:
                 # This is an unexpected error, so let's log it and give back

--- a/bodhi/server/views/__init__.py
+++ b/bodhi/server/views/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright © 2017 Red Hat, Inc.
 #
 # This file is part of Bodhi.

--- a/bodhi/server/views/admin.py
+++ b/bodhi/server/views/admin.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright © 2014-2017 Red Hat, Inc. and others
 #
 # This file is part of Bodhi.

--- a/bodhi/server/views/generic.py
+++ b/bodhi/server/views/generic.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright © 2014-2017 Red Hat, Inc. and others
 #
 # This file is part of Bodhi.
@@ -26,7 +25,6 @@ from pyramid.exceptions import HTTPForbidden
 from pyramid.httpexceptions import HTTPFound
 import cornice.errors
 import sqlalchemy as sa
-import six
 
 from bodhi.server import log, models
 from bodhi.server.config import config
@@ -56,7 +54,7 @@ def get_top_testers():
         .filter(models.Comment.timestamp > start_time)
 
     for user in blacklist:
-        query = query.filter(models.User.name != six.text_type(user))
+        query = query.filter(models.User.name != str(user))
 
     return query\
         .group_by(models.User)\
@@ -242,8 +240,6 @@ def new_update(request):
     if not user:
         raise HTTPForbidden("You must be logged in.")
     suggestions = list(models.UpdateSuggestion.values())
-    if six.PY2:  # pragma: no cover
-        suggestions = reversed(suggestions)
     return dict(
         update=None,
         types=reversed(list(models.UpdateType.values())),
@@ -331,7 +327,7 @@ def latest_builds(request):
     builds = {}
     koji = request.koji
     package = request.params.get('package')
-    for tag_type, tags in six.iteritems(models.Release.get_tags(request.db)[0]):
+    for tag_type, tags in models.Release.get_tags(request.db)[0].items():
         for tag in tags:
             try:
                 for build in koji.getLatestBuilds(tag, package=package):
@@ -390,7 +386,7 @@ def popup_toggle(request):
     userid = request.authenticated_userid
     if userid is None:
         raise HTTPForbidden("You must be logged in.")
-    user = request.db.query(models.User).filter_by(name=six.text_type(userid)).first()
+    user = request.db.query(models.User).filter_by(name=str(userid)).first()
 
     # Toggle the value.
     user.show_popups = not user.show_popups

--- a/bodhi/server/views/metrics.py
+++ b/bodhi/server/views/metrics.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright © 2014-2017 Red Hat, Inc. and others.
 #
 # This file is part of Bodhi.

--- a/bodhi/server/webapp.py
+++ b/bodhi/server/webapp.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright © 2018 Red Hat, Inc.
 #
 # This file is part of Bodhi.

--- a/bodhi/tests/server/__init__.py
+++ b/bodhi/tests/server/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright © 2007-2018 Red Hat, Inc.
 #
 # This file is part of Bodhi.
@@ -19,8 +18,8 @@
 """Test the bodhi.server package."""
 
 from datetime import datetime, timedelta
-
 import mock
+
 import sqlalchemy
 
 from bodhi.server.models import (

--- a/bodhi/tests/server/base.py
+++ b/bodhi/tests/server/base.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright © 2016-2018 Red Hat, Inc.
 #
 # This file is part of Bodhi.
@@ -18,6 +17,7 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 """Contains a useful base test class that helps with common testing needs for bodhi.server."""
 from contextlib import contextmanager
+import mock
 import os
 import subprocess
 import unittest
@@ -25,7 +25,6 @@ import unittest
 from webtest import TestApp
 from sqlalchemy import event
 import createrepo_c
-import mock
 
 from bodhi.server import (bugs, buildsys, models, initialize_db, Session, config, main, metadata,
                           webapp)

--- a/bodhi/tests/server/consumers/__init__.py
+++ b/bodhi/tests/server/consumers/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright © 2018 Red Hat, Inc.
 #
 # This file is part of Bodhi.

--- a/bodhi/tests/server/consumers/test_signed.py
+++ b/bodhi/tests/server/consumers/test_signed.py
@@ -1,5 +1,7 @@
-# -*- coding: utf-8 -*-
-
+# Copyright © 2016-2018 Red Hat, Inc.
+#
+# This file is part of Bodhi.
+#
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
 # as published by the Free Software Foundation; either version 2
@@ -14,11 +16,9 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 """This test suite contains tests for the bodhi.server.consumers.signed module."""
-from __future__ import absolute_import, unicode_literals
-
-import unittest
 
 import mock
+import unittest
 
 from bodhi.server.consumers import signed
 

--- a/bodhi/tests/server/consumers/test_updates.py
+++ b/bodhi/tests/server/consumers/test_updates.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright © 2016-2018 Red Hat, Inc. and Caleigh Runge-Hotman
 #
 # This file is part of Bodhi.
@@ -20,9 +19,9 @@
 
 import copy
 import json
+import mock
 import unittest
 
-import mock
 import sqlalchemy
 
 from bodhi.server import config, exceptions, models, util

--- a/bodhi/tests/server/functional/__init__.py
+++ b/bodhi/tests/server/functional/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright © 2018 Red Hat, Inc.
 #
 # This file is part of Bodhi.

--- a/bodhi/tests/server/functional/test_packages.py
+++ b/bodhi/tests/server/functional/test_packages.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License

--- a/bodhi/tests/server/functional/test_stacks.py
+++ b/bodhi/tests/server/functional/test_stacks.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright © 2014-2018 Red Hat, Inc.
 #
 # This file is part of Bodhi.
@@ -18,8 +17,8 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 import copy
-
 import mock
+
 import webtest
 from fedora_messaging import api, testing as fml_testing
 

--- a/bodhi/tests/server/scripts/__init__.py
+++ b/bodhi/tests/server/scripts/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright © 2018 Red Hat, Inc.
 #
 # This file is part of Bodhi.

--- a/bodhi/tests/server/scripts/test_approve_testing.py
+++ b/bodhi/tests/server/scripts/test_approve_testing.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright © 2016-2018 Red Hat, Inc. and others.
 #
 # This file is part of Bodhi.
@@ -20,10 +19,10 @@
 This module contains tests for the bodhi.server.scripts.approve_testing module.
 """
 from datetime import datetime, timedelta
+from io import StringIO
+from mock import patch
 
 from fedora_messaging import api, testing as fml_testing
-from mock import patch
-from six import StringIO
 
 from bodhi.server.config import config
 from bodhi.server import models

--- a/bodhi/tests/server/scripts/test_bshell.py
+++ b/bodhi/tests/server/scripts/test_bshell.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright © 2018 Sebastian Wojciechowski
 #
 # This file is part of Bodhi.
@@ -20,10 +19,10 @@
 This module contains tests for the bodhi.server.scripts.bshell module.
 """
 
+from mock import patch
 import unittest
 
 from click import testing
-from mock import patch
 
 from bodhi.server.scripts import bshell
 

--- a/bodhi/tests/server/scripts/test_check_policies.py
+++ b/bodhi/tests/server/scripts/test_check_policies.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright © 2017-2018 Red Hat, Inc.
 #
 # This file is part of Bodhi.
@@ -17,11 +16,12 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 """This module contains tests for the bodhi.server.scripts.check_policies module."""
+
+from mock import patch
 import datetime
 import json
 
 from click import testing
-from mock import patch
 
 from bodhi.server import models
 from bodhi.server.scripts import check_policies

--- a/bodhi/tests/server/scripts/test_clean_old_mashes.py
+++ b/bodhi/tests/server/scripts/test_clean_old_mashes.py
@@ -14,13 +14,14 @@
 """
 This module contains tests for the bodhi.server.scripts.clean_old_mashes module.
 """
+
+from mock import patch
 import os
 import shutil
 import tempfile
 import unittest
 
 from click import testing
-from mock import patch
 
 from bodhi.server import config
 from bodhi.server.scripts import clean_old_mashes

--- a/bodhi/tests/server/scripts/test_dequeue_stable.py
+++ b/bodhi/tests/server/scripts/test_dequeue_stable.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright © 2017 Caleigh Runge-Hottman and Red Hat, Inc.
 #
 # This file is part of Bodhi.
@@ -20,10 +19,10 @@
 This module contains tests for the bodhi.server.scripts.dequeue_stable module.
 """
 from datetime import datetime, timedelta
+import mock
 
 from click import testing
 from fedora_messaging import api, testing as fml_testing
-import mock
 
 from bodhi.server import config, models
 from bodhi.server.scripts import dequeue_stable

--- a/bodhi/tests/server/scripts/test_expire_overrides.py
+++ b/bodhi/tests/server/scripts/test_expire_overrides.py
@@ -1,3 +1,7 @@
+# Copyright © 2016-2018 Red Hat, Inc. and others.
+#
+# This file is part of Bodhi.
+#
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
 # as published by the Free Software Foundation; either version 2
@@ -14,12 +18,12 @@
 """
 This module contains tests for the bodhi.server.scripts.expire_overrides module.
 """
+import mock
 import unittest
 from datetime import timedelta
+from io import StringIO
 
-import mock
 from fedora_messaging import api, testing as fml_testing
-from six import StringIO
 
 from bodhi.server import models
 from bodhi.server.scripts import expire_overrides

--- a/bodhi/tests/server/scripts/test_initializedb.py
+++ b/bodhi/tests/server/scripts/test_initializedb.py
@@ -1,5 +1,4 @@
-# -*- coding: utf-8 -*-
-# Copyright © 2017 Red Hat, Inc.
+# Copyright © 2017-2018 Red Hat, Inc.
 #
 # This file is part of Bodhi.
 #
@@ -17,10 +16,10 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 """Contains tests for the bodhi.server.scripts.initializedb module."""
-import unittest
 
+from io import StringIO
 import mock
-from six import StringIO
+import unittest
 
 from bodhi.server.scripts import initializedb
 

--- a/bodhi/tests/server/scripts/test_manage_releases.py
+++ b/bodhi/tests/server/scripts/test_manage_releases.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright © 2017 Red Hat, Inc.
 #
 # This file is part of Bodhi.
@@ -17,9 +16,9 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 """This module contains tests for bodhi.server.scripts.manage_releases."""
-import unittest
 
 import mock
+import unittest
 
 from bodhi.server.scripts import manage_releases
 from bodhi.client import cli

--- a/bodhi/tests/server/scripts/test_monitor_composes.py
+++ b/bodhi/tests/server/scripts/test_monitor_composes.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright © 2017-2018 Red Hat, Inc.
 #
 # This file is part of Bodhi.
@@ -20,9 +19,9 @@
 This module contains tests for the bodhi.server.scripts.monitor_composes module.
 """
 import json
+import mock
 
 from click import testing
-import mock
 
 from bodhi.server import models
 from bodhi.server.scripts import monitor_composes

--- a/bodhi/tests/server/scripts/test_sar.py
+++ b/bodhi/tests/server/scripts/test_sar.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright © 2018-2019 Sebastian Wojciechowski and Red Hat, Inc.
 #
 # This file is part of Bodhi.
@@ -19,11 +18,12 @@
 """
 This module contains tests for the bodhi.server.scripts.sar module.
 """
+
+import mock
 import os
 from datetime import datetime
 
 from click import testing
-import mock
 
 from bodhi.server import models
 from bodhi.server.scripts import sar

--- a/bodhi/tests/server/scripts/test_untag_branched.py
+++ b/bodhi/tests/server/scripts/test_untag_branched.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright © 2016-2018 Red Hat, Inc.
 #
 # This file is part of Bodhi.
@@ -20,9 +19,8 @@
 This module contains tests for the bodhi.server.scripts.untag_branched module.
 """
 from datetime import datetime, timedelta
-
+from io import StringIO
 from mock import call, patch
-from six import StringIO
 
 from bodhi.server import models
 from bodhi.server.scripts import untag_branched

--- a/bodhi/tests/server/services/__init__.py
+++ b/bodhi/tests/server/services/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright © 2018 Red Hat, Inc.
 #
 # This file is part of Bodhi.

--- a/bodhi/tests/server/services/test_builds.py
+++ b/bodhi/tests/server/services/test_builds.py
@@ -1,4 +1,3 @@
-# # -*- coding: utf-8 -*-
 # Copyright © 2014-2017 Red Hat Inc. and others.
 #
 # This file is part of Bodhi.

--- a/bodhi/tests/server/services/test_comments.py
+++ b/bodhi/tests/server/services/test_comments.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright © 2014-2018 Red Hat, Inc. and others.
 #
 # This file is part of Bodhi.
@@ -18,10 +17,10 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 import copy
+import mock
 from datetime import datetime, timedelta
 
 from fedora_messaging import api, testing as fml_testing
-import mock
 import webtest
 
 from bodhi.server import main

--- a/bodhi/tests/server/services/test_composes.py
+++ b/bodhi/tests/server/services/test_composes.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2017-2018 Red Hat, Inc.
 #
 # This file is part of Bodhi.

--- a/bodhi/tests/server/services/test_csrf.py
+++ b/bodhi/tests/server/services/test_csrf.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright © 2017 Red Hat, Inc.
 #
 # This file is part of Bodhi.

--- a/bodhi/tests/server/services/test_errors.py
+++ b/bodhi/tests/server/services/test_errors.py
@@ -1,5 +1,4 @@
-# -*- coding: utf-8 -*-
-# Copyright © 2017 Red Hat, Inc.
+# Copyright © 2018 Red Hat, Inc.
 #
 # This file is part of Bodhi.
 #
@@ -18,7 +17,6 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 """This module contains tests for bodhi.server.services.errors.py"""
 import mock
-import six
 
 from bodhi.tests.server import base
 
@@ -40,5 +38,4 @@ class TestHTMLHandlerErrors(base.BaseTestCase):
         self.assertIn("Traceback (most recent call last):\n", error_log_message)
         self.assertIn("summary=status2summary(errors.status),\n", error_log_message)
         self.assertIn("raise effect\n", error_log_message)
-        exception_str = 'IOError' if six.PY2 else 'OSError'
-        self.assertIn(exception_str + ": random error\n", error_log_message)
+        self.assertIn("OSError: random error\n", error_log_message)

--- a/bodhi/tests/server/services/test_overrides.py
+++ b/bodhi/tests/server/services/test_overrides.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright © 2014-2018 Red Hat, Inc. and others.
 #
 # This file is part of Bodhi.
@@ -19,9 +18,9 @@
 
 from datetime import datetime, timedelta
 import copy
+import mock
 
 from fedora_messaging import api, testing as fml_testing
-import mock
 import webtest
 
 from bodhi.server.models import (

--- a/bodhi/tests/server/services/test_releases.py
+++ b/bodhi/tests/server/services/test_releases.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright © 2014-2018 Red Hat, Inc. and others.
 #
 # This file is part of Bodhi.

--- a/bodhi/tests/server/services/test_updates.py
+++ b/bodhi/tests/server/services/test_updates.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2011-2019 Red Hat, Inc. and others.
 #
 # This file is part of Bodhi.
@@ -18,18 +17,17 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 """This module contains tests for bodhi.server.services.updates."""
 from datetime import datetime, timedelta
+from mock import ANY
+from urllib import parse as urlparse
 import copy
+import mock
 import re
 import textwrap
 import time
 
 from fedora_messaging import api, testing as fml_testing
-from mock import ANY
 import koji
-import mock
 import requests
-import six
-from six.moves.urllib import parse as urlparse
 from webtest import TestApp
 
 from bodhi.server import main
@@ -204,18 +202,6 @@ class TestNewUpdate(BaseTestCase):
         assert build.update is not None
         publish.assert_called_once_with(
             topic='update.request.testing', msg=mock.ANY)
-
-    @mock.patch(**mock_valid_requirements)
-    def test_pkgdb_outage(self, *args):
-        "Test the case where our call to the pkgdb throws an exception"
-        update = self.get_update(u'bodhi-2.0-2.fc17')
-        update['csrf_token'] = self.get_csrf_token()
-
-        with mock.patch.dict('bodhi.server.validators.config',
-                             {'acl_system': 'pkgdb', 'pkgdb_url': 'invalidurl'}):
-            res = self.app.post_json('/updates/', update, status=400)
-
-        assert "Unable to access the Package Database" in res, res
 
     @mock.patch(**mock_valid_requirements)
     def test_invalid_acl_system(self, *args):
@@ -3187,7 +3173,7 @@ class TestUpdatesService(BaseTestCase):
         self.assertEqual(up.status, UpdateStatus.pending)
         self.assertEqual(up.request, UpdateRequest.testing)
 
-        text = six.text_type(config.get('testing_approval_msg_based_on_karma'))
+        text = str(config.get('testing_approval_msg_based_on_karma'))
         up.comment(self.db, text, author=u'bodhi')
         self.assertIn('pushed to stable now if the maintainer wishes', up.comments[-1]['text'])
 
@@ -5019,7 +5005,7 @@ class TestUpdatesService(BaseTestCase):
         self.assertEqual(upd.autokarma, False)
         self.assertEqual(upd.pushed, True)
 
-        text = six.text_type(config.get('testing_approval_msg_based_on_karma'))
+        text = str(config.get('testing_approval_msg_based_on_karma'))
         upd.comment(self.db, text, author=u'bodhi')
 
         # Checks Push to Stable text in the html page for this update
@@ -5067,7 +5053,7 @@ class TestUpdatesService(BaseTestCase):
         self.assertEqual(upd.request, None)
         self.assertEqual(upd.autokarma, False)
 
-        text = six.text_type(config.get('testing_approval_msg_based_on_karma'))
+        text = str(config.get('testing_approval_msg_based_on_karma'))
         upd.comment(self.db, text, author=u'bodhi')
 
         # Checks Push to Batched text in the html page for this update

--- a/bodhi/tests/server/test___init__.py
+++ b/bodhi/tests/server/test___init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright © 2007-2018 Red Hat, Inc. and others.
 #
 # This file is part of Bodhi.
@@ -18,10 +17,10 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 """This test suite contains tests for bodhi.server.__init__."""
 import collections
+import mock
 import unittest
 
 from pyramid import authentication, authorization, testing
-import mock
 import munch
 
 from bodhi import server

--- a/bodhi/tests/server/test_alembic.py
+++ b/bodhi/tests/server/test_alembic.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright © 2017, 2018 Red Hat, Inc.
 #
 # This file is part of Bodhi.
@@ -41,8 +40,8 @@ class TestAlembic(unittest.TestCase):
         """
         alembic = None
         # Fedora calls the executable alembic-3, but the pip installed alembic will be alembic.
-        for executable in ('alembic-3', 'alembic'):
-            if os.path.exists(os.path.join('/', 'usr', 'bin', executable)):
+        for executable in ('/usr/local/bin/alembic', '/usr/bin/alembic-3'):
+            if os.path.exists(executable):
                 alembic = executable
                 break
 

--- a/bodhi/tests/server/test_bugs.py
+++ b/bodhi/tests/server/test_bugs.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright © 2007-2018 Red Hat, Inc. and others.
 #
 # This file is part of Bodhi.
@@ -18,11 +17,9 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 """This test suite contains tests for bodhi.server.bugs."""
 
-from __future__ import division
 import unittest
-
 import mock
-from six.moves import xmlrpc_client
+import xmlrpc.client
 
 from bodhi.server import bugs, models
 
@@ -122,7 +119,7 @@ class TestBugzilla(unittest.TestCase):
         bz._bz = mock.MagicMock()
         bz._bz.getbug.return_value.private = False
         bz._bz.getbug.return_value.product = 'aproduct'
-        bz._bz.getbug.return_value.close.side_effect = xmlrpc_client.Fault(
+        bz._bz.getbug.return_value.close.side_effect = xmlrpc.client.Fault(
             410, 'You must log in before using this part of Red Hat Bugzilla.')
 
         # This should not raise an Exception.
@@ -279,7 +276,7 @@ class TestBugzilla(unittest.TestCase):
         bz._bz = mock.MagicMock()
         bz._bz.getbug.return_value.private = False
         bz._bz.getbug.return_value.addcomment.side_effect = \
-            xmlrpc_client.Fault(
+            xmlrpc.client.Fault(
                 42,
                 'Someone turned the microwave on and now the WiFi is down.'
             )
@@ -448,7 +445,7 @@ class TestBugzilla(unittest.TestCase):
         """Test we log an error if update_details raises one"""
         bz = bugs.Bugzilla()
         bz._bz = mock.MagicMock()
-        bz._bz.getbug.side_effect = xmlrpc_client.Fault(42, 'You found the meaning.')
+        bz._bz.getbug.side_effect = xmlrpc.client.Fault(42, 'You found the meaning.')
         bug = mock.MagicMock()
         bug.bug_id = 123
 
@@ -464,7 +461,7 @@ class TestBugzilla(unittest.TestCase):
         """Test we set the bug as private and log the info"""
         bz = bugs.Bugzilla()
         bz._bz = mock.MagicMock()
-        bz._bz.getbug.side_effect = xmlrpc_client.Fault(102, 'The bug is private.')
+        bz._bz.getbug.side_effect = xmlrpc.client.Fault(102, 'The bug is private.')
         bug = mock.MagicMock()
         bug.bug_id = 123
 

--- a/bodhi/tests/server/test_buildsys.py
+++ b/bodhi/tests/server/test_buildsys.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright © 2016-2018 Red Hat, Inc.
 #
 # This file is part of Bodhi.
@@ -19,10 +18,10 @@
 """This test suite contains tests for the bodhi.server.buildsys module."""
 
 from threading import Lock
+import mock
 import unittest
 
 import koji
-import mock
 
 from bodhi.server import buildsys
 

--- a/bodhi/tests/server/test_captcha.py
+++ b/bodhi/tests/server/test_captcha.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright © 2016-2018 Red Hat, Inc.
 #
 # This file is part of Bodhi.
@@ -18,12 +17,11 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 """This test suite contains tests for bodhi.server.captcha."""
 
+import mock
 import unittest
 
-import mock
 import PIL.Image
 from pyramid.httpexceptions import HTTPGone, HTTPNotFound
-import six
 
 from bodhi.server import captcha
 from bodhi.server.config import config
@@ -93,7 +91,7 @@ class TestDecrypt(unittest.TestCase):
         with self.assertRaises(HTTPNotFound) as exc:
             captcha.decrypt(base64_unsafe_message, config)
 
-        self.assertEqual(six.text_type(exc.exception), '$@#his3##d*f is garbage')
+        self.assertEqual(str(exc.exception), '$@#his3##d*f is garbage')
 
     @mock.patch.dict(config, {'captcha.secret': 'gFqE6rcBXVLssjLjffsQsAa-nlm5Bg06MTKrVT9hsMA='})
     def test_invalid_token(self):
@@ -106,7 +104,7 @@ class TestDecrypt(unittest.TestCase):
 
     @mock.patch.dict(config, {'captcha.secret': 'gFqE6rcBXVLssjLjffsQsAa-nlm5Bg06MTKrVT9hsMA='})
     def test_text_type_cipherkey(self):
-        """Ensure that decrypt can decrypt what encrypt generated, when it is a six.text_type."""
+        """Ensure that decrypt can decrypt what encrypt generated, when it is a str."""
         plaintext = "don't let eve see this!"
         bobs_message = captcha.encrypt(plaintext, config).decode('utf-8')
 
@@ -128,7 +126,7 @@ class TestGenerateCaptcha(unittest.TestCase):
         cipherkey, url = captcha.generate_captcha(None, request)
 
         self.assertEqual(request.session['captcha'], cipherkey)
-        self.assertTrue(isinstance(cipherkey, six.text_type))
+        self.assertTrue(isinstance(cipherkey, str))
         request.route_url.assert_called_once_with('captcha_image', cipherkey=cipherkey)
         self.assertEqual(url, request.route_url.return_value)
         # Let's cheat and find out what the correct value for this cipherkey is and make sure it is

--- a/bodhi/tests/server/test_config.py
+++ b/bodhi/tests/server/test_config.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright © 2017-2018 Red Hat, Inc.
 #
 # This file is part of Bodhi.
@@ -17,10 +16,8 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
-import unittest
-
 import mock
-import six
+import unittest
 
 from bodhi.server import config
 
@@ -267,7 +264,7 @@ class GenerateListValidatorTests(unittest.TestCase):
         result = config._generate_list_validator('|')('thing 1| thing 2')
 
         self.assertEqual(result, [u'thing 1', u'thing 2'])
-        self.assertTrue(all([isinstance(v, six.text_type) for v in result]))
+        self.assertTrue(all([isinstance(v, str) for v in result]))
 
     def test_custom_validator(self):
         """Test with a non-default validator."""
@@ -281,7 +278,7 @@ class GenerateListValidatorTests(unittest.TestCase):
         result = config._generate_list_validator()('play it again sam')
 
         self.assertEqual(result, [u'play', u'it', u'again', u'sam'])
-        self.assertTrue(all([isinstance(v, six.text_type) for v in result]))
+        self.assertTrue(all([isinstance(v, str) for v in result]))
 
     def test_with_list(self):
         """Test with a list."""
@@ -346,7 +343,7 @@ class ValidateColorTests(unittest.TestCase):
         color = config._validate_color('#65FE00')
 
         self.assertEqual(color, u'#65FE00')
-        self.assertTrue(isinstance(color, six.text_type))
+        self.assertTrue(isinstance(color, str))
 
     def test_wrong_base(self):
         """A string that isn't a base-16 number should raise a ValueError."""
@@ -392,26 +389,19 @@ class ValidateFernetKey(unittest.TestCase):
         result = config._validate_fernet_key(key)
 
         self.assertEqual(result, key)
-        if six.PY2:
-            self.assertIs(type(result), str)
-        else:
-            self.assertIs(type(result), bytes)
+        self.assertIs(type(result), bytes)
 
     def test_valid_key_text_type(self):
-        """Assert that we can pass a six.text_type and get the right type back."""
-        key = six.text_type('gFqE6rcBXVLssjLjffsQsAa-nlm5Bg06MTKrVT9hsMA=')
+        """Assert that we can pass a str and get the right type back."""
+        key = str('gFqE6rcBXVLssjLjffsQsAa-nlm5Bg06MTKrVT9hsMA=')
 
         result = config._validate_fernet_key(key)
 
-        if six.PY3:
-            # In Python 3, this will become a byte array and the equality test later will fail.
-            # Let's encode key to assert the right thing happens there.
-            key = key.encode('utf-8')
+        # In Python 3, this will become a byte array and the equality test later will fail.
+        # Let's encode key to assert the right thing happens there.
+        key = key.encode('utf-8')
         self.assertEqual(result, key)
-        if six.PY2:
-            self.assertIs(type(result), str)
-        else:
-            self.assertIs(type(result), bytes)
+        self.assertIs(type(result), bytes)
 
     def test_wrong_length_key(self):
         """An key with wrong length should raise a ValueError."""
@@ -425,16 +415,16 @@ class ValidateNoneOrTests(unittest.TestCase):
     """Test the _validate_none_or() function."""
     def test_with_none(self):
         """Assert that None is allowed."""
-        result = config._validate_none_or(six.text_type)(None)
+        result = config._validate_none_or(str)(None)
 
         self.assertTrue(result is None)
 
     def test_with_string(self):
         """Assert that a string is validated and converted to unicode."""
-        result = config._validate_none_or(six.text_type)('unicode?')
+        result = config._validate_none_or(str)('unicode?')
 
         self.assertEqual(result, u'unicode?')
-        self.assertTrue(isinstance(result, six.text_type))
+        self.assertTrue(isinstance(result, str))
 
 
 class ValidatePathTests(unittest.TestCase):
@@ -451,7 +441,7 @@ class ValidatePathTests(unittest.TestCase):
         result = config.validate_path(__file__)
 
         self.assertEqual(result, __file__)
-        self.assertTrue(isinstance(result, six.text_type))
+        self.assertTrue(isinstance(result, str))
 
 
 class ValidateRstrippedStrTests(unittest.TestCase):
@@ -483,7 +473,7 @@ class ValidateSecretTests(unittest.TestCase):
         result = config._validate_secret('secret')
 
         self.assertEqual(result, u'secret')
-        self.assertTrue(isinstance(result, six.text_type))
+        self.assertTrue(isinstance(result, str))
 
 
 class ValidateTLSURL(unittest.TestCase):
@@ -500,4 +490,4 @@ class ValidateTLSURL(unittest.TestCase):
         result = config._validate_tls_url('https://example.com')
 
         self.assertEqual(result, u'https://example.com')
-        self.assertTrue(isinstance(result, six.text_type))
+        self.assertTrue(isinstance(result, str))

--- a/bodhi/tests/server/test_mail.py
+++ b/bodhi/tests/server/test_mail.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2017-2018 Red Hat, Inc.
 #
 # This file is part of Bodhi.
@@ -17,12 +16,13 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 """Tests for bodhi.server.mail."""
+
+import mock
 import os
 import smtplib
 import unittest
 
 from kitchen.text import converters
-import mock
 
 from bodhi.server import config, mail, models
 from bodhi.server.util import get_absolute_path

--- a/bodhi/tests/server/test_metadata.py
+++ b/bodhi/tests/server/test_metadata.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2007-2018 Red Hat, Inc. and others.
 #
 # This file is part of Bodhi.
@@ -21,12 +20,12 @@ from datetime import datetime, timedelta
 from hashlib import sha256
 from os.path import join, exists, basename
 import glob
+import mock
 import os
 import shutil
 import tempfile
 
 import createrepo_c
-import mock
 
 from bodhi.server.buildsys import (setup_buildsystem, teardown_buildsystem,
                                    DevBuildsys)

--- a/bodhi/tests/server/test_models.py
+++ b/bodhi/tests/server/test_models.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright © 2011-2018 Red Hat, Inc. and others.
 #
 # This file is part of Bodhi.
@@ -18,7 +17,9 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 """Test suite for bodhi.server.models"""
 from datetime import datetime, timedelta
+import html.parser
 import json
+import mock
 import pickle
 import time
 import unittest
@@ -27,9 +28,6 @@ import uuid
 from pyramid.testing import DummyRequest
 from sqlalchemy.exc import IntegrityError
 import cornice
-import mock
-from six.moves.html_parser import HTMLParser
-import six
 
 from bodhi.server import models as model, buildsys, mail, util, Session
 from bodhi.server.config import config
@@ -74,7 +72,7 @@ class ModelTest(BaseTestCase):
         pass
 
     def test_query_obj(self):
-        for key, value in six.iteritems(self.attrs):
+        for key, value in self.attrs.items():
             self.assertEqual(getattr(self.obj, key), value)
 
     def test_json(self):
@@ -206,7 +204,7 @@ class TestBodhiBase(BaseTestCase):
         self.assertEqual(
             j,
             {'release_id': 1, 'ci_url': b.ci_url, 'epoch': b.epoch, 'nvr': b.nvr,
-             'signed': b.signed, 'type': six.text_type(b.type.value)})
+             'signed': b.signed, 'type': str(b.type.value)})
 
     def test_grid_columns(self):
         """Assert correct return value from the grid_columns() method."""
@@ -552,8 +550,8 @@ class TestEnumSymbol(unittest.TestCase):
         """Ensure correct operation of the __unicode__() method."""
         s = model.EnumSymbol(model.UpdateStatus, 'name', 'value', 'description')
 
-        self.assertEqual(six.text_type(s), 'value')
-        self.assertEqual(type(six.text_type(s)), six.text_type)
+        self.assertEqual(str(s), 'value')
+        self.assertEqual(type(str(s)), str)
 
 
 class TestCompose(BaseTestCase):
@@ -930,7 +928,7 @@ class TestModulePackage(ModelTest, unittest.TestCase):
             self.package.builds.append(build2)
 
         self.assertEqual(
-            six.text_type(exc_context.exception),
+            str(exc_context.exception),
             ("A RPM Build cannot be associated with a Module Package. A Package's "
              "builds must be the same type as the package."))
 
@@ -943,7 +941,7 @@ class TestModulePackage(ModelTest, unittest.TestCase):
             self.package.builds = [build1, build2]
 
         self.assertEqual(
-            six.text_type(exc_context.exception),
+            str(exc_context.exception),
             ("A RPM Build cannot be associated with a Module Package. A Package's "
              "builds must be the same type as the package."))
 
@@ -965,7 +963,7 @@ class TestModulePackage(ModelTest, unittest.TestCase):
             build2.package = self.package
 
         self.assertEqual(
-            six.text_type(exc_context.exception),
+            str(exc_context.exception),
             ("A RPM Build cannot be associated with a Module Package. A Package's "
              "builds must be the same type as the package."))
 
@@ -1225,7 +1223,7 @@ class TestRpmPackage(ModelTest, unittest.TestCase):
             self.package.builds.append(build2)
 
         self.assertEqual(
-            six.text_type(exc_context.exception),
+            str(exc_context.exception),
             ("A Module Build cannot be associated with a RPM Package. A Package's "
              "builds must be the same type as the package."))
 
@@ -1247,7 +1245,7 @@ class TestRpmPackage(ModelTest, unittest.TestCase):
             build2.package = self.package
 
         self.assertEqual(
-            six.text_type(exc_context.exception),
+            str(exc_context.exception),
             ("A Module Build cannot be associated with a RPM Package. A Package's "
              "builds must be the same type as the package."))
 
@@ -1983,7 +1981,7 @@ class TestUpdate(ModelTest):
 
         subject = self.obj.greenwave_subject_json
 
-        self.assertTrue(isinstance(subject, six.string_types))
+        self.assertTrue(isinstance(subject, str))
         self.assertEqual(
             json.loads(subject),
             [{'item': u'TurboGears-1.0.8-3.fc11', 'type': 'koji_build'},
@@ -2474,7 +2472,7 @@ class TestUpdate(ModelTest):
         self.assertEqual(update.beautify_title(nvr=True),
                          u'TurboGears-1.0.8-3.fc11, TurboGears-1.0.8-3.fc11, and 1 more')
 
-        p = HTMLParser()
+        p = html.parser.HTMLParser()
         self.assertEqual(
             p.unescape(update.beautify_title(amp=True)), u'TurboGears, TurboGears, & 1 more')
         self.assertEqual(p.unescape(update.beautify_title(amp=True, nvr=True)),
@@ -3097,7 +3095,7 @@ class TestUpdate(ModelTest):
         # The update should be eligible to receive the testing_approval_msg now.
         self.assertEqual(self.obj.meets_testing_requirements, True)
         # Add the testing_approval_message
-        text = six.text_type(config.get('testing_approval_msg') % self.obj.days_in_testing)
+        text = str(config.get('testing_approval_msg') % self.obj.days_in_testing)
         self.obj.comment(self.db, text, author=u'bodhi')
 
         # met_testing_requirement() should return True since Bodhi has commented on the Update to
@@ -3215,7 +3213,7 @@ class TestUpdate(ModelTest):
         self.obj.comment(self.db, u'testing', author=u'hunter2', anonymous=False, karma=1)
         self.obj.comment(self.db, u'testing', author=u'hunter3', anonymous=False, karma=1)
         # Add the testing_approval_message
-        text = six.text_type(config.get('testing_approval_msg_based_on_karma'))
+        text = config.get('testing_approval_msg_based_on_karma')
         self.obj.comment(self.db, text, author=u'bodhi')
 
         # met_testing_requirement() should return True since Bodhi has commented on the Update to

--- a/bodhi/tests/server/test_notifications.py
+++ b/bodhi/tests/server/test_notifications.py
@@ -1,5 +1,4 @@
-# -*- coding: utf-8 -*-
-# Copyright 2016-2017 Red Hat, Inc.
+# Copyright 2016-2018 Red Hat, Inc.
 #
 # This file is part of Bodhi.
 #
@@ -18,11 +17,11 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 """This test module contains tests for bodhi.server.notifications."""
 
+import mock
 import unittest
 
 from fedora_messaging import api, testing as fml_testing, exceptions as fml_exceptions
 from sqlalchemy import exc
-import mock
 
 from bodhi.server import notifications, Session, models
 from bodhi.tests.server import base

--- a/bodhi/tests/server/test_push.py
+++ b/bodhi/tests/server/test_push.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright © 2016-2018 Red Hat, Inc. and others.
 #
 # This file is part of Bodhi.
@@ -19,10 +18,10 @@
 """This test suite contains tests on the bodhi.server.push module."""
 
 from datetime import datetime
+import mock
 
 from click.testing import CliRunner
 import click
-import mock
 
 from bodhi.server import push
 from bodhi.server import models

--- a/bodhi/tests/server/test_renderers.py
+++ b/bodhi/tests/server/test_renderers.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright © 2018 Red Hat, Inc.
 #
 # This file is part of Bodhi.
@@ -17,6 +16,7 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
+from io import BytesIO
 import copy
 import datetime
 import mock
@@ -24,7 +24,6 @@ import re
 
 import PIL.Image
 import webtest
-from six import BytesIO
 
 from bodhi.server import main
 from bodhi.tests.server import base

--- a/bodhi/tests/server/test_security.py
+++ b/bodhi/tests/server/test_security.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2014-2018 Red Hat, Inc. and others.
 #
 # This file is part of Bodhi.
@@ -17,13 +16,14 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 """Test the bodhi.server.security module."""
+
+import mock
 import unittest
 
 from cornice import errors
 from pyramid import testing
 from pyramid.security import Allow, ALL_PERMISSIONS, DENY_ALL
 from zope.interface import interfaces
-import mock
 
 from bodhi.server import models, security
 from bodhi.tests.server import base

--- a/bodhi/tests/server/test_util.py
+++ b/bodhi/tests/server/test_util.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright © 2007-2018 Red Hat, Inc. and others.
 #
 # This file is part of Bodhi.
@@ -18,23 +17,18 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 from xml.etree import ElementTree
 import json
+import mock
 import os
 import shutil
 import subprocess
 import tempfile
 import unittest
 
-import mock
-import six
-
 from bodhi.server import util, models
 from bodhi.server.config import config
 from bodhi.server.models import (ComposeState, TestGatingStatus, Update, UpdateRequest,
                                  UpdateSeverity, UpdateStatus, UpdateType)
 from bodhi.tests.server import base
-
-if six.PY2:
-    import pkgdb2client
 
 
 class TestAvatar(unittest.TestCase):
@@ -707,30 +701,6 @@ class TestUtils(base.BaseTestCase):
         """
         self.assertEqual(util.get_critpath_components(), ['kernel', 'glibc'])
 
-    if six.PY2:
-        @mock.patch.object(pkgdb2client.PkgDB, 'get_critpath_packages')
-        @mock.patch.dict(util.config, {
-            'critpath.type': 'pkgdb',
-            'pkgdb_url': 'http://domain.local'
-        })
-        def test_get_critpath_components_pkgdb_success(self, mock_get_critpath):
-            """ Ensure that critpath packages can be found using PkgDB.
-            """
-            # A subset of critpath packages
-            critpath_pkgs = [
-                'pth',
-                'xorg-x11-server-utils',
-                'giflib',
-                'basesystem'
-            ]
-            mock_get_critpath.return_value = {
-                'pkgs': {
-                    'f20': critpath_pkgs
-                }
-            }
-            pkgs = util.get_critpath_components('f20')
-            assert critpath_pkgs == pkgs, pkgs
-
     @mock.patch('bodhi.server.util.http_session')
     @mock.patch('bodhi.server.util.time.sleep')
     @mock.patch.dict(util.config, {
@@ -748,7 +718,7 @@ class TestUtils(base.BaseTestCase):
             util.get_critpath_components('f25')
             assert False, 'Did not raise a RuntimeError'
         except RuntimeError as error:
-            actual_error = six.text_type(error)
+            actual_error = str(error)
         # We are not testing the whole error message because there is no
         # guarantee of the ordering of the GET parameters.
         assert 'Bodhi failed to get a resource from PDC' in actual_error
@@ -946,7 +916,7 @@ class TestUtils(base.BaseTestCase):
             util.pagure_api_get('http://domain.local/api/0/rpms/python')
             assert False, 'Did not raise a RuntimeError'
         except RuntimeError as error:
-            actual_error = six.text_type(error)
+            actual_error = str(error)
 
         expected_error = (
             'Bodhi failed to get a resource from Pagure at the following URL '
@@ -966,7 +936,7 @@ class TestUtils(base.BaseTestCase):
             util.pagure_api_get('http://domain.local/api/0/rpms/python')
             assert False, 'Did not raise a RuntimeError'
         except RuntimeError as error:
-            actual_error = six.text_type(error)
+            actual_error = str(error)
 
         expected_error = (
             'Bodhi failed to get a resource from Pagure at the following URL '
@@ -987,7 +957,7 @@ class TestUtils(base.BaseTestCase):
             util.pagure_api_get('http://domain.local/api/0/rpms/python')
             assert False, 'Did not raise a RuntimeError'
         except RuntimeError as error:
-            actual_error = six.text_type(error)
+            actual_error = str(error)
 
         expected_error = (
             'Bodhi failed to get a resource from Pagure at the following URL '
@@ -1038,7 +1008,7 @@ class TestUtils(base.BaseTestCase):
                 'http://domain.local/rest_api/v1/component-branch-slas/')
             assert False, 'Did not raise a RuntimeError'
         except RuntimeError as error:
-            actual_error = six.text_type(error)
+            actual_error = str(error)
 
         expected_error = (
             'Bodhi failed to get a resource from PDC at the following URL '
@@ -1062,7 +1032,7 @@ class TestUtils(base.BaseTestCase):
                 'http://domain.local/rest_api/v1/component-branch-slas/3/')
             assert False, 'Did not raise a RuntimeError'
         except RuntimeError as error:
-            actual_error = six.text_type(error)
+            actual_error = str(error)
 
         expected_error = (
             'Bodhi failed to get a resource from PDC at the following URL '
@@ -1085,7 +1055,7 @@ class TestUtils(base.BaseTestCase):
                 'http://domain.local/rest_api/v1/component-branch-slas/3/')
             assert False, 'Did not raise a RuntimeError'
         except RuntimeError as error:
-            actual_error = six.text_type(error)
+            actual_error = str(error)
 
         expected_error = (
             'Bodhi failed to get a resource from PDC at the following URL '
@@ -1132,7 +1102,7 @@ class TestUtils(base.BaseTestCase):
                                     data)
             assert False, 'Did not raise a RuntimeError'
         except RuntimeError as error:
-            actual_error = six.text_type(error)
+            actual_error = str(error)
 
         expected_error = (
             'Bodhi failed to send POST request to Greenwave at the following URL '
@@ -1160,7 +1130,7 @@ class TestUtils(base.BaseTestCase):
                                     data)
             assert False, 'Did not raise a RuntimeError'
         except RuntimeError as error:
-            actual_error = six.text_type(error)
+            actual_error = str(error)
 
         expected_error = (
             'Bodhi failed to send POST request to Greenwave at the following URL '
@@ -1187,7 +1157,7 @@ class TestUtils(base.BaseTestCase):
                                     data)
             assert False, 'Did not raise a RuntimeError'
         except RuntimeError as error:
-            actual_error = six.text_type(error)
+            actual_error = str(error)
 
         expected_error = (
             'Bodhi failed to send POST request to Greenwave at the following URL '

--- a/bodhi/tests/server/test_validators.py
+++ b/bodhi/tests/server/test_validators.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright © 2017-2018 Red Hat, Inc.
 #
 # This file is part of bodhi.
@@ -18,15 +17,15 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 """This module contains tests for bodhi.server.validators."""
 import datetime
+import mock
 import unittest
 
-import mock
 from cornice.errors import Errors
 from fedora_messaging import api, testing as fml_testing
 from pyramid import exceptions
 
 from bodhi.tests.server.base import BaseTestCase
-from bodhi.server import buildsys, captcha, config, models, validators
+from bodhi.server import buildsys, captcha, models, validators
 
 
 class TestValidateCSRFToken(BaseTestCase):
@@ -124,32 +123,6 @@ class TestValidateAcls(BaseTestCase):
 
         self.assertEqual(len(request.errors), 0)
         gpcfp.assert_called_once_with()
-
-    @mock.patch('bodhi.server.models.Package.get_pkg_pushers',
-                return_value=((['guest'], []), ([], [])))
-    @mock.patch.dict('bodhi.server.validators.config', {'acl_system': 'pkgdb'})
-    def test_pkgdb_allowed(self, get_pkg_pushers):
-        """Test the integration with pkgdb."""
-        request = self.get_mock_request()
-
-        validators.validate_acls(request)
-
-        self.assertEqual(len(request.errors), 0)
-        get_pkg_pushers.assert_called_once_with('f17', config.config)
-
-    @mock.patch('bodhi.server.models.Package.get_pkg_pushers',
-                return_value=(([], []), (['some_group_guest_is_not_in'], [])))
-    @mock.patch.dict('bodhi.server.validators.config', {'acl_system': 'pkgdb'})
-    def test_pkgdb_disallowed(self, get_pkg_pushers):
-        """Test the integration with pkgdb."""
-        request = self.get_mock_request()
-
-        validators.validate_acls(request)
-
-        error = [{'location': 'body', 'name': 'builds',
-                  'description': 'guest does not have commit access to bodhi'}]
-        self.assertEqual(request.errors, error)
-        get_pkg_pushers.assert_called_once_with('f17', config.config)
 
     def test_unable_to_infer_content_type(self):
         """Test the error handler for when Bodhi cannot determine the content type of a build."""

--- a/bodhi/tests/server/test_webapp.py
+++ b/bodhi/tests/server/test_webapp.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright © 2018 Red Hat, Inc.
 #
 # This file is part of Bodhi.

--- a/bodhi/tests/server/views/__init__.py
+++ b/bodhi/tests/server/views/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright © 2018 Red Hat, Inc.
 #
 # This file is part of Bodhi.

--- a/bodhi/tests/server/views/test_generic.py
+++ b/bodhi/tests/server/views/test_generic.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2014-2018 Red Hat, Inc. and others.
 #
 # This file is part of Bodhi.
@@ -19,9 +18,9 @@
 
 from datetime import datetime
 import copy
+import mock
 import re
 
-import mock
 import webtest
 
 from bodhi.server import main, util

--- a/bodhi/tests/server/views/test_search.py
+++ b/bodhi/tests/server/views/test_search.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2017 Red Hat, Inc.
 #
 # This file is part of Bodhi.

--- a/devel/ansible/roles/bodhi/files/.bashrc
+++ b/devel/ansible/roles/bodhi/files/.bashrc
@@ -10,7 +10,7 @@ fi
 
 shopt -s expand_aliases
 alias bci="sudo -E /home/vagrant/bodhi/devel/ci/bodhi-ci"
-alias bdiff-cover="btest; diff-cover /home/vagrant/bodhi/coverage.xml --compare-branch=develop --fail-under=100"
+alias bdiff-cover="py.test-3 $@ /home/vagrant/bodhi/; diff-cover /home/vagrant/bodhi/coverage.xml --compare-branch=develop --fail-under=100"
 alias bdocs="make -C /home/vagrant/bodhi/docs clean && make -C /home/vagrant/bodhi/docs html && make -C /home/vagrant/bodhi/docs man"
 alias blog="sudo journalctl -u bodhi"
 alias brestart="sudo systemctl restart bodhi && echo 'The Application is running on http://localhost:6543'"
@@ -34,7 +34,7 @@ function bresetdb {
 
 function btest {
     find /home/vagrant/bodhi -name "*.pyc" -delete;
-    bteststyle && bdocs && py.test-2 $@ /home/vagrant/bodhi/bodhi/tests/ && py.test-3 $@ /home/vagrant/bodhi/bodhi/tests/
+    bteststyle && bdocs && bci unit -r f29
 }
 
 export BODHI_URL="http://localhost:6543/"

--- a/devel/ansible/roles/bodhi/tasks/main.yml
+++ b/devel/ansible/roles/bodhi/tasks/main.yml
@@ -21,50 +21,16 @@
       - make
       - nmap-ncat
       - openssl-devel
-      - packagedb-cli
       - pcaro-hermit-fonts
       - pcp-system-tools
       - postgresql-devel
       - postgresql-server
-      - python2
-      - python2-alembic
-      - python2-arrow
-      - python2-bleach
-      - python2-bugzilla
       - python2-click
-      - python2-colander
-      - python2-cornice
-      - python2-createrepo_c
-      - python2-cryptography
-      - python2-devel
-      - python2-dnf
-      - python2-dogpile-cache
-      - python2-fedmsg-commands
-      - python2-fedmsg-consumers
       - python2-fedora
-      - python2-feedgen
       - python2-ipdb
-      - python2-jinja2
-      - python2-kitchen
       - python2-koji
-      - python2-librepo
-      - python2-markdown
       - python2-mock
-      - python2-openid
-      - python2-pillow
-      - python2-psycopg2
-      - python2-pylibravatar
-      - python2-pyramid
-      - python2-pyramid-fas-openid
-      - python2-pyramid-mako
       - python2-pytest-cov
-      - python2-responses
-      - python2-simplemediawiki
-      - python2-sphinx
-      - python2-sqlalchemy
-      - python2-waitress
-      - python2-webtest
-      - python2-yaml
       - python3-arrow
       - python3-bleach
       - python3-click
@@ -80,6 +46,7 @@
       - python3-flake8
       - python3-ipdb
       - python3-kitchen
+      - python3-koji
       - python3-librepo
       - python3-markdown
       - python3-mock
@@ -139,10 +106,6 @@
     name: sqlalchemy_schemadisplay
 
 # This isn't packaged in Fedora yet, but it's only a development tool (we should still add it)
-- name: pip install debugtoolbar
-  pip:
-      name: pyramid_debugtoolbar
-
 - name: pip install debugtoolbar
   pip:
       name: pyramid_debugtoolbar

--- a/devel/ci/Dockerfile-f28
+++ b/devel/ci/Dockerfile-f28
@@ -12,34 +12,20 @@ RUN dnf install --disablerepo rawhide-modular -y \
     findutils \
     git \
     liberation-mono-fonts \
-    packagedb-cli \
-    python2-createrepo_c \
-    python2-hawkey \
-    python2-jinja2 \
+    python2-click \
+    python2-fedora \
     python2-koji \
-    python2-librepo \
-    python2-yaml \
     python3-createrepo_c \
     python3-hawkey \
+    python3-koji \
     python3-yaml \
     make \
-    python2-arrow \
-    python2-bleach \
-    python2-colander \
-    python2-dogpile-cache \
-    python2-fedmsg \
-    python2-feedgen \
-    python2-kitchen \
-    python2-markdown \
     python2-mock \
-    python2-pillow \
-    python2-pyramid-mako \
     python2-pytest-cov \
-    python2-responses \
-    python2-sqlalchemy \
     python3-alembic \
     python3-arrow \
     python3-bleach \
+    python3-bugzilla \
     python3-colander \
     python3-diff-cover \
     python3-dogpile-cache \
@@ -63,24 +49,14 @@ RUN dnf install --disablerepo rawhide-modular -y \
     python3-simplemediawiki \
     python3-sqlalchemy \
     python3-webtest \
-    python2-alembic \
-    python2-bugzilla \
-    python2-cornice \
     python2-munch \
-    python2-openid \
-    python2-pylibravatar \
-    python2-pyramid-fas-openid \
-    python2-simplemediawiki \
     python3-cornice \
     python3-cornice-sphinx \
-    python2-webtest \
-    python3-pyramid-fas-openid \
-    python2-libcomps
+    python3-pyramid-fas-openid
 
 # sqlalchemy_schemadisplay is not packaged for Python 3 in Fedora < 30
 # fedora_messaging isn't packaged for Fedora 28
 RUN pip-3 install sqlalchemy_schemadisplay fedora_messaging
-RUN pip install fedora_messaging
 
 # Fake pungi being installed so we can avoid it and all its dependencies
 RUN ln -s /usr/bin/true /usr/bin/pungi-koji

--- a/devel/ci/Dockerfile-f29
+++ b/devel/ci/Dockerfile-f29
@@ -13,31 +13,17 @@ RUN dnf install --disablerepo rawhide-modular -y \
     findutils \
     git \
     liberation-mono-fonts \
-    packagedb-cli \
-    python2-createrepo_c \
-    python2-hawkey \
-    python2-jinja2 \
+    python2-click \
+    python2-fedora \
     python2-koji \
-    python2-librepo \
-    python2-yaml \
+    python3-bugzilla \
     python3-createrepo_c \
     python3-hawkey \
+    python3-koji \
     python3-yaml \
     make \
-    python2-arrow \
-    python2-bleach \
-    python2-colander \
-    python2-dogpile-cache \
-    python2-fedmsg \
-    python2-feedgen \
-    python2-kitchen \
-    python2-markdown \
     python2-mock \
-    python2-pillow \
-    python2-pyramid-mako \
     python2-pytest-cov \
-    python2-responses \
-    python2-sqlalchemy \
     python3-alembic \
     python3-arrow \
     python3-bleach \
@@ -64,24 +50,13 @@ RUN dnf install --disablerepo rawhide-modular -y \
     python3-simplemediawiki \
     python3-sqlalchemy \
     python3-webtest \
-    python2-alembic \
-    python2-bugzilla \
-    python2-cornice \
     python2-munch \
-    python2-openid \
-    python2-pylibravatar \
-    python2-pyramid-fas-openid \
-    python2-simplemediawiki \
     python3-cornice \
     python3-cornice-sphinx \
-    python2-webtest \
-    python3-pyramid-fas-openid \
-    python2-libcomps
+    python3-pyramid-fas-openid
 
 # sqlalchemy_schemadisplay is not packaged for Python 3 in Fedora < 30
 RUN pip-3 install sqlalchemy_schemadisplay
-# fedora_messaging isn't packaged for Python 2 in Fedora
-RUN pip install fedora_messaging
 
 # Fake pungi being installed so we can avoid it and all its dependencies
 RUN ln -s /usr/bin/true /usr/bin/pungi-koji

--- a/devel/ci/Dockerfile-pip
+++ b/devel/ci/Dockerfile-pip
@@ -12,15 +12,10 @@ RUN dnf install --disablerepo rawhide-modular -y \
     findutils \
     git \
     liberation-mono-fonts \
-    packagedb-cli \
-    python2-createrepo_c \
-    python2-hawkey \
-    python2-jinja2 \
     python2-koji \
-    python2-librepo \
-    python2-yaml \
     python3-createrepo_c \
     python3-hawkey \
+    python3-koji \
     python3-yaml \
     createrepo_c \
     gcc \
@@ -31,21 +26,20 @@ RUN dnf install --disablerepo rawhide-modular -y \
     python3-librepo \
     python3-simplemediawiki \
     redhat-rpm-config \
-    python2-libcomps \
     python3-libcomps
 
 COPY requirements.txt /bodhi/requirements.txt
 
-RUN pip-2 install -r /bodhi/requirements.txt
 RUN pip-3 install -r /bodhi/requirements.txt
 RUN pip-2 install \
+    click \
     diff-cover \
     mock \
-    responses \
     pytest \
     pytest-cov \
-    webtest
+    python-fedora
 RUN pip-3 install \
+    alembic \
     cornice_sphinx \
     diff-cover \
     flake8 \

--- a/devel/ci/bodhi-ci
+++ b/devel/ci/bodhi-ci
@@ -848,8 +848,8 @@ class UnitJob(Job):
         test_command = ('({} setup.py develop && {} {} || (cp *.xml /results && exit 1)) '
                         '&& cp *.xml /results')
 
-        if pyver == 2 and self.release not in ('f28', 'f29', 'pip'):
-            # We do not support the server on Fedora >= 30:
+        if pyver == 2:
+            # We do not support the server on Python 2:
             test_command = (
                 'rm requirements.txt && touch requirements.txt && rm .coveragerc && '
                 'rm -rf bodhi/tests/server && {}'.format(test_command))
@@ -1011,9 +1011,8 @@ def _build_jobs_list(
                     depends_on=build_job, buffer_output=buffer_output)
                 jobs.append(unit_job)
                 if command in ('all', 'diff_cover'):
-                    if pyver == 2 and release not in ('f27', 'f28', 'f29', 'pip'):
-                        # We don't support Python 2 on the server for Fedora >= 30, so don't
-                        # enforce coverage there.
+                    if pyver == 2:
+                        # We don't support Python 2 on the server, so don't enforce coverage there.
                         continue
                     diff_cover_job = DiffCoverJob(
                         archive=archive, archive_path=archive_path, pyver=pyver,

--- a/devel/ci/cico.pipeline
+++ b/devel/ci/cico.pipeline
@@ -114,7 +114,6 @@ def test_release = { String release ->
         },
         unitpy2: {
             bodhi_ci(release, 'unit', 'python2-unit', '--no-build --no-init -p 2')
-            bodhi_ci(release, 'diff_cover', 'python2-diff-cover', '--no-build --no-init -p 2')
         },
         unitpy3: {
             bodhi_ci(release, 'unit', 'python3-unit', '--no-build --no-init -p 3')

--- a/docs/user/release_notes.rst
+++ b/docs/user/release_notes.rst
@@ -11,6 +11,17 @@ This is a major release with many backwards incompatible changes.
 Backwards incompatible changes
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+* Integration with pkgdb is no longer supported (:issue:`1970`).
+* Bodhi server no longer supports Python 2. Python 3 is the only supported Python release
+  (:issue:`2759`).
+
+
+Dependency changes
+^^^^^^^^^^^^^^^^^^
+
+* pkgdb is no longer required (:issue:`1970`).
+* six is no longer required for the server (:issue:`2759`).
+
 
 Server upgrade instructions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/production.ini
+++ b/production.ini
@@ -347,8 +347,7 @@ use = egg:bodhi-server
 
 ##
 ## ACL system
-## Choices are 'pkgdb', which will send a JSON query to the pkgdb_url below,
-## 'pagure', which will query the pagure_url below, or 'dummy', which will
+## Choices are 'pagure', which will query the pagure_url below, or 'dummy', which will
 ## always return guest credentials (used for local development).
 ##
 # acl_system = dummy
@@ -356,11 +355,6 @@ use = egg:bodhi-server
 # Add your username here to enable ACL rights in the development environment. Only has an effect if
 # you are using the dummy acl_system.
 # acl_dummy_committer =
-
-##
-## Package DB
-##
-# pkgdb_url = https://admin.fedoraproject.org/pkgdb
 
 ##
 ## Pagure
@@ -426,8 +420,7 @@ use = egg:bodhi-server
 ## https://fedoraproject.org/wiki/Critical_path_package
 ##
 
-# You can allow Bodhi to query for critpath packages from the Fedora Package
-# Database by setting this value to `pkgdb` or the Product Definition
+# You can allow Bodhi to query for critpath packages from the Product Definition
 # Center by setting this value to `pdc`. If it isn't set, it'll just use the
 # hardcoded list below.
 # critpath.type =

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,10 +13,8 @@ feedgen
 jinja2
 kitchen
 markdown
-packagedb-cli; python_version <= '2.7'
 # for captchas
 Pillow
-pyDNS; python_version <= '2.7'  # Should be required by pyLibravatar https://bugs.launchpad.net/pylibravatar/+bug/1661218
 py3dns; python_version >= '3.0'  # Should be required by pyLibravatar https://bugs.launchpad.net/pylibravatar/+bug/1661218
 pylibravatar
 pyramid~=1.7

--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,6 @@
-# The following two imports are required to shut up an
-# atexit error when running tests with python 2.7
-from setuptools import setup, find_packages  # noqa
-import logging  # noqa
-import multiprocessing  # noqa
-import os  # noqa
-import setuptools.command.egg_info  # noqa
-import sys  # noqa
+from setuptools import setup, find_packages
+import os
+import setuptools.command.egg_info
 
 
 def get_requirements(requirements_file='requirements.txt'):
@@ -50,7 +45,6 @@ CLASSIFIERS = [
     'Intended Audience :: System Administrators',
     'License :: OSI Approved :: GNU General Public License v2 or later (GPLv2+)',
     'Operating System :: POSIX :: Linux',
-    'Programming Language :: Python :: 2.7',
     'Programming Language :: Python :: 3',
     'Programming Language :: Python :: 3.6',
     'Programming Language :: Python :: 3.7',
@@ -70,7 +64,7 @@ setup(
     version=VERSION,
     description='bodhi common package',
     long_description=README,
-    classifiers=CLASSIFIERS,
+    classifiers=CLASSIFIERS + ['Programming Language :: Python :: 2.7'],
     license=LICENSE,
     maintainer=MAINTAINER,
     maintainer_email=MAINTAINER_EMAIL,
@@ -105,7 +99,7 @@ setup(
     version=VERSION,
     description='bodhi client',
     long_description=README,
-    classifiers=CLASSIFIERS,
+    classifiers=CLASSIFIERS + ['Programming Language :: Python :: 2.7'],
     license=LICENSE,
     maintainer=MAINTAINER,
     maintainer_email=MAINTAINER_EMAIL,


### PR DESCRIPTION
Python 2 support goes away upstream in two months, so it is time
to embrace the glorious future.

This change also drops support for pkgdb integration, since the
pkgdb client library does not support Python 3.

Mock imports were moved to be grouped with the stdlib imports as
per PEP-8, since mock is part of the stdlib in Python 3.

fixes #1970
fixes #2759

Signed-off-by: Randy Barlow <randy@electronsweatshop.com>