### PR TITLE
Keep the commit we are testing as a branch.

### DIFF
--- a/devel/ci/cico.pipeline
+++ b/devel/ci/cico.pipeline
@@ -120,12 +120,13 @@ def test_release = { String release ->
 
 
 node('bodhi') {
-    commit_hash = checkout(scm).GIT_COMMIT
+    checkout scm
     // diff-cover sometimes fails to identify origin/develop, so let's check out the develop branch
-    // and then switch back to the commit hash we are testing so there is a develop branch available
+    // and then switch back to the commit we are testing so there is a develop branch available
     // for diff-cover to use later. See https://github.com/Bachmann1234/diff-cover/issues/55
+    sh 'git checkout -b the_commit_we_are_testing'
     sh 'git checkout develop'
-    sh 'git checkout ' + commit_hash
+    sh 'git checkout the_commit_we_are_testing'
 
     stage('Allocate Duffy node') {
         env.CICO_API_KEY = readFile("${env.HOME}/duffy.key").trim()


### PR DESCRIPTION
I had attempted to fix an error that sometimes happened with
diff_cover where it could not find the develop branch in CI by
remembering the commit hash we are testing, checking out develop,
then checking out that commit hash again. The problem with that is
that Jenkins actually creates a merge commit for branches that
aren't based on the HEAD of develop, and this code fails in that
scenario because the commit we are testing no longer exists. This
led to errors like this:

+ git checkout 60a073cbddfadea7cde0b0f4647b4d6e527cab83
fatal: reference is not a tree: 60a073cbddfadea7cde0b0f4647b4d6e527cab83

This commit fixes that problem by again using the Jenkins
Pipeline's checkout scm command, and instead of checking out the
commit we are testing, it creates a new branch based on the merge
commit we are testing, checks out develop, then checks out the new
named branch again.

Signed-off-by: Randy Barlow <randy@electronsweatshop.com>