### PR TITLE
Force the commit_we_are_testing branch in CI.

### DIFF
--- a/devel/ci/cico.pipeline
+++ b/devel/ci/cico.pipeline
@@ -124,7 +124,7 @@ node('bodhi') {
     // diff-cover sometimes fails to identify origin/develop, so let's check out the develop branch
     // and then switch back to the commit we are testing so there is a develop branch available
     // for diff-cover to use later. See https://github.com/Bachmann1234/diff-cover/issues/55
-    sh 'git checkout -b the_commit_we_are_testing'
+    sh 'git branch -f the_commit_we_are_testing HEAD'
     sh 'git checkout develop'
     sh 'git checkout the_commit_we_are_testing'
 


### PR DESCRIPTION
I forgot that CI jobs persist the git repository between runs. This
means that my last commit causes failures in CI because you can't
create a branch that already exists.

This commit forces the commit_we_are_testing branch to be the
current HEAD every run, which should work for the persisted branch
name.

Signed-off-by: Randy Barlow <randy@electronsweatshop.com>