### PR TITLE
Build the integration test containers with the build command.

### DIFF
--- a/devel/ci/bodhi-ci
+++ b/devel/ci/bodhi-ci
@@ -883,9 +883,21 @@ def _build_jobs_list(
         buffer_output = concurrency != 1 and len(releases) != 1
     jobs = []
     for release in releases:
-        if command in ('all', 'build', 'docs', 'flake8', 'pydocstyle', 'diff_cover', 'unit'):
+        if command in ('all', 'build', 'docs', 'flake8', 'integration', 'pydocstyle', 'diff_cover',
+                       'unit'):
             build_job = BuildJob(release, jobs, buffer_output=buffer_output)
             jobs.append(build_job)
+            if (pyvers is None or 3 in pyvers) and release == 'f29':
+                integration_build_jobs = [
+                    IntegrationBuildJob(app_name="resultsdb", release="f29", all_jobs=jobs,
+                                        buffer_output=buffer_output),
+                    IntegrationBuildJob(app_name="waiverdb", release="f29", all_jobs=jobs,
+                                        buffer_output=buffer_output),
+                    IntegrationBuildJob(app_name="greenwave", release="f29", all_jobs=jobs,
+                                        buffer_output=buffer_output),
+                    IntegrationBuildJob(app_name="bodhi", release="f29", all_jobs=jobs,
+                                        buffer_output=buffer_output)]
+                jobs.extend(integration_build_jobs)
         if command in ('all', 'docs'):
             docs_job = DocsJob(release, jobs, depends_on=build_job, buffer_output=buffer_output)
             jobs.append(docs_job)
@@ -913,20 +925,9 @@ def _build_jobs_list(
                         all_jobs=jobs)
                     jobs.append(diff_cover_job)
     if command in ('all', 'integration') and 3 in pyvers and "f29" in releases:
-        build_jobs = [
-            IntegrationBuildJob(app_name="resultsdb", release="f29", all_jobs=jobs,
-                                buffer_output=buffer_output),
-            IntegrationBuildJob(app_name="waiverdb", release="f29", all_jobs=jobs,
-                                buffer_output=buffer_output),
-            IntegrationBuildJob(app_name="greenwave", release="f29", all_jobs=jobs,
-                                buffer_output=buffer_output),
-            IntegrationBuildJob(app_name="bodhi", release="f29", all_jobs=jobs,
-                                buffer_output=buffer_output),
-        ]
-        jobs.extend(build_jobs)
         integration_job = IntegrationJob(
             archive=archive, archive_path=archive_path, pyver=3, release="f29",
-            depends_on=build_jobs, buffer_output=buffer_output, all_jobs=jobs)
+            depends_on=integration_build_jobs, buffer_output=buffer_output, all_jobs=jobs)
         jobs.append(integration_job)
 
     return jobs


### PR DESCRIPTION
The integration test containers had been getting built when
bodhi-ci integration was run. This commit moves them to be built
when the bodhi-ci build command is used instead.

Signed-off-by: Randy Barlow <randy@electronsweatshop.com>