### PR TITLE
Configure Mergify to use the Bodhi team.

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -6,7 +6,7 @@ pull_request_rules:
       strict: true
   conditions:
   - label!=no-mergify
-  - approved-reviews-by=bowlofeggs
+  - approved-reviews-by=@fedora-infra/bodhi
   - status-success=DCO
   - status-success=f28-docs
   - status-success=f28-flake8
@@ -39,7 +39,7 @@ pull_request_rules:
       strict: true
   conditions:
   - label!=no-mergify
-  - author=bowlofeggs
+  - author=@fedora-infra/bodhi
   - "#approved-reviews-by>=1"
   - status-success=DCO
   - status-success=f28-docs


### PR DESCRIPTION
Mergify now supports GitHub teams[0], so we can now express our
rules in a broader way. This commit requires reviews from Bodhi
team members for pull requests submitted by most people, and
accepts reviews from anyone in the fedora-infra organization for
pull requests by Bodhi team members.

[0] https://github.com/Mergifyio/mergify-engine/issues/310

Signed-off-by: Randy Barlow <randy@electronsweatshop.com>