### PR TITLE
Conditionally assert the Request: line in the CLI.

### DIFF
--- a/devel/ci/integration/tests/test_bodhi_cli.py
+++ b/devel/ci/integration/tests/test_bodhi_cli.py
@@ -1,4 +1,4 @@
-# Copyright © 2018 Red Hat, Inc.
+# Copyright © 2018-2019 Red Hat, Inc.
 #
 # This file is part of Bodhi.
 #
@@ -234,7 +234,9 @@ def test_updates_query_details(bodhi_container, db_container, greenwave_containe
         "Autokarma: {u.autokarma}  [{u.unstable_karma}, {u.stable_karma}]"
     ).format(u=update)
     assert expected_autokarma in result.output
-    assert "Request: {}".format(update.request) in result.output
+    # If the update doesn't have a request, the CLI does not render the Request: line.
+    if update.request:
+        assert "Request: {}".format(update.request) in result.output
     # Notes are formatted
     formatted_notes = list(itertools.chain(*[
         textwrap.wrap(line, width=66)


### PR DESCRIPTION
The Request: line is only rendered by the CLI when the Request is
truthy. This commit adjusts a test assertion to only test for its
presence if the update's request is truthy.

fixes #2892

Signed-off-by: Randy Barlow <randy@electronsweatshop.com>