### PR TITLE
Compare strings to strings to in Greenwave decision in web UI.

### DIFF
--- a/bodhi/server/templates/update.html
+++ b/bodhi/server/templates/update.html
@@ -3,6 +3,8 @@
 <%namespace name="json" module="json"/>
 <%
   from urllib.parse import urljoin
+
+  from bodhi.server import models
 %>
 
 <%block name="pagetitle">
@@ -362,7 +364,8 @@ ${update.type} update for ${update.beautify_title(amp=True) | n}
 
     get_greenwave_information({
         'product_version': '${update.product_version}',
-% if update.request == 'testing' and update.status == 'pending':
+% if update.request == models.UpdateRequest.testing and \
+    update.status == models.UpdateStatus.pending:
         'decision_context': 'bodhi_update_push_testing',
 % else:
         'decision_context': 'bodhi_update_push_stable',

--- a/bodhi/tests/server/services/test_updates.py
+++ b/bodhi/tests/server/services/test_updates.py
@@ -1034,6 +1034,36 @@ class TestUpdatesService(BaseTestCase):
 
         self.assertTrue('RPM' not in res.text)
 
+    def test_decision_context_pending_stable(self):
+        """The HTML should include the correct decision context for Pending/Stable updates."""
+        u = Update.query.one()
+        u.request = UpdateRequest.stable
+        u.status = UpdateStatus.pending
+
+        res = self.app.get(f'/updates/{u.alias}', status=200, headers={'Accept': 'text/html'})
+
+        self.assertIn("'decision_context': 'bodhi_update_push_stable',", res)
+
+    def test_decision_context_pending_testing(self):
+        """The HTML should include the correct decision context for Pending/Testing updates."""
+        u = Update.query.one()
+        u.request = UpdateRequest.testing
+        u.status = UpdateStatus.pending
+
+        res = self.app.get(f'/updates/{u.alias}', status=200, headers={'Accept': 'text/html'})
+
+        self.assertIn("'decision_context': 'bodhi_update_push_testing',", res)
+
+    def test_decision_context_testing(self):
+        """The HTML should include the correct decision context for Testing updates."""
+        u = Update.query.one()
+        u.request = None
+        u.status = UpdateStatus.testing
+
+        res = self.app.get(f'/updates/{u.alias}', status=200, headers={'Accept': 'text/html'})
+
+        self.assertIn("'decision_context': 'bodhi_update_push_stable',", res)
+
     def test_home_html_legal(self):
         """Test the home page HTML when a legal link is configured."""
         with mock.patch.dict(


### PR DESCRIPTION
There was a bug discovered by Adam Williamson where the web
interface always used the stable decision context for updates,
even when they were pending testing. The bug was due to an if
statement that compared Enums to strings in the HTML template,
rather than comparing the string values of the Enums to string.

Signed-off-by: Randy Barlow <randy@electronsweatshop.com>