### PR TITLE
get_pkg_committers_from_pagure: use flatpaks/ namespace for Flatpaks

### DIFF
--- a/bodhi/server/models.py
+++ b/bodhi/server/models.py
@@ -1058,8 +1058,6 @@ class Package(Base):
         # container. Flatpaks build directly from the 'modules' namespace
         if self.type.name == 'container':
             namespace = self.type.name
-        elif self.type.name == 'flatpak':
-            namespace = 'modules'
         else:
             namespace = self.type.name + 's'
         package_pagure_url = '{0}/api/0/{1}/{2}?expand_group=1'.format(

--- a/bodhi/tests/server/test_models.py
+++ b/bodhi/tests/server/test_models.py
@@ -1130,7 +1130,7 @@ class TestFlatpakPackage(ModelTest, unittest.TestCase):
             "custom_keys": [],
             "date_created": "1494947106",
             "description": "Flatpak Runtime",
-            "fullname": "modules/flatpak-runtime",
+            "fullname": "flatpaks/flatpak-runtime",
             "group_details": {},
             "id": 2,
             "milestones": {},
@@ -1151,7 +1151,7 @@ class TestFlatpakPackage(ModelTest, unittest.TestCase):
 
         self.assertEqual(rv, (['otaylor'], []))
         http_session.get.assert_called_once_with(
-            ('https://src.fedoraproject.org/pagure/api/0/modules/flatpak-runtime'
+            ('https://src.fedoraproject.org/pagure/api/0/flatpaks/flatpak-runtime'
              '?expand_group=1'),
             timeout=60)
 


### PR DESCRIPTION
Flatpaks will be moved from sharing the modules/ namespace to their
own namespace in Fedora dist-git, so change the committer lookup
accordingly.

(I considered making this more complicated and trying the flatpaks/ namespace and falling back to modules/, but that would have required considerable added complexity, and I didn't want to leave that in the code just to make transition a bit easier. I'm thinking that we can just coordinate landing this with reconfiguring the other pieces needed for the flatpaks/ namespace, and if flatpak updates can't be filed for a few days, that's OK.)