### PR TITLE
Add missing composes info subcommand to bodhi client docs

### DIFF
--- a/docs/user/man_pages/bodhi.rst
+++ b/docs/user/man_pages/bodhi.rst
@@ -60,7 +60,7 @@ in more detail in their own sections below.
 
 ``bodhi composes <subcommand> [options] [args]``
 
-    Provides an interface to view composes. Supports one subcommand, ``list``, described below.
+    Provides an interface to view composes. Supports subcommands ``list`` and ``info``, described below.
 
 ``bodhi overrides <subcommand> [options] [args]``
 


### PR DESCRIPTION
Signed-off-by: Sebastian Wojciechowski <s.wojciechowski89@gmail.com>