### PR TITLE
Move mail templates to /etc/bodhi/email_templates

### DIFF
--- a/bodhi/server/config.py
+++ b/bodhi/server/config.py
@@ -475,7 +475,7 @@ class BodhiConfig(dict):
             'value': True,
             'validator': _validate_bool},
         'mail.templates_basepath': {
-            'value': 'bodhi:server/email/templates/',
+            'value': '/etc/bodhi/email_templates/',
             'validator': str},
         'mako.directories': {
             'value': 'bodhi:server/templates',

--- a/bodhi/server/mail.py
+++ b/bodhi/server/mail.py
@@ -26,7 +26,7 @@ from kitchen.text.converters import to_unicode, to_bytes
 
 from bodhi.server import log
 from bodhi.server.config import config
-from bodhi.server.util import get_rpm_header, get_absolute_path
+from bodhi.server.util import get_rpm_header
 
 
 #
@@ -251,9 +251,8 @@ def read_template(name):
         basestring: The text read from the file.
     """
     location = config.get('mail.templates_basepath')
-    directory = get_absolute_path(location)
     file_name = "%s.tpl" % (name)
-    template_path = os.path.join(directory, file_name)
+    template_path = os.path.join(location, file_name)
 
     if os.path.exists(template_path):
         try:

--- a/bodhi/server/schemas.py
+++ b/bodhi/server/schemas.py
@@ -38,7 +38,7 @@ from bodhi.server.validators import validate_csrf_token
 CVE_REGEX = re.compile(r"CVE-[0-9]{4,4}-[0-9]{4,}")
 
 # Retrieving list of templates from filesystem for `mail_template` validation in SaveReleaseSchema
-template_directory = util.get_absolute_path(config.get('mail.templates_basepath'))
+template_directory = config.get('mail.templates_basepath')
 MAIL_TEMPLATES = [os.path.splitext(file)[0] for file in os.listdir(template_directory)]
 
 

--- a/bodhi/tests/server/services/test_releases.py
+++ b/bodhi/tests/server/services/test_releases.py
@@ -23,7 +23,6 @@ import webtest
 from bodhi import server
 from bodhi.server.config import config
 from bodhi.server.models import Release, ReleaseState, Update, UpdateStatus
-from bodhi.server.util import get_absolute_path
 from bodhi.tests.server import base, create_update
 
 
@@ -350,8 +349,7 @@ class TestReleasesService(base.BaseTestCase):
         """Test appropriate error is returned when provided `mail_template` doesn't exist."""
         name = u"F22"
         location = config.get('mail.templates_basepath')
-        directory = get_absolute_path(location)
-        template_list = [os.path.splitext(file)[0] for file in os.listdir(directory)]
+        template_list = [os.path.splitext(file)[0] for file in os.listdir(location)]
         template_vals = ", ".join(template_list)
 
         res = self.app.get('/releases/%s' % name, status=200)

--- a/bodhi/tests/server/test_mail.py
+++ b/bodhi/tests/server/test_mail.py
@@ -25,7 +25,6 @@ import unittest
 from kitchen.text import converters
 
 from bodhi.server import config, mail, models
-from bodhi.server.util import get_absolute_path
 from bodhi.tests.server import base
 
 
@@ -180,9 +179,8 @@ class TestGetTemplate(base.BaseTestCase):
         """Reading from invalid template name should log appropriate error."""
         name = "invalid_template_name"
         location = config.config.get('mail.templates_basepath')
-        directory = get_absolute_path(location)
         file_name = "%s.tpl" % (name)
-        template_path = os.path.join(directory, file_name)
+        template_path = os.path.join(location, file_name)
 
         mail.read_template(name)
 
@@ -195,9 +193,8 @@ class TestGetTemplate(base.BaseTestCase):
         """IOError while opening template file should be logged appropriately."""
         name = "fedora_errata_template"
         location = config.config.get('mail.templates_basepath')
-        directory = get_absolute_path(location)
         file_name = "%s.tpl" % (name)
-        template_path = os.path.join(directory, file_name)
+        template_path = os.path.join(location, file_name)
 
         with mock.patch('bodhi.server.mail.open', side_effect=IOError()):
             mail.read_template(name)

--- a/devel/ansible/roles/bodhi/tasks/main.yml
+++ b/devel/ansible/roles/bodhi/tasks/main.yml
@@ -196,6 +196,17 @@
       dest: /etc/motd
       mode: 0644
 
+- name: Create /etc/bodhi
+  file:
+    path: /etc/bodhi/
+    state: directory
+
+- name: Copy email templates to /etc/bodhi/email_templates
+  command: cp -r /home/vagrant/bodhi/bodhi/server/email/templates /etc/bodhi/email_templates
+  args:
+      creates: /etc/bodhi/email_templates
+
+
 - name: Set up the RabbitMQ broker
   import_tasks: rabbitmq.yml
 

--- a/docs/user/release_notes.rst
+++ b/docs/user/release_notes.rst
@@ -12,6 +12,7 @@ Backwards incompatible changes
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 * Integration with pkgdb is no longer supported (:issue:`1970`).
+* Email templates are now stored in ``/etc/bodhi/email_templates/`` (:issue:`2753`).
 * Bodhi server no longer supports Python 2. Python 3 is the only supported Python release
   (:issue:`2759`).
 


### PR DESCRIPTION
Fixes #2753

Signed-off-by: Sebastian Wojciechowski <s.wojciechowski89@gmail.com>

I'm not sure about final solution. How to copy email templates during deployment? Should it be done by some scripts or manually?