### PR TITLE
Fetch all branches during CI.

### DIFF
--- a/devel/ci/bodhi-ci
+++ b/devel/ci/bodhi-ci
@@ -663,7 +663,7 @@ class DiffCoverJob(Job):
         self.archive_path = archive_path
 
         self._command = ['/usr/bin/diff-cover', '/results/coverage.xml',
-                         '--compare-branch=develop', '--fail-under=100']
+                         '--compare-branch=origin/develop', '--fail-under=100']
         self._label = '{}-py{}'.format(self._label, pyver)
         self._convert_command_for_container(archive=archive, archive_path=archive_path)
 

--- a/devel/ci/cico.pipeline
+++ b/devel/ci/cico.pipeline
@@ -130,12 +130,9 @@ def test_release = { String release ->
 
 node('bodhi') {
     checkout scm
-    // diff-cover sometimes fails to identify origin/develop, so let's check out the develop branch
-    // and then switch back to the commit we are testing so there is a develop branch available
-    // for diff-cover to use later. See https://github.com/Bachmann1234/diff-cover/issues/55
-    sh 'git branch -f the_commit_we_are_testing HEAD'
-    sh 'git checkout develop'
-    sh 'git checkout the_commit_we_are_testing'
+    // diff-cover needs to be able to reference origin/develop, so let's just fetch all branches.
+    sh 'git config --add remote.origin.fetch +refs/heads/*:refs/remotes/origin/*'
+    sh 'git fetch -p --no-tags origin'
 
     stage('Allocate Duffy node') {
         env.CICO_API_KEY = readFile("${env.HOME}/duffy.key").trim()


### PR DESCRIPTION
We recently altered the Jenkins config so that it only tests PRs
as they are, rather than testing them merged with their destination
branch. This apparently caused the git checkout not to have the
reference for the destination branch, which is needed for
diff-cover to work.

Signed-off-by: Randy Barlow <randy@electronsweatshop.com>