### PR TITLE
Introduce a new warm_cache_on_start setting.

### DIFF
--- a/bodhi/server/__init__.py
+++ b/bodhi/server/__init__.py
@@ -316,9 +316,7 @@ def main(global_config, testing=None, session=None, **settings):
     # https://github.com/fedora-infra/bodhi/issues/2294
     from bodhi.server import models
     from bodhi.server.views import generic
-    # Let's warm up the Releases._all_releases cache. We can just call the function - we don't need
-    # to capture the return value.
-    models.Release.all_releases()
+
     # Let's put a cache on the home page stats, but only if it isn't already cached. The cache adds
     # an invalidate attribute to the method, so that's how we can tell. The server would not
     # encounter this function already having a cache in normal operation, but the unit tests do run
@@ -328,9 +326,16 @@ def main(global_config, testing=None, session=None, **settings):
         generic._generate_home_page_stats = get_cacheregion(None).cache_on_arguments()(
             generic._generate_home_page_stats)
 
-    # Let's warm up the home page cache by calling _generate_home_page_stats(). We can ignore the
-    # return value.
-    generic._generate_home_page_stats()
+    if bodhi_config['warm_cache_on_start']:
+        log.info('Warming up caches…')
+
+        # Let's warm up the Releases._all_releases cache. We can just call the function - we don't
+        # need to capture the return value.
+        models.Release.all_releases()
+
+        # Let's warm up the home page cache by calling _generate_home_page_stats(). We can ignore
+        # the return value.
+        generic._generate_home_page_stats()
 
     # Let's close out the db session we used to warm the caches.
     Session.remove()

--- a/bodhi/server/config.py
+++ b/bodhi/server/config.py
@@ -1,4 +1,4 @@
-# Copyright © 2013-2017 Red Hat, Inc. and others.
+# Copyright © 2013-2019 Red Hat, Inc. and others.
 #
 # This file is part of Bodhi.
 #
@@ -633,6 +633,9 @@ class BodhiConfig(dict):
             'validator': str},
         'wait_for_repo_sig': {
             'value': False,
+            'validator': _validate_bool},
+        'warm_cache_on_start': {
+            'value': True,
             'validator': _validate_bool},
         'wiki_url': {
             'value': 'https://fedoraproject.org/w/api.php',

--- a/devel/development.ini.example
+++ b/devel/development.ini.example
@@ -57,6 +57,8 @@ skopeo.extra_copy_flags = --dest-tls-verify=false
 openid.provider = https://id.stg.fedoraproject.org/openid/
 openid.url = https://id.stg.fedoraproject.org/
 openid_template = {username}.id.stg.fedoraproject.org
+# The cache warming is annoying during development because it takes so long. Let's disable it by default.
+warm_cache_on_start = false
 
 
 [server:main]

--- a/production.ini
+++ b/production.ini
@@ -304,6 +304,10 @@ use = egg:bodhi-server
 # dogpile.cache.expiration_time = 100
 # dogpile.cache.arguments.filename = /var/cache/bodhi-dogpile-cache.dbm
 
+# If True (the default), warm up caches when the Bodhi process starts up. Otherwise, they will get warmed
+# on first use.
+# warm_cache_on_start = True
+
 # Exclude sending emails to these users
 # exclude_mail = autoqa taskotron
 


### PR DESCRIPTION
If warm_cache_on_start is True (the default), Bodhi will build two
caches when the server process starts as it has done for many
months. If False, it will not. The goal of this patch is to allow
the development environment to turn this caching off because it
takes a long time (about 33 seconds on my laptop) and when
developing Bodhi it is typical to restart the server repeatedly.

Signed-off-by: Randy Barlow <randy@electronsweatshop.com>