### PR TITLE
Rename masher to composer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,6 @@ docs/images/database.png
 dogpile-cache.dbm*
 html-docs
 htmlcov/
-masher/
+composer/
 nosetests.xml
 virtenv

--- a/bodhi/server/config.py
+++ b/bodhi/server/config.py
@@ -486,13 +486,13 @@ class BodhiConfig(dict):
         'mandatory_packager_groups': {
             'value': ['packager'],
             'validator': _generate_list_validator()},
-        'mash_dir': {
+        'compose_dir': {
             'value': None,
             'validator': _validate_none_or(str)},
-        'mash_stage_dir': {
+        'compose_stage_dir': {
             'value': None,
             'validator': _validate_none_or(str)},
-        'max_concurrent_mashes': {
+        'max_concurrent_composes': {
             'value': 2,
             'validator': int},
         'max_update_length_for_ui': {

--- a/bodhi/server/metadata.py
+++ b/bodhi/server/metadata.py
@@ -15,7 +15,7 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
-"""Create metadata files when mashing repositories."""
+"""Create metadata files when composing repositories."""
 from datetime import datetime
 import logging
 import os
@@ -96,22 +96,22 @@ class UpdateInfoMetadata(object):
     """
     This class represents the updateinfo.xml yum metadata.
 
-    It is generated during push time by the bodhi masher based on koji tags
+    It is generated during push time by the bodhi composer based on koji tags
     and is injected into the yum repodata using the `modifyrepo_c` tool,
     which is included in the `createrepo_c` package.
     """
 
-    def __init__(self, release, request, db, mashdir, close_shelf=True):
+    def __init__(self, release, request, db, composedir, close_shelf=True):
         """
         Initialize the UpdateInfoMetadata object.
 
         Args:
-            release (bodhi.server.models.Release): The Release that is being mashed.
-            request (bodhi.server.models.UpdateRequest): The Request that is being mashed.
+            release (bodhi.server.models.Release): The Release that is being composed.
+            request (bodhi.server.models.UpdateRequest): The Request that is being composed.
             db (): A database session to be used for queries.
-            mashdir (basestring): A path to the mashdir.
+            composedir (basestring): A path to the composedir.
             close_shelf (bool): Whether to close the shelve, which is used to cache updateinfo
-                between mashes.
+                between composes.
         """
         self.request = request
         if request is UpdateRequest.stable:

--- a/bodhi/server/models.py
+++ b/bodhi/server/models.py
@@ -635,7 +635,7 @@ class UpdateRequest(DeclEnum):
         testing (EnumSymbol): The update is requested to change to testing.
         obsolete (EnumSymbol): The update has been obsoleted by another update.
         unpush (EnumSymbol): The update no longer needs to be released.
-        revoke (EnumSymbol): The unpushed update will no longer be mashed in any repository.
+        revoke (EnumSymbol): The unpushed update will no longer be composed in any repository.
         stable (EnumSymbol): The update is ready to be pushed to the stable repository.
     """
 
@@ -766,9 +766,9 @@ class Release(Base):
         pending_signing_tag (unicode): The koji tag that specifies that a build is waiting to be
             signed, such as 'f27-signing-pending'.
         pending_testing_tag (unicode): The koji tag that indicates that a build is waiting to be
-            mashed into the testing repository, such as 'f27-updates-testing-pending'.
+            composed into the testing repository, such as 'f27-updates-testing-pending'.
         pending_stable_tag (unicode): The koji tag that indicates that a build is waiting to be
-            mashed into the stable repository, such as 'f27-updates-pending'.
+            composed into the stable repository, such as 'f27-updates-pending'.
         override_tag (unicode): The koji tag that is used when a build is added as a buildroot
             override, such as 'f27-override'.
         mail_template (unicode): The notification mail template.
@@ -1589,7 +1589,7 @@ class Update(Base):
         suggest (EnumSymbol): Suggested action a user should take after applying the update.
             This must be one of the values defined in :class:`UpdateSuggestion`.
         locked (bool): Indicates whether or not the update is locked and un-editable.
-            This is usually set by the masher because the update is going through a state
+            This is usually set by the composer because the update is going through a state
             transition.
         pushed (bool): Indicates whether or not the update has been pushed to its requested
             repository.
@@ -1625,7 +1625,7 @@ class Update(Base):
         greenwave_unsatisfied_requirements (unicode): When test_gating_status is failed, Bodhi will
             set this to a JSON representation of the unsatisfied_requirements field from Greewave's
             response.
-        compose (Compose): The :class:`Compose` that this update is currently being mashed in. The
+        compose (Compose): The :class:`Compose` that this update is currently being composed in. The
             update is locked if this is defined.
     """
 
@@ -1712,7 +1712,7 @@ class Update(Base):
         """
         return self.status == UpdateStatus.side_tag_active and self.request is not None
 
-    # WARNING: consumers/masher.py assumes that this validation is performed!
+    # WARNING: consumers/composer.py assumes that this validation is performed!
     @validates('builds')
     def validate_builds(self, key, build):
         """
@@ -2544,7 +2544,7 @@ class Update(Base):
                             action = UpdateRequest.testing
 
         # Add the appropriate 'pending' koji tag to this update, so tools like
-        # AutoQA can mash repositories of them for testing.
+        # AutoQA can compose repositories of them for testing.
         if action is UpdateRequest.testing:
             self.add_tag(self.release.pending_signing_tag)
         elif action is UpdateRequest.stable:
@@ -2668,7 +2668,7 @@ class Update(Base):
         """
         Comment on and close this update's bugs as necessary.
 
-        This typically gets called by the Masher at the end.
+        This typically gets called by the Composer at the end.
         """
         if self.status is UpdateStatus.testing:
             for bug in self.bugs:
@@ -3076,7 +3076,7 @@ class Update(Base):
         Obsolete this update.
 
         Even though unpushing/obsoletion is an "instant" action, changes in the repository will not
-        propagate until the next mash takes place.
+        propagate until the next compose takes place.
 
         Args:
             db (sqlalchemy.orm.session.Session): A database session.
@@ -3557,7 +3557,7 @@ class Compose(Base):
         __exclude_columns__ (tuple): A tuple of columns to exclude when __json__() is called.
         __include_extras__ (tuple): A tuple of attributes to add when __json__() is called.
         __tablename__ (str): The name of the table in the database.
-        checkpoints (unicode): A JSON serialized object describing the checkpoints the masher has
+        checkpoints (unicode): A JSON serialized object describing the checkpoints the composer has
             reached.
         date_created (datetime.datetime): The time this Compose was created.
         error_message (unicode): An error message indicating what happened if the Compose failed.
@@ -3575,8 +3575,8 @@ class Compose(Base):
     """
 
     __exclude_columns__ = ('updates')
-    # We need to include content_type and security so the masher can collate the Composes and so it
-    # can pick the right masher class to use.
+    # We need to include content_type and security so the composer can collate the Composes and so
+    # it can pick the right composer class to use.
     __include_extras__ = ('content_type', 'security', 'update_summary')
     __tablename__ = 'composes'
 
@@ -3730,8 +3730,8 @@ class Compose(Base):
         if composer:
             exclude = ('checkpoints', 'error_message', 'date_created', 'state_date', 'release',
                        'state', 'updates')
-            # We need to include content_type and security so the masher can collate the Composes
-            # and so it can pick the right masher class to use.
+            # We need to include content_type and security so the composer can collate the Composes
+            # and so it can pick the right composer class to use.
             include = ('content_type', 'security')
         return super(Compose, self).__json__(request=request, anonymize=anonymize, exclude=exclude,
                                              include=include)

--- a/bodhi/server/push.py
+++ b/bodhi/server/push.py
@@ -1,4 +1,4 @@
-# Copyright © 2007-2018 Red Hat, Inc.
+# Copyright © 2007-2019 Red Hat, Inc.
 #
 # This file is part of Bodhi.
 #
@@ -88,8 +88,8 @@ def push(username, cert_prefix, yes, **kwargs):
         if resume:
             for compose in session.query(Compose).all():
                 if len(compose.updates) == 0:
-                    # Compose objects can end up with 0 updates in them if the masher ejects all the
-                    # updates in a compose for some reason. Composes with no updates cannot be
+                    # Compose objects can end up with 0 updates in them if the composer ejects all
+                    # the updates in a compose for some reason. Composes with no updates cannot be
                     # serialized because their content_type property uses the content_type of the
                     # first update in the Compose. Additionally, it doesn't really make sense to go
                     # forward with running an empty Compose. It makes the most sense to delete them.
@@ -171,12 +171,12 @@ def push(username, cert_prefix, yes, **kwargs):
         composes = [c.__json__(composer=True) for c in composes]
 
     if composes:
-        click.echo('\nSending masher.start fedmsg')
+        click.echo('\nSending composer.start fedmsg')
         # Because we're a script, we want to send to the fedmsg-relay,
         # that's why we say active=True
         bodhi.server.notifications.init(active=True, cert_prefix=cert_prefix)
         bodhi.server.notifications.publish(
-            topic='masher.start',
+            topic='composer.start',
             msg=dict(
                 api_version=2,
                 composes=composes,

--- a/bodhi/server/scripts/clean_old_composes.py
+++ b/bodhi/server/scripts/clean_old_composes.py
@@ -1,4 +1,4 @@
-# Copyright © 2016-2018 Red Hat, Inc.
+# Copyright © 2016-2019 Red Hat, Inc.
 #
 # This file is part of Bodhi.
 #
@@ -15,7 +15,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
-"""Cleans up old mashes that are left over in mash_dir."""
+"""Cleans up old composes that are left over in compose_dir."""
 import collections
 
 import click
@@ -25,27 +25,28 @@ import shutil
 from bodhi.server import config
 
 
-# How many of the newest mash dirs to keep during cleanup
+# How many of the newest compose dirs to keep during cleanup
 NUM_TO_KEEP = 10
 
 
 @click.command()
 @click.version_option(message='%(version)s')
 def clean_up():
-    """Delete any repo mashes that are older than the newest 10 from each repo series."""
+    """Delete any repo composes that are older than the newest 10 from each repo series."""
     remove_old_composes()
 
 
-# Helper function used in auto clean composes (masher.py)
+# Helper function used in auto clean composes (composer.py)
 def remove_old_composes():
-    """Delete any repo mashes that are older than the newest 10 from each repo series."""
-    mash_dir = config.config['mash_dir']
+    """Delete any repo composes that are older than the newest 10 from each repo series."""
+    compose_dir = config.config['compose_dir']
 
     # This data structure will map the beginning of a group of dirs for the same repo to a list of
     # the dirs that start off the same way.
     pattern_matched_dirs = collections.defaultdict(list)
 
-    for directory in [d for d in os.listdir(mash_dir) if os.path.isdir(os.path.join(mash_dir, d))]:
+    for directory in [d for d in os.listdir(compose_dir)
+                      if os.path.isdir(os.path.join(compose_dir, d))]:
         # If this directory ends with a float, it is a candidate for potential deletion
         try:
             split_dir = directory.split('-')
@@ -66,6 +67,6 @@ def remove_old_composes():
     if dirs_to_delete:
         print('Deleting the following directories:')
         for d in dirs_to_delete:
-            d = os.path.join(mash_dir, d)
+            d = os.path.join(compose_dir, d)
             print(d)
             shutil.rmtree(d)

--- a/bodhi/server/scripts/untag_branched.py
+++ b/bodhi/server/scripts/untag_branched.py
@@ -1,4 +1,4 @@
-# Copyright © 2015-2018 Red Hat, Inc. and others.
+# Copyright © 2015-2019 Red Hat, Inc. and others.
 #
 # This file is part of Bodhi.
 #
@@ -18,7 +18,7 @@
 """
 Used to remove the pending and testing tags from updates in a branched release.
 
-Since a separate task mashes the branched stable repos, this will leave
+Since a separate task composes the branched stable repos, this will leave
 those stable updates with the testing tags for 1 day before untagging.
 
 https://github.com/fedora-infra/bodhi/issues/576

--- a/bodhi/tests/server/test_config.py
+++ b/bodhi/tests/server/test_config.py
@@ -1,4 +1,4 @@
-# Copyright © 2017-2018 Red Hat, Inc.
+# Copyright © 2017-2019 Red Hat, Inc.
 #
 # This file is part of Bodhi.
 #
@@ -240,7 +240,7 @@ class BodhiConfigValidate(unittest.TestCase):
         """We don't want compose specific paths to be checked for existence."""
         c = config.BodhiConfig()
         c.load_config()
-        for s in ('pungi.cmd', 'mash_dir', 'mash_stage_dir'):
+        for s in ('pungi.cmd', 'compose_dir', 'compose_stage_dir'):
             c[s] = '/does/not/exist'
 
             # This should not raise an Exception.

--- a/bodhi/tests/server/test_metadata.py
+++ b/bodhi/tests/server/test_metadata.py
@@ -233,14 +233,14 @@ class TestUpdateInfoMetadata(UpdateInfoMetadataTestCase):
     def setUp(self):
         super(TestUpdateInfoMetadata, self).setUp()
 
-        self._new_mash_stage_dir = tempfile.mkdtemp()
-        self._mash_stage_dir = config['mash_stage_dir']
-        self._mash_dir = config['mash_dir']
-        config['mash_stage_dir'] = self._new_mash_stage_dir
-        config['mash_dir'] = os.path.join(config['mash_stage_dir'], 'mash')
-        config['cache_dir'] = os.path.join(config['mash_stage_dir'], 'cache')
+        self._new_compose_stage_dir = tempfile.mkdtemp()
+        self._compose_stage_dir = config['compose_stage_dir']
+        self._compose_dir = config['compose_dir']
+        config['compose_stage_dir'] = self._new_compose_stage_dir
+        config['compose_dir'] = os.path.join(config['compose_stage_dir'], 'compose')
+        config['cache_dir'] = os.path.join(config['compose_stage_dir'], 'cache')
         os.makedirs(config['cache_dir'])
-        os.makedirs(os.path.join(config['mash_dir'], 'f17-updates-testing'))
+        os.makedirs(os.path.join(config['compose_dir'], 'f17-updates-testing'))
 
         # Initialize our temporary repo
         base.mkmetadatadir(self.temprepo, updateinfo=False)
@@ -264,10 +264,10 @@ class TestUpdateInfoMetadata(UpdateInfoMetadataTestCase):
         }]
 
     def tearDown(self):
-        config['mash_stage_dir'] = self._mash_stage_dir
-        config['mash_dir'] = self._mash_dir
+        config['compose_stage_dir'] = self._compose_stage_dir
+        config['compose_dir'] = self._compose_dir
         config['cache_dir'] = None
-        shutil.rmtree(self._new_mash_stage_dir)
+        shutil.rmtree(self._new_compose_stage_dir)
         super(TestUpdateInfoMetadata, self).tearDown()
 
     def _verify_updateinfo(self, repodata):

--- a/bodhi/tests/server/test_push.py
+++ b/bodhi/tests/server/test_push.py
@@ -1,4 +1,4 @@
-# Copyright © 2016-2018 Red Hat, Inc. and others.
+# Copyright © 2016-2019 Red Hat, Inc. and others.
 #
 # This file is part of Bodhi.
 #
@@ -67,7 +67,7 @@ class TestFilterReleases(base.BaseTestCase):
         self.db.commit()
 
         test_config = base.original_config.copy()
-        test_config['mash_dir'] = '/mashdir/'
+        test_config['compose_dir'] = '/composedir/'
         mock_config = mock.patch.dict('bodhi.server.push.config', test_config)
         mock_config.start()
         self.addCleanup(mock_config.stop)
@@ -192,7 +192,7 @@ Push these 2 updates? [y/N]: y
 
 Locking updates...
 
-Sending masher.start fedmsg
+Sending composer.start fedmsg
 """
 
 TEST_CERT_PREFIX_FLAG_EXPECTED_OUTPUT = """
@@ -208,7 +208,7 @@ Push these 3 updates? [y/N]: y
 
 Locking updates...
 
-Sending masher.start fedmsg
+Sending composer.start fedmsg
 """
 
 TEST_YES_FLAG_EXPECTED_OUTPUT = """
@@ -224,7 +224,7 @@ Pushing 3 updates.
 
 Locking updates...
 
-Sending masher.start fedmsg
+Sending composer.start fedmsg
 """
 
 TEST_LOCKED_UPDATES_EXPECTED_OUTPUT = """Existing composes detected: <Compose: F17 testing>. Do you wish to resume them all? [y/N]: y
@@ -239,7 +239,7 @@ Push these 1 updates? [y/N]: y
 
 Locking updates...
 
-Sending masher.start fedmsg
+Sending composer.start fedmsg
 """
 
 TEST_LOCKED_UPDATES_YES_FLAG_EXPECTED_OUTPUT = """Existing composes detected: <Compose: F17 testing>. Resuming all.
@@ -254,7 +254,7 @@ Pushing 1 updates.
 
 Locking updates...
 
-Sending masher.start fedmsg
+Sending composer.start fedmsg
 """
 
 TEST_RELEASES_FLAG_EXPECTED_OUTPUT = """
@@ -273,7 +273,7 @@ Push these 2 updates? [y/N]: y
 
 Locking updates...
 
-Sending masher.start fedmsg
+Sending composer.start fedmsg
 """
 
 TEST_REQUEST_FLAG_EXPECTED_OUTPUT = """
@@ -288,7 +288,7 @@ Push these 2 updates? [y/N]: y
 
 Locking updates...
 
-Sending masher.start fedmsg
+Sending composer.start fedmsg
 """
 
 TEST_RESUME_FLAG_EXPECTED_OUTPUT = """Resume <Compose: F17 testing>? [y/N]: y
@@ -303,7 +303,7 @@ Push these 1 updates? [y/N]: y
 
 Locking updates...
 
-Sending masher.start fedmsg
+Sending composer.start fedmsg
 """
 
 TEST_RESUME_AND_YES_FLAGS_EXPECTED_OUTPUT = """Resuming <Compose: F17 testing>.
@@ -318,7 +318,7 @@ Pushing 1 updates.
 
 Locking updates...
 
-Sending masher.start fedmsg
+Sending composer.start fedmsg
 """
 
 TEST_RESUME_EMPTY_COMPOSE = """Resume <Compose: F17 testing>? [y/N]: y
@@ -334,7 +334,7 @@ Push these 1 updates? [y/N]: y
 
 Locking updates...
 
-Sending masher.start fedmsg
+Sending composer.start fedmsg
 """
 
 TEST_RESUME_HUMAN_SAYS_NO_EXPECTED_OUTPUT = """Resume <Compose: F17 testing>? [y/N]: y
@@ -350,7 +350,7 @@ Push these 1 updates? [y/N]: y
 
 Locking updates...
 
-Sending masher.start fedmsg
+Sending composer.start fedmsg
 """
 
 
@@ -371,7 +371,7 @@ class TestPush(base.BaseTestCase):
         self.db.commit()
 
         test_config = base.original_config.copy()
-        test_config['mash_dir'] = '/mashdir/'
+        test_config['compose_dir'] = '/composedir/'
         mock_config = mock.patch.dict('bodhi.server.push.config', test_config)
         mock_config.start()
         self.addCleanup(mock_config.stop)
@@ -430,7 +430,7 @@ class TestPush(base.BaseTestCase):
         self.assertEqual(result.exit_code, 0)
         self.assertEqual(result.output, TEST_BUILDS_FLAG_EXPECTED_OUTPUT)
         publish.assert_called_once_with(
-            topic='masher.start',
+            topic='composer.start',
             msg={
                 'composes': [{'security': False, 'release_id': ejabberd.release.id,
                               'request': u'testing', 'content_type': u'rpm'}],
@@ -464,7 +464,7 @@ class TestPush(base.BaseTestCase):
         self.assertEqual(result.output, TEST_CERT_PREFIX_FLAG_EXPECTED_OUTPUT)
         init.assert_called_once_with(active=True, cert_prefix='some_prefix')
         publish.assert_called_once_with(
-            topic='masher.start',
+            topic='composer.start',
             msg={
                 'composes': [{'security': False, 'release_id': 1, 'request': u'testing',
                               'content_type': u'rpm'}],
@@ -489,7 +489,7 @@ class TestPush(base.BaseTestCase):
         self.assertEqual(result.output, TEST_YES_FLAG_EXPECTED_OUTPUT)
         init.assert_called_once_with(active=True, cert_prefix='shell')
         publish.assert_called_once_with(
-            topic='masher.start',
+            topic='composer.start',
             msg={
                 'composes': [{'security': False, 'release_id': 1, 'request': u'testing',
                               'content_type': u'rpm'}],
@@ -534,7 +534,7 @@ class TestPush(base.BaseTestCase):
         mock_init.assert_called_once_with(active=True, cert_prefix=u'shell')
         self.assertEqual(result.output, TEST_LOCKED_UPDATES_EXPECTED_OUTPUT)
         publish.assert_called_once_with(
-            topic='masher.start',
+            topic='composer.start',
             msg={'composes': [ejabberd.compose.__json__(composer=True)],
                  'resume': True, 'agent': 'bowlofeggs', 'api_version': 2},
             force=True)
@@ -579,7 +579,7 @@ class TestPush(base.BaseTestCase):
         mock_init.assert_called_once_with(active=True, cert_prefix=u'shell')
         self.assertEqual(result.output, TEST_LOCKED_UPDATES_YES_FLAG_EXPECTED_OUTPUT)
         publish.assert_called_once_with(
-            topic='masher.start',
+            topic='composer.start',
             msg={'composes': [ejabberd.compose.__json__(composer=True)],
                  'resume': True, 'agent': 'bowlofeggs', 'api_version': 2},
             force=True)
@@ -693,7 +693,7 @@ class TestPush(base.BaseTestCase):
         f26_python_paste_deploy = self.db.query(models.Update).filter_by(
             title=u'python-paste-deploy-1.5.2-8.fc26').one()
         publish.assert_called_once_with(
-            topic='masher.start',
+            topic='composer.start',
             msg={
                 'composes': [f25_python_nose.compose.__json__(composer=True),
                              f26_python_paste_deploy.compose.__json__(composer=True)],
@@ -778,7 +778,7 @@ class TestPush(base.BaseTestCase):
         f26_python_paste_deploy = self.db.query(models.Update).filter_by(
             title=u'python-paste-deploy-1.5.2-8.fc26').one()
         publish.assert_called_once_with(
-            topic='masher.start',
+            topic='composer.start',
             msg={
                 'composes': [f25_python_nose.compose.__json__(composer=True),
                              f26_python_paste_deploy.compose.__json__(composer=True)],
@@ -835,7 +835,7 @@ class TestPush(base.BaseTestCase):
         python_paste_deploy = self.db.query(models.Update).filter_by(
             title=u'python-paste-deploy-1.5.2-8.fc17').one()
         publish.assert_called_once_with(
-            topic='masher.start',
+            topic='composer.start',
             msg={'composes': [python_paste_deploy.compose.__json__(composer=True)],
                  'resume': False, 'agent': 'bowlofeggs', 'api_version': 2},
             force=True)
@@ -878,7 +878,7 @@ class TestPush(base.BaseTestCase):
         python_paste_deploy = self.db.query(models.Update).filter_by(
             title=u'python-paste-deploy-1.5.2-8.fc17').one()
         publish.assert_called_once_with(
-            topic='masher.start',
+            topic='composer.start',
             msg={'composes': [ejabberd.compose.__json__(composer=True)],
                  'resume': True, 'agent': 'bowlofeggs', 'api_version': 2},
             force=True)
@@ -922,7 +922,7 @@ class TestPush(base.BaseTestCase):
         python_paste_deploy = self.db.query(models.Update).filter_by(
             title=u'python-paste-deploy-1.5.2-8.fc17').one()
         publish.assert_called_once_with(
-            topic='masher.start',
+            topic='composer.start',
             msg={'composes': [ejabberd.compose.__json__(composer=True)],
                  'resume': True, 'agent': 'bowlofeggs', 'api_version': 2},
             force=True)
@@ -971,7 +971,7 @@ class TestPush(base.BaseTestCase):
         python_paste_deploy = self.db.query(models.Update).filter_by(
             title=u'python-paste-deploy-1.5.2-8.fc17').one()
         publish.assert_called_once_with(
-            topic='masher.start',
+            topic='composer.start',
             msg={'composes': [ejabberd.compose.__json__(composer=True)],
                  'resume': True, 'agent': 'bowlofeggs', 'api_version': 2},
             force=True)
@@ -1028,7 +1028,7 @@ class TestPush(base.BaseTestCase):
         python_paste_deploy = self.db.query(models.Update).filter_by(
             title=u'python-paste-deploy-1.5.2-8.fc17').one()
         publish.assert_called_once_with(
-            topic='masher.start',
+            topic='composer.start',
             msg={'composes': [ejabberd.compose.__json__(composer=True)],
                  'resume': True, 'agent': 'bowlofeggs', 'api_version': 2},
             force=True)
@@ -1072,7 +1072,7 @@ class TestPush(base.BaseTestCase):
         python_paste_deploy = self.db.query(models.Update).filter_by(
             title=u'python-paste-deploy-1.5.2-8.fc17').one()
         publish.assert_called_once_with(
-            topic='masher.start',
+            topic='composer.start',
             msg={'composes': [python_paste_deploy.compose.__json__(composer=True)],
                  'resume': False, 'agent': 'bowlofeggs', 'api_version': 2},
             force=True)
@@ -1112,7 +1112,7 @@ class TestPush(base.BaseTestCase):
         python_paste_deploy = self.db.query(models.Update).filter_by(
             title=u'python-paste-deploy-1.5.2-8.fc17').one()
         publish.assert_called_once_with(
-            topic='masher.start',
+            topic='composer.start',
             msg={'composes': [python_paste_deploy.compose.__json__(composer=True)],
                  'resume': False, 'agent': 'bowlofeggs', 'api_version': 2},
             force=True)

--- a/devel/ci/integration/tests/fixtures/bodhi.py
+++ b/devel/ci/integration/tests/fixtures/bodhi.py
@@ -73,9 +73,9 @@ def bodhi_container(
         "default_email_domain": "fedoraproject.org",
         "releng_fedmsg_certname": "bodhi",
         # Only on bodhi-backend
-        # "mash_dir": "/mnt/koji/compose/updates/",
-        # "mash_stage_dir": "/mnt/koji/compose/updates/",
-        "max_concurrent_mashes": "3",
+        # "compose_dir": "/mnt/koji/compose/updates/",
+        # "compose_stage_dir": "/mnt/koji/compose/updates/",
+        "max_concurrent_composes": "3",
         "clean_old_composes": "false",
         "pungi.conf.rpm": "pungi.rpm.conf.j2",
         "pungi.conf.module": "pungi.module.conf.j2",

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -249,7 +249,7 @@ man_pages = [
      ['Randy Barlow'], 1),
     ('user/man_pages/bodhi-check-policies', 'bodhi-check-policies', u'check policies',
      ['Matt Jia'], 1),
-    ('user/man_pages/bodhi-clean-old-mashes', 'bodhi-clean-old-mashes', u'clean old mashes',
+    ('user/man_pages/bodhi-clean-old-composes', 'bodhi-clean-old-composes', u'clean old composes',
      ['Randy Barlow'], 1),
     ('user/man_pages/bodhi-push', 'bodhi-push', u'push Fedora updates', ['Randy Barlow'], 1),
     ('user/man_pages/initialize_bodhi_db', 'initialize_bodhi_db', u'intialize bodhi\'s database',

--- a/docs/user/3.x_release_notes.rst
+++ b/docs/user/3.x_release_notes.rst
@@ -1047,7 +1047,7 @@ Features
 * It is now possible to configure a maximum number of mash threads that Bodhi will run at once,
   which is handy if the new Pungi masher has been mean to your NAS. There is a new
   ``max_concurrent_mashes`` setting in production.ini, which defaults to ``2``.
-* There is now a man page for :doc:`man_pages/bodhi-clean-old-mashes`.
+* There is now a man page for ``man_pages/bodhi-clean-old-mashes``.
 * The documentation was reorganized by type of reader (:commit:`14e81a81`).
 * The documentation now uses the Alabaster theme (:commit:`f15351e2`).
 * The CLI now has a ``--arch`` flag that can be used when downloading updates to specify which

--- a/docs/user/man_pages/bodhi-clean-old-composes.rst
+++ b/docs/user/man_pages/bodhi-clean-old-composes.rst
@@ -1,17 +1,17 @@
-======================
-bodhi-clean-old-mashes
-======================
+========================
+bodhi-clean-old-composes
+========================
 
 Synopsis
 ========
 
-``bodhi-clean-old-mashes``
+``bodhi-clean-old-composes``
 
 
 Description
 ===========
 
-``bodhi-clean-old-mashes`` deletes all but the 10 newest mash directories.
+``bodhi-clean-old-composes`` deletes all but the 10 newest compose directories.
 
 
 Options

--- a/docs/user/man_pages/bodhi-untag-branched.rst
+++ b/docs/user/man_pages/bodhi-untag-branched.rst
@@ -14,7 +14,7 @@ Description
 ``bodhi-untag-branched`` is used to remove the pending and testing tags from updates in a branched
 release.
 
-Since a separate task mashes the branched stable repos, this will leave
+Since a separate task compose the branched stable repos, this will leave
 those stable updates with the testing tags for 1 day before untagging.
 
 

--- a/docs/user/man_pages/index.rst
+++ b/docs/user/man_pages/index.rst
@@ -8,7 +8,7 @@ Man pages
    bodhi
    bodhi-approve-testing
    bodhi-check-policies
-   bodhi-clean-old-mashes
+   bodhi-clean-old-composes
    bodhi-expire-overrides
    bodhi-push
    bodhi-sar

--- a/docs/user/release_notes.rst
+++ b/docs/user/release_notes.rst
@@ -16,6 +16,13 @@ Backwards incompatible changes
 * Support for CVE tracking was dropped. It was technically not possible to use the feature, so it
   is unlikely to affect any deployments (:issue:`1998`).
 * The ``/masher`` API has been removed (:issue:`2024`).
+* The ``Masher`` was renamed to ``Composer``. As a result, the ``bodhi-clean-old-mashes`` script
+  was renamed to ``bodhi-clean-old-composes``, notification topics ``mashtask.start``,
+  ``mashtask.composing``, ``mashtask.complete``, ``mashtask.sync.wait`` and ``mashtask.sync.done``
+  was renamed to ``compose.start``, ``compose.composing``, ``compose.complete``, ``compose.sync.wait``
+  and ``compose.sync.done``, configuration settings ``mash_dir``, ``mash_stage_dir`` and
+  ``max_concurrent_mashes`` was renamed to ``compose_dir``, ``compose_stage_dir`` and
+  ``max_concurrent_composes`` (:issue:`2151`).
 * The ``bodhi-monitor-composes`` script has been removed (:issue:`2171`).
 * The stacks feature has been removed (:issue:`2241`).
 * The ``bodhi-manage-releases`` script has been removed (:issue:`2420`).

--- a/fedmsg.d/composer.py
+++ b/fedmsg.d/composer.py
@@ -1,5 +1,5 @@
 config = dict(
-    masher=True,
-    masher_topic='bodhi.masher.start',
+    composer=True,
+    composer_topic='bodhi.composer.start',
     releng_fedmsg_certname=None,  # Enables strict cert checking
 )

--- a/production.ini
+++ b/production.ini
@@ -136,21 +136,21 @@ use = egg:bodhi-server
 
 
 ##
-## Masher settings
+## Composer settings
 ##
 
-# Where to initially mash repositories. You can use %(here)s to reference the location of this file.
-# mash_dir =
+# Where to initially compose repositories. You can use %(here)s to reference the location of this file.
+# compose_dir =
 
-# The max number of mash threads running at the same time
-# max_concurrent_mashes = 2
+# The max number of compose threads running at the same time
+# max_concurrent_composes = 2
 
 # Whether to clean old composes at the end of each run.
 # clean_old_composes = true
 
 # Where to symlink the latest repos by their tag name. You can use %(here)s to reference the
 # location of this file.
-# mash_stage_dir =
+# compose_stage_dir =
 
 # Whether to wait for repomd.xml.asc signature files in the repo when composing updates or not
 # wait_for_repo_sig = False
@@ -158,10 +158,10 @@ use = egg:bodhi-server
 # The following jinja2 template variables are available for use to customize the Pungi configs and
 # variants files to the Release and Updates:
 #
-#  * 'id': The id of the Release being mashed.
-#  * 'release': The Release being mashed.
-#  * 'request': The request being mashed.
-#  * 'updates': The Updates being mashed.
+#  * 'id': The id of the Release being composed.
+#  * 'release': The Release being composed.
+#  * 'request': The request being composed.
+#  * 'updates': The Updates being composed.
 #
 # NOTE: The jinja2 configuration for these templates replaces the {'s and }'s with ['s and ]'.
 # e.g.: a block becomes [% if <something %], and a variable is [[ varname ]].
@@ -172,15 +172,15 @@ use = egg:bodhi-server
 # composes and module composes, respectively.
 # pungi.basepath = /etc/bodhi
 
-# The Pungi executable to use when mashing.
+# The Pungi executable to use when composing.
 # pungi.cmd = /usr/bin/pungi-koji
 
 # The following settings reference filenames of jinja2 templates found in pungi.basepath to be used
-# as Pungi configs for mashing modules or RPMs (The RPM config includes dnf, yum, and atomic repos).
+# as Pungi configs for composing modules or RPMs (The RPM config includes dnf, yum, and atomic repos).
 # pungi.conf.module = pungi.module.conf
 # pungi.conf.rpm = pungi.rpm.conf
 
-# A space separated list of extra arguments to be passed on to Pungi during mashing.
+# A space separated list of extra arguments to be passed on to Pungi during composing.
 # pungi.extracmdline =
 
 # What to pass to Pungi's --label flag, which is metadata included in its composeinfo.json.
@@ -212,9 +212,9 @@ use = egg:bodhi-server
 # file_url: Used in the repo metadata to set RPM URLs.
 # file_url = https://download.fedoraproject.org/pub/fedora/linux/updates
 
-# {release}_({version}_){request}_master_repomd: This is used by the masher to determine when a
+# {release}_({version}_){request}_master_repomd: This is used by the composer to determine when a
 #     primary architecture push has been synchronized to the master mirror for a given release and
-#     request. The masher will verify that the checksum of repomd.xml at the master URL matches the
+#     request. The composer will verify that the checksum of repomd.xml at the master URL matches the
 #     expected value, and will poll the URL until this test passes. Substitute release and request
 #     for each release id (replacing -'s with _'s) and request (stable, testing). Used for the
 #     arches listed in {release}_{version}_primary_arches when it is defined, else used for all
@@ -228,9 +228,9 @@ use = egg:bodhi-server
 #     fedora_epel_stable_master_repomd = http://download01.phx2.fedoraproject.org/pub/epel/%%s/%%s/repodata/repomd.xml
 #     fedora_epel_testing_master_repomd = http://download01.phx2.fedoraproject.org/pub/epel/testing/%%s/%%s/repodata/repomd.xml
 
-# {release}_({version}_){request}_alt_master_repomd: This is used by the masher to determine when a
+# {release}_({version}_){request}_alt_master_repomd: This is used by the composer to determine when a
 #     secondary architecture push has been synchronized to the master mirror for a given release and
-#     request. The masher will verify that the checksum of repomd.xml at the master URL matches the
+#     request. The composer will verify that the checksum of repomd.xml at the master URL matches the
 #     expected value, and will poll the URL until this test passes. Substitute release and request
 #     for each release id (replacing -'s with _'s) and request (stable, testing). Used for the
 #     arches not listed in {release}_{version}_primary_arches if it is defined. You must put two
@@ -250,9 +250,9 @@ use = egg:bodhi-server
 ## Primary architechures by release
 ##
 ## {release}_{version}_primary_arches: Releases that have alternative arches must define their
-##      primary arches here. Any arches found during mashing that are not present here are asssumed
-##      to be alternative arches. This is used during the wait_for_repo() step of the mash where
-##      Bodhi polls the master repo to find out whether the mash has made it to the repo or not.
+##      primary arches here. Any arches found during composing that are not present here are asssumed
+##      to be alternative arches. This is used during the wait_for_repo() step of the compose where
+##      Bodhi polls the master repo to find out whether the compose has made it to the repo or not.
 ##      Bodhi looks for primary arches with the {release}_{request}_master_repomd setting above, and
 ##      for alternative arches at the {release}_{request}_alt_master_repomd setting above. If this
 ##      is not set, Bodhi will assume the release only has primary arches.
@@ -305,7 +305,7 @@ use = egg:bodhi-server
 # These are the default requirements that we apply to packages and updates.
 # Users have free-reign to override them for each kind of entity.  At
 # the end of the day, we only consider the requirements defined by single
-# updates themselves when gating in the backend masher process.
+# updates themselves when gating in the backend composer process.
 # site_requirements = dist.rpmdeplint dist.upgradepath
 
 # Cache settings

--- a/setup.py
+++ b/setup.py
@@ -150,7 +150,7 @@ setup(
     main = bodhi.server:main
     [console_scripts]
     initialize_bodhi_db = bodhi.server.scripts.initializedb:main
-    bodhi-clean-old-mashes = bodhi.server.scripts.clean_old_mashes:clean_up
+    bodhi-clean-old-composes = bodhi.server.scripts.clean_old_composes:clean_up
     bodhi-dequeue-stable = bodhi.server.scripts.dequeue_stable:dequeue_stable
     bodhi-push = bodhi.server.push:push
     bodhi-expire-overrides = bodhi.server.scripts.expire_overrides:main
@@ -161,7 +161,7 @@ setup(
     bodhi-sar = bodhi.server.scripts.sar:get_user_data
     bodhi-shell = bodhi.server.scripts.bshell:get_bodhi_shell
     [moksha.consumer]
-    masher = bodhi.server.consumers.masher:Masher
+    composer = bodhi.server.consumers.composer:Composer
     updates = bodhi.server.consumers.updates:UpdatesHandler
     signed = bodhi.server.consumers.signed:SignedHandler
     """,


### PR DESCRIPTION
Fixes #2151

Signed-off-by: Sebastian Wojciechowski <s.wojciechowski89@gmail.com>

I'm not sure if we can substitute fedmsgs notification topics like 'masher.start' to 'composer.start'.
How it will affect external systems?