### PR TITLE
[WIP] Add a fake Pungi that can be used during development.

### DIFF
--- a/devel/ansible/roles/bodhi/files/fake_pungi
+++ b/devel/ansible/roles/bodhi/files/fake_pungi
@@ -1,0 +1,23 @@
+#!/usr/bin/python3
+
+import os
+
+import createrepo_c
+
+from bodhi.tests.server.base import mkmetadatadir
+
+
+dir = '/home/vagrant/mash_dir/neat_i_can_compose'
+metadata = os.path.join(dir, 'compose', 'metadata')
+
+try:
+    os.makedirs(metadata)
+except FileExistsError:
+    pass
+
+with open(os.path.join(metadata, 'composeinfo.json'), 'w') as composeinfo:
+    composeinfo.write('{}')
+
+mkmetadatadir(os.path.join(metadata, '..', 'Everything', 'x86_64'))
+
+print('Compose dir: {}'.format(dir))


### PR DESCRIPTION
Since Bodhi's development environment does not have a running Koji
yet, it is not possible to run Pungi to test changes to the
composer. This commit introduces a fake Pungi that creates enough
of a repository that the compose can succeed locally. It does not
really compose the updates, it just does the minimum needed to
trick Bodhi into thinking the compose suceeded.

Signed-off-by: Randy Barlow <randy@electronsweatshop.com>