### PR TITLE
[WIP] Provide a way for users to create updates from Koji side tags.

### DIFF
--- a/bodhi/client/__init__.py
+++ b/bodhi/client/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright © 2014-2018 Red Hat, Inc. and others.
+# Copyright © 2014-2019 Red Hat, Inc. and others.
 #
 # This file is part of Bodhi.
 #
@@ -367,6 +367,7 @@ def require_severity_for_security_update(type, severity):
 @add_options(new_edit_options)
 @click.argument('builds')
 @click.option('--file', help='A text file containing all the update details')
+@click.option('--side-tag', help='Get the builds from the given side tag')
 @handle_errors
 @openid_option
 @url_option

--- a/bodhi/server/services/updates.py
+++ b/bodhi/server/services/updates.py
@@ -447,6 +447,10 @@ def new_update(request):
         releases = set()
         builds = []
 
+        if 'side_tag' in data:
+            data['builds'] = koji.getTag(data['side_tag'])['nvrs']
+            target_release = figure_out_target_release(data['side_tag'])
+
         # Create the Package and Build entities
         for nvr in data['builds']:
             name, version, release = request.buildinfo[nvr]['nvr']

--- a/bodhi/server/templates/new_update.html
+++ b/bodhi/server/templates/new_update.html
@@ -60,6 +60,12 @@
         </div>
 
         <div class="card card-form">
+        % if not update:
+            <div>
+                <input name='type' type='radio'/>
+                <input name='side_tag' type="text" placeholder="The name of a Koji side tag you wish to merge"/>
+            </div>
+        % endif
           <div class="card-header clearfix">
             <span class="pull-left" data-placement="bottom" data-toggle="tooltip" title="Here you can add a list of candidate builds that you want to be included in this update.  This is required.  (What is an update without a list of builds anyways... it doesn't make any sense.)">
             Candidate Builds</span>


### PR DESCRIPTION
Users can now select a Koji side tag to create an Update. Bodhi
will look at the Koji tag to find the list of Builds and use that
to create the resulting update.

fixes #3009 

Signed-off-by: Randy Barlow <randy@electronsweatshop.com>