### PR TITLE
[WIP] Respond synchronously to Greenwave decisions.

### DIFF
--- a/bodhi/server/consumers/greenwave.py
+++ b/bodhi/server/consumers/greenwave.py
@@ -1,0 +1,43 @@
+# Copyright © 2019 Red Hat Inc., and others.
+#
+# This file is part of Bodhi.
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+import typing
+
+from bodhi.server import initialize_db, models
+from bodhi.server.util import transactional_session_maker
+
+
+if typing.TYPE_CHECKING:  # pragma: no cover
+    import fedora_messaging  # noqa: 401
+
+
+class Handler(object):
+    """Automatically create Updates for Koji builds."""
+    def __init__(self):
+        initialize_db(config)
+        self.db_factory = transactional_session_maker()
+
+    def __call__(self, message: 'fedora_messaging.api.Message'):
+        """
+        Process messages on the topic org.fedoraproject.prod.greewave.something
+        """
+        nvr = message['nvr']
+        build = models.Build.query.filter_by(nvr=message['nvr']).one()
+        if build:
+            with self.db_factory():
+                build.update.refresh_greenwave_decision()


### PR DESCRIPTION
This commit adds a Greenwave message listener so that Bodhi can
react synchronously to Greenwave decisions.

fixes #3008 

Signed-off-by: Randy Barlow <randy@electronsweatshop.com>