### PR TITLE
Fix pipeline results showing with heading 'undefined'

### DIFF
--- a/bodhi/server/templates/update.html
+++ b/bodhi/server/templates/update.html
@@ -220,7 +220,7 @@ ${update.type} update for ${update.beautify_title(amp=True) | n}
         // seem to break anything
         var arch = result.data.arch;
         var item = result.data.item;
-        if (item === undefined && testcase == 'org.centos.prod.ci.pipeline.complete'){
+        if (item === undefined && testcase.startsWith('org.centos.prod.ci.pipeline')){
             item = result.data.original_spec_nvr[0] + '#' + result.data.rev;
         }
         var submit_time = new Date(result.submit_time);


### PR DESCRIPTION
Pipeline results currently show in the Automated Tests tab under
a header 'undefined'. It looks like the code touched in this
commit wasn't updated when the pipeline message topics changed,
so it broke. This way should be a bit more robust against any
more changes...

Signed-off-by: Adam Williamson <awilliam@redhat.com>