### PR TITLE
Download database dumps first in CentOS CI

### DIFF
--- a/devel/ci/bodhi-ci
+++ b/devel/ci/bodhi-ci
@@ -299,6 +299,15 @@ def integration_build(concurrency, container_runtime, failfast, pyver, release, 
     _run_jobs(_build_jobs_list('integration-build', concurrency, release, pyvers=pyver))
 
 
+@cli.command("integration-download")
+@concurrency_option
+@failfast_option
+@tty_option
+def integration_download(concurrency, failfast, tty):
+    """Download the database dumps for integration testing."""
+    _run_jobs(_build_jobs_list('integration-download', concurrency, releases=[], pyvers=[3]))
+
+
 @cli.command()
 @archive_option
 @concurrency_option
@@ -1145,11 +1154,13 @@ def _build_jobs_list(
         buffer_output = concurrency != 1 and len(releases) != 1
     jobs = []  # type: typing.List[Job]
     integration_deps_build_jobs = []  # type: typing.List[Job]
-    if command in ('all', 'integration-build', 'integration') and 3 in pyvers:
-        integration_deps_build_jobs.extend([
-            IntegrationBuildJob(app_name=app_name, release="prod", buffer_output=buffer_output)
-            for app_name in ("resultsdb", "waiverdb", "greenwave")
-        ])
+    if command in ('all', 'integration-build', 'integration', 'integration-download') \
+            and 3 in pyvers:
+        if command != 'integration-download':
+            integration_deps_build_jobs.extend([
+                IntegrationBuildJob(app_name=app_name, release="prod", buffer_output=buffer_output)
+                for app_name in ("resultsdb", "waiverdb", "greenwave")
+            ])
         # Download the DB dumps
         integration_deps_build_jobs.extend([
             IntegrationDumpDownloadJob(app_name="waiverdb", release="prod", buffer_output=buffer_output),

--- a/devel/ci/bodhi-ci
+++ b/devel/ci/bodhi-ci
@@ -1017,13 +1017,37 @@ class IntegrationDumpDownloadJob(BuildJob):
 
         self._app_name = app_name
         self._label = 'integration-dump-download-{}'.format(app_name)
-        filepath = os.path.join("devel", "ci", "integration", "dumps", "{}.dump".format(self._app_name))
+        self.filepath = os.path.join(
+            "devel", "ci", "integration", "dumps", "{}.dump".format(self._app_name))
         url = "https://infrastructure.fedoraproject.org/infra/db-dumps/{app}.dump.xz".format(app=self._app_name)
         self._popen_kwargs['shell'] = True
-        self._command = ["curl -o {filepath}.xz -R -z {filepath}.xz {url} && xz -d --keep --force {filepath}.xz".format(url=url, filepath=filepath)]
+        self._command = [
+            (f"curl -o {self.filepath}.xz {url} && xz -d --keep --force {self.filepath}.xz")]
 
     def __repr__(self):
         return "<{} app={!r}>".format(self.__class__.__name__, self._app_name)
+
+    async def run(self) -> 'IntegrationDumpDownloadJob':
+        """
+        Run the download, unless we already have the file and it's recent enough.
+
+        Returns:
+            Returns self.
+        """
+        if os.path.exists(self.filepath):
+            # st_mtime is going to use the filesystem's timestamp, not necessarily UTC. Thus, we
+            # will use tz=None on fromttimestamp() so that the time is expressed in the system's
+            # local time. Therefore, we also need to collect the current time in the system's local
+            # time for comparison.
+            modified_time = datetime.datetime.fromtimestamp(os.stat(self.filepath).st_mtime)
+            if datetime.datetime.now() - modified_time < datetime.timedelta(days=1):
+                # Our download is within a day and infrastructure only produces downloads once a
+                # day, so let's skip this task.
+                self.complete.set()
+                self.skipped = True
+        else:
+            await super(IntegrationDumpDownloadJob, self).run()
+        return self
 
 
 class IntegrationJob(Job):

--- a/devel/ci/cico.pipeline
+++ b/devel/ci/cico.pipeline
@@ -155,6 +155,9 @@ node('bodhi') {
             synctoduffynode('bodhi')
         }
 
+        // Download the database dumps for the integration tests.
+        onmyduffynode 'cd payload && python36 ./devel/ci/bodhi-ci integration-download --no-tty'
+
         parallel(
             f28: {test_release('f28')},
             f29: {test_release('f29')},


### PR DESCRIPTION
There are two commits in this pull request, with detailed commit messages. The overall theme of this pull request is to make sure that database downloads only happen once, even when multiple bodhi-ci processes are run in CentOS CI.