### PR TITLE
Use a UUID in the test network name.

### DIFF
--- a/devel/ci/integration/tests/fixtures/backend.py
+++ b/devel/ci/integration/tests/fixtures/backend.py
@@ -1,4 +1,4 @@
-# Copyright © 2018 Red Hat, Inc.
+# Copyright © 2018-2019 Red Hat, Inc.
 #
 # This file is part of Bodhi.
 #
@@ -19,6 +19,7 @@
 from __future__ import absolute_import, unicode_literals
 
 import logging
+import uuid
 
 import pytest
 from conu import DockerBackend
@@ -46,6 +47,6 @@ def docker_network(docker_backend):
     Yields:
         dict: The Docker network.
     """
-    network = docker_backend.d.create_network("bodhi_test", driver="bridge")
+    network = docker_backend.d.create_network(f"bodhi_test-{uuid.uuid4()}", driver="bridge")
     yield network
     docker_backend.d.remove_network(network["Id"])


### PR DESCRIPTION
When run in parallel, the integration test processes all created
the same network name. This caused trouble when the tests ended,
because they would try to remove the network that the others were
still using.

This commit gives the test network a UUID so it has a unique name.

fixes #2983

Signed-off-by: Randy Barlow <randy@electronsweatshop.com>