### PR TITLE
Avoid deadlock when database downloads are old.

### DIFF
--- a/devel/ci/bodhi-ci
+++ b/devel/ci/bodhi-ci
@@ -1054,9 +1054,9 @@ class IntegrationDumpDownloadJob(BuildJob):
                 # day, so let's skip this task.
                 self.complete.set()
                 self.skipped = True
-        else:
-            await super(IntegrationDumpDownloadJob, self).run()
-        return self
+                return self
+
+        return await super(IntegrationDumpDownloadJob, self).run()
 
 
 class IntegrationJob(Job):


### PR DESCRIPTION
I recently wrote a patch for bodhi-ci that attempted to skip
downloading database dumps if they were recently downloaded.
Unfortunately, my implementation's control logic caused a deadlock
if the download existed locally, but was older than a day because
the superclass's run() was never called and the function returned.
This caused a deadlock.

This patch ensures that we call the superclass run() when we have
a copy of the database that is older than one day.

Signed-off-by: Randy Barlow <randy@electronsweatshop.com>