### PR TITLE
Use a setting to configure the fedmsg-hub WS URL.

### DIFF
--- a/bodhi/server/config.py
+++ b/bodhi/server/config.py
@@ -428,6 +428,9 @@ class BodhiConfig(dict):
         'fedmsg_enabled': {
             'value': False,
             'validator': _validate_bool},
+        'fedmsg_gateway': {
+            'value': 'wss://hub.fedoraproject.org:9939',
+            'validator': str},
         'file_url': {
             'value': 'https://download.fedoraproject.org/pub/fedora/linux/updates',
             'validator': str},

--- a/bodhi/server/static/js/live.js
+++ b/bodhi/server/static/js/live.js
@@ -22,7 +22,7 @@ function WebSocketSetup(attempts) {
 
   if ("WebSocket" in window) {
     // Let us open a web socket
-    var socket_url = "wss://hub.fedoraproject.org:9939";
+    var socket_url = settings.fedmsg_gateway;
     //var socket_url = "wss://209.132.181.16:9939";
     var ws = new WebSocket(socket_url);
     ws.onopen = function(e) {

--- a/bodhi/server/templates/master.html
+++ b/bodhi/server/templates/master.html
@@ -2,6 +2,9 @@
 <%namespace name="pager" file="pager.html" inheritable="True" />
 <%namespace name="tables" file="tables.html" inheritable="True" />
 <%namespace name="fragments" file="fragments.html" inheritable="True" />
+<%
+    from bodhi.server.config import config
+%>
 
 <!DOCTYPE html>
 <html lang="en">
@@ -37,6 +40,11 @@
     <link href="${request.static_url('bodhi:server/static/css/panel.css') }" rel="stylesheet" />
     <script src="${request.static_url('bodhi:server/static/js/jquery-1.10.2.min.js')}"></script>
     <script src="${request.static_url('bodhi:server/static/js/Chart-0.2.0.min.js')}"></script>
+    <script type="text/javascript">
+        var settings = {
+            fedmsg_gateway: "${ config['fedmsg_gateway'] }"
+        };
+    </script>
   </head>
 
   <body>

--- a/production.ini
+++ b/production.ini
@@ -45,6 +45,9 @@ use = egg:bodhi-server
 # Set this to True in order to send fedmsg messages.
 # fedmsg_enabled = False
 
+# Web socket URL to the fedmsg gateway. This is used to display live fedmsgs in the web interface.
+# fedmsg_gateway = wss://hub.fedoraproject.org:9939
+
 
 ##
 ## Legal


### PR DESCRIPTION
The fedmsg-hub web socket URL was hardcoded in live.js. This commit
adds a setting for that URL and injects it into the master template
via a <script> tag so that all subsequently loaded JavaScript can
assume that setting is available for use.

This change also adds a nice place for other settings to be added
later, if desired.

fixes #2523

Signed-off-by: Randy Barlow <randy@electronsweatshop.com>