### PR TITLE
Use Python 3 when provisioning Vagrant with Ansible.

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -57,7 +57,6 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
  config.vm.provision "shell", inline: "sudo dnf upgrade -y"
 
  # bootstrap and run with ansible
- config.vm.provision "shell", inline: "sudo dnf -y install python2-dnf libselinux-python"
  config.vm.provision "ansible" do |ansible|
      ansible.playbook = "devel/ansible/playbook.yml"
  end

--- a/devel/ansible/playbook.yml
+++ b/devel/ansible/playbook.yml
@@ -3,5 +3,6 @@
   become: true
   become_method: sudo
   vars:
+      ansible_python_interpreter: /usr/bin/python3
   roles:
     - bodhi


### PR DESCRIPTION
Signed-off-by: Randy Barlow <randy@electronsweatshop.com>