### PR TITLE
Rename prefer_ssl to libravatar_prefer_tls.

### DIFF
--- a/bodhi/server/config.py
+++ b/bodhi/server/config.py
@@ -477,6 +477,9 @@ class BodhiConfig(dict):
         'libravatar_enabled': {
             'value': True,
             'validator': _validate_bool},
+        'libravatar_prefer_tls': {
+            'value': True,
+            'validator': bool},
         'mail.templates_basepath': {
             'value': 'bodhi:server/email/templates/',
             'validator': str},
@@ -534,9 +537,6 @@ class BodhiConfig(dict):
         'pdc_url': {
             'value': 'https://pdc.fedoraproject.org/',
             'validator': _validate_tls_url},
-        'prefer_ssl': {
-            'value': None,
-            'validator': _validate_none_or(bool)},
         'privacy_link': {
             'value': '',
             'validator': str},

--- a/bodhi/server/util.py
+++ b/bodhi/server/util.py
@@ -347,7 +347,7 @@ def avatar(context, username, size):
 
     # context is a mako context object
     request = context['request']
-    https = request.registry.settings.get('prefer_ssl')
+    https = request.registry.settings.get('libravatar_prefer_tls')
 
     @request.cache.cache_on_arguments()
     def get_libravatar_url(openid, https, size):

--- a/bodhi/tests/server/test_util.py
+++ b/bodhi/tests/server/test_util.py
@@ -45,8 +45,9 @@ class TestAvatar(unittest.TestCase):
 
         self.assertEqual(util.avatar(context, 'bowlofeggs', 50), 'libravatar.org')
 
-    @mock.patch.dict(config,
-                     {'libravatar_enabled': True, 'libravatar_dns': True, 'prefer_ssl': False})
+    @mock.patch.dict(
+        config,
+        {'libravatar_enabled': True, 'libravatar_dns': True, 'libravatar_prefer_tls': False})
     @mock.patch('bodhi.server.util.libravatar.libravatar_url', return_value='cool url')
     def test_libravatar_dns_set_ssl_false(self, libravatar_url):
         """Test the correct return value when libravatar_dns is set in config."""
@@ -63,8 +64,9 @@ class TestAvatar(unittest.TestCase):
         libravatar_url.assert_called_once_with(openid='http://bowlofeggs.id.fedoraproject.org/',
                                                https=False, size=50, default='retro')
 
-    @mock.patch.dict(config,
-                     {'libravatar_enabled': True, 'libravatar_dns': True, 'prefer_ssl': True})
+    @mock.patch.dict(
+        config,
+        {'libravatar_enabled': True, 'libravatar_dns': True, 'libravatar_prefer_tls': True})
     @mock.patch('bodhi.server.util.libravatar.libravatar_url', return_value='cool url')
     def test_libravatar_dns_set_ssl_true(self, libravatar_url):
         """Test the correct return value when libravatar_dns is set in config."""

--- a/docs/user/release_notes.rst
+++ b/docs/user/release_notes.rst
@@ -12,6 +12,8 @@ Backwards incompatible changes
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 * Values NULL and 0 are not allowed in update's stable_karma and unstable_karma (:issue:`1029`).
+* The ``prefer_ssl`` setting has been renamed to ``libravatar_prefer_tls`` and now defaults to
+  ``True`` instead of ``None`` (:issue:`1921`).
 * Integration with pkgdb is no longer supported (:issue:`1970`).
 * The ``/admin/`` API has been removed (:issue:`1985`).
 * Support for CVE tracking was dropped. It was technically not possible to use the feature, so it

--- a/production.ini
+++ b/production.ini
@@ -37,10 +37,10 @@ use = egg:bodhi-server
 # Set this to true if you want to do federated dns libravatar lookup
 # libravatar_dns = False
 
-# If libravatar_dns is True, prefer_ssl will define what gets handed to
+# If libravatar_dns is True, libravatar_prefer_tls will define what gets handed to
 # libravatar.libravatar_url()'s https setting. It may be set to True or False, but defaults to None,
 # which is effectively False.
-# prefer_ssl =
+# libravatar_prefer_tls = True
 
 # Set this to True in order to send fedmsg messages.
 # fedmsg_enabled = False


### PR DESCRIPTION
The prefer_ssl setting is renamed to libravatar_prefer_tls by this
commit. The previous name was far too generic of a name, and
implied that it had some global impact when it only affected
libravatar.

The new setting also defaults to True instead of None, a saner
default.

fixes #1921

Signed-off-by: Randy Barlow <randy@electronsweatshop.com>