### PR TITLE
Explicitly require psycopg2.

### DIFF
--- a/devel/ci/Dockerfile-f28
+++ b/devel/ci/Dockerfile-f28
@@ -43,6 +43,7 @@ RUN dnf install --disablerepo rawhide-modular -y \
     python3-munch \
     python3-openid \
     python3-pillow \
+    python3-psycopg2 \
     python3-pydocstyle \
     python3-pylibravatar \
     python3-pyramid \

--- a/devel/ci/Dockerfile-f29
+++ b/devel/ci/Dockerfile-f29
@@ -44,6 +44,7 @@ RUN dnf install --disablerepo rawhide-modular -y \
     python3-munch \
     python3-openid \
     python3-pillow \
+    python3-psycopg2 \
     python3-pydocstyle \
     python3-pylibravatar \
     python3-pyramid \

--- a/devel/ci/Dockerfile-rawhide
+++ b/devel/ci/Dockerfile-rawhide
@@ -46,6 +46,7 @@ RUN dnf install --disablerepo rawhide-modular -y \
     python3-munch \
     python3-openid \
     python3-pillow \
+    python3-psycopg2 \
     python3-pydocstyle \
     python3-pylibravatar \
     python3-pyramid \

--- a/devel/ci/integration/bodhi/Dockerfile-f28
+++ b/devel/ci/integration/bodhi/Dockerfile-f28
@@ -14,7 +14,6 @@ RUN dnf install -y \
     httpd \
     intltool \
     python3-mod_wsgi \
-    "python3dist(psycopg2)" \
     skopeo \
     /usr/bin/koji
 

--- a/devel/ci/integration/bodhi/Dockerfile-f29
+++ b/devel/ci/integration/bodhi/Dockerfile-f29
@@ -14,7 +14,6 @@ RUN dnf install -y \
     httpd \
     intltool \
     python3-mod_wsgi \
-    "python3dist(psycopg2)" \
     skopeo \
     /usr/bin/koji
 

--- a/devel/ci/integration/bodhi/Dockerfile-pip
+++ b/devel/ci/integration/bodhi/Dockerfile-pip
@@ -19,9 +19,6 @@ RUN dnf install -y \
     python3-dnf \
     skopeo
 
-RUN pip-3 install \
-    psycopg2
-
 # Mimic RPM's handling of Python3-specific binaries
 RUN ln -s alembic /usr/local/bin/alembic-3
 

--- a/devel/ci/integration/bodhi/Dockerfile-rawhide
+++ b/devel/ci/integration/bodhi/Dockerfile-rawhide
@@ -14,7 +14,6 @@ RUN dnf install -y \
     httpd \
     intltool \
     python3-mod_wsgi \
-    "python3dist(psycopg2)" \
     skopeo \
     /usr/bin/koji
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,6 +15,7 @@ kitchen
 markdown
 # for captchas
 Pillow
+psycopg2
 py3dns; python_version >= '3.0'  # Should be required by pyLibravatar https://bugs.launchpad.net/pylibravatar/+bug/1661218
 pylibravatar
 pyramid~=1.7


### PR DESCRIPTION
The downstream spec file was recently refactored to use Python
dependency autogeneration, and in the process all Requires: lines
on Python packages were removed, including psycopg2. This caused
Bodhi to fail to run when installed from that spec file,
highlighting that upstream should have listed psycopg2 as a
requirement.

PostgreSQL is Bodhi's only supported database and has long been so,
though it has not been formally listed in the requirements.txt
until this commit.

Signed-off-by: Randy Barlow <randy@electronsweatshop.com>