### PR TITLE
The CLI now defaults to the BRO --wait flag.

### DIFF
--- a/bodhi/client/__init__.py
+++ b/bodhi/client/__init__.py
@@ -126,7 +126,7 @@ save_edit_options = [
                  help='Notes on why this override is in place.'),
     click.option('--user'),
     click.option('--password', hide_input=True),
-    click.option('--wait', is_flag=True, default=False,
+    click.option('--wait/--no-wait', is_flag=True, default=True,
                  help='Wait and ensure that the override is active'),
     openid_option,
     staging_option,

--- a/docs/user/release_notes.rst
+++ b/docs/user/release_notes.rst
@@ -42,6 +42,8 @@ Backwards incompatible changes
   As a result, the bodhi-dequeue-stable CLI has also been removed (:issue:`2977`).
 * Support for obsolete scripts in ``tools`` folder was dropped (:issue:`2980`).
 * Bug objects no longer include a ``private`` field (:issue:`3016`).
+* The CLI now defaults to the ``--wait`` flag when creating or editing buildroot overrides. The old
+  behavior can be achieved with the ``--no-wait`` flag.
 
 
 Dependency changes


### PR DESCRIPTION
The CLI will now wait on Koji to finish the new buildroot when
creating or editing buildroot overrides by default. The old
behavior can be achieved with the --no-wait flag.

Signed-off-by: Randy Barlow <randy@electronsweatshop.com>