### PR TITLE
Compare enum values instead of descriptions.

### DIFF
--- a/bodhi/server/templates/new_update.html
+++ b/bodhi/server/templates/new_update.html
@@ -176,7 +176,7 @@ ${update.notes}
                   % for value in types:
                   <label class="c-input c-radio">
                     <input type="radio" name="type" value="${value}"
-                    % if update and update.type.description == value:
+                    % if update and update.type.value == value:
                     checked="checked"
                     % endif
                     > ${value}
@@ -189,10 +189,10 @@ ${update.notes}
                   % for value in severities:
                   <label class="c-input c-radio">
                     <input type="radio" name="severity" value="${value}"
-                    % if update and update.severity.description == value:
+                    % if update and update.severity.value == value:
                     checked="checked"
                     % endif
-                    % if update and update.type.description == 'security' and value == 'unspecified':
+                    % if update and update.type.value == 'security' and value == 'unspecified':
                     disabled="disabled"
                     % endif
                     > ${value}
@@ -208,7 +208,7 @@ ${update.notes}
                   % for value in suggestions:
                   <label class="c-input c-radio">
                     <input type="radio" name="suggest" value="${value}"
-                    % if update and update.suggest.description == value:
+                    % if update and update.suggest.value == value:
                     checked="checked"
                     % endif
                     > ${value}

--- a/bodhi/server/templates/update.html
+++ b/bodhi/server/templates/update.html
@@ -587,13 +587,13 @@ $(document).ready(function(){
           % if not update.pushed:
             <a id='edit' class="btn btn-sm btn-primary"><span class="fa fa-fw fa-pencil"></span> Edit</a>
             % if update.request is None:
-              % if update.status.description != 'testing':
+              % if update.status.value != 'testing':
               <a id='testing' class="btn btn-sm btn-success"><span class="fa fa-fw fa-arrow-circle-right"></span> Push to Testing</a>
               % endif
             % else:
               <a id='revoke' class="btn btn-sm btn-danger"><span class="fa fa-fw fa-arrow-circle-left"></span> Revoke</a>
             % endif
-          % elif update.pushed and (update.status.description != 'stable' or (update.status.description == 'stable' and 'releng' in [group.name for group in request.user.groups])):
+          % elif update.pushed and (update.status.value != 'stable' or (update.status.value == 'stable' and 'releng' in [group.name for group in request.user.groups])):
             <a id='edit' class="btn btn-sm btn-primary"><span class="fa fa-fw fa-pencil"></span> Edit</a>
             % if update.meets_testing_requirements:
                 <a id="stable" class="btn btn-sm btn-success">
@@ -695,7 +695,7 @@ $(document).ready(function(){
           % endif
 
           % if update.content_type:
-          % if update.content_type.description == 'RPM' and ('testing' in update.status or 'stable' in update.status):
+          % if update.content_type.value == 'rpm' and ('testing' in update.status or 'stable' in update.status):
           <div class="p-t-1">
           <h4>How to install</h4>
             <pre style="position: relative;"><span class="label label-default" id="copybutton" style="position: absolute; top: 0px; right: 0px; cursor: pointer;" title="Copy to clipboard"><i class="fa fa-copy"></i></span><code id="commandtext">${self.util.update_install_command(update)}</code></pre>
@@ -1030,7 +1030,7 @@ $(document).ready(function(){
                     </tr>
                     % endif
 
-                    % if update.days_to_stable and update.status.description == 'testing':
+                    % if update.days_to_stable and update.status.value == 'testing':
                     <tr>
                       <td>days to stable</td>
                       <td class="text-muted">


### PR DESCRIPTION
There were multiple places in the template code that were
comparing Enum human readable descriptions instead of the Enum
values. The descriptions are meant to be human readable and are
subject to change, so this code was at risk of breaking if someone
changes those descriptions in the future.

Signed-off-by: Randy Barlow <randy@electronsweatshop.com>