### PR TITLE
Vagrant: Fold bdiff-cover into btest.

### DIFF
--- a/devel/ansible/roles/bodhi/files/.bashrc
+++ b/devel/ansible/roles/bodhi/files/.bashrc
@@ -10,7 +10,6 @@ fi
 
 shopt -s expand_aliases
 alias bci="sudo -E /home/vagrant/bodhi/devel/ci/bodhi-ci"
-alias bdiff-cover="py.test-3 $@ /home/vagrant/bodhi/; diff-cover /home/vagrant/bodhi/coverage.xml --compare-branch=develop --fail-under=100"
 alias bdocs="make -C /home/vagrant/bodhi/docs clean && make -C /home/vagrant/bodhi/docs html && make -C /home/vagrant/bodhi/docs man"
 alias blog="sudo journalctl -u bodhi"
 alias brestart="sudo systemctl restart bodhi && echo 'The Application is running on http://localhost:6543'"
@@ -34,7 +33,7 @@ function bresetdb {
 
 function btest {
     find /home/vagrant/bodhi -name "*.pyc" -delete;
-    bteststyle && bdocs && bci unit -r f29
+    bteststyle && bdocs && py.test-3 $@ /home/vagrant/bodhi/bodhi/tests && diff-cover /home/vagrant/bodhi/coverage.xml --compare-branch=develop --fail-under=100
 }
 
 export BODHI_URL="http://localhost:6543/"

--- a/devel/ansible/roles/bodhi/files/motd
+++ b/devel/ansible/roles/bodhi/files/motd
@@ -2,7 +2,6 @@
 Welcome to the Bodhi development environment! Here are some helpful commands:
 
 bci:         Run the Bodhi CI test suite.
-bdiff-cover: Run btest and then run diff-cover against the develop branch
 bdocs:       Build Bodhi's documentation.
 bfedmsg:     Display the log of Bodhi's fedmsgs.
 blog:        View Bodhi's log. (Support all the systemctl options, such as -lf)


### PR DESCRIPTION
Having a separate bdiff-cover command is not useful since running
the tests are necessary to measure the test coverage, and since
diff-cover itself takes very little time to run in comparison to
the tests.

Therefore, it makes more sense to fold the diff-cover test into
btest and get rid of bdiff-cover.

Signed-off-by: Randy Barlow <randy@electronsweatshop.com>