### PR TITLE
Gracefully handle private bugs

### DIFF
--- a/bodhi/server/bugs.py
+++ b/bodhi/server/bugs.py
@@ -137,9 +137,6 @@ class Bugzilla(object):
             if len(comment) > 65535:
                 raise InvalidComment("Comment is too long: %s" % comment)
             bug = self.bz.getbug(bug_id)
-            if bug.private:
-                log.info('Unable to comment on private bug #%d' % bug_id)
-                return
             attempts = 0
             while attempts < 5:
                 try:
@@ -172,9 +169,6 @@ class Bugzilla(object):
         """
         try:
             bug = self.bz.getbug(bug_id)
-            if bug.private:
-                log.info('Unable to modify status of private bug #%d' % bug_id)
-                return
             if bug.product not in config.get('bz_products'):
                 log.info("Skipping set on_qa on {0!r} bug #{1}".format(bug.product, bug_id))
                 return
@@ -201,9 +195,6 @@ class Bugzilla(object):
         args = {'comment': comment}
         try:
             bug = self.bz.getbug(bug_id)
-            if bug.private:
-                log.info('Unable to modify status of private bug #%d' % bug_id)
-                return
             if bug.product not in config.get('bz_products'):
                 log.info("Skipping set closed on {0!r} bug #{1}".format(bug.product, bug_id))
                 return
@@ -246,15 +237,10 @@ class Bugzilla(object):
         if not bug:
             try:
                 bug = self.bz.getbug(bug_entity.bug_id)
-            except xmlrpc_client.Fault as err:
-                if err.faultCode == 102:
-                    bug_entity.title = 'Private bug'
-                    bug_entity.private = True
-                    log.info("Marked bug #" + str(bug_entity.bug_id) + " as private.")
-                else:
-                    bug_entity.title = 'Invalid bug number'
-                    log.error("Got fault from Bugzilla: fault code: %d, fault string: %s" % (
-                        err.faultCode, err.faultString))
+            except xmlrpc_client.Fault as e:
+                bug_entity.title = 'Invalid bug number'
+                log.error("Got fault from Bugzilla: fault code: %d, fault string: %s" % (
+                    e.faultCode, e.faultString))
                 return
             except Exception:
                 log.exception("Unknown exception from Bugzilla")
@@ -284,9 +270,6 @@ class Bugzilla(object):
         """
         try:
             bug = self.bz.getbug(bug_id)
-            if bug.private:
-                log.info('Unable to modify status of private bug #%s' % bug_id)
-                return
             if bug.product not in config.get('bz_products'):
                 log.info("Skipping set modified on {0!r} bug #{1}".format(bug.product, bug_id))
                 return

--- a/bodhi/server/bugs.py
+++ b/bodhi/server/bugs.py
@@ -150,6 +150,13 @@ class Bugzilla(object):
         except InvalidComment:
             log.error(
                 "Comment too long for bug #%d:  %s" % (bug_id, comment))
+        except xmlrpc_client.Fault as err:
+            if err.faultCode == 102:
+                log.info('Cannot retrieve private bug #%d.', bug_id)
+            else:
+                log.exception(
+                    "Got fault from Bugzilla on #%d: fault code: %d, fault string: %s",
+                    bug_id, err.faultCode, err.faultString)
         except Exception:
             log.exception("Unable to add comment to bug #%d" % bug_id)
 
@@ -177,6 +184,13 @@ class Bugzilla(object):
                 bug.setstatus('ON_QA', comment=comment)
             else:
                 bug.addcomment(comment)
+        except xmlrpc_client.Fault as err:
+            if err.faultCode == 102:
+                log.info('Cannot retrieve private bug #%d.', bug_id)
+            else:
+                log.exception(
+                    "Got fault from Bugzilla on #%d: fault code: %d, fault string: %s",
+                    bug_id, err.faultCode, err.faultString)
         except Exception:
             log.exception("Unable to alter bug #%d" % bug_id)
 
@@ -219,10 +233,13 @@ class Bugzilla(object):
                     args['fixedin'] = " ".join([fixedin_str, version]).strip()
 
             bug.close('ERRATA', **args)
-        except xmlrpc_client.Fault as e:
-            log.error(
-                "Unable to close bug #%d: a fault has occurred\nFault code: %d\nFault string: %s" %
-                (bug_id, e.faultCode, e.faultString))
+        except xmlrpc_client.Fault as err:
+            if err.faultCode == 102:
+                log.info('Cannot retrieve private bug #%d.', bug_id)
+            else:
+                log.exception(
+                    "Got fault from Bugzilla on #%d: fault code: %d, fault string: %s",
+                    bug_id, err.faultCode, err.faultString)
 
     def update_details(self, bug: typing.Union[typing.Any, None],
                        bug_entity: 'models.Bug'):
@@ -237,10 +254,15 @@ class Bugzilla(object):
         if not bug:
             try:
                 bug = self.bz.getbug(bug_entity.bug_id)
-            except xmlrpc_client.Fault as e:
-                bug_entity.title = 'Invalid bug number'
-                log.error("Got fault from Bugzilla: fault code: %d, fault string: %s" % (
-                    e.faultCode, e.faultString))
+            except xmlrpc_client.Fault as err:
+                if err.faultCode == 102:
+                    log.info('Cannot retrieve private bug #%d.', bug_entity.bug_id)
+                    bug_entity.title = 'Private bug'
+                else:
+                    log.exception(
+                        "Got fault from Bugzilla on #%d: fault code: %d, fault string: %s",
+                        bug_entity.bug_id, err.faultCode, err.faultString)
+                    bug_entity.title = 'Invalid bug number'
                 return
             except Exception:
                 log.exception("Unknown exception from Bugzilla")
@@ -278,6 +300,13 @@ class Bugzilla(object):
                 bug.setstatus('MODIFIED', comment=comment)
             else:
                 bug.addcomment(comment)
+        except xmlrpc_client.Fault as err:
+            if err.faultCode == 102:
+                log.info('Cannot retrieve private bug #%d.', bug_id)
+            else:
+                log.exception(
+                    "Got fault from Bugzilla on #%d: fault code: %d, fault string: %s",
+                    bug_id, err.faultCode, err.faultString)
         except Exception:
             log.exception("Unable to alter bug #%s" % bug_id)
 

--- a/bodhi/server/consumers/updates.py
+++ b/bodhi/server/consumers/updates.py
@@ -171,9 +171,6 @@ class UpdatesHandler(fedmsg.consumers.FedmsgConsumer):
         details from Bugzilla, comment on the bug to let watchers know about the update, and mark
         the bug as MODIFIED. If the bug is a security issue, mark the update as a security update.
 
-        If the bug is private, Bodhi can't retrieve any information, comment on it, or modify
-        it, so we just associate the bug id with the update and mark it to be private.
-
         If handle_bugs is not True, return and do nothing.
 
         Args:
@@ -193,10 +190,6 @@ class UpdatesHandler(fedmsg.consumers.FedmsgConsumer):
 
                 log.info("Updating our details for %r" % bug.bug_id)
                 bug.update_details(rhbz_bug)
-                if bug.private:
-                    # Bodhi can't retrieve any information so just continue with the next bug
-                    log.info("  Skipping bug %r because it is private" % (bug.bug_id))
-                    continue
                 log.info("  Got title %r for %r" % (bug.title, bug.bug_id))
 
                 # If you set the type of your update to 'enhancement' but you

--- a/bodhi/server/mail.py
+++ b/bodhi/server/mail.py
@@ -323,9 +323,9 @@ def get_template(update, use_template='fedora_errata_template'):
                     if parent and not bug.parent:
                         log.debug("Skipping tracker bug %s" % bug)
                         continue
-                title = (bug.title != 'Unable to fetch title'
-                         and bug.title != 'Invalid bug number'
-                         and not bug.private) and ' - %s' % bug.title or ''
+                title = (
+                    bug.title != 'Unable to fetch title' and bug.title != 'Invalid bug number') \
+                    and ' - %s' % bug.title or ''
                 info['references'] += u"  [ %d ] Bug #%d%s\n        %s\n" % \
                                       (i, bug.bug_id, title, bug.url)
                 i += 1

--- a/bodhi/server/migrations/versions/aae0d29d49b7_remove_the_private_field_on_the_bug_.py
+++ b/bodhi/server/migrations/versions/aae0d29d49b7_remove_the_private_field_on_the_bug_.py
@@ -1,0 +1,43 @@
+# Copyright (c) 2019 Red Hat, Inc.
+#
+# This file is part of Bodhi.
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+"""
+Remove the private field on the Bug model.
+
+Revision ID: aae0d29d49b7
+Revises: 190ba571c7d2
+Create Date: 2019-02-19 01:53:37.699933
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'aae0d29d49b7'
+down_revision = '190ba571c7d2'
+
+
+def upgrade():
+    """Remove the private field from the bugs table."""
+    op.drop_column('bugs', 'private')
+
+
+def downgrade():
+    """Add the private field back to the bugs table."""
+    op.add_column('bugs', sa.Column('private', sa.BOOLEAN(), autoincrement=False, nullable=True))
+    op.execute("""UPDATE bugs SET private = FALSE""")
+    op.alter_column('bugs', 'private', nullable=False)

--- a/bodhi/server/models.py
+++ b/bodhi/server/models.py
@@ -3959,9 +3959,6 @@ class Bug(Base):
     # If this bug is a parent tracker bug for release-specific bugs
     parent = Column(Boolean, default=False)
 
-    # Is it public or private
-    private = Column(Boolean, default=False)
-
     @property
     def url(self):
         """
@@ -4017,9 +4014,6 @@ class Bug(Base):
             comment (basestring or None): The comment to add to the bug. If None, a default message
                 is added to the bug. Defaults to None.
         """
-        if self.private:
-            log.debug('Not commenting on private bug %s', self.bug_id)
-            return
         if update.type is UpdateType.security and self.parent \
                 and update.status is not UpdateStatus.stable:
             log.debug('Not commenting on parent security bug %s', self.bug_id)
@@ -4039,9 +4033,6 @@ class Bug(Base):
         Args:
             update (Update): The update associated with the bug.
         """
-        if self.private:
-            log.debug('Not modifying private bug %s', self.bug_id)
-            return
         # Skip modifying Security Response bugs for testing updates
         if update.type is UpdateType.security and self.parent:
             log.debug('Not modifying parent security bug %s', self.bug_id)
@@ -4056,9 +4047,6 @@ class Bug(Base):
         Args:
             update (Update): The update associated with the bug.
         """
-        if self.private:
-            log.debug('Not modifying private bug %s', self.bug_id)
-            return
         # Build a mapping of package names to build versions
         # so that .close() can figure out which build version fixes which bug.
         versions = dict([
@@ -4075,9 +4063,6 @@ class Bug(Base):
         Args:
             update (Update): The update that is associated with this bug.
         """
-        if self.private:
-            log.debug('Not modifying private bug %s', self.bug_id)
-            return
         if update.type is UpdateType.security and self.parent:
             log.debug('Not modifying parent security bug %s', self.bug_id)
         else:

--- a/bodhi/server/util.py
+++ b/bodhi/server/util.py
@@ -852,12 +852,9 @@ def bug_link(context, bug, short=False):
     link = "<a target='_blank' href='%s'>%s</a>" % (url, display)
     if not short:
         if bug.title:
-            if bug.private:
-                link = link + " <span class='label label-danger'>Private bug</span>"
-            else:
-                # We're good, but we do need to clean the bug title in case it contains malicious
-                # tags. See CVE-2017-1002152: https://github.com/fedora-infra/bodhi/issues/1740
-                link = link + " " + bleach.clean(bug.title, tags=[], attributes=[])
+            # We're good, but we do need to clean the bug title in case it contains malicious
+            # tags. See CVE-2017-1002152: https://github.com/fedora-infra/bodhi/issues/1740
+            link = link + " " + bleach.clean(bug.title, tags=[], attributes=[])
         else:
             # Otherwise, the backend is async grabbing the title from rhbz, so
             link = link + " <img class='spinner' src='static/img/spinner.gif'>"

--- a/bodhi/tests/server/consumers/test_updates.py
+++ b/bodhi/tests/server/consumers/test_updates.py
@@ -463,25 +463,3 @@ class TestUpdatesHandlerWorkOnBugs(base.BaseTestCase):
             h.work_on_bugs(h.db_factory, update, bugs)
 
         warning.assert_called_once_with('Error occurred during updating single bug', exc_info=True)
-
-    @mock.patch('bodhi.server.bugs.Bugzilla.modified')
-    @mock.patch('bodhi.server.consumers.updates.log.info')
-    def test_private_bug_skipped(self, info, modified):
-        """Assert that Bodhi doesn't try to change private bugs."""
-        hub = mock.MagicMock()
-        hub.config = {'environment': 'environment',
-                      'topic_prefix': 'topic_prefix'}
-        h = updates.UpdatesHandler(hub)
-        h.db_factory = base.TransactionalSessionMaker(self.Session)
-        update = self.db.query(models.Update).filter(
-            models.Build.nvr == u'bodhi-2.0-1.fc17').one()
-        bug = models.Bug.query.first()
-        # Set this bug to private.
-        bug.private = True
-        self.db.flush()
-        bugs = self.db.query(models.Bug).all()
-
-        h.work_on_bugs(h.db_factory, update, bugs)
-
-        info.assert_called_with('  Skipping bug 12345 because it is private')
-        modified.assert_not_called()

--- a/bodhi/tests/server/test_bugs.py
+++ b/bodhi/tests/server/test_bugs.py
@@ -1,4 +1,4 @@
-# Copyright © 2007-2018 Red Hat, Inc. and others.
+# Copyright © 2007-2019 Red Hat, Inc. and others.
 #
 # This file is part of Bodhi.
 #
@@ -125,8 +125,9 @@ class TestBugzilla(unittest.TestCase):
         bz.close(12345, {'bodhi': 'bodhi-3.1.0-1.fc27'}, 'whabam!')
 
         error.assert_called_once_with(
-            ('Unable to close bug #12345: a fault has occurred\nFault code: 410\nFault string: You '
-             'must log in before using this part of Red Hat Bugzilla.'))
+            'Got fault from Bugzilla on #%d: fault code: %d, fault string: %s',
+            12345, 410, 'You must log in before using this part of Red Hat Bugzilla.',
+            exc_info=True)
 
     @mock.patch('bodhi.server.bugs.log.info')
     @mock.patch.dict('bodhi.server.bugs.config', {'bz_products': 'aproduct'})
@@ -191,6 +192,23 @@ class TestBugzilla(unittest.TestCase):
         self.assertEqual(info.call_count, 0)
 
     @mock.patch('bodhi.server.bugs.log.info')
+    def test_close_private_bug(self, info):
+        """close() should gracefully handle private bugs."""
+        bz = bugs.Bugzilla()
+        bz._bz = mock.MagicMock()
+        bz._bz.getbug.side_effect = xmlrpc.client.Fault(
+            102,
+            ('You are not authorized to access bug #1563797. To see this bug, you must first log in'
+             'to an account with the appropriate permissions.'))
+
+        bz.close(1563797, {'bodhi': 'bodhi-35.103.109-1.fc27'},
+                 'Fixed. Closing bug and adding version to fixed_in field.')
+
+        bz._bz.getbug.assert_called_once_with(1563797)
+        info.assert_called_once_with(
+            'Cannot retrieve private bug #%d.', 1563797)
+
+    @mock.patch('bodhi.server.bugs.log.info')
     def test_close_product_skipped(self, info):
         """Test the close() method when the bug's product is not in the bz_products config."""
         bz = bugs.Bugzilla()
@@ -203,6 +221,37 @@ class TestBugzilla(unittest.TestCase):
         bz._bz.getbug.assert_called_once_with(12345)
         info.assert_called_once_with("Skipping set closed on 'not fedora!' bug #12345")
         self.assertEqual(bz._bz.getbug.return_value.setstatus.call_count, 0)
+
+    @mock.patch('bodhi.server.bugs.log.exception')
+    def test_comment_fault(self, exception):
+        """comment() should gracefully handle Bugzilla faults."""
+        bz = bugs.Bugzilla()
+        bz._bz = mock.MagicMock()
+        bz._bz.getbug.side_effect = xmlrpc.client.Fault(
+            42, 'The meaning')
+
+        bz.comment(1563797, 'Bodhi has fixed all of your bugs.')
+
+        bz._bz.getbug.assert_called_once_with(1563797)
+        exception.assert_called_once_with(
+            'Got fault from Bugzilla on #%d: fault code: %d, fault string: %s', 1563797, 42,
+            'The meaning')
+
+    @mock.patch('bodhi.server.bugs.log.info')
+    def test_comment_private_bug(self, info):
+        """comment() should gracefully handle private bugs."""
+        bz = bugs.Bugzilla()
+        bz._bz = mock.MagicMock()
+        bz._bz.getbug.side_effect = xmlrpc.client.Fault(
+            102,
+            ('You are not authorized to access bug #1563797. To see this bug, you must first log in'
+             'to an account with the appropriate permissions.'))
+
+        bz.comment(1563797, 'Bodhi has fixed all of your bugs.')
+
+        bz._bz.getbug.assert_called_once_with(1563797)
+        info.assert_called_once_with(
+            'Cannot retrieve private bug #%d.', 1563797)
 
     @mock.patch('bodhi.server.bugs.log.info')
     def test_comment_successful(self, info):
@@ -319,6 +368,37 @@ class TestBugzilla(unittest.TestCase):
         bz._bz.getbug.assert_called_once_with(1411188)
         bz._bz.getbug.return_value.addcomment.assert_called_once_with('A mean message.')
 
+    @mock.patch('bodhi.server.bugs.log.exception')
+    def test_modified_fault(self, exception):
+        """modified() should gracefully handle Bugzilla faults."""
+        bz = bugs.Bugzilla()
+        bz._bz = mock.MagicMock()
+        bz._bz.getbug.side_effect = xmlrpc.client.Fault(
+            42, 'The meaning')
+
+        bz.modified(1563797, 'Bodhi has fixed all of your bugs.')
+
+        bz._bz.getbug.assert_called_once_with(1563797)
+        exception.assert_called_once_with(
+            'Got fault from Bugzilla on #%d: fault code: %d, fault string: %s', 1563797, 42,
+            'The meaning')
+
+    @mock.patch('bodhi.server.bugs.log.info')
+    def test_modified_private_bug(self, info):
+        """modified() should gracefully handle private bugs."""
+        bz = bugs.Bugzilla()
+        bz._bz = mock.MagicMock()
+        bz._bz.getbug.side_effect = xmlrpc.client.Fault(
+            102,
+            ('You are not authorized to access bug #1563797. To see this bug, you must first log in'
+             'to an account with the appropriate permissions.'))
+
+        bz.modified(1563797, 'Bodhi has fixed all of your bugs.')
+
+        bz._bz.getbug.assert_called_once_with(1563797)
+        info.assert_called_once_with(
+            'Cannot retrieve private bug #%d.', 1563797)
+
     @mock.patch('bodhi.server.bugs.log.info')
     def test_modified_product_skipped(self, info):
         """Test the modified() method when the bug's product is not in the bz_products config."""
@@ -382,6 +462,25 @@ class TestBugzilla(unittest.TestCase):
         self.assertIs(bug_entity.parent, True)
         self.assertEqual(bug_entity.title, 'Fedora gets you, good job guys!')
 
+    @mock.patch('bodhi.server.bugs.log.info')
+    def test_update_details_private_bug(self, info):
+        """update_details() should gracefully handle private bugs."""
+        bz = bugs.Bugzilla()
+        bz._bz = mock.MagicMock()
+        bz._bz.getbug.side_effect = xmlrpc.client.Fault(
+            102,
+            ('You are not authorized to access bug #1563797. To see this bug, you must first log in'
+             'to an account with the appropriate permissions.'))
+        bug = mock.MagicMock()
+        bug.bug_id = 1563797
+
+        bz.update_details(None, bug)
+
+        self.assertEqual(bug.title, 'Private bug')
+        bz._bz.getbug.assert_called_once_with(1563797)
+        info.assert_called_once_with(
+            'Cannot retrieve private bug #%d.', 1563797)
+
     @mock.patch('bodhi.server.bugs.log.error')
     def test_update_details_xmlrpc_fault(self, error):
         """Test we log an error if update_details raises one"""
@@ -396,7 +495,8 @@ class TestBugzilla(unittest.TestCase):
         self.assertEqual(bug.title, 'Invalid bug number')
         bz._bz.getbug.assert_called_once_with(123)
         error.assert_called_once_with(
-            'Got fault from Bugzilla: fault code: 42, fault string: You found the meaning.')
+            'Got fault from Bugzilla on #%d: fault code: %d, fault string: %s', 123, 42,
+            'You found the meaning.', exc_info=True)
 
     @mock.patch('bodhi.server.bugs.log.exception')
     @mock.patch.dict('bodhi.server.bugs.config', {'bz_products': 'aproduct'})
@@ -416,6 +516,37 @@ class TestBugzilla(unittest.TestCase):
         bz._bz.getbug.return_value.setstatus.assert_called_once_with('ON_QA',
                                                                      comment='A mean message.')
         exception.assert_called_once_with('Unable to alter bug #1411188')
+
+    @mock.patch('bodhi.server.bugs.log.exception')
+    def test_on_qa_fault(self, exception):
+        """on_qa() should gracefully handle Bugzilla faults."""
+        bz = bugs.Bugzilla()
+        bz._bz = mock.MagicMock()
+        bz._bz.getbug.side_effect = xmlrpc.client.Fault(
+            42, 'The meaning')
+
+        bz.on_qa(1563797, 'Bodhi has fixed all of your bugs.')
+
+        bz._bz.getbug.assert_called_once_with(1563797)
+        exception.assert_called_once_with(
+            'Got fault from Bugzilla on #%d: fault code: %d, fault string: %s', 1563797, 42,
+            'The meaning')
+
+    @mock.patch('bodhi.server.bugs.log.info')
+    def test_on_qa_private_bug(self, info):
+        """on_qa() should gracefully handle private bugs."""
+        bz = bugs.Bugzilla()
+        bz._bz = mock.MagicMock()
+        bz._bz.getbug.side_effect = xmlrpc.client.Fault(
+            102,
+            ('You are not authorized to access bug #1563797. To see this bug, you must first log in'
+             'to an account with the appropriate permissions.'))
+
+        bz.on_qa(1563797, 'Bodhi has fixed all of your bugs.')
+
+        bz._bz.getbug.assert_called_once_with(1563797)
+        info.assert_called_once_with(
+            'Cannot retrieve private bug #%d.', 1563797)
 
     @mock.patch('bodhi.server.bugs.log.info')
     @mock.patch.dict('bodhi.server.bugs.config', {'bz_products': 'aproduct'})

--- a/bodhi/tests/server/test_models.py
+++ b/bodhi/tests/server/test_models.py
@@ -251,20 +251,6 @@ class TestBugAddComment(BaseTestCase):
         debug.assert_called_once_with('Not commenting on parent security bug %s', bug.bug_id)
         self.assertEqual(comment.call_count, 0)
 
-    @mock.patch('bodhi.server.models.bugs.bugtracker.comment')
-    @mock.patch('bodhi.server.models.log.debug')
-    def test_private_bug(self, debug, comment):
-        """The method should not comment if a bug is flagged as private."""
-        update = model.Update.query.first()
-        update.type = model.UpdateType.security
-        bug = model.Bug.query.first()
-        bug.private = True
-
-        bug.add_comment(update)
-
-        debug.assert_called_once_with('Not commenting on private bug %s', bug.bug_id)
-        self.assertEqual(comment.call_count, 0)
-
 
 class TestBugDefaultMessage(BaseTestCase):
     """Test Bug.default_mesage()."""
@@ -323,20 +309,6 @@ class TestBugModified(BaseTestCase):
         debug.assert_called_once_with('Not modifying parent security bug %s', bug.bug_id)
         self.assertEqual(modified.call_count, 0)
 
-    @mock.patch('bodhi.server.models.bugs.bugtracker.modified')
-    @mock.patch('bodhi.server.models.log.debug')
-    def test_private_bug(self, debug, modified):
-        """The method should not act on a bug flagged as private."""
-        update = model.Update.query.first()
-        update.type = model.UpdateType.security
-        bug = model.Bug.query.first()
-        bug.private = True
-
-        bug.modified(update, 'this should not be used')
-
-        debug.assert_called_once_with('Not modifying private bug %s', bug.bug_id)
-        self.assertEqual(modified.call_count, 0)
-
 
 class TestBugTesting(BaseTestCase):
     """Test Bug.testing()."""
@@ -354,38 +326,6 @@ class TestBugTesting(BaseTestCase):
 
         debug.assert_called_once_with('Not modifying parent security bug %s', bug.bug_id)
         self.assertEqual(on_qa.call_count, 0)
-
-    @mock.patch('bodhi.server.models.bugs.bugtracker.on_qa')
-    @mock.patch('bodhi.server.models.log.debug')
-    def test_private_bug(self, debug, on_qa):
-        """The method should not act on a bug flagged as private."""
-        update = model.Update.query.first()
-        update.type = model.UpdateType.security
-        bug = model.Bug.query.first()
-        bug.private = True
-
-        bug.testing(update)
-
-        debug.assert_called_once_with('Not modifying private bug %s', bug.bug_id)
-        self.assertEqual(on_qa.call_count, 0)
-
-
-class TestBugClose(BaseTestCase):
-    """Test Bug.close()."""
-
-    @mock.patch('bodhi.server.models.bugs.bugtracker.close')
-    @mock.patch('bodhi.server.models.log.debug')
-    def test_private_bug(self, debug, close):
-        """The method should not act on a bug flagged as private."""
-        update = model.Update.query.first()
-        update.type = model.UpdateType.security
-        bug = model.Bug.query.first()
-        bug.private = True
-
-        bug.close_bug(update)
-
-        debug.assert_called_once_with('Not modifying private bug %s', bug.bug_id)
-        self.assertEqual(close.call_count, 0)
 
 
 class TestQueryProperty(BaseTestCase):

--- a/bodhi/tests/server/test_util.py
+++ b/bodhi/tests/server/test_util.py
@@ -89,7 +89,6 @@ class TestBugLink(base.BaseTestCase):
         bug = mock.MagicMock()
         bug.bug_id = 1234567
         bug.title = "Lucky bug number"
-        bug.private = False
 
         link = util.bug_link(None, bug)
 
@@ -97,20 +96,6 @@ class TestBugLink(base.BaseTestCase):
             link,
             ("<a target='_blank' href='https://bugzilla.redhat.com/show_bug.cgi?id=1234567'>"
              "#1234567</a> Lucky bug number"))
-
-    def test_short_false_with_title_but_private(self):
-        """Test a call to bug_link() with short=False on a Bug that is private."""
-        bug = mock.MagicMock()
-        bug.bug_id = 1234567
-        bug.title = "Lucky bug number"
-        bug.private = True
-
-        link = util.bug_link(None, bug)
-
-        self.assertEqual(
-            link,
-            ("<a target='_blank' href='https://bugzilla.redhat.com/show_bug.cgi?id=1234567'>"
-             "#1234567</a> <span class='label label-danger'>Private bug</span>"))
 
     def test_short_false_with_title_sanitizes_safe_tags(self):
         """
@@ -120,7 +105,6 @@ class TestBugLink(base.BaseTestCase):
         bug = mock.MagicMock()
         bug.bug_id = 1234567
         bug.title = 'Check <b>this</b> out'
-        bug.private = False
 
         link = util.bug_link(None, bug)
 
@@ -137,7 +121,6 @@ class TestBugLink(base.BaseTestCase):
         bug = mock.MagicMock()
         bug.bug_id = 1473091
         bug.title = '<disk> <driver name="..."> should be optional'
-        bug.private = False
 
         link = util.bug_link(None, bug)
 

--- a/docs/user/3.x_release_notes.rst
+++ b/docs/user/3.x_release_notes.rst
@@ -5,6 +5,25 @@
 These are the release notes for the 3.x series of Bodhi releases.
 
 
+v3.13.1
+-------
+
+Server upgrade instructions
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+No special instructions are needed for this release.
+
+
+Bug fix
+^^^^^^^
+
+
+This is a bugfix release, addressing an issue that was introduced in 3.13.0:
+
+* Gracefully handle private bugs via a different approach than was used in 3.13.0 (:issue:`3016` and
+  :issue:`344`).
+
+
 v3.13.0
 -------
 

--- a/docs/user/release_notes.rst
+++ b/docs/user/release_notes.rst
@@ -27,6 +27,7 @@ Backwards incompatible changes
 * Support for update's old_updateid was dropped (:issue:`2903`).
 * The batching feature was dropped, and thus updates can no longer be in the batched request state.
   As a result, the bodhi-dequeue-stable CLI has also been removed (:issue:`2977`).
+* Bug objects no longer include a ``private`` field (:issue:`3016`).
 
 
 Dependency changes


### PR DESCRIPTION
There are 4 commits in this pull request, each with detailed descriptions. The overall goal is to improve the error handling in ```bugs.py``` and to fix a regression in 3.13.0.

fixes #344 
fixes #3016