### PR TITLE
Set log level to ERROR in bodhi-approve-testing

### DIFF
--- a/bodhi/server/scripts/approve_testing.py
+++ b/bodhi/server/scripts/approve_testing.py
@@ -34,7 +34,7 @@ from bodhi.server import Session, initialize_db, notifications
 
 
 logger = logging.getLogger('approve-testing')
-logging.basicConfig(level=logging.INFO)
+logging.basicConfig(level=logging.ERROR)
 
 
 def usage(argv):


### PR DESCRIPTION
Fixes #3021

Signed-off-by: Sebastian Wojciechowski <s.wojciechowski89@gmail.com>