### PR TITLE
Mark the bugs.private field as nullable.

### DIFF
--- a/bodhi/server/migrations/versions/9991cf10ec50_mark_the_bugs_private_field_as_nullable.py
+++ b/bodhi/server/migrations/versions/9991cf10ec50_mark_the_bugs_private_field_as_nullable.py
@@ -1,5 +1,4 @@
-# -*- coding: utf-8 -*-
-# Copyright (c) 2019 Sebastian Wojciechowski
+# Copyright (c) 2019 Red Hat, Inc.
 #
 # This file is part of Bodhi.
 #
@@ -17,27 +16,26 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 """
-Obsolete updates for archived release.
+Mark the bugs.private field as nullable.
 
-Revision ID: 8e9dc57e082d
-Revises: 9991cf10ec50
-Create Date: 2019-01-06 13:04:35.158562
+Revision ID: 9991cf10ec50
+Revises: d986618207bc
+Create Date: 2019-02-19 15:54:53.058707
 """
 from alembic import op
 
 
 # revision identifiers, used by Alembic.
-revision = '8e9dc57e082d'
-down_revision = '9991cf10ec50'
+revision = '9991cf10ec50'
+down_revision = 'd986618207bc'
 
 
 def upgrade():
-    """Set archived releases updates status to 'obsolete'."""
-    op.execute("UPDATE updates SET status='obsolete' WHERE release_id in \
-                (SELECT id FROM releases WHERE state='archived') AND status NOT IN \
-                ('unpushed', 'obsolete', 'stable')")
+    """Set the bugs.private column to be nullable."""
+    op.alter_column('bugs', 'private', nullable=True)
 
 
 def downgrade():
-    """Raise an exception explaining that this migration cannot be reversed."""
-    raise NotImplementedError('This migration cannot be reversed.')
+    """Set the bugs.private column to be non-nullable."""
+    op.execute("""UPDATE bugs SET private = FALSE WHERE private = NULL""")
+    op.alter_column('bugs', 'private', nullable=False)

--- a/bodhi/server/migrations/versions/aae0d29d49b7_remove_the_private_field_on_the_bug_.py
+++ b/bodhi/server/migrations/versions/aae0d29d49b7_remove_the_private_field_on_the_bug_.py
@@ -39,5 +39,3 @@ def upgrade():
 def downgrade():
     """Add the private field back to the bugs table."""
     op.add_column('bugs', sa.Column('private', sa.BOOLEAN(), autoincrement=False, nullable=True))
-    op.execute("""UPDATE bugs SET private = FALSE""")
-    op.alter_column('bugs', 'private', nullable=False)


### PR DESCRIPTION
In my fix for #3016, I opted to revert the commit that added the
private column to the bugs table, but not to remove the column
itself since that would be a backwards incompatible change.

Unfortunately, it did not occur to me that the private field being
non-nullable would mean that users would not be able to create
updates that have bugs associated with them, because there is no
longer code to set that column to a value.

This commit adjusts the column to be nullable so that we don't
introduce a backwards incompatible change, but also can allow users
to associate updates with bugs. Bodhi 4.0.0 will drop the column
entirely.

fixes #3024

Signed-off-by: Randy Barlow <randy@electronsweatshop.com>