### PR TITLE
Drop the update.title field from the database

### DIFF
--- a/bodhi/client/bindings.py
+++ b/bodhi/client/bindings.py
@@ -224,7 +224,7 @@ class BodhiClient(OpenIdBaseClient):
         Save an update.
 
         This entails either creating a new update, or editing an existing one.
-        To edit an existing update, you must specify the update title in
+        To edit an existing update, you must specify the update alias in
         the ``edited`` keyword argument.
 
         Args:
@@ -248,7 +248,7 @@ class BodhiClient(OpenIdBaseClient):
             stable_karma (int): The upper threshold for marking an update as
                 ``stable``.
             unstable_karma (int): The lower threshold for unpushing an update.
-            edited (basestring): The update title of the existing update that we are
+            edited (basestring): The update alias of the existing update that we are
                 editing.
             severity (basestring): The severity of this update (``urgent``, ``high``,
                 ``medium``, ``low``).
@@ -275,7 +275,7 @@ class BodhiClient(OpenIdBaseClient):
         Request an update state change.
 
         Args:
-            update (basestring): The title of the update.
+            update (basestring): The alias of the update.
             request (basestring): The request (``testing``, ``stable``, ``obsolete``,
                 ``unpush``, ``revoke``).
         Returns:
@@ -301,7 +301,7 @@ class BodhiClient(OpenIdBaseClient):
         Waive unsatisfied requirements on an update.
 
         Args:
-            update (basestring): The title of the update.
+            update (basestring): The alias of the update.
             comment (basestring): A comment explaining the waiver.
             tests (tuple(basestring) or None): The list of unsatisfied requirements
                 to waive. If not specified, all unsatisfied requirements of this
@@ -328,7 +328,6 @@ class BodhiClient(OpenIdBaseClient):
         Query bodhi for a list of updates.
 
         Args:
-            title (basestring): The update title.
             alias (basestring): The update alias.
             updateid (basestring): The update ID (eg: FEDORA-2015-0001).
             content_type (basestring): A content type (rpm, module) to limit the query to.
@@ -374,9 +373,6 @@ class BodhiClient(OpenIdBaseClient):
         Returns:
             munch.Munch: The response from Bodhi describing the query results.
         """
-        if 'title' in kwargs:
-            kwargs['like'] = kwargs['title']
-            del kwargs['title']
         # bodhi1 compat
         if 'limit' in kwargs:
             kwargs['rows_per_page'] = kwargs['limit']
@@ -414,7 +410,7 @@ class BodhiClient(OpenIdBaseClient):
         Query bodhi for the test status of the specified update..
 
         Args:
-            update (basestring): The title or identifier of the update to
+            update (basestring): The alias of the update to
                 retrieve the test status of.
         Returns:
             munch.Munch: The response from Bodhi describing the query results.
@@ -427,7 +423,7 @@ class BodhiClient(OpenIdBaseClient):
         Add a comment to an update.
 
         Args:
-            update (basestring): The title of the update comment on.
+            update (basestring): The alias of the update comment on.
             comment (basestring): The text of the comment to add to the update.
             karma (int): The amount of karma to leave. May be -1, 0, or 1. Defaults to 0.
             email (basestring or None): Email address for an anonymous user. If an email address is
@@ -796,16 +792,15 @@ class BodhiClient(OpenIdBaseClient):
         update_lines = ['{:=^80}\n'.format('=')]
         update_lines += [
             line + '\n' for line in textwrap.wrap(
-                update['title'].replace(',', ', '),
+                update['title'],
                 width=80,
                 initial_indent=' ' * 5,
                 subsequent_indent=' ' * 5)
         ]
         update_lines.append('{:=^80}\n'.format('='))
 
-        if update['alias']:
-            update_lines.append(
-                line_formatter.format('Update ID', update['alias']))
+        update_lines.append(
+            line_formatter.format('Update ID', update['alias']))
 
         update_lines += [
             line_formatter.format('Content Type', update['content_type']),
@@ -900,12 +895,8 @@ class BodhiClient(OpenIdBaseClient):
                     comments_lines[1:])
             ]
 
-        if update['alias']:
-            update_lines.append(
-                '\n  {0}updates/{1}\n'.format(self.base_url, update['alias']))
-        else:
-            update_lines.append(
-                '\n  {0}updates/{1}\n'.format(self.base_url, update['title']))
+        update_lines.append(
+            '\n  {0}updates/{1}\n'.format(self.base_url, update['alias']))
 
         return ''.join(update_lines)
 

--- a/bodhi/server/consumers/updates.py
+++ b/bodhi/server/consumers/updates.py
@@ -1,4 +1,4 @@
-# Copyright 2015-2018 Red Hat Inc., and others.
+# Copyright 2015-2019 Red Hat Inc., and others.
 #
 # This file is part of Bodhi.
 #
@@ -111,11 +111,6 @@ class UpdatesHandler(fedmsg.consumers.FedmsgConsumer):
         # https://github.com/fedora-infra/bodhi/issues/458
         time.sleep(1)
 
-        if not alias:
-            log.error("Update Handler got update with no "
-                      "alias %s." % pprint.pformat(msg))
-            return
-
         with self.db_factory() as session:
             update = Update.get(alias)
             if not update:
@@ -202,7 +197,7 @@ class UpdatesHandler(fedmsg.consumers.FedmsgConsumer):
 
                 log.info("Commenting on %r" % bug.bug_id)
                 comment = config['initial_bug_msg'] % (
-                    update.title, update.release.long_name, update.abs_url())
+                    update.alias, update.release.long_name, update.abs_url())
 
                 log.info("Modifying %r" % bug.bug_id)
                 bug.modified(update, comment)

--- a/bodhi/server/metadata.py
+++ b/bodhi/server/metadata.py
@@ -146,8 +146,6 @@ class UpdateInfoMetadata(object):
 
         self.uinfo = cr.UpdateInfo()
         for update in self.updates:
-            if not update.alias:
-                update.assign_alias()
             self.add_update(update)
 
         if close_shelf:

--- a/bodhi/server/migrations/versions/58b7919b942c_remove_the_updates_title_column.py
+++ b/bodhi/server/migrations/versions/58b7919b942c_remove_the_updates_title_column.py
@@ -1,0 +1,53 @@
+# Copyright (c) 2019 Red Hat, Inc.
+#
+# This file is part of Bodhi.
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+"""
+Remove the updates.title column.
+
+Revision ID: 58b7919b942c
+Revises: aae0d29d49b7
+Create Date: 2019-02-20 17:13:01.260748
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '58b7919b942c'
+down_revision = 'eec610d7ab3a'
+
+
+def upgrade():
+    """Drop the updates.title column."""
+    op.alter_column('updates', 'alias', existing_type=sa.BOOLEAN(), nullable=False)
+    op.drop_index('ix_updates_title', table_name='updates')
+    op.drop_column('updates', 'title')
+
+
+def downgrade():
+    """Bring back the updates.title column and try to guess what it should be set to."""
+    op.add_column('updates', sa.Column('title', sa.TEXT(), autoincrement=False, nullable=True))
+    # Set the title back to something similar to what it might have been. This isn't guaranteed to
+    # be the title it was before, because we can't know what order the nvrs appeared in, but it will
+    # set it to the expected format and expected set of NVRs. Single build updates should at least
+    # get their old title back.
+    op.execute(
+        ("UPDATE updates SET title=("
+         "SELECT string_agg(nvr, ' ') as title FROM ("
+         "SELECT builds.nvr FROM builds WHERE update_id=updates.id ORDER BY nvr) as nvr)"))
+    op.create_index('ix_updates_title', 'updates', ['title'], unique=True)
+    op.alter_column('updates', 'alias', existing_type=sa.BOOLEAN(), nullable=True)

--- a/bodhi/server/migrations/versions/eec610d7ab3a_index_the_builds_update_id_column.py
+++ b/bodhi/server/migrations/versions/eec610d7ab3a_index_the_builds_update_id_column.py
@@ -1,0 +1,40 @@
+# Copyright (c) 2019 Red Hat, Inc.
+#
+# This file is part of Bodhi.
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+"""
+Index the builds.update_id column.
+
+Revision ID: eec610d7ab3a
+Revises: e5b3ddb35df3
+Create Date: 2019-02-20 20:18:02.474734
+"""
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = 'eec610d7ab3a'
+down_revision = 'e5b3ddb35df3'
+
+
+def upgrade():
+    """Add an index on builds.update_id."""
+    op.create_index(op.f('ix_builds_update_id'), 'builds', ['update_id'], unique=False)
+
+
+def downgrade():
+    """Drop the index on builds.update_id."""
+    op.drop_index(op.f('ix_builds_update_id'), table_name='builds')

--- a/bodhi/server/models.py
+++ b/bodhi/server/models.py
@@ -1255,7 +1255,7 @@ class Build(Base):
     package_id = Column(Integer, ForeignKey('packages.id'), nullable=False)
     release_id = Column(Integer, ForeignKey('releases.id'))
     signed = Column(Boolean, default=False, nullable=False)
-    update_id = Column(Integer, ForeignKey('updates.id'))
+    update_id = Column(Integer, ForeignKey('updates.id'), index=True)
 
     release = relationship('Release', backref='builds', lazy=False)
 

--- a/bodhi/server/push.py
+++ b/bodhi/server/push.py
@@ -128,8 +128,8 @@ def push(username, cert_prefix, yes, **kwargs):
                 update_sig_status(update)
 
                 if not update.signed:
-                    click.echo('Warning: %s has unsigned builds and has been skipped' %
-                               update.title)
+                    click.echo(
+                        'Warning: {update.get_title()} has unsigned builds and has been skipped')
                     continue
 
                 updates.append(update)
@@ -155,7 +155,7 @@ def push(username, cert_prefix, yes, **kwargs):
         for compose in composes:
             click.echo('\n\n===== {} =====\n'.format(compose))
             for update in compose.updates:
-                click.echo(update.title)
+                click.echo(update.get_title())
 
         if composes:
             if yes:

--- a/bodhi/server/renderers.py
+++ b/bodhi/server/renderers.py
@@ -1,4 +1,4 @@
-# Copyright © 2014-2017 Red Hat, Inc.
+# Copyright © 2014-2019 Red Hat, Inc.
 #
 # This file is part of Bodhi.
 #
@@ -87,7 +87,7 @@ def rss(info):
 
         getters = {
             'updates': {
-                'title': operator.itemgetter('title'),
+                'title': operator.itemgetter('alias'),
                 'link': linker('update', 'id', 'title'),
                 'description': operator.itemgetter('notes'),
                 'pubdate': lambda obj: utc.localize(obj['date_submitted']),

--- a/bodhi/server/scripts/approve_testing.py
+++ b/bodhi/server/scripts/approve_testing.py
@@ -87,7 +87,7 @@ def main(argv=sys.argv):
             # Approval message when testing based on karma threshold
             if update.karma >= update.stable_karma \
                     and not update.autokarma and update.meets_testing_requirements:
-                print('%s now reaches stable karma threshold' % update.title)
+                print(f'{update.alias} now reaches stable karma threshold')
                 text = config.get('testing_approval_msg_based_on_karma')
                 update.comment(db, text, author=u'bodhi')
                 db.commit()
@@ -99,7 +99,7 @@ def main(argv=sys.argv):
             # this function only needs to consider the time requirements because these updates have
             # not reached the karma threshold.
             if update.meets_testing_requirements:
-                print('%s now meets testing requirements' % update.title)
+                print(f'{update.alias} now meets testing requirements')
                 text = str(
                     config.get('testing_approval_msg') % update.mandatory_days_in_testing)
                 update.comment(db, text, author=u'bodhi')

--- a/bodhi/server/scripts/untag_branched.py
+++ b/bodhi/server/scripts/untag_branched.py
@@ -78,7 +78,6 @@ def main(argv=sys.argv):
             log.info(release.name)
             for update in db.query(Update).filter_by(
                     release=release, status=UpdateStatus.stable).all():
-                assert update.date_stable, update.title
                 if now - update.date_stable > one_day:
                     for build in update.builds:
                         tags = build.get_tags()

--- a/bodhi/server/services/builds.py
+++ b/bodhi/server/services/builds.py
@@ -1,4 +1,4 @@
-# Copyright © 2014-2017 Red Hat, Inc. and others.
+# Copyright © 2014-2019 Red Hat, Inc. and others.
 #
 # This file is part of Bodhi.
 #
@@ -98,9 +98,7 @@ def query_builds(request):
     updates = data.get('updates')
     if updates is not None:
         query = query.join(Build.update)
-        args = \
-            [Update.title == update.title for update in updates] +\
-            [Update.alias == update.alias for update in updates]
+        args = [Update.alias == update.alias for update in updates]
         query = query.filter(or_(*args))
 
     packages = data.get('packages')

--- a/bodhi/server/services/releases.py
+++ b/bodhi/server/services/releases.py
@@ -1,4 +1,4 @@
-# Copyright © 2014-2018 Red Hat Inc., and others.
+# Copyright © 2014-2019 Red Hat Inc., and others.
 #
 # This file is part of Bodhi.
 #
@@ -249,9 +249,7 @@ def query_releases_json(request):
     updates = data.get('updates')
     if updates is not None:
         query = query.join(Release.builds).join(Build.update)
-        args = \
-            [Update.title == update.title for update in updates] +\
-            [Update.alias == update.alias for update in updates]
+        args = [Update.alias == update.alias for update in updates]
         query = query.filter(or_(*args))
 
     packages = data.get('packages')

--- a/bodhi/server/services/user.py
+++ b/bodhi/server/services/user.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2018 Red Hat, Inc. and others
+# Copyright 2014-2019 Red Hat, Inc. and others
 #
 # This file is part of Bodhi.
 #
@@ -153,9 +153,7 @@ def query_users(request):
     updates = data.get('updates')
     if updates is not None:
         query = query.join(User.updates)
-        args = \
-            [Update.title == update.title for update in updates] +\
-            [Update.alias == update.alias for update in updates]
+        args = [Update.alias == update.alias for update in updates]
         query = query.filter(or_(*args))
 
     packages = data.get('packages')

--- a/bodhi/server/static/js/search.js
+++ b/bodhi/server/static/js/search.js
@@ -51,8 +51,6 @@ $(document).ready(function() {
     function resultUrl(data){
       if (data.alias != undefined) {
           return '/updates/' + data.alias;
-      } else if (data.title != undefined ) {
-          return '/updates/' + data.title;
       } else if (data.hasOwnProperty('stack')) {
           return'/updates/?packages=' + encodeURIComponent(data.name);
       } else if (data.name != undefined) {

--- a/bodhi/server/static/js/update_form.js
+++ b/bodhi/server/static/js/update_form.js
@@ -15,7 +15,7 @@ $(document).ready(function() {
             if (data.updates === undefined) {
                 // Single-release update
                 // Now redirect to the update display
-                document.location.href = base + "updates/" + data.title;
+                document.location.href = base + "updates/" + data.alias;
             } else {
                 // Multi-release update
                 // Redirect to updates created by *me*

--- a/bodhi/server/templates/new_update.html
+++ b/bodhi/server/templates/new_update.html
@@ -26,16 +26,7 @@
           <h2 class="pull-left">New Update</span>
         % else:
           <h2 class="pull-left">Edit
-            % if update.alias:
             ${update.alias}
-            % else:
-            ${update.get_title(', ', 2, ", &hellip;") | n}
-            <div>
-              <span title="${(', ').join(map(lambda x: x.nvr, update.builds[2:]))}">
-                <small>${ "(+ " + str(len(update.builds) - 2) + " more)" if len(update.builds) > 2 else "" }</small>
-              </span>
-            </div>
-          % endif
         </h2>
         % endif
       </div>
@@ -297,7 +288,7 @@ ${update.notes}
             <input type="hidden" name="csrf_token" value="${request.session.get_csrf_token()}"/>
 
             % if update:
-            <input type="hidden" name="edited" value="${update.title}">
+            <input type="hidden" name="edited" value="${update.alias}">
             % endif
 
             <button id="submit" class="btn btn-success">

--- a/bodhi/server/templates/update.html
+++ b/bodhi/server/templates/update.html
@@ -8,9 +8,7 @@
 %>
 
 <%block name="pagetitle">
-% if update.alias:
   ${update.alias}
-% endif
 &mdash;
 ${update.type} update for ${update.beautify_title(amp=True) | n}
 &mdash; Fedora Updates System
@@ -42,7 +40,7 @@ ${update.type} update for ${update.beautify_title(amp=True) | n}
       ABSENT: 'question-circle',
     }
 
-    var update = '${update.title}';
+    var update = '${update.alias}';
     var builds = ${update.builds_json | n};
 
     // These are the required taskotron tests
@@ -379,7 +377,7 @@ ${update.type} update for ${update.beautify_title(amp=True) | n}
 <script type="text/javascript">
 $(document).ready(function() {
     var messenger = Messenger({theme: 'flat'});
-    var update_id = '${update.title}';
+    var update_id = '${update.alias}';
     $("#updatebuttons #edit").attr('href',
         '${request.route_url("update_edit", id=update.alias)}');
 
@@ -568,16 +566,7 @@ $(document).ready(function(){
           </a>
           <span class="sr-only">Locked</span>
       % endif
-      % if update.alias:
       ${update.alias}
-      % else:
-      ${update.get_title(', ', 2, ", &hellip;") | n}
-      <div>
-        <span title="${(', ').join(map(lambda x: x.nvr, update.builds[2:]))}">
-          <small>${ "(+ " + str(len(update.builds) - 2) + " more)" if len(update.builds) > 2 else "" }</small>
-        </span>
-      </div>
-      % endif
       % if update.type:
         ${self.util.type2icon(update.type) | n}
       % endif
@@ -729,7 +718,7 @@ $(document).ready(function(){
               <div class="clearfix"></div>
 
               <input type="hidden" name="csrf_token" value="${request.session.get_csrf_token()}"/>
-              <input type="hidden" name="update" value="${update.title}"/>
+              <input type="hidden" name="update" value="${update.alias}"/>
 
               <hr/>
 

--- a/bodhi/server/validators.py
+++ b/bodhi/server/validators.py
@@ -232,7 +232,7 @@ def validate_builds(request, **kwargs):
         return
 
     if edited:
-        up = request.db.query(Update).filter_by(title=edited).first()
+        up = request.db.query(Update).filter_by(alias=edited).first()
         if not up:
             request.errors.add('body', 'builds',
                                'Cannot find update to edit: %s' % edited)
@@ -249,7 +249,7 @@ def validate_builds(request, **kwargs):
         for nvr in request.validated.get('builds', []):
             # Ensure it doesn't already exist in another update
             build = request.db.query(Build).filter_by(nvr=nvr).first()
-            if build and build.update is not None and up.title != build.update.title:
+            if build and build.update is not None and up.alias != build.update.alias:
                 request.errors.add('body', 'builds',
                                    "Update for {} already exists".format(nvr))
 
@@ -277,7 +277,7 @@ def validate_build_tags(request, **kwargs):
     release = None
     if edited:
         valid_tags = tag_types['candidate'] + tag_types['testing']
-        update = request.db.query(Update).filter_by(title=edited).first()
+        update = request.db.query(Update).filter_by(alias=edited).first()
         if not update:
             # No need to tack on any more errors here, since they should have
             # already been added by `validate_builds`
@@ -361,7 +361,7 @@ def validate_acls(request, **kwargs):
     # One of them is for submitting something new with a list of builds (a new
     # update, or editing an update by changing the list of builds).  The other
     # is for changing the request on an existing update -- where an update
-    # title has been passed to us, but not a list of builds.
+    # alias has been passed to us, but not a list of builds.
     # We need to validate that the user has commit rights on all the build
     # (either the explicitly listed ones or on the ones associated with the
     # pre-existing update).. and so we'll do some conditional branching below
@@ -611,10 +611,7 @@ def validate_updates(request, **kwargs):
     validated_updates = []
 
     for u in updates:
-        update = db.query(Update).filter(or_(
-            Update.title == u,
-            Update.alias == u,
-        )).first()
+        update = db.query(Update).filter(Update.alias == u).first()
 
         if not update:
             bad_updates.append(u)

--- a/bodhi/tests/client/__init__.py
+++ b/bodhi/tests/client/__init__.py
@@ -67,7 +67,7 @@ EXAMPLE_COMMENT_MUNCH = Munch({
     u'caveats': []})
 
 # EXAMPLE_COMMENT_MUNCH is expected to generate this output in update_str
-EXPECTED_COMMENT_OUTPUT = """The following comment was added to nodejs-grunt-wrap-0.3.0-2.fc25
+EXPECTED_COMMENT_OUTPUT = """The following comment was added to FEDORA-2017-c95b33872d
 i found $10000
 """
 

--- a/bodhi/tests/client/test___init__.py
+++ b/bodhi/tests/client/test___init__.py
@@ -116,7 +116,7 @@ class TestDownload(unittest.TestCase):
 
         self.assertEqual(result.exit_code, 0)
         self.assertEqual(result.output,
-                         'Downloading packages from nodejs-grunt-wrap-0.3.0-2.fc25\n')
+                         'Downloading packages from FEDORA-2017-c95b33872d\n')
         bindings_client = send_request.mock_calls[0][1][0]
         send_request.assert_called_once_with(
             bindings_client, 'updates/', verb='GET',
@@ -143,7 +143,7 @@ class TestDownload(unittest.TestCase):
 
         self.assertEqual(result.exit_code, 0)
         self.assertEqual(result.output,
-                         'Downloading packages from nodejs-grunt-wrap-0.3.0-2.fc25\n')
+                         'Downloading packages from FEDORA-2017-c95b33872d\n')
         call.assert_called_once_with((
             'koji', 'download-build', '--arch=noarch', '--arch=x86_64',
             'nodejs-grunt-wrap-0.3.0-2.fc25'))
@@ -165,7 +165,7 @@ class TestDownload(unittest.TestCase):
 
         self.assertEqual(result.exit_code, 0)
         self.assertEqual(result.output,
-                         'Downloading packages from nodejs-grunt-wrap-0.3.0-2.fc25\n')
+                         'Downloading packages from FEDORA-2017-c95b33872d\n')
         call.assert_called_once_with((
             'koji', 'download-build', 'nodejs-grunt-wrap-0.3.0-2.fc25'))
 
@@ -220,7 +220,7 @@ class TestDownload(unittest.TestCase):
         self.assertEqual(result.exit_code, 0)
         self.assertEqual(result.output,
                          ('WARNING: Some builds not found!\nDownloading packages '
-                          'from nodejs-grunt-wrap-0.3.0-2.fc25\n'))
+                          'from FEDORA-2017-c95b33872d\n'))
         call.assert_called_once_with((
             'koji', 'download-build', '--arch=noarch', '--arch={}'.format(platform.machine()),
             'nodejs-grunt-wrap-0.3.0-2.fc25'))
@@ -243,7 +243,7 @@ class TestDownload(unittest.TestCase):
 
         self.assertEqual(result.exit_code, 0)
         self.assertEqual(result.output,
-                         ('Downloading packages from nodejs-grunt-wrap-0.3.0-2.fc25\n'
+                         ('Downloading packages from FEDORA-2017-c95b33872d\n'
                           'WARNING: download of nodejs-grunt-wrap-0.3.0-2.fc25 failed!\n'))
         call.assert_called_once_with((
             'koji', 'download-build', '--arch=noarch', '--arch={}'.format(platform.machine()),
@@ -730,7 +730,7 @@ class TestQuery(unittest.TestCase):
             mock.call(
                 bindings_client, 'updates/', verb='GET',
                 params={
-                    'updateid': None, 'alias': None, 'approved_since': None, 'like': None,
+                    'updateid': None, 'alias': None, 'approved_since': None,
                     'approved_before': None, 'status': None, 'locked': None,
                     'builds': u'nodejs-grunt-wrap-0.3.0-2.fc25', 'releases': None,
                     'content_type': None, 'severity': None,
@@ -771,7 +771,7 @@ class TestQuery(unittest.TestCase):
         send_request.assert_called_once_with(
             bindings_client, 'updates/', verb='GET',
             params={
-                'updateid': None, 'alias': None, 'approved_since': None, 'like': None,
+                'updateid': None, 'alias': None, 'approved_since': None,
                 'approved_before': None, 'status': None, 'locked': None,
                 'builds': u'nodejs-grunt-wrap-0.3.0-2.fc25', 'releases': None,
                 'content_type': None, 'severity': None,
@@ -804,7 +804,7 @@ class TestQuery(unittest.TestCase):
             mock.call(
                 bindings_client, 'updates/', verb='GET',
                 params={
-                    'updateid': None, 'alias': None, 'approved_since': None, 'like': None,
+                    'updateid': None, 'alias': None, 'approved_since': None,
                     'approved_before': None, 'status': None, 'locked': None,
                     'builds': u'nodejs-grunt-wrap-0.3.0-2.fc25', 'releases': None,
                     'content_type': None, 'severity': None,
@@ -845,7 +845,7 @@ class TestQuery(unittest.TestCase):
             mock.call(
                 bindings_client, 'updates/', verb='GET',
                 params={
-                    'updateid': None, 'alias': None, 'approved_since': None, 'like': None,
+                    'updateid': None, 'alias': None, 'approved_since': None,
                     'approved_before': None, 'status': None, 'locked': None,
                     'builds': None, 'releases': None,
                     'content_type': None, 'severity': None, 'submitted_since': None,
@@ -887,7 +887,7 @@ class TestQuery(unittest.TestCase):
                 params={
                     'updateid': None, 'alias': None, 'approved_since': None,
                     'approved_before': None, 'status': None, 'locked': None,
-                    'builds': None, 'releases': None, 'like': None,
+                    'builds': None, 'releases': None,
                     'content_type': None, 'severity': None,
                     'submitted_since': None, 'submitted_before': None, 'suggest': None,
                     'request': None, 'bugs': None, 'staging': False, 'modified_since': None,
@@ -926,52 +926,13 @@ class TestQuery(unittest.TestCase):
                 params={
                     'updateid': None, 'alias': None, 'approved_since': None,
                     'approved_before': None, 'status': None, 'locked': None,
-                    'builds': None, 'releases': None, 'like': None,
+                    'builds': None, 'releases': None,
                     'content_type': None, 'severity': None,
                     'submitted_since': None, 'submitted_before': None, 'suggest': None,
                     'request': None, 'bugs': None, 'staging': False, 'modified_since': None,
                     'modified_before': None, 'pushed': None, 'pushed_since': None,
                     'pushed_before': None, 'user': None, 'critpath': None, 'packages': None,
                     'type': None, 'rows_per_page': None, 'page': 5
-                },
-            ),
-            mock.call(
-                bindings_client,
-                u'updates/FEDORA-2017-c95b33872d/get-test-results',
-                verb='GET'
-            )
-        ]
-        self.assertEqual(send_request.mock_calls, calls)
-
-    @mock.patch('bodhi.client.bindings.BodhiClient.csrf',
-                mock.MagicMock(return_value='a_csrf_token'))
-    @mock.patch('bodhi.client.bindings.BodhiClient.send_request',
-                return_value=client_test_data.EXAMPLE_QUERY_MUNCH, autospec=True)
-    def test_title_flag(self, send_request):
-        """
-        Assert correct behavior with the --title flag.
-        """
-        runner = testing.CliRunner()
-
-        result = runner.invoke(
-            client.query,
-            ['--title', 'nodejs-grunt-wrap-0.3.0-2.fc25'])
-
-        self.assertEqual(result.exit_code, 0)
-        bindings_client = send_request.mock_calls[0][1][0]
-        calls = [
-            mock.call(
-                bindings_client, 'updates/', verb='GET',
-                params={
-                    'updateid': None, 'alias': None, 'approved_since': None,
-                    'approved_before': None, 'status': None, 'locked': None,
-                    'builds': None, 'releases': None, 'like': u'nodejs-grunt-wrap-0.3.0-2.fc25',
-                    'content_type': None, 'severity': None,
-                    'submitted_since': None, 'submitted_before': None, 'suggest': None,
-                    'request': None, 'bugs': None, 'staging': False, 'modified_since': None,
-                    'modified_before': None, 'pushed': None, 'pushed_since': None,
-                    'pushed_before': None, 'user': None, 'critpath': None, 'packages': None,
-                    'type': None, 'rows_per_page': None, 'page': None
                 },
             ),
             mock.call(
@@ -1489,21 +1450,21 @@ class TestEdit(unittest.TestCase):
         runner = testing.CliRunner()
 
         result = runner.invoke(
-            client.edit, ['FEDORA-2017-cc8582d738', '--user', 'bowlofeggs',
+            client.edit, ['FEDORA-2017-c95b33872d', '--user', 'bowlofeggs',
                           '--password', 's3kr3t', '--bugs', '1234,5678'])
 
         self.assertEqual(result.exit_code, 0)
         bindings_client = query.mock_calls[0][1][0]
         query.assert_called_with(
-            bindings_client, updateid='FEDORA-2017-cc8582d738')
+            bindings_client, updateid='FEDORA-2017-c95b33872d')
         bindings_client = send_request.mock_calls[0][1][0]
         calls = [
             mock.call(
                 bindings_client, 'updates/', auth=True, verb='POST',
                 data={
                     'close_bugs': False, 'stable_karma': 3, 'csrf_token': 'a_csrf_token',
-                    'staging': False, 'builds': 'nodejs-grunt-wrap-0.3.0-2.fc25',
-                    'autokarma': False, 'edited': 'nodejs-grunt-wrap-0.3.0-2.fc25',
+                    'staging': False, 'builds': ['nodejs-grunt-wrap-0.3.0-2.fc25'],
+                    'autokarma': False, 'edited': 'FEDORA-2017-c95b33872d',
                     'suggest': 'unspecified', 'notes': 'New package.',
                     'notes_file': None, 'request': None, 'unstable_karma': -3,
                     'bugs': '1234,5678', 'requirements': '', 'type': 'newpackage',
@@ -1525,22 +1486,22 @@ class TestEdit(unittest.TestCase):
         runner = testing.CliRunner()
 
         result = runner.invoke(
-            client.edit, ['FEDORA-2017-cc8582d738', '--user', 'bowlofeggs',
+            client.edit, ['FEDORA-2017-c95b33872d', '--user', 'bowlofeggs',
                           '--password', 's3kr3t', '--severity', 'low',
                           '--notes', 'Updated package.'])
 
         self.assertEqual(result.exit_code, 0)
         bindings_client = query.mock_calls[0][1][0]
         query.assert_called_with(
-            bindings_client, updateid=u'FEDORA-2017-cc8582d738')
+            bindings_client, updateid=u'FEDORA-2017-c95b33872d')
         bindings_client = send_request.mock_calls[0][1][0]
         calls = [
             mock.call(
                 bindings_client, 'updates/', auth=True, verb='POST',
                 data={
                     'close_bugs': False, 'stable_karma': 3, 'csrf_token': 'a_csrf_token',
-                    'staging': False, 'builds': u'nodejs-grunt-wrap-0.3.0-2.fc25',
-                    'autokarma': False, 'edited': u'nodejs-grunt-wrap-0.3.0-2.fc25',
+                    'staging': False, 'builds': ['nodejs-grunt-wrap-0.3.0-2.fc25'],
+                    'autokarma': False, 'edited': 'FEDORA-2017-c95b33872d',
                     'suggest': u'unspecified', 'notes': u'Updated package.',
                     'notes_file': None, 'request': None, 'unstable_karma': -3,
                     'bugs': '1420605', 'requirements': u'', 'type': 'newpackage',
@@ -1568,22 +1529,22 @@ class TestEdit(unittest.TestCase):
         runner = testing.CliRunner()
 
         result = runner.invoke(
-            client.edit, ['FEDORA-2017-cc8582d738', '--user', 'bowlofeggs',
+            client.edit, ['FEDORA-2017-c95b33872d', '--user', 'bowlofeggs',
                           '--password', 's3kr3t', '--notes', 'this is an edited note',
                           '--url', 'http://localhost:6543'])
 
         self.assertEqual(result.exit_code, 0)
         bindings_client = query.mock_calls[0][1][0]
         query.assert_called_with(
-            bindings_client, updateid=u'FEDORA-2017-cc8582d738')
+            bindings_client, updateid=u'FEDORA-2017-c95b33872d')
         bindings_client = send_request.mock_calls[0][1][0]
         calls = [
             mock.call(
                 bindings_client, 'updates/', auth=True, verb='POST',
                 data={
                     'close_bugs': False, 'stable_karma': 3, 'csrf_token': 'a_csrf_token',
-                    'staging': False, 'builds': u'nodejs-grunt-wrap-0.3.0-2.fc25',
-                    'autokarma': False, 'edited': u'nodejs-grunt-wrap-0.3.0-2.fc25',
+                    'staging': False, 'builds': ['nodejs-grunt-wrap-0.3.0-2.fc25'],
+                    'autokarma': False, 'edited': 'FEDORA-2017-c95b33872d',
                     'suggest': u'unspecified', 'notes': u'this is an edited note',
                     'notes_file': None, 'request': None, 'severity': u'low',
                     'bugs': '1420605', 'requirements': u'', 'unstable_karma': -3,
@@ -1616,22 +1577,22 @@ class TestEdit(unittest.TestCase):
                 f.write('This is a --notes-file note!')
 
             result = runner.invoke(
-                client.edit, ['FEDORA-2017-cc8582d738', '--user', 'bowlofeggs',
+                client.edit, ['FEDORA-2017-c95b33872d', '--user', 'bowlofeggs',
                               '--password', 's3kr3t', '--notes-file', 'notefile.txt',
                               '--url', 'http://localhost:6543'])
 
             self.assertEqual(result.exit_code, 0)
             bindings_client = query.mock_calls[0][1][0]
             query.assert_called_with(
-                bindings_client, updateid=u'FEDORA-2017-cc8582d738')
+                bindings_client, updateid=u'FEDORA-2017-c95b33872d')
             bindings_client = send_request.mock_calls[0][1][0]
             calls = [
                 mock.call(
                     bindings_client, 'updates/', auth=True, verb='POST',
                     data={
                         'close_bugs': False, 'stable_karma': 3, 'csrf_token': 'a_csrf_token',
-                        'staging': False, 'builds': u'nodejs-grunt-wrap-0.3.0-2.fc25',
-                        'autokarma': False, 'edited': u'nodejs-grunt-wrap-0.3.0-2.fc25',
+                        'staging': False, 'builds': ['nodejs-grunt-wrap-0.3.0-2.fc25'],
+                        'autokarma': False, 'edited': 'FEDORA-2017-c95b33872d',
                         'suggest': 'unspecified', 'notes': 'This is a --notes-file note!',
                         'notes_file': 'notefile.txt', 'request': None, 'severity': 'low',
                         'bugs': '1420605', 'requirements': u'', 'unstable_karma': -3,
@@ -1665,50 +1626,9 @@ class TestEdit(unittest.TestCase):
             self.assertEqual(result.exit_code, 1)
             self.assertEqual(result.output, u'ERROR: Cannot specify --notes and --notes-file\n')
 
-    @mock.patch('bodhi.client.bindings.BodhiClient.csrf',
-                mock.MagicMock(return_value='a_csrf_token'))
-    @mock.patch('bodhi.client.bindings.BodhiClient.query',
-                return_value=client_test_data.EXAMPLE_QUERY_MUNCH, autospec=True)
-    @mock.patch('bodhi.client.bindings.BodhiClient.send_request',
-                return_value=client_test_data.EXAMPLE_UPDATE_MUNCH, autospec=True)
-    def test_update_title(self, send_request, query):
+    def test_wrong_update_id_argument(self):
         """
-        Assert that we can successfully edit an update using the update title.
-        """
-        runner = testing.CliRunner()
-
-        result = runner.invoke(
-            client.edit, ['drupal7-i18n-1.17-1.fc26', '--user', 'bowlofeggs',
-                          '--password', 's3kr3t', '--notes', 'this is an edited note',
-                          '--url', 'http://localhost:6543'])
-
-        self.assertEqual(result.exit_code, 0)
-        bindings_client = send_request.mock_calls[0][1][0]
-        calls = [
-            mock.call(
-                bindings_client, 'updates/', auth=True, verb='POST',
-                data={
-                    'close_bugs': False, 'stable_karma': 3, 'csrf_token': 'a_csrf_token',
-                    'staging': False, 'builds': u'drupal7-i18n-1.17-1.fc26',
-                    'autokarma': False, 'edited': u'drupal7-i18n-1.17-1.fc26',
-                    'suggest': u'unspecified', 'notes': u'this is an edited note',
-                    'notes_file': None, 'request': None, 'bugs': '1420605',
-                    'unstable_karma': -3, 'type': 'newpackage', 'severity': u'low',
-                    'requirements': u''
-                }
-            ),
-            mock.call(
-                bindings_client,
-                u'updates/FEDORA-EPEL-2016-3081a94111/get-test-results',
-                verb='GET'
-            )
-        ]
-        self.assertEqual(send_request.mock_calls, calls)
-
-    def test_wrong_update_title_argument(self):
-        """
-         Assert that an error is given if the edit update argument given is not an update id
-         nor an update title.
+        Assert that an error is given if the edit update argument given is not an update id.
         """
         runner = testing.CliRunner()
 
@@ -1724,31 +1644,7 @@ class TestEdit(unittest.TestCase):
             label = 'UPDATE'
         expected = u'Usage: edit [OPTIONS] UPDATE\n\n' \
                    u'Error: Invalid value for "{}": ' \
-                   u'Please provide an Update ID or an Update Title\n'
-        expected = expected.format(label)
-
-        self.assertEqual(result.output, expected)
-
-    def test_wrong_update_id_argument(self):
-        """
-         Assert that an error is given if the edit update argument given is not an update id
-         nor an update title.
-        """
-        runner = testing.CliRunner()
-
-        result = runner.invoke(
-            client.edit, ['FEDORA-20-cc8582d738', '--user', 'bowlofeggs',
-                          '--password', 's3kr3t', '--notes', 'this is an edited note',
-                          '--url', 'http://localhost:6543'])
-        self.assertEqual(result.exit_code, 2)
-        # Click 7.0 capitalizes UPDATE, and < 7 does not.
-        if [int(n) for n in click.__version__.split('.')] < [7, 0]:
-            label = 'update'
-        else:
-            label = 'UPDATE'
-        expected = u'Usage: edit [OPTIONS] UPDATE\n\n' \
-                   u'Error: Invalid value for "{}": ' \
-                   u'Please provide an Update ID or an Update Title\n'
+                   u'Please provide an Update ID\n'
         expected = expected.format(label)
 
         self.assertEqual(result.output, expected)
@@ -1767,7 +1663,7 @@ class TestEdit(unittest.TestCase):
         runner = testing.CliRunner()
 
         result = runner.invoke(
-            client.edit, ['FEDORA-2017-cc8582d738', '--user', 'bowlofeggs',
+            client.edit, ['FEDORA-2017-c95b33872d', '--user', 'bowlofeggs',
                           '--password', 's3kr3t', '--notes', 'testing required tasks',
                           '--requirements', 'dist.depcheck dist.rpmdeplint', '--url',
                           'http://localhost:6543'])
@@ -1775,15 +1671,15 @@ class TestEdit(unittest.TestCase):
         self.assertEqual(result.exit_code, 0)
         bindings_client = query.mock_calls[0][1][0]
         query.assert_called_with(
-            bindings_client, updateid=u'FEDORA-2017-cc8582d738')
+            bindings_client, updateid=u'FEDORA-2017-c95b33872d')
         bindings_client = send_request.mock_calls[0][1][0]
         calls = [
             mock.call(
                 bindings_client, 'updates/', auth=True, verb='POST',
                 data={
                     'close_bugs': False, 'stable_karma': 3, 'csrf_token': 'a_csrf_token',
-                    'staging': False, 'builds': u'nodejs-grunt-wrap-0.3.0-2.fc25',
-                    'autokarma': False, 'edited': u'nodejs-grunt-wrap-0.3.0-2.fc25',
+                    'staging': False, 'builds': ['nodejs-grunt-wrap-0.3.0-2.fc25'],
+                    'autokarma': False, 'edited': 'FEDORA-2017-c95b33872d',
                     'suggest': u'unspecified', 'notes': u'testing required tasks',
                     'notes_file': None, 'request': None, 'severity': u'low',
                     'bugs': '1420605', 'unstable_karma': -3,
@@ -1829,21 +1725,21 @@ class TestEdit(unittest.TestCase):
         runner = testing.CliRunner()
 
         result = runner.invoke(
-            client.edit, ['FEDORA-2017-cc8582d738', '--user', 'bowlofeggs',
+            client.edit, ['FEDORA-2017-c95b33872d', '--user', 'bowlofeggs',
                           '--password', 's3kr3t'])
 
         self.assertEqual(result.exit_code, 0)
         bindings_client = query.mock_calls[0][1][0]
         query.assert_called_with(
-            bindings_client, updateid=u'FEDORA-2017-cc8582d738')
+            bindings_client, updateid=u'FEDORA-2017-c95b33872d')
         bindings_client = send_request.mock_calls[0][1][0]
         calls = [
             mock.call(
                 bindings_client, 'updates/', auth=True, verb='POST',
                 data={
                     'close_bugs': False, 'stable_karma': 3, 'csrf_token': 'a_csrf_token',
-                    'staging': False, 'builds': u'nodejs-grunt-wrap-0.3.0-2.fc25',
-                    'autokarma': False, 'edited': u'nodejs-grunt-wrap-0.3.0-2.fc25',
+                    'staging': False, 'builds': ['nodejs-grunt-wrap-0.3.0-2.fc25'],
+                    'autokarma': False, 'edited': u'FEDORA-2017-c95b33872d',
                     'suggest': u'unspecified', 'notes': u'New package.',
                     'notes_file': None, 'request': None, 'severity': u'low',
                     'bugs': '', 'requirements': u'', 'unstable_karma': -3, 'type': 'newpackage'

--- a/bodhi/tests/client/test_bindings.py
+++ b/bodhi/tests/client/test_bindings.py
@@ -906,19 +906,6 @@ class TestBodhiClient_query(unittest.TestCase):
         client.send_request.assert_called_once_with(
             'updates/', verb='GET', params={'packages': 'bodhi', 'page': 5})
 
-    def test_with_title(self):
-        """
-        Test with the 'title' kwarg.
-        """
-        client = bindings.BodhiClient()
-        client.send_request = mock.MagicMock(return_value='return_value')
-
-        result = client.query(title='nest-2.16.0-1.fc28')
-
-        self.assertEqual(result, 'return_value')
-        client.send_request.assert_called_once_with(
-            'updates/', verb='GET', params={'like': 'nest-2.16.0-1.fc28'})
-
 
 class TestBodhiClient_save(unittest.TestCase):
     """
@@ -1309,23 +1296,6 @@ class TestBodhiClient_update_str(unittest.TestCase):
         text = client.update_str(client_test_data.EXAMPLE_UPDATE_MUNCH)
 
         self.assertIn(u'Notes: This note contains a unicode char ☺', text)
-
-    @mock.patch.dict(
-        client_test_data.EXAMPLE_UPDATE_MUNCH, {u'alias': None})
-    def test_update_with_no_alias(self):
-        """Ensure we render an update with no alias set properly"""
-        client = bindings.BodhiClient()
-        client.base_url = 'http://example.com/tests/'
-
-        text = client.update_str(client_test_data.EXAMPLE_UPDATE_MUNCH)
-
-        expected_output = client_test_data.EXPECTED_UPDATE_OUTPUT.replace(
-            "http://example.com/tests/updates/FEDORA-EPEL-2016-3081a94111",
-            "http://example.com/tests/updates/bodhi-2.2.4-1.el7")
-        expected_output = expected_output.replace(
-            "   Update ID: FEDORA-EPEL-2016-3081a94111\n",
-            "")
-        self.assertTrue(compare_output(text, expected_output))
 
     @mock.patch('bodhi.client.bindings.BodhiClient.get_test_status')
     def test_ci_status_errors(self, get_test_status):

--- a/bodhi/tests/server/__init__.py
+++ b/bodhi/tests/server/__init__.py
@@ -73,7 +73,7 @@ def create_update(session, build_nvrs, release_name=u'F17'):
         session.add(override)
 
     update = Update(
-        title=', '.join(build_nvrs), builds=builds, user=user, request=UpdateRequest.testing,
+        builds=builds, user=user, request=UpdateRequest.testing,
         notes=u'Useful details!', type=UpdateType.bugfix, date_submitted=datetime(1984, 11, 2),
         requirements=u'rpmlint', stable_karma=3, unstable_karma=-3, release=release)
     session.add(update)
@@ -109,7 +109,9 @@ def populate(db):
         branch=u'f17', state=ReleaseState.current)
     db.add(release)
     db.flush()
-    update = create_update(db, [u'bodhi-2.0-1.fc17'])
+    # This mock will help us generate a consistent update alias.
+    with mock.patch(target='uuid.uuid4', return_value='wat'):
+        update = create_update(db, [u'bodhi-2.0-1.fc17'])
     update.type = UpdateType.bugfix
     update.severity = UpdateSeverity.medium
     bug = Bug(bug_id=12345)
@@ -126,8 +128,6 @@ def populate(db):
     db.add(comment)
     update.comments.append(comment)
 
-    with mock.patch(target='uuid.uuid4', return_value='wat'):
-        update.assign_alias()
     db.add(update)
 
     db.commit()

--- a/bodhi/tests/server/consumers/test_updates.py
+++ b/bodhi/tests/server/consumers/test_updates.py
@@ -43,9 +43,10 @@ class TestUpdatesHandlerConsume(base.BaseTestCase):
                       'topic_prefix': 'topic_prefix'}
         h = updates.UpdatesHandler(hub)
         h.db_factory = base.TransactionalSessionMaker(self.Session)
+        update = models.Build.query.filter_by(nvr='bodhi-2.0-1.fc17').one().update
         message = {
             'topic': 'bodhi.update.edit',
-            'body': {'msg': {'update': {'alias': u'bodhi-2.0-1.fc17'},
+            'body': {'msg': {'update': {'alias': update.alias},
                              'new_bugs': ['12345', '123456']}}}
 
         h.consume(message)
@@ -62,7 +63,7 @@ class TestUpdatesHandlerConsume(base.BaseTestCase):
 
         # Inexisting bug with id '123456' should now exists in DB as a bug attached to update
         bug = models.Bug.query.filter_by(bug_id=123456).one()
-        update = models.Update.query.filter_by(title=u'bodhi-2.0-1.fc17').one()
+        update = models.Build.query.filter_by(nvr='bodhi-2.0-1.fc17').one().update
         self.assertIn(bug, update.bugs)
 
     @mock.patch('bodhi.server.consumers.updates.UpdatesHandler.fetch_test_cases')
@@ -80,9 +81,10 @@ class TestUpdatesHandlerConsume(base.BaseTestCase):
                       'topic_prefix': 'topic_prefix'}
         h = updates.UpdatesHandler(hub)
         h.db_factory = base.TransactionalSessionMaker(self.Session)
+        update = models.Build.query.filter_by(nvr='bodhi-2.0-1.fc17').one().update
         message = {
             'topic': 'bodhi.update.edit',
-            'body': {'msg': {'update': {'alias': u'bodhi-2.0-1.fc17'},
+            'body': {'msg': {'update': {'alias': update.alias},
                              'new_bugs': ['12345', '123456']}}}
 
         h.consume(message)
@@ -99,7 +101,7 @@ class TestUpdatesHandlerConsume(base.BaseTestCase):
 
         # Bug with id '123456' should be attached to update
         bug = models.Bug.query.filter_by(bug_id=123456).one()
-        update = models.Update.query.filter_by(title=u'bodhi-2.0-1.fc17').one()
+        update = models.Build.query.filter_by(nvr='bodhi-2.0-1.fc17').one().update
         self.assertIn(bug, update.bugs)
 
     # We're going to use side effects to mock but still call work_on_bugs and fetch_test_cases so we
@@ -119,9 +121,10 @@ class TestUpdatesHandlerConsume(base.BaseTestCase):
                       'topic_prefix': 'topic_prefix'}
         h = updates.UpdatesHandler(hub)
         h.db_factory = base.TransactionalSessionMaker(self.Session)
+        update = models.Build.query.filter_by(nvr='bodhi-2.0-1.fc17').one().update
         message = {
             'topic': 'bodhi.update.edit',
-            'body': {'msg': {'update': {'alias': u'bodhi-2.0-1.fc17'},
+            'body': {'msg': {'update': {'alias': update.alias},
                              'new_bugs': ['12345']}}}
 
         h.consume(message)
@@ -139,7 +142,7 @@ class TestUpdatesHandlerConsume(base.BaseTestCase):
     @mock.patch.dict('bodhi.server.config.config', {'test_gating.required': False})
     def test_gating_required_false(self, sleep):
         """Assert that test_gating_status is not updated if test_gating is not enabled."""
-        update = models.Update.query.filter_by(title=u'bodhi-2.0-1.fc17').one()
+        update = models.Build.query.filter_by(nvr='bodhi-2.0-1.fc17').one().update
         update.test_gating_status = None
         hub = mock.MagicMock()
         hub.config = {'environment': 'environment',
@@ -149,7 +152,7 @@ class TestUpdatesHandlerConsume(base.BaseTestCase):
         # Throw a bogus bug id in there to ensure it doesn't raise AssertionError.
         message = {
             'topic': 'bodhi.update.request.testing',
-            'body': {'msg': {'update': {'alias': u'bodhi-2.0-1.fc17'},
+            'body': {'msg': {'update': {'alias': update.alias},
                              'new_bugs': []}}}
 
         with mock.patch('bodhi.server.models.util.greenwave_api_post') as mock_greenwave:
@@ -171,14 +174,14 @@ class TestUpdatesHandlerConsume(base.BaseTestCase):
 
             h.consume(message)
 
-        update = models.Update.query.filter_by(title=u'bodhi-2.0-1.fc17').one()
+        update = models.Build.query.filter_by(nvr='bodhi-2.0-1.fc17').one().update
         self.assertIsNone(update.test_gating_status)
         sleep.assert_called_once_with(1)
 
     @mock.patch.dict('bodhi.server.config.config', {'test_gating.required': True})
     def test_gating_required_true(self, sleep):
         """Assert that test_gating_status is updated when test_gating is enabled."""
-        update = models.Update.query.filter_by(title=u'bodhi-2.0-1.fc17').one()
+        update = models.Build.query.filter_by(nvr='bodhi-2.0-1.fc17').one().update
         update.test_gating_status = None
         hub = mock.MagicMock()
         hub.config = {'environment': 'environment',
@@ -188,7 +191,7 @@ class TestUpdatesHandlerConsume(base.BaseTestCase):
         # Throw a bogus bug id in there to ensure it doesn't raise AssertionError.
         message = {
             'topic': 'bodhi.update.request.testing',
-            'body': {'msg': {'update': {'alias': u'bodhi-2.0-1.fc17'},
+            'body': {'msg': {'update': {'alias': update.alias},
                              'new_bugs': []}}}
 
         with mock.patch('bodhi.server.models.util.greenwave_api_post') as mock_greenwave:
@@ -210,7 +213,7 @@ class TestUpdatesHandlerConsume(base.BaseTestCase):
 
             h.consume(message)
 
-        update = models.Update.query.filter_by(title=u'bodhi-2.0-1.fc17').one()
+        update = models.Build.query.filter_by(nvr='bodhi-2.0-1.fc17').one().update
         self.assertEqual(update.test_gating_status, models.TestGatingStatus.failed)
         sleep.assert_called_once_with(1)
 
@@ -230,10 +233,11 @@ class TestUpdatesHandlerConsume(base.BaseTestCase):
                       'topic_prefix': 'topic_prefix'}
         h = updates.UpdatesHandler(hub)
         h.db_factory = base.TransactionalSessionMaker(self.Session)
+        update = models.Build.query.filter_by(nvr='bodhi-2.0-1.fc17').one().update
         # Throw a bogus bug id in there to ensure it doesn't raise AssertionError.
         message = {
             'topic': 'bodhi.update.request.testing',
-            'body': {'msg': {'update': {'alias': u'bodhi-2.0-1.fc17'},
+            'body': {'msg': {'update': {'alias': update.alias},
                              'new_bugs': ['this isnt a real bug lol']}}}
 
         h.consume(message)
@@ -260,10 +264,11 @@ class TestUpdatesHandlerConsume(base.BaseTestCase):
                       'topic_prefix': 'topic_prefix'}
         h = updates.UpdatesHandler(hub)
         h.db_factory = base.TransactionalSessionMaker(self.Session)
+        update = models.Build.query.filter_by(nvr='bodhi-2.0-1.fc17').one().update
         # Use a bogus topic to trigger the NotImplementedError.
         message = {
             'topic': 'bodhi.update.nawjustkiddin',
-            'body': {'msg': {'update': {'alias': u'bodhi-2.0-1.fc17'},
+            'body': {'msg': {'update': {'alias': update.alias},
                              'new_bugs': ['12345']}}}
 
         self.assertRaises(NotImplementedError, h.consume, message)
@@ -283,42 +288,17 @@ class TestUpdatesHandlerConsume(base.BaseTestCase):
                       'topic_prefix': 'topic_prefix'}
         h = updates.UpdatesHandler(hub)
         h.db_factory = base.TransactionalSessionMaker(self.Session)
-        # Use a bogus topic to trigger the NotImplementedError.
+        # Use a bogus alias to trigger the NotImplementedError.
         message = {
             'topic': 'bodhi.update.request.testing',
-            'body': {'msg': {'update': {'alias': u'hurd-1.0-1.fc26'}}}}
+            'body': {'msg': {'update': {'alias': 'does not exist'}}}}
 
         with self.assertRaises(exceptions.BodhiException) as exc:
             h.consume(message)
 
-        self.assertEqual(str(exc.exception), "Couldn't find alias 'hurd-1.0-1.fc26' in DB")
+        self.assertEqual(str(exc.exception), "Couldn't find alias 'does not exist' in DB")
         self.assertEqual(work_on_bugs.call_count, 0)
         self.assertEqual(fetch_test_cases.call_count, 0)
-        sleep.assert_called_once_with(1)
-
-    @mock.patch('bodhi.server.consumers.updates.log.error')
-    @mock.patch('bodhi.server.consumers.updates.UpdatesHandler.fetch_test_cases')
-    @mock.patch('bodhi.server.consumers.updates.UpdatesHandler.work_on_bugs')
-    def test_without_alias(self, work_on_bugs, fetch_test_cases, error, sleep):
-        """
-        An error should get logged and the function should return if the message has no alias.
-        """
-        hub = mock.MagicMock()
-        hub.config = {'environment': 'environment',
-                      'topic_prefix': 'topic_prefix'}
-        h = updates.UpdatesHandler(hub)
-        h.db_factory = base.TransactionalSessionMaker(self.Session)
-        message = {
-            'topic': 'bodhi.update.edit',
-            'body': {'msg': {'update': {},
-                             'new_bugs': ['12345']}}}
-
-        h.consume(message)
-
-        self.assertEqual(work_on_bugs.call_count, 0)
-        self.assertEqual(fetch_test_cases.call_count, 0)
-        error.assert_called_once_with(
-            "Update Handler got update with no alias {'new_bugs': ['12345'], 'update': {}}.")
         sleep.assert_called_once_with(1)
 
 

--- a/bodhi/tests/server/functional/test_users.py
+++ b/bodhi/tests/server/functional/test_users.py
@@ -200,12 +200,6 @@ class TestUsersService(base.BaseTestCase):
         self.assertEqual(len(body['users']), 0)
         assert 'errors' not in res.json_body
 
-    def test_list_users_by_update_title(self):
-        res = self.app.get('/users/', {"updates": 'bodhi-2.0-1.fc17'})
-        body = res.json_body
-        self.assertEqual(len(body['users']), 1)
-        self.assertEqual(body['users'][0]['name'], 'guest')
-
     def test_list_users_by_update_alias(self):
         update = self.db.query(Update).first()
         update.alias = u'some_alias'

--- a/bodhi/tests/server/scripts/test_approve_testing.py
+++ b/bodhi/tests/server/scripts/test_approve_testing.py
@@ -146,7 +146,7 @@ class TestMain(BaseTestCase):
              'maintainer wishes'),
             author=u'bodhi')
         self.assertEqual(stdout.getvalue(),
-                         'bodhi-2.0-1.fc17 now meets testing requirements\nThe DB died lol\n')
+                         f'{update.alias} now meets testing requirements\nThe DB died lol\n')
         remove.assert_called_once_with()
 
     @patch('bodhi.server.models.Update.comment', side_effect=[None, IOError('The DB died lol')])
@@ -187,8 +187,8 @@ class TestMain(BaseTestCase):
         )
         self.assertEqual(comment.call_args_list, [comment_expected_call, comment_expected_call])
         self.assertEqual(stdout.getvalue(),
-                         ('bodhi2-2.0-1.fc17 now meets testing requirements\n'
-                          'bodhi-2.0-1.fc17 now meets testing requirements\nThe DB died lol\n'))
+                         (f'{update2.alias} now meets testing requirements\n'
+                          f'{update.alias} now meets testing requirements\nThe DB died lol\n'))
         remove.assert_called_once_with()
 
     def test_non_autokarma_critpath_update_meeting_karma_requirements_gets_one_comment(self):

--- a/bodhi/tests/server/services/test_builds.py
+++ b/bodhi/tests/server/services/test_builds.py
@@ -1,4 +1,4 @@
-# Copyright © 2014-2017 Red Hat Inc. and others.
+# Copyright © 2014-2019 Red Hat Inc. and others.
 #
 # This file is part of Bodhi.
 #
@@ -100,8 +100,11 @@ class TestBuildsService(base.BaseTestCase):
         up = res.json_body['builds'][0]
         self.assertEqual(up['nvr'], u'bodhi-2.0-1.fc17')
 
-    def test_list_builds_by_update_title(self):
-        res = self.app.get('/builds/', {"updates": ["bodhi-2.0-1.fc17"]})
+    def test_list_builds_by_update_alias(self):
+        update = RpmBuild.query.filter_by(nvr='bodhi-2.0-1.fc17').one().update
+
+        res = self.app.get('/builds/', {"updates": [update.alias]})
+
         up = res.json_body['builds'][0]
         self.assertEqual(up['nvr'], u'bodhi-2.0-1.fc17')
 

--- a/bodhi/tests/server/services/test_releases.py
+++ b/bodhi/tests/server/services/test_releases.py
@@ -22,7 +22,7 @@ import webtest
 
 from bodhi import server
 from bodhi.server.config import config
-from bodhi.server.models import Release, ReleaseState, Update, UpdateStatus
+from bodhi.server.models import Build, Release, ReleaseState, Update, UpdateStatus
 from bodhi.server.util import get_absolute_path
 from bodhi.tests.server import base, create_update
 
@@ -141,12 +141,6 @@ class TestReleasesService(base.BaseTestCase):
     def test_list_releases_by_name_match_miss(self):
         res = self.app.get('/releases/', {"name": '%wat%'})
         self.assertEqual(len(res.json_body['releases']), 0)
-
-    def test_list_releases_by_update_title(self):
-        res = self.app.get('/releases/', {"updates": 'bodhi-2.0-1.fc17'})
-        body = res.json_body
-        self.assertEqual(len(body['releases']), 1)
-        self.assertEqual(body['releases'][0]['name'], 'F17')
 
     def test_list_releases_by_update_alias(self):
         update = self.db.query(Update).first()
@@ -396,28 +390,28 @@ class TestReleasesService(base.BaseTestCase):
         self.assertEqual(r.state, ReleaseState.archived)
 
         # Expect update status not changed
-        python_nose = self.db.query(Update).filter_by(
-            title=u'python-nose-1.3.7-11.fc17').one()
+        python_nose = self.db.query(Build).filter_by(
+            nvr='python-nose-1.3.7-11.fc17').one().update
         self.assertEqual(python_nose.status, UpdateStatus.stable)
         # Expect update status not changed
-        python_paste_deploy = self.db.query(Update).filter_by(
-            title=u'python-paste-deploy-1.5.2-8.fc17').one()
+        python_paste_deploy = self.db.query(Build).filter_by(
+            nvr='python-paste-deploy-1.5.2-8.fc17').one().update
         self.assertEqual(python_paste_deploy.status, UpdateStatus.obsolete)
         # Expect update status not changed
-        firefox = self.db.query(Update).filter_by(
-            title=u'firefox-61.0.2-3.fc17').one()
+        firefox = self.db.query(Build).filter_by(
+            nvr='firefox-61.0.2-3.fc17').one().update
         self.assertEqual(firefox.status, UpdateStatus.unpushed)
         # Expect update status changed to 'obsolete'
-        bodhi_update = self.db.query(Update).filter_by(
-            title=u'bodhi-2.0-1.fc17').one()
+        bodhi_update = self.db.query(Build).filter_by(
+            nvr='bodhi-2.0-1.fc17').one().update
         self.assertEqual(bodhi_update.status, UpdateStatus.obsolete)
         # Check for the comment
         expected_comment = (u'This update is marked obsolete because the F17 release '
                             'is archived.')
         self.assertEqual(bodhi_update.comments[-1].text, expected_comment)
         # Expect update status not changed
-        python_test_update = self.db.query(Update).filter_by(
-            title=u'python-test-update.fc22').one()
+        python_test_update = self.db.query(Build).filter_by(
+            nvr='python-test-update.fc22').one().update
         self.assertEqual(python_test_update.status, UpdateStatus.pending)
 
     def test_get_single_release_html(self):

--- a/bodhi/tests/server/test_metadata.py
+++ b/bodhi/tests/server/test_metadata.py
@@ -306,11 +306,9 @@ class TestUpdateInfoMetadata(UpdateInfoMetadataTestCase):
 
         self.assertEqual(md.comp_type, createrepo_c.XZ)
 
-    def test_extended_metadata(self):
-        self._test_extended_metadata(True)
-
-    def test_extended_metadata_no_alias(self):
-        self._test_extended_metadata(False)
+    def test_extended_metadata_once(self):
+        """Assert that a single call to update the metadata works as expected."""
+        self._test_extended_metadata()
 
     def test_extended_metadata_cache(self):
         """Asserts that when the same update is retrieved twice, the info is unshelved.
@@ -319,22 +317,20 @@ class TestUpdateInfoMetadata(UpdateInfoMetadataTestCase):
         again retrieve the info from the buildsystem, and it'll have to be returned from the
         cache.
         """
-        self._test_extended_metadata(True)
+        self._test_extended_metadata()
         shutil.rmtree(self.temprepo)
         base.mkmetadatadir(self.temprepo, updateinfo=False)
         base.mkmetadatadir(join(self.tempcompdir, 'compose', 'Everything', 'source', 'tree'),
                            updateinfo=False)
         DevBuildsys.__rpms__ = []
-        self._test_extended_metadata(True)
+        self._test_extended_metadata()
 
-    def _test_extended_metadata(self, has_alias):
+    def _test_extended_metadata(self):
         update = self.db.query(Update).one()
 
         # Pretend it's pushed to testing
         update.status = UpdateStatus.testing
         update.request = None
-        if not has_alias:
-            update.alias = None
         update.date_pushed = datetime.utcnow()
         DevBuildsys.__tagged__[update.title] = ['f17-updates-testing']
 

--- a/bodhi/tests/server/test_validators.py
+++ b/bodhi/tests/server/test_validators.py
@@ -52,7 +52,7 @@ class TestValidateCSRFToken(BaseTestCase):
         """No exception should be raised with a valid token."""
         update = models.Update.query.one()
         """colander.Invalid should be raised if the CSRF token doesn't match."""
-        comment = {'update': update.title, 'text': 'invalid CSRF', 'karma': 0,
+        comment = {'update': update.alias, 'text': 'invalid CSRF', 'karma': 0,
                    'csrf_token': self.get_csrf_token()}
 
         # This should not cause any error.
@@ -97,8 +97,8 @@ class TestValidateAcls(BaseTestCase):
         A helper function that creates a mock request.
         :return: a Mock object representing a request
         """
-        update = self.db.query(models.Update).filter_by(
-            title=u'bodhi-2.0-1.fc17').one()
+        update = self.db.query(models.Build).filter_by(
+            nvr='bodhi-2.0-1.fc17').one().update
         user = self.db.query(models.User).filter_by(id=1).one()
         mock_request = mock.Mock()
         mock_request.user = user

--- a/bodhi/tests/server/views/test_generic.py
+++ b/bodhi/tests/server/views/test_generic.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2019 Red Hat, Inc. and others.
+# Copyright © 2014-2019 Red Hat, Inc. and others.
 #
 # This file is part of Bodhi.
 #
@@ -451,7 +451,6 @@ class TestFrontpageView(base.BaseTestCase):
                 for j in i[1]:
                     for k in range(0, j[1]):
                         update = Update(
-                            title=u'bodhi-2.0-1%s.%s' % (str(count), packagesuffix),
                             user=user,
                             status=i[0],
                             type=j[0],

--- a/devel/ci/integration/tests/test_bodhi_cli.py
+++ b/devel/ci/integration/tests/test_bodhi_cli.py
@@ -299,7 +299,7 @@ def test_updates_download(bodhi_container, db_container):
     # Fetch the last updates from the DB
     builds = []
     db_ip = db_container.get_IPv4s()[0]
-    query_updates = "SELECT id, alias, title FROM updates ORDER BY date_submitted DESC LIMIT 3"
+    query_updates = "SELECT id, alias FROM updates ORDER BY date_submitted DESC LIMIT 3"
     query_builds = "SELECT nvr FROM builds WHERE update_id = %s ORDER BY nvr"
     conn = psycopg2.connect("dbname=bodhi2 user=postgres host={}".format(db_ip))
     with conn:
@@ -322,6 +322,6 @@ def test_updates_download(bodhi_container, db_container):
         result = _run_cli(bodhi_container, cmd)
     assert result.exit_code == 0
     for update in updates:
-        assert "Downloading packages from {}".format(update['title']) in result.output
+        assert "Downloading packages from {}".format(update['alias']) in result.output
     for build_id in builds:
         assert "TESTING CALL /usr/bin/koji download-build {}".format(build_id) in result.output

--- a/docs/user/release_notes.rst
+++ b/docs/user/release_notes.rst
@@ -12,6 +12,9 @@ Backwards incompatible changes
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 * Values NULL and 0 are not allowed in update's stable_karma and unstable_karma (:issue:`1029`).
+* Updates no longer have a ``title`` attribute. This affects many elements of Bodhi's REST API,
+  including URLs (update titles can no longer be used to reference updates, only aliases), REST API
+  data structures, and Bodhi's messages (:issue:`1542`).
 * The ``prefer_ssl`` setting has been renamed to ``libravatar_prefer_tls`` and now defaults to
   ``True`` instead of ``None`` (:issue:`1921`).
 * Integration with pkgdb is no longer supported (:issue:`1970`).


### PR DESCRIPTION
There are two commits in this pull request. Please see their messages for details. The summary:

* The first one indexes a field that really should have always been indexed. This is needed for the downgrade() on the migration for the second commit, which takes more than 10 minutes without an index (I killed it, so no idea how long it actually takes, just that it's more than 10 minutes). With the index, the downgrade() takes about 7 seconds on my laptop.
* The second commit drops the title field from updates, and disallows referencing updates by title.