### PR TITLE
Correct the update command for EPEL

### DIFF
--- a/bodhi/client/__init__.py
+++ b/bodhi/client/__init__.py
@@ -171,6 +171,10 @@ release_options = [
     click.option('--mail-template', help='Name of the email template for this release'),
     click.option('--composed-by-bodhi/--not-composed-by-bodhi', is_flag=True, default=True,
                  help='The flag that indicates whether the release is composed by Bodhi or not'),
+    click.option('--package-manager', type=click.Choice(['unspecified', 'dnf', 'yum']),
+                 help='The package manager used by this release'),
+    click.option('--testing-repository',
+                 help='The name of the testing repository used to test updates'),
     click.option(
         '--create-automatic-updates/--no-create-automatic-updates',
         help=('Configure for this release, whether or not automatic updates are '
@@ -1241,6 +1245,8 @@ def print_release(release):
     click.echo("  Email Template:           %s" % release['mail_template'])
     click.echo("  Composed by Bodhi:        %s" % release['composed_by_bodhi'])
     click.echo("  Create Automatic Updates: %s" % release['create_automatic_updates'])
+    click.echo("  Package Manager:          %s" % release['package_manager'])
+    click.echo("  Testing Repository:       %s" % release['testing_repository'])
 
 
 def print_errors(data):

--- a/bodhi/server/migrations/versions/5703ddfe855d_add_package_manager_and_testing_.py
+++ b/bodhi/server/migrations/versions/5703ddfe855d_add_package_manager_and_testing_.py
@@ -1,0 +1,60 @@
+# Copyright (c) 2019 Mattia Verga
+#
+# This file is part of Bodhi.
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+"""
+Add package_manager and testing_repository columns to the Release model.
+
+Revision ID: 5703ddfe855d
+Revises: e8a059156d38
+Create Date: 2019-05-05 07:05:03.434601
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+# revision identifiers, used by Alembic.
+revision = '5703ddfe855d'
+down_revision = 'e8a059156d38'
+
+
+def upgrade():
+    """Add package_manager Enum type and testing_repository string type."""
+    package_manager = postgresql.ENUM('unspecified', 'dnf', 'yum', name='ck_package_manager')
+    package_manager.create(op.get_bind())
+    op.add_column('releases',
+                  sa.Column('package_manager',
+                            postgresql.ENUM('unspecified',
+                                            'dnf',
+                                            'yum',
+                                            name='ck_package_manager'),
+                            nullable=True,
+                            server_default='unspecified')
+                  )
+    op.add_column('releases',
+                  sa.Column('testing_repository',
+                            sa.UnicodeText(),
+                            nullable=True)
+                  )
+    op.alter_column('releases', 'package_manager', server_default=None)
+
+
+def downgrade():
+    """Drop package_manager and testing_repository."""
+    op.drop_column('releases', 'testing_repository')
+    op.drop_column('releases', 'package_manager')
+    op.execute("DROP TYPE ck_package_manager")

--- a/bodhi/server/models.py
+++ b/bodhi/server/models.py
@@ -714,6 +714,21 @@ class ComposeState(DeclEnum):
     cleaning = 'cleaning', 'Cleaning old composes'
 
 
+class PackageManager(DeclEnum):
+    """
+    An enum used to specify what package manager is used by a specific Release.
+
+    Attributes:
+        unspecified (EnumSymbol): for releases where the package manager is not specified.
+        dnf (EnumSymbol): DNF package manager.
+        yum (EnumSymbol): YUM package manager.
+    """
+
+    unspecified = 'unspecified', 'package manager not specified'
+    dnf = 'dnf', 'dnf'
+    yum = 'yum', 'yum'
+
+
 ##
 #  Association tables
 ##
@@ -761,6 +776,10 @@ class Release(Base):
         create_automatic_updates (bool): A flag indicating that updates should
             be created automatically for Koji builds tagged into the
             `candidate_tag`. Defaults to False.
+        package_manager (EnumSymbol): The package manager this release uses. This must be one of
+            the values defined in :class:`PackageManager`.
+        testing_repository (unicode): The name of repository where updates are placed for
+            testing before being pushed to the main repository.
     """
 
     __tablename__ = 'releases'
@@ -788,6 +807,9 @@ class Release(Base):
     create_automatic_updates = Column(Boolean, default=False)
 
     _version_int_regex = re.compile(r'\D+(\d+)[CMF]?$')
+
+    package_manager = Column(PackageManager.db_type(), default=PackageManager.unspecified)
+    testing_repository = Column(UnicodeText, nullable=True)
 
     @property
     def version_int(self):
@@ -1916,6 +1938,32 @@ class Update(Base):
         api_url = '{}/decision'.format(config.get('greenwave_api_url'))
 
         return util.greenwave_api_post(api_url, data)
+
+    def install_command(self) -> str:
+        """
+        Return the appropriate command for installing the Update.
+
+        Returns:
+            The dnf command to install the Update.
+        Raises:
+            ValueError: When the update is not in stable or testing state, or when
+                the package manager or the testing repository are not known.
+        """
+        if self.status != UpdateStatus.stable and self.status != UpdateStatus.testing:
+            raise ValueError('Only updates in stable or testing can be installed!')
+
+        if self.release.package_manager == PackageManager.unspecified \
+                or self.release.testing_repository is None:
+            raise ValueError('We don\'t know the package manager or the testing repository!')
+
+        command = 'sudo {} {}{} --advisory={}{}'.format(
+            self.release.package_manager.value,
+            'install' if self.type == UpdateType.newpackage else 'upgrade',
+            (' --enablerepo=' + self.release.testing_repository)
+            if self.status == UpdateStatus.testing else '',
+            self.alias,
+            r' \*' if self.type == UpdateType.newpackage else '')
+        return command
 
     def update_test_gating_status(self):
         """Query Greenwave about this update and set the test_gating_status as appropriate."""

--- a/bodhi/server/schemas.py
+++ b/bodhi/server/schemas.py
@@ -24,6 +24,7 @@ from bodhi.server import util
 from bodhi.server.config import config
 from bodhi.server.models import (
     ContentType,
+    PackageManager,
     ReleaseState,
     UpdateRequest,
     UpdateSeverity,
@@ -399,6 +400,15 @@ class SaveReleaseSchema(CSRFProtectedSchema, colander.MappingSchema):
     create_automatic_updates = colander.SchemaNode(
         colander.Boolean(true_choices=('true', '1')),
         missing=False,
+    )
+    package_manager = colander.SchemaNode(
+        colander.String(),
+        validator=colander.OneOf(list(PackageManager.values())),
+        missing="unspecified",
+    )
+    testing_repository = colander.SchemaNode(
+        colander.String(),
+        missing=None,
     )
 
 

--- a/bodhi/server/templates/update.html
+++ b/bodhi/server/templates/update.html
@@ -680,10 +680,10 @@ $(document).ready(function(){
           % endif
 
           % if update.content_type:
-          % if update.content_type.value == 'rpm' and ('testing' in update.status or 'stable' in update.status):
+          % if update.status in [models.UpdateStatus.testing, models.UpdateStatus.stable] and not (update.release.package_manager == models.PackageManager.unspecified or update.release.testing_repository is None):
           <div class="p-t-1">
           <h4>How to install</h4>
-            <pre style="position: relative;"><span class="label label-default" id="copybutton" style="position: absolute; top: 0px; right: 0px; cursor: pointer;" title="Copy to clipboard"><i class="fa fa-copy"></i></span><code id="commandtext">${self.util.update_install_command(update)}</code></pre>
+            <pre style="position: relative;"><span class="label label-default" id="copybutton" style="position: absolute; top: 0px; right: 0px; cursor: pointer;" title="Copy to clipboard"><i class="fa fa-copy"></i></span><code id="commandtext">${update.install_command}</code></pre>
           </div>
           % endif
           % endif

--- a/bodhi/server/util.py
+++ b/bodhi/server/util.py
@@ -1487,30 +1487,3 @@ def get_absolute_path(location):
     module, final = location.split(':')
     base = os.path.dirname(__import__(module).__file__)
     return base + "/" + final
-
-
-def update_install_command(context, update):
-    """
-    Return the dnf command for installing the Update.
-
-    Args:
-        context (mako.runtime.Context): Unused.
-        update (bodhi.server.models.Update): The Update you want to install.
-    Returns:
-        basestring: The dnf command to install the Update.
-    Raises:
-        ValueError: When provided update is not in stable or testing state.
-    """
-    status = str(update.status)
-    alias = update.alias
-    update_type = str(update.type)
-
-    if status != 'stable' and status != 'testing':
-        raise ValueError('Only updates in stable or testing can be installed!')
-
-    command = 'sudo dnf {}{} --advisory={}{}'.format(
-        'install' if update_type == 'newpackage' else 'upgrade',
-        ' --enablerepo=updates-testing' if status == 'testing' else '',
-        alias,
-        r' \*' if update_type == 'newpackage' else '')
-    return command

--- a/bodhi/server/validators.py
+++ b/bodhi/server/validators.py
@@ -36,6 +36,7 @@ from .models import (
     ContentType,
     Group,
     Package,
+    PackageManager,
     Release,
     RpmBuild,
     ReleaseState,
@@ -552,7 +553,8 @@ def validate_enums(request, **kwargs):
                         ("suggest", UpdateSuggestion),
                         ("type", UpdateType),
                         ("content_type", ContentType),
-                        ("state", ReleaseState)):
+                        ("state", ReleaseState),
+                        ("package_manager", PackageManager)):
         value = request.validated.get(param)
         if value is None:
             continue

--- a/bodhi/tests/client/__init__.py
+++ b/bodhi/tests/client/__init__.py
@@ -56,7 +56,8 @@ EXAMPLE_COMMENT_MUNCH = Munch({
                 'state': 'current', 'version': '25', 'override_tag': 'f25-override',
                 'branch': 'f25', 'id_prefix': 'FEDORA',
                 'pending_testing_tag': 'f25-updates-testing-pending',
-                'stable_tag': 'f25-updates', 'candidate_tag': 'f25-updates-candidate'})}),
+                'stable_tag': 'f25-updates', 'candidate_tag': 'f25-updates-candidate',
+                'package_manager': 'unspecified', 'testing_repository': None})}),
         'update_id': 79733, 'karma': 0, 'text': 'i found $10000',
         'update_title': 'nodejs-grunt-wrap-0.3.0-2.fc25', 'id': 562626,
         'user': Munch({
@@ -102,7 +103,8 @@ EXAMPLE_COMPOSE_MUNCH = Munch({
             'state': 'current', 'version': '7', 'override_tag': 'epel7-override',
             'branch': 'epel7', 'id_prefix': 'FEDORA-EPEL',
             'pending_testing_tag': 'epel7-testing-pending', 'stable_tag': 'epel7',
-            'candidate_tag': 'epel7-testing-candidate'}),
+            'candidate_tag': 'epel7-testing-candidate',
+            'package_manager': 'unspecified', 'testing_repository': None}),
         'date_created': '2018-03-15 17:25:22', 'security': True})})
 
 
@@ -122,7 +124,8 @@ EXAMPLE_COMPOSES_MUNCH = Munch({
                 'state': 'current', 'version': '7', 'override_tag': 'epel7-override',
                 'branch': 'epel7', 'id_prefix': 'FEDORA-EPEL',
                 'pending_testing_tag': 'epel7-testing-pending', 'stable_tag': 'epel7',
-                'candidate_tag': 'epel7-testing-candidate'}),
+                'candidate_tag': 'epel7-testing-candidate',
+                'package_manager': 'unspecified', 'testing_repository': None}),
             'date_created': '2018-03-15 17:25:22', 'security': True}),
         Munch({
             'release_id': 8, 'content_type': 'rpm',
@@ -138,7 +141,8 @@ EXAMPLE_COMPOSES_MUNCH = Munch({
                 'state': 'current', 'version': '7', 'override_tag': 'epel7-override',
                 'branch': 'epel7', 'id_prefix': 'FEDORA-EPEL',
                 'pending_testing_tag': 'epel7-testing-pending', 'stable_tag': 'epel7',
-                'candidate_tag': 'epel7-testing-candidate'}),
+                'candidate_tag': 'epel7-testing-candidate',
+                'package_manager': 'unspecified', 'testing_repository': None}),
             'date_created': '2018-03-15 17:25:22', 'security': False})]})
 
 
@@ -268,7 +272,9 @@ EXAMPLE_QUERY_MUNCH = Munch({
                     'stable_tag': 'f25-updates',
                     'state': 'current',
                     'testing_tag': 'f25-updates-testing',
-                    'version': '25'},
+                    'version': '25',
+                    'package_manager': 'unspecified',
+                    'testing_repository': None},
         'request': None,
         'require_bugs': False,
         'require_testcases': False,
@@ -371,7 +377,9 @@ EXAMPLE_QUERY_MUNCH_MULTI = Munch({
                     'stable_tag': 'f25-updates',
                     'state': 'current',
                     'testing_tag': 'f25-updates-testing',
-                    'version': '25'},
+                    'version': '25',
+                    'package_manager': 'unspecified',
+                    'testing_repository': None},
         'request': None,
         'require_bugs': False,
         'require_testcases': False,
@@ -436,7 +444,9 @@ EXAMPLE_QUERY_MUNCH_MULTI = Munch({
                     'stable_tag': 'f25-updates',
                     'state': 'current',
                     'testing_tag': 'f25-updates-testing',
-                    'version': '25'},
+                    'version': '25',
+                    'package_manager': 'unspecified',
+                    'testing_repository': None},
         'request': None,
         'require_bugs': False,
         'require_testcases': False,
@@ -744,7 +754,8 @@ EXAMPLE_UPDATE_MUNCH = Munch({
         'long_name': 'Fedora EPEL 7', 'state': 'current', 'version': '7',
         'override_tag': 'epel7-override', 'branch': 'epel7', 'id_prefix': 'FEDORA-EPEL',
         'pending_testing_tag': 'epel7-testing-pending', 'stable_tag': 'epel7',
-        'candidate_tag': 'epel7-testing-candidate'}), 'date_stable': '2016-10-21 13:23:01',
+        'candidate_tag': 'epel7-testing-candidate', 'package_manager': 'unspecified',
+        'testing_repository': None}), 'date_stable': '2016-10-21 13:23:01',
     'content_type': 'rpm'})
 
 SINGLE_UPDATE_MUNCH = Munch({
@@ -801,7 +812,8 @@ SINGLE_UPDATE_MUNCH = Munch({
             'long_name': 'Fedora EPEL 7', 'state': 'current', 'version': '7',
             'override_tag': 'epel7-override', 'branch': 'epel7', 'id_prefix': 'FEDORA-EPEL',
             'pending_testing_tag': 'epel7-testing-pending', 'stable_tag': 'epel7',
-            'candidate_tag': 'epel7-testing-candidate'}), 'date_stable': '2016-10-21 13:23:01',
+            'candidate_tag': 'epel7-testing-candidate', 'package_manager': 'unspecified',
+            'testing_repository': None}), 'date_stable': '2016-10-21 13:23:01',
         'content_type': 'rpm'})})
 
 
@@ -814,7 +826,8 @@ EXAMPLE_GET_RELEASE_15 = Munch(
                 'state': 'current', 'version': '25', 'override_tag': 'f25-override',
                 'branch': 'f25', 'id_prefix': 'FEDORA',
                 'pending_testing_tag': 'f25-updates-testing-pending',
-                'stable_tag': 'f25-updates', 'candidate_tag': 'f25-updates-candidate'})],
+                'stable_tag': 'f25-updates', 'candidate_tag': 'f25-updates-candidate',
+                'package_manager': 'unspecified', 'testing_repository': None})],
      'page': 1})
 
 
@@ -879,7 +892,8 @@ EXAMPLE_RELEASE_MUNCH = Munch({
     'override_tag': 'f27-override', 'id_prefix': 'FEDORA', 'composed_by_bodhi': True,
     'pending_testing_tag': 'f27-updates-testing-pending', 'stable_tag': 'f27-updates',
     'candidate_tag': 'f27-updates-candidate', 'mail_template': 'fedora_errata_template',
-    'create_automatic_updates': False})
+    'create_automatic_updates': False, 'package_manager': 'unspecified',
+    'testing_repository': None})
 
 
 EXPECTED_RELEASE_OUTPUT = """Saved release:
@@ -900,6 +914,8 @@ EXPECTED_RELEASE_OUTPUT = """Saved release:
   Email Template:           fedora_errata_template
   Composed by Bodhi:        True
   Create Automatic Updates: False
+  Package Manager:          unspecified
+  Testing Repository:       None
 """
 
 EXAMPLE_ARCHIVED_RELEASE_MUNCH = Munch({
@@ -910,7 +926,8 @@ EXAMPLE_ARCHIVED_RELEASE_MUNCH = Munch({
     'pending_signing_tag': 'f26-signing-pending',
     'pending_testing_tag': 'f26-updates-testing-pending',
     'candidate_tag': 'f26-updates-candidate', 'stable_tag': 'f26-updates',
-    'override_tag': 'f26-override', 'composed_by_bodhi': True
+    'override_tag': 'f26-override', 'composed_by_bodhi': True,
+    'package_manager': 'unspecified', 'testing_repository': None
 })
 
 EXAMPLE_CURRENT_RELEASE_MUNCH = Munch({
@@ -921,7 +938,8 @@ EXAMPLE_CURRENT_RELEASE_MUNCH = Munch({
     'pending_signing_tag': 'f28-signing-pending',
     'pending_testing_tag': 'f28-updates-testing-pending',
     'candidate_tag': 'f28-updates-candidate', 'stable_tag': 'f28-updates',
-    'override_tag': 'f28-override', 'composed_by_bodhi': True
+    'override_tag': 'f28-override', 'composed_by_bodhi': True,
+    'package_manager': 'unspecified', 'testing_repository': None
 })
 
 EXAMPLE_PENDING_RELEASE_MUNCH = Munch({
@@ -932,7 +950,8 @@ EXAMPLE_PENDING_RELEASE_MUNCH = Munch({
     'pending_signing_tag': 'f29-signing-pending',
     'pending_testing_tag': 'f29-updates-testing-pending',
     'candidate_tag': 'f29-updates-candidate', 'stable_tag': 'f29-updates',
-    'override_tag': 'f29-override', 'composed_by_bodhi': True
+    'override_tag': 'f29-override', 'composed_by_bodhi': True,
+    'package_manager': 'unspecified', 'testing_repository': None
 })
 
 EXAMPLE_RELEASE_MUNCH_NO_ARCHIVED = Munch({

--- a/bodhi/tests/client/test___init__.py
+++ b/bodhi/tests/client/test___init__.py
@@ -1967,7 +1967,8 @@ class TestCreate(unittest.TestCase):
                   'version': None, 'override_tag': None, 'branch': None, 'id_prefix': None,
                   'pending_testing_tag': None, 'pending_signing_tag': None, 'stable_tag': None,
                   'candidate_tag': None, 'mail_template': None, 'composed_by_bodhi': True,
-                  'create_automatic_updates': False})
+                  'create_automatic_updates': False, 'package_manager': None,
+                  'testing_repository': None})
         self.assertEqual(bindings_client.base_url, 'http://localhost:6543/')
 
     @mock.patch('bodhi.client.bindings.BodhiClient.csrf',
@@ -2028,7 +2029,8 @@ class TestEditRelease(unittest.TestCase):
                       'id_prefix': 'FEDORA', 'pending_testing_tag': 'f27-updates-testing-pending',
                       'stable_tag': 'f27-updates', 'candidate_tag': 'f27-updates-candidate',
                       'mail_template': 'fedora_errata_template', 'composed_by_bodhi': True,
-                      'create_automatic_updates': False}))
+                      'create_automatic_updates': False, 'package_manager': 'unspecified',
+                      'testing_repository': None}))
         self.assertEqual(bindings_client.base_url, 'http://localhost:6543/')
 
     @mock.patch('bodhi.client.bindings.BodhiClient.csrf',
@@ -2065,7 +2067,8 @@ class TestEditRelease(unittest.TestCase):
                       'id_prefix': 'FEDORA', 'pending_testing_tag': 'f27-updates-testing-pending',
                       'stable_tag': 'f27-updates', 'candidate_tag': 'f27-updates-candidate',
                       'mail_template': 'fedora_errata_template', 'composed_by_bodhi': True,
-                      'create_automatic_updates': False}))
+                      'create_automatic_updates': False, 'package_manager': 'unspecified',
+                      'testing_repository': None}))
 
     @mock.patch('bodhi.client.bindings.BodhiClient.csrf',
                 mock.MagicMock(return_value='a_csrf_token'))
@@ -2136,7 +2139,8 @@ class TestEditRelease(unittest.TestCase):
                       'id_prefix': 'FEDORA', 'pending_testing_tag': 'f27-updates-testing-pending',
                       'stable_tag': 'f27-updates', 'candidate_tag': 'f27-updates-candidate',
                       'mail_template': 'edited_fedora_errata_template', 'composed_by_bodhi': True,
-                      'create_automatic_updates': False}))
+                      'create_automatic_updates': False, 'package_manager': 'unspecified',
+                      'testing_repository': None}))
 
     @mock.patch('bodhi.client.bindings.BodhiClient.csrf',
                 mock.MagicMock(return_value='a_csrf_token'))
@@ -2171,7 +2175,8 @@ class TestEditRelease(unittest.TestCase):
                       'id_prefix': 'FEDORA', 'pending_testing_tag': 'f27-updates-testing-pending',
                       'stable_tag': 'f27-updates', 'candidate_tag': 'f27-updates-candidate',
                       'mail_template': 'fedora_errata_template',
-                      'composed_by_bodhi': False, 'create_automatic_updates': False}))
+                      'composed_by_bodhi': False, 'package_manager': 'unspecified',
+                      'testing_repository': None, 'create_automatic_updates': False}))
 
     @mock.patch('bodhi.client.bindings.BodhiClient.csrf',
                 mock.MagicMock(return_value='a_csrf_token'))
@@ -2206,7 +2211,8 @@ class TestEditRelease(unittest.TestCase):
                       'id_prefix': 'FEDORA', 'pending_testing_tag': 'f27-updates-testing-pending',
                       'stable_tag': 'f27-updates', 'candidate_tag': 'f27-updates-candidate',
                       'mail_template': 'fedora_errata_template',
-                      'composed_by_bodhi': True, 'create_automatic_updates': True}))
+                      'composed_by_bodhi': True, 'create_automatic_updates': True,
+                      'package_manager': 'unspecified', 'testing_repository': None}))
 
 
 class TestInfo(unittest.TestCase):

--- a/bodhi/tests/server/__init__.py
+++ b/bodhi/tests/server/__init__.py
@@ -24,7 +24,7 @@ import sqlalchemy
 
 from bodhi.server.models import (
     Bug, BuildrootOverride, Comment, Group, RpmPackage, Release, ReleaseState, RpmBuild,
-    Update, UpdateRequest, UpdateSeverity, UpdateType, User, TestCase)
+    Update, UpdateRequest, UpdateSeverity, UpdateType, User, TestCase, PackageManager)
 
 
 def create_update(session, build_nvrs, release_name='F17'):
@@ -107,7 +107,7 @@ def populate(db):
         override_tag='f17-override',
         branch='f17', state=ReleaseState.current,
         create_automatic_updates=True,
-    )
+        package_manager=PackageManager.unspecified, testing_repository=None)
     db.add(release)
     db.flush()
     # This mock will help us generate a consistent update alias.

--- a/bodhi/tests/server/base.py
+++ b/bodhi/tests/server/base.py
@@ -280,7 +280,8 @@ class BaseTestCaseMixin:
             override_tag='f{}-override'.format(version),
             branch='f{}'.format(version), state=models.ReleaseState.current,
             create_automatic_updates=create_automatic_updates,
-        )
+            package_manager=models.PackageManager.unspecified,
+            testing_repository=None)
         self.db.add(release)
         models.Release._all_releases = None
         models.Release._tag_cache = None

--- a/bodhi/tests/server/consumers/test_composer.py
+++ b/bodhi/tests/server/consumers/test_composer.py
@@ -48,7 +48,7 @@ from bodhi.server.exceptions import LockedUpdateException
 from bodhi.server.models import (
     Build, BuildrootOverride, Compose, ComposeState, ContainerBuild, FlatpakBuild,
     Release, ReleaseState, RpmBuild, TestGatingStatus, Update, UpdateRequest, UpdateStatus,
-    UpdateType, User, ModuleBuild, ContentType, Package)
+    UpdateType, User, ModuleBuild, ContentType, Package, PackageManager)
 from bodhi.tests.server import base
 
 
@@ -879,7 +879,9 @@ That was the actual one'''
                 pending_stable_tag='f18-updates-pending',
                 override_tag='f18-override',
                 state=ReleaseState.current,
-                branch='f18')
+                branch='f18',
+                package_manager=PackageManager.unspecified,
+                testing_repository=None)
             db.add(release)
             build = RpmBuild(nvr='bodhi-2.0-1.fc18', release=release, package=up.builds[0].package,
                              signed=True)
@@ -956,7 +958,9 @@ That was the actual one'''
                 pending_stable_tag='f18-updates-pending',
                 override_tag='f18-override',
                 state=ReleaseState.current,
-                branch='f18')
+                branch='f18',
+                package_manager=PackageManager.unspecified,
+                testing_repository=None)
             db.add(release)
             build = RpmBuild(nvr='bodhi-2.0-1.fc18', release=release, package=up.builds[0].package,
                              signed=True)
@@ -1024,7 +1028,9 @@ That was the actual one'''
                 pending_stable_tag='f18-updates-pending',
                 override_tag='f18-override',
                 state=ReleaseState.current,
-                branch='f18')
+                branch='f18',
+                package_manager=PackageManager.unspecified,
+                testing_repository=None)
             db.add(release)
             build = RpmBuild(nvr='bodhi-2.0-1.fc18', release=release, package=up.builds[0].package,
                              signed=True)

--- a/bodhi/tests/server/services/test_overrides.py
+++ b/bodhi/tests/server/services/test_overrides.py
@@ -26,6 +26,7 @@ import webtest
 from bodhi.messages.schemas import buildroot_override as override_schemas
 from bodhi.server.models import (
     BuildrootOverride,
+    PackageManager,
     RpmBuild,
     RpmPackage,
     Release,
@@ -167,7 +168,9 @@ class TestOverridesService(base.BaseTestCase):
                             pending_testing_tag='f42-updates-testing-pending',
                             pending_stable_tag='f42-updates-pending',
                             override_tag='f42-override',
-                            branch='f42'))
+                            branch='f42',
+                            package_manager=PackageManager.dnf,
+                            testing_repository='updates-testing'))
         self.db.flush()
 
         res = self.app.get('/overrides/', {'releases': 'F42'})

--- a/bodhi/tests/server/services/test_updates.py
+++ b/bodhi/tests/server/services/test_updates.py
@@ -35,7 +35,7 @@ from bodhi.server.config import config
 from bodhi.server.models import (
     Build, BuildrootOverride, Compose, Group, RpmPackage, ModulePackage, Release,
     ReleaseState, RpmBuild, Update, UpdateRequest, UpdateStatus, UpdateType,
-    UpdateSeverity, UpdateSuggestion, User, TestGatingStatus)
+    UpdateSeverity, UpdateSuggestion, User, TestGatingStatus, PackageManager)
 from bodhi.server.util import call_api
 from bodhi.tests.server.base import BaseTestCase
 from bodhi.server.exceptions import BodhiException, LockedUpdateException
@@ -2852,7 +2852,9 @@ class TestUpdatesService(BaseTestCase):
             pending_testing_tag='f18-updates-testing-pending',
             pending_stable_tag='f18-updates-pending',
             override_tag='f18-override',
-            branch='f18')
+            branch='f18',
+            package_manager=PackageManager.unspecified,
+            testing_repository=None)
         self.db.add(release)
         pkg = RpmPackage(name='nethack')
         self.db.add(pkg)
@@ -3781,7 +3783,9 @@ class TestUpdatesService(BaseTestCase):
             pending_testing_tag='f18-updates-testing-pending',
             pending_stable_tag='f18-updates-pending',
             override_tag='f18-override',
-            branch='f18')
+            branch='f18',
+            package_manager=PackageManager.unspecified,
+            testing_repository=None)
         self.db.add(release)
         pkg = RpmPackage(name='nethack')
         self.db.add(pkg)

--- a/bodhi/tests/server/test_models.py
+++ b/bodhi/tests/server/test_models.py
@@ -37,7 +37,7 @@ from bodhi.server.config import config
 from bodhi.server.exceptions import BodhiException, LockedUpdateException
 from bodhi.server.models import (
     BugKarma, ReleaseState, UpdateRequest, UpdateSeverity, UpdateStatus,
-    UpdateSuggestion, UpdateType, TestGatingStatus)
+    UpdateSuggestion, UpdateType, TestGatingStatus, PackageManager)
 from bodhi.tests.server.base import BaseTestCase, DummyUser
 
 
@@ -692,7 +692,9 @@ class TestRelease(ModelTest):
         pending_stable_tag="dist-f11-updates-pending",
         override_tag="dist-f11-override",
         state=model.ReleaseState.current,
-        composed_by_bodhi=True)
+        composed_by_bodhi=True,
+        package_manager=PackageManager.yum,
+        testing_repository='updates-testing')
 
     def test_collection_name(self):
         """Test the collection_name property of the Release."""
@@ -738,7 +740,9 @@ class TestReleaseModular(ModelTest):
         pending_stable_tag="dist-f11-updates-pending",
         override_tag="dist-f11-override",
         state=model.ReleaseState.current,
-        composed_by_bodhi=True)
+        composed_by_bodhi=True,
+        package_manager=PackageManager.dnf,
+        testing_repository='updates-testing')
 
     def test_version_int(self):
         self.assertEqual(self.obj.version_int, 11)
@@ -770,7 +774,9 @@ class TestReleaseContainer(ModelTest):
         pending_stable_tag="dist-f11-updates-pending",
         override_tag="dist-f11-override",
         state=model.ReleaseState.current,
-        composed_by_bodhi=True)
+        composed_by_bodhi=True,
+        package_manager=PackageManager.unspecified,
+        testing_repository=None)
 
     def test_version_int(self):
         self.assertEqual(self.obj.version_int, 11)
@@ -802,7 +808,9 @@ class TestReleaseFlatpak(ModelTest):
         pending_stable_tag="f29-flatpak-updates-pending",
         override_tag="f29-flatpak-override",
         state=model.ReleaseState.current,
-        composed_by_bodhi=True)
+        composed_by_bodhi=True,
+        package_manager=PackageManager.unspecified,
+        testing_repository=None)
 
     def test_version_int(self):
         self.assertEqual(self.obj.version_int, 29)
@@ -1638,6 +1646,96 @@ class TestUpdateGetBugKarma(BaseTestCase):
 
         self.assertEqual(bad, 0)
         self.assertEqual(good, 0)
+
+
+class TestUpdateInstallCommand(BaseTestCase):
+    """Test the update_install_command() function."""
+
+    def test_upgrade_in_testing(self):
+        """Update is an enhancement, a security or a bugfix and is in testing."""
+        update = model.Update.query.first()
+        update.status = UpdateStatus.testing
+        update.type = UpdateType.bugfix
+        update.release.package_manager = PackageManager.dnf
+        update.release.testing_repository = 'updates-testing'
+
+        command = update.install_command()
+
+        self.assertEqual(
+            command,
+            'sudo dnf upgrade --enablerepo=updates-testing --advisory={}'.format(update.alias))
+
+    def test_upgrade_in_stable(self):
+        """Update is an enhancement, a security or a bugfix and is in stable."""
+        update = model.Update.query.first()
+        update.status = UpdateStatus.stable
+        update.type = UpdateType.bugfix
+        update.release.package_manager = PackageManager.dnf
+        update.release.testing_repository = 'updates-testing'
+
+        command = update.install_command()
+
+        self.assertEqual(
+            command,
+            'sudo dnf upgrade --advisory={}'.format(update.alias))
+
+    def test_newpackage_in_testing(self):
+        """Update is a newpackage and is in testing."""
+        update = model.Update.query.first()
+        update.status = UpdateStatus.testing
+        update.type = UpdateType.newpackage
+        update.release.package_manager = PackageManager.dnf
+        update.release.testing_repository = 'updates-testing'
+
+        command = update.install_command()
+
+        self.assertEqual(
+            command,
+            r'sudo dnf install --enablerepo=updates-testing --advisory={} \*'.format(update.alias))
+
+    def test_newpackage_in_stable(self):
+        """Update is a newpackage and is in stable."""
+        update = model.Update.query.first()
+        update.status = UpdateStatus.stable
+        update.type = UpdateType.newpackage
+        update.release.package_manager = PackageManager.dnf
+        update.release.testing_repository = 'updates-testing'
+
+        command = update.install_command()
+
+        self.assertEqual(
+            command,
+            r'sudo dnf install --advisory={} \*'.format(update.alias))
+
+    def test_cannot_install(self):
+        """Update is out of stable or testing repositories."""
+        update = model.Update.query.first()
+        update.status = UpdateStatus.obsolete
+
+        with self.assertRaises(ValueError):
+            update.install_command()
+
+    def test_update_command_not_possible_missing_packagemanager(self):
+        """The Release of the Update misses the package manager definition."""
+        update = model.Update.query.first()
+        update.status = UpdateStatus.stable
+        update.type = UpdateType.newpackage
+        update.release.package_manager = PackageManager.unspecified
+        update.release.testing_repository = 'updates-testing'
+
+        with self.assertRaises(ValueError):
+            update.install_command()
+
+    def test_update_command_not_possible_missing_repo(self):
+        """The Release of the Update misses the testing repository definition."""
+        update = model.Update.query.first()
+        update.status = UpdateStatus.stable
+        update.type = UpdateType.newpackage
+        update.release.package_manager = PackageManager.dnf
+        update.release.testing_repository = None
+
+        with self.assertRaises(ValueError):
+            update.install_command()
 
 
 class TestUpdateGetTestcaseKarma(BaseTestCase):

--- a/devel/ci/integration/tests/test_bodhi_cli.py
+++ b/devel/ci/integration/tests/test_bodhi_cli.py
@@ -231,6 +231,8 @@ def test_releases_info(bodhi_container, db_container):
   Email Template:           {mail_template}
   Composed by Bodhi:        {composed_by_bodhi}
   Create Automatic Updates: {create_automatic_updates}
+  Package Manager:          {package_manager}
+  Testing Repository:       {testing_repository}
 """.format(**release)
         assert result.output == expected
 

--- a/docs/user/man_pages/bodhi.rst
+++ b/docs/user/man_pages/bodhi.rst
@@ -506,6 +506,10 @@ The ``releases`` command allows users to manage update releases.
 
         The Koji tag to use for buildroot overrides (e.g., f29-override).
 
+    ``--package-manager [unspecified|dnf|yum]``
+
+        The package manager used by this release. If not specified it defaults to 'unspecified'.
+
     ``--password TEXT``
 
         The password to use when authenticating to Bodhi.
@@ -525,6 +529,10 @@ The ``releases`` command allows users to manage update releases.
     ``--state [disabled|pending|current|archived]``
 
         The state of the release.
+
+    ``--testing-repository TEXT``
+
+        The name of the testing repository used to test updates. Not required.
 
     ``--testing-tag TEXT``
 


### PR DESCRIPTION
Fixes #3017 

This will correct the command outputted for installing EPEL updates.
However, this fixes only actual cases (EPEL = yum; FEDORA < 22 = yum; FEDORA >= 22 = dnf).
A better and less Fedora-centric solution could be to modify the Release model adding a `pkg_manager` string property and a `testing_repo` string property, so that for every release it can be specified what package manager is in use and what name has the testing repository.
After that, in `update_install_command()` we can build command for the different package managers we want to support.
What do you think?

Signed-off-by: Mattia Verga <mattia.verga@tiscali.it>