### PR TITLE
Reshuffle the greenwave_failed migration.

### DIFF
--- a/bodhi/server/migrations/versions/8c4d6aad9b78_add_the_greenwave_failed_enum_to_.py
+++ b/bodhi/server/migrations/versions/8c4d6aad9b78_add_the_greenwave_failed_enum_to_.py
@@ -19,7 +19,7 @@
 Add the greenwave_failed enum to TestGatingStatus.
 
 Revision ID: 8c4d6aad9b78
-Revises: aae0d29d49b7
+Revises: 9991cf10ec50
 Create Date: 2019-02-26 22:38:15.420477
 """
 from alembic import op
@@ -28,7 +28,7 @@ from sqlalchemy import exc
 
 # revision identifiers, used by Alembic.
 revision = '8c4d6aad9b78'
-down_revision = 'aae0d29d49b7'
+down_revision = '9991cf10ec50'
 
 
 def upgrade():

--- a/bodhi/server/migrations/versions/8e9dc57e082d_obsolete_updates_for_archived_release.py
+++ b/bodhi/server/migrations/versions/8e9dc57e082d_obsolete_updates_for_archived_release.py
@@ -20,7 +20,7 @@
 Obsolete updates for archived release.
 
 Revision ID: 8e9dc57e082d
-Revises: 9991cf10ec50
+Revises: 8c4d6aad9b78
 Create Date: 2019-01-06 13:04:35.158562
 """
 from alembic import op
@@ -28,7 +28,7 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = '8e9dc57e082d'
-down_revision = '9991cf10ec50'
+down_revision = '8c4d6aad9b78'
 
 
 def upgrade():


### PR DESCRIPTION
I accidentally put the migration that adds the greenwave_failed
value to the TestGatingStatus enum at the end of the list of
migrations on the develop branch. This was problematic when I
tried to backport the patch to the 3.13 branch, which does not
have the referenced down_revision, which is a migration that will
be part of the upcoming 4.0 release.

This commit reshuffles the order of migrations so that the new
migrations is inserted at the end of the 3.13 branch head, and
just before the new migrations in 4.0.

Signed-off-by: Randy Barlow <randy@electronsweatshop.com>