### PR TITLE
Make the pagure namespace for 'flatpaks' configurable

### DIFF
--- a/bodhi/server/config.py
+++ b/bodhi/server/config.py
@@ -531,6 +531,9 @@ class BodhiConfig(dict):
         'openid_template': {
             'value': '{username}.id.fedoraproject.org',
             'validator': str},
+        'pagure_flatpak_namespace': {
+            'value': 'modules',
+            'validator': str},
         'pagure_url': {
             'value': 'https://src.fedoraproject.org/pagure/',
             'validator': _validate_tls_url},

--- a/bodhi/server/models.py
+++ b/bodhi/server/models.py
@@ -997,9 +997,12 @@ class Package(Base):
         """
         pagure_url = config.get('pagure_url')
         # Pagure uses plural names for its namespaces such as "rpms" except for
-        # container. Flatpaks build directly from the 'modules' namespace
+        # container. Flatpaks were moved from 'modules' to 'flatpaks' - hence
+        # a config setting.
         if self.type.name == 'container':
             namespace = self.type.name
+        elif self.type.name == 'flatpak':
+            namespace = config.get('pagure_flatpak_namespace')
         else:
             namespace = self.type.name + 's'
         package_pagure_url = '{0}/api/0/{1}/{2}?expand_group=1'.format(

--- a/production.ini
+++ b/production.ini
@@ -367,6 +367,10 @@ use = egg:bodhi-server
 ##
 # pagure_url = https://src.fedoraproject.org/pagure/
 
+# This is the namespace where we expect to find the git sources for a Flatpak.
+# The default - 'modules' instead of 'flatpaks' - is for backward compatibility
+# pagure_flatpak_namespace = modules
+
 ##
 ## Product Definition Center (PDC)
 ##


### PR DESCRIPTION
The previous change to look up Flatpaks under 'flatpaks/' rather than
'modules/' was backwards incompatible - to restore compatibility, make
this a new config setting: pagure_flatpak_namespace.

Signed-off-by: Owen W. Taylor <otaylor@fishsoup.net>