### PR TITLE
Add Fedora 30 to the CI Greenwave policy.

### DIFF
--- a/devel/ci/integration/greenwave/policy.yaml
+++ b/devel/ci/integration/greenwave/policy.yaml
@@ -59,6 +59,7 @@ rules:
 --- !Policy
 id: "taskotron_release_critical_tasks_for_testing"
 product_versions:
+  - fedora-30
   - fedora-29
   - fedora-28
   - fedora-27
@@ -73,6 +74,7 @@ rules:
 --- !Policy
 id: "taskotron_release_critical_tasks_for_stable"
 product_versions:
+  - fedora-30
   - fedora-29
   - fedora-28
   - fedora-27
@@ -87,6 +89,8 @@ rules:
 --- !Policy
 id: "no_requirements_testing"
 product_versions:
+  - fedora-30-modular
+  - fedora-30-containers
   - fedora-29-modular
   - fedora-29-containers
   - fedora-28-modular
@@ -101,6 +105,8 @@ rules: []
 --- !Policy
 id: "no_requirements_for_stable"
 product_versions:
+  - fedora-30-modular
+  - fedora-30-containers
   - fedora-29-modular
   - fedora-29-containers
   - fedora-28-modular


### PR DESCRIPTION
The tests started to fail due to not having Fedora 30 in the
policy.

Signed-off-by: Randy Barlow <randy@electronsweatshop.com>