### PR TITLE
log why buildroot overrides are expired

### DIFF
--- a/bodhi/server/consumers/composer.py
+++ b/bodhi/server/consumers/composer.py
@@ -608,6 +608,7 @@ class ComposerThread(threading.Thread):
                 for build in update.builds:
                     if build.override:
                         try:
+                            log.debug(f"Expiring BRO for {build.nvr} because it is being pushed.")
                             build.override.expire()
                         except Exception:
                             log.exception('Problem expiring override')

--- a/bodhi/server/models.py
+++ b/bodhi/server/models.py
@@ -2061,6 +2061,7 @@ class Update(Base):
 
                 # Expire any associated buildroot override
                 if b.override:
+                    log.debug(f"Expiring BRO for {b.nvr} because the build is unpushed.")
                     b.override.expire()
                 else:
                     # Only delete the Build entity if it isn't associated with
@@ -4212,6 +4213,7 @@ class BuildrootOverride(Base):
         if old_build is not None and old_build.override is not None:
             # There already is a buildroot override for an older build of this
             # package in this release. Expire it
+            log.debug(f"Expiring BRO for {old_build.nvr} because it's superseded by {build.nvr}.")
             old_build.override.expire()
             db.add(old_build.override)
 
@@ -4256,6 +4258,7 @@ class BuildrootOverride(Base):
             override.enable()
 
         elif data['expired']:
+            log.debug(f"Expiring BRO for {override.build.nvr} because it was edited.")
             override.expire()
 
         db.add(override)

--- a/bodhi/server/scripts/expire_overrides.py
+++ b/bodhi/server/scripts/expire_overrides.py
@@ -75,6 +75,7 @@ def main(argv=sys.argv):
         log.info("Expiring %d buildroot overrides...", count)
 
         for override in overrides:
+            log.debug(f"Expiring BRO for {override.build.nvr} because it's due to expire.")
             override.expire()
             db.add(override)
             log.info("Expired %s" % override.build.nvr)


### PR DESCRIPTION
This lets us debug BROs unexpectedly getting untagged in Koji easier.

Fixes #3060

Signed-off-by: Nils Philippsen <nils@redhat.com>

The relevant unit tests seem to run fine here, but I have some trouble with unrelated tests and the dev Vagrant box, so someone with a working env should double-check this to be on the safe side.