### PR TITLE
Add fedora-messaging consumer to the vagrant environment.

### DIFF
--- a/devel/ansible/roles/bodhi/files/bodhi.toml
+++ b/devel/ansible/roles/bodhi/files/bodhi.toml
@@ -1,0 +1,63 @@
+# A sample configuration for fedora-messaging. This file is in the TOML format.
+# For complete details on all configuration options, see the documentation.
+
+amqp_url = "amqp://"
+
+publish_exchange = "amq.topic"
+
+callback = "bodhi.server.consumers:messaging_callback"
+
+# The topic_prefix configuration value will add a prefix to the topics of every sent message.
+# This is used for migrating from fedmsg, and should not be used afterwards.
+topic_prefix = "org.fedoraproject.dev"
+
+# Note the double brackets below.
+# To add another binding, add another [[bindings]] section.
+[[bindings]]
+queue = "my_queue"
+exchange = "amq.topic"
+routing_keys = [
+    "org.fedoraproject.*.bodhi.composer.start",
+    "org.fedoraproject.*.buildsys.tag",
+    "org.fedoraproject.*.bodhi.update.request.testing",
+    "org.fedoraproject.*.bodhi.update.edit",
+]
+
+[tls]
+ca_cert = "/etc/pki/tls/certs/ca-bundle.crt"
+keyfile = "/my/client/key.pem"
+certfile = "/my/client/cert.pem"
+
+[client_properties]
+app = "Bodhi"
+
+[queues.my_queue]
+durable = true
+auto_delete = false
+exclusive = false
+arguments = {}
+
+[qos]
+prefetch_size = 0
+prefetch_count = 25
+
+[log_config]
+version = 1
+disable_existing_loggers = true
+
+[log_config.formatters.simple]
+format = "[%(name)s %(levelname)s] %(message)s"
+
+[log_config.handlers.console]
+class = "logging.StreamHandler"
+formatter = "simple"
+stream = "ext://sys.stdout"
+
+[log_config.loggers.fedora_messaging]
+level = "INFO"
+propagate = false
+handlers = ["console"]
+
+[log_config.root]
+level = "WARNING"
+handlers = ["console"]

--- a/devel/ansible/roles/bodhi/tasks/main.yml
+++ b/devel/ansible/roles/bodhi/tasks/main.yml
@@ -192,6 +192,14 @@
     dest: /etc/fedmsg.d/bodhi.py
     state: link
 
+- name: Copy the fedora-messaging configuration file bodhi.toml
+  copy:
+      src: bodhi.toml
+      dest: /etc/fedora-messaging/bodhi.toml
+      owner: root
+      group: root
+      mode: 644
+
 - name: Start and enable the bodhi service
   service:
       name: bodhi
@@ -201,6 +209,12 @@
 - name: Start and enable the docker service
   service:
       name: docker
+      state: started
+      enabled: yes
+
+- name: Start and enable the bodhi consumer service
+  service:
+      name: fm-consumer@bodhi
       state: started
       enabled: yes
 


### PR DESCRIPTION
This commit adds a fedora-messaging configuration file example and
start the fedora-messaging service.

Signed-off-by: Clement Verna <cverna@tutanota.com>