### PR TITLE
Ignore update passing CI when retrieving the greenwave status information

### DIFF
--- a/bodhi/server/scripts/check_policies.py
+++ b/bodhi/server/scripts/check_policies.py
@@ -48,6 +48,11 @@ def check():
     ).filter(
         models.Release.state.in_(
             [models.ReleaseState.current, models.ReleaseState.pending])
+    ).filter(
+        models.Update.test_gating_status.notin_(
+            models.TestGatingStatus.passed,
+            models.TestGatingStatus.ignored
+        )
     ).order_by(
         # Check the older updates first so there is more time for the newer to
         # get their test results


### PR DESCRIPTION
Basically, this script, ran as a cron job, was asking greenwave for all
updates pending to be move to testing or to stable, regardless of the
CI status that the update could have been assigned to in a previous run.
This means that during freeze periods when updates pile on pending to go
to stable, the cron job will keep on checking all the updates including
the ones that we know already passed CI.

Signed-off-by: Pierre-Yves Chibon <pingou@pingoured.fr>