### PR TITLE
Drop the dependency on kitchen.

### DIFF
--- a/bodhi/server/bugs.py
+++ b/bodhi/server/bugs.py
@@ -22,7 +22,6 @@ import logging
 import typing
 
 from collections import namedtuple
-from kitchen.text.converters import to_unicode
 import bugzilla
 
 from bodhi.server.config import config
@@ -269,7 +268,7 @@ class Bugzilla(object):
                 return
         if bug.product == 'Security Response':
             bug_entity.parent = True
-        bug_entity.title = to_unicode(bug.short_desc)
+        bug_entity.title = bug.short_desc
         if isinstance(bug.keywords, str):
             keywords = bug.keywords.split()
         else:  # python-bugzilla 0.8.0+

--- a/bodhi/server/mail.py
+++ b/bodhi/server/mail.py
@@ -371,7 +371,7 @@ def _send_mail(from_addr, to_addr, body):
     try:
         log.debug('Connecting to %s', smtp_server)
         smtp = smtplib.SMTP(smtp_server)
-        smtp.sendmail(from_addr, [to_addr], body)
+        smtp.sendmail(from_addr, [to_addr], body.encode('utf-8'))
     except smtplib.SMTPRecipientsRefused as e:
         log.warning('"recipient refused" for %r, %r' % (to_addr, e))
     except Exception:
@@ -388,8 +388,8 @@ def send_mail(from_addr, to_addr, subject, body_text, headers=None):
     Args:
         from_addr (str): The address to use in the From: header.
         to_addr (str): The address to send the e-mail to.
-        subject (basestring): The subject of the e-mail.
-        body_text (basestring): The body of the e-mail to be sent.
+        subject (str): The subject of the e-mail.
+        body_text (str): The body of the e-mail to be sent.
         headers (dict or None): A mapping of header fields to values to be included in the e-mail,
             if not None.
     """
@@ -401,16 +401,13 @@ def send_mail(from_addr, to_addr, subject, body_text, headers=None):
     if to_addr in config.get('exclude_mail'):
         return
 
-    subject = subject.encode('utf-8')
-    body_text = body_text.encode('utf-8')
-
-    msg = [f'From: {from_addr}'.encode('utf-8'), f'To: {to_addr}'.encode('utf-8')]
+    msg = [f'From: {from_addr}', f'To: {to_addr}']
     if headers:
         for key, value in headers.items():
-            msg.append(f'{key}: {value}'.encode('utf-8'))
-    msg.append(f"X-Bodhi: {config.get('default_email_domain')}".encode('utf-8'))
-    msg += [b'Subject: %s' % subject, b'', body_text]
-    body = b'\r\n'.join(msg)
+            msg.append(f'{key}: {value}')
+    msg.append(f"X-Bodhi: {config.get('default_email_domain')}")
+    msg += [f'Subject: {subject}', '', body_text]
+    body = '\r\n'.join(msg)
 
     log.info('Sending mail to %s: %s', to_addr, subject)
     _send_mail(from_addr, to_addr, body)

--- a/bodhi/server/metadata.py
+++ b/bodhi/server/metadata.py
@@ -23,7 +23,6 @@ import shelve
 import shutil
 import tempfile
 
-from kitchen.text.converters import to_bytes
 import createrepo_c as cr
 
 from bodhi.server import util
@@ -206,13 +205,13 @@ class UpdateInfoMetadata(object):
         rec.fromstr = config.get('bodhi_email')
         rec.status = update.status.value
         rec.type = update.type.value
-        rec.id = to_bytes(update.alias)
-        rec.title = to_bytes(update.title)
+        rec.id = update.alias.encode('utf-8')
+        rec.title = update.title.encode('utf-8')
         rec.severity = util.severity_updateinfo_str(update.severity.value)
-        rec.summary = to_bytes('%s %s update' % (update.get_title(),
-                                                 update.type.value))
-        rec.description = to_bytes(update.notes)
-        rec.release = to_bytes(update.release.long_name)
+        rec.summary = ('%s %s update' % (update.get_title(),
+                                         update.type.value)).encode('utf-8')
+        rec.description = update.notes.encode('utf-8')
+        rec.release = update.release.long_name.encode('utf-8')
         rec.rights = config.get('updateinfo_rights')
 
         if update.date_pushed:
@@ -229,8 +228,8 @@ class UpdateInfoMetadata(object):
             rec.updated_date = datetime.utcnow()
 
         col = cr.UpdateCollection()
-        col.name = to_bytes(update.release.long_name)
-        col.shortname = to_bytes(update.release.name)
+        col.name = update.release.long_name.encode('utf-8')
+        col.shortname = update.release.name.encode('utf-8')
 
         koji = get_session()
         for build in update.builds:
@@ -273,9 +272,9 @@ class UpdateInfoMetadata(object):
         for bug in update.bugs:
             ref = cr.UpdateReference()
             ref.type = 'bugzilla'
-            ref.id = to_bytes(bug.bug_id)
-            ref.href = to_bytes(bug.url)
-            ref.title = to_bytes(bug.title)
+            ref.id = str(bug.bug_id).encode('utf-8')
+            ref.href = bug.url.encode('utf-8')
+            ref.title = bug.title.encode('utf-8') if bug.title else ''
             rec.append_reference(ref)
 
         self.uinfo.append(rec)

--- a/bodhi/server/util.py
+++ b/bodhi/server/util.py
@@ -32,7 +32,6 @@ import tempfile
 import time
 import typing
 
-from kitchen.iterutils import iterate
 from pyramid.i18n import TranslationStringFactory
 import arrow
 import bleach
@@ -399,9 +398,11 @@ def splitter(value):
     """
     if value == colander.null:
         return
+    if isinstance(value, str):
+        value = [value]
 
     items = []
-    for v in iterate(value):
+    for v in value:
         if isinstance(v, str):
             for item in v.replace(',', ' ').split():
                 items.append(item)

--- a/bodhi/tests/server/consumers/test_composer.py
+++ b/bodhi/tests/server/consumers/test_composer.py
@@ -559,7 +559,7 @@ References:
                                 mock.ANY)
         self.assertEqual(len(mail.mock_calls), 2)
         body = mail.mock_calls[1][1][2]
-        self.assertTrue(body.decode('utf-8').startswith(
+        self.assertTrue(body.startswith(
             ('From: updates@fedoraproject.org\r\nTo: %s\r\nX-Bodhi: fedoraproject.org\r\nSubject: '
              'Fedora 17 updates-testing report\r\n\r\nThe following builds have been pushed to '
              'Fedora 17 updates-testing\n\n    bodhi-2.0-1.fc17\n\nDetails about builds:\n\n\n====='

--- a/bodhi/tests/server/test_mail.py
+++ b/bodhi/tests/server/test_mail.py
@@ -217,7 +217,7 @@ class TestSend(base.BaseTestCase):
         sendmail = SMTP.return_value.sendmail
         update = models.Update.query.all()[0]
 
-        mail.send('bowlofeggs@example.com', 'new', update, agent='bodhi')
+        mail.send(['bowlofeggs@example.com'], 'new', update, agent='bodhi')
 
         SMTP.assert_called_once_with('smtp.fp.o')
         self.assertEqual(sendmail.call_count, 1)
@@ -236,7 +236,7 @@ class TestSend(base.BaseTestCase):
         """Assert that the sent e-mail has the full NVR in the subject."""
         update = models.Update.query.all()[0]
 
-        mail.send('fake@news.com', 'comment', update, agent='bowlofeggs')
+        mail.send(['fake@news.com'], 'comment', update, agent='bowlofeggs')
 
         SMTP.assert_called_once_with('smtp.example.com')
         sendmail = SMTP.return_value.sendmail
@@ -254,7 +254,7 @@ class TestSend(base.BaseTestCase):
         """Assert that we log an exception if _send_mail catches one"""
         update = models.Update.query.all()[0]
 
-        mail.send('fake@news.com', 'comment', update, agent='bowlofeggs')
+        mail.send(['fake@news.com'], 'comment', update, agent='bowlofeggs')
 
         exception_log.assert_called_once_with('Unable to send mail')
         sendmail = SMTP.return_value.sendmail

--- a/bodhi/tests/server/test_mail.py
+++ b/bodhi/tests/server/test_mail.py
@@ -351,7 +351,7 @@ class Test_SendMail(unittest.TestCase):
         mail._send_mail('archer@spies.com', 'lana@spies.com', 'hi')
 
         SMTP.assert_called_once_with('smtp.fp.o')
-        smtp.sendmail.assert_called_once_with('archer@spies.com', ['lana@spies.com'], 'hi')
+        smtp.sendmail.assert_called_once_with('archer@spies.com', ['lana@spies.com'], b'hi')
         warning.assert_called_once_with(
             '"recipient refused" for \'lana@spies.com\', {}'.format(
                 repr(smtp.sendmail.side_effect)))

--- a/devel/ansible/roles/bodhi/tasks/main.yml
+++ b/devel/ansible/roles/bodhi/tasks/main.yml
@@ -36,7 +36,6 @@
       - python3-fedora
       - python3-flake8
       - python3-ipdb
-      - python3-kitchen
       - python3-koji
       - python3-librepo
       - python3-markdown

--- a/devel/ci/Dockerfile-f28
+++ b/devel/ci/Dockerfile-f28
@@ -29,7 +29,6 @@ RUN dnf install --disablerepo rawhide-modular -y \
     python3-feedgen \
     python3-flake8 \
     python3-jinja2 \
-    python3-kitchen \
     python3-libcomps \
     python3-librepo \
     python3-markdown \

--- a/devel/ci/Dockerfile-f29
+++ b/devel/ci/Dockerfile-f29
@@ -28,7 +28,6 @@ RUN dnf install --disablerepo rawhide-modular -y \
     python3-feedgen \
     python3-flake8 \
     python3-jinja2 \
-    python3-kitchen \
     python3-libcomps \
     python3-librepo \
     python3-markdown \

--- a/devel/ci/Dockerfile-f30
+++ b/devel/ci/Dockerfile-f30
@@ -26,7 +26,6 @@ RUN dnf install --disablerepo rawhide-modular -y \
     python3-flake8 \
     python3-hawkey \
     python3-jinja2 \
-    python3-kitchen \
     python3-koji \
     python3-libcomps \
     python3-librepo \

--- a/devel/ci/Dockerfile-rawhide
+++ b/devel/ci/Dockerfile-rawhide
@@ -26,7 +26,6 @@ RUN dnf install --disablerepo rawhide-modular -y \
     python3-flake8 \
     python3-hawkey \
     python3-jinja2 \
-    python3-kitchen \
     python3-koji \
     python3-libcomps \
     python3-librepo \

--- a/docs/user/release_notes.rst
+++ b/docs/user/release_notes.rst
@@ -75,6 +75,7 @@ Dependency changes
   (:issue:`2700`).
 * pillow is no longer required (:issue:`2700`).
 * six is no longer required for the client or server (:issue:`2759`).
+* kitchen is no longer required.
 
 
 Server upgrade instructions

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,6 @@ pyasn1-modules  # Due to an unfortunate dash in its name, installs break if pyas
 fedora_messaging
 feedgen
 jinja2
-kitchen
 markdown
 psycopg2
 py3dns  # Should be required by pyLibravatar https://bugs.launchpad.net/pylibravatar/+bug/1661218

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,9 +28,6 @@ ignore_missing_imports = True
 [mypy-fedora_messaging.*]
 ignore_missing_imports = True
 
-[mypy-kitchen.*]
-ignore_missing_imports = True
-
 [mypy-koji.*]
 ignore_missing_imports = True
 


### PR DESCRIPTION
Bodhi had been using kitchen to do a few different things, all of
which were either not useful or silly:

0. Encode strs into strs.
1. Encode strs into bytes. This is silly because we can do that
   just as easily and more correctly with the standard library
   (more correctly because kitchen uses the replace method on
   errors - we would be much better off to know about the errors
   so we can fix them).
2. Iterate on iterables, or turn a non-iterable into a single item
   iterable.

Each of these were replaced by using the standard library.

Signed-off-by: Randy Barlow <randy@electronsweatshop.com>