### PR TITLE
Configure Mergify to use WIP instead of no-mergify.

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -5,7 +5,7 @@ pull_request_rules:
       rebase_fallback: null
       strict: true
   conditions:
-  - label!=no-mergify
+  - label!=WIP
   - approved-reviews-by=@fedora-infra/bodhi
   - status-success=DCO
   - status-success=f28-docs
@@ -40,7 +40,7 @@ pull_request_rules:
       rebase_fallback: null
       strict: true
   conditions:
-  - label!=no-mergify
+  - label!=WIP
   - author=@fedora-infra/bodhi
   - "#approved-reviews-by>=1"
   - status-success=DCO
@@ -75,7 +75,7 @@ pull_request_rules:
       branches:
       - '3.12'
   conditions:
-  - label!=no-mergify
+  - label!=WIP
   - label=3.12-backports
   name: backport 3.12
 - actions:
@@ -83,7 +83,7 @@ pull_request_rules:
       branches:
       - '3.13'
   conditions:
-  - label!=no-mergify
+  - label!=WIP
   - label=3.13-backports
   name: backport 3.13
 - actions:
@@ -91,6 +91,6 @@ pull_request_rules:
       branches:
       - '3.14'
   conditions:
-  - label!=no-mergify
+  - label!=WIP
   - label=3.14-backports
   name: backport 3.14


### PR DESCRIPTION
The WIP (Work in Progress) label is more generally useful than
the no-mergify label. no-mergify has historically only been used
to prevent things that are a work in progress from being merged,
so let's make the label name clearer.

Signed-off-by: Randy Barlow <randy@electronsweatshop.com>