### PR TITLE
Configure Vagrant to use unsafe IO.

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -67,13 +67,12 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
         domain.memory = 4096
         domain.video_type = "qxl"
 
-        # Uncomment the following line if you would like to enable libvirt's unsafe cache
+        # Enable libvirt's unsafe cache
         # mode. It is called unsafe for a reason, as it causes the virtual host to ignore all
         # fsync() calls from the guest. Only do this if you are comfortable with the possibility of
         # your development guest becoming corrupted (in which case you should only need to do a
         # vagrant destroy and vagrant up to get a new one).
-        #
-        # domain.volume_cache = "unsafe"
+        domain.volume_cache = "unsafe"
     end
  end
 end


### PR DESCRIPTION
Since we use Vagrant for development only, and since we don't
store any of our work in Vagrant (the work is stored on the host
and is shared into the guest via sshfs), it is sensible to
configure the guest's IO mode to use unsafe synchronization. This
will give us a significant performance boost, since calls to
fsync() will be ignored by the host.

Signed-off-by: Randy Barlow <randy@electronsweatshop.com>