### PR TITLE
Drop remaining source code encoding declarations.

### DIFF
--- a/bodhi/__init__.py
+++ b/bodhi/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright © 2018 Red Hat, Inc.
 #
 # This file is part of Bodhi.

--- a/bodhi/client/__init__.py
+++ b/bodhi/client/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright © 2014-2019 Red Hat, Inc. and others.
 #
 # This file is part of Bodhi.

--- a/bodhi/client/bindings.py
+++ b/bodhi/client/bindings.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-#
 # Copyright © 2007-2019 Red Hat, Inc. and others.
 #
 # This file is part of bodhi.

--- a/bodhi/server/migrations/versions/8e9dc57e082d_obsolete_updates_for_archived_release.py
+++ b/bodhi/server/migrations/versions/8e9dc57e082d_obsolete_updates_for_archived_release.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) 2019 Sebastian Wojciechowski
 #
 # This file is part of Bodhi.

--- a/bodhi/tests/__init__.py
+++ b/bodhi/tests/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright © 2018 Red Hat, Inc.
 #
 # This file is part of Bodhi.

--- a/bodhi/tests/client/__init__.py
+++ b/bodhi/tests/client/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright © 2016-2019 Red Hat, Inc. and others.
 #
 # This file is part of Bodhi.

--- a/bodhi/tests/client/test___init__.py
+++ b/bodhi/tests/client/test___init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright © 2016-2019 Red Hat, Inc. and others.
 #
 # This file is part of Bodhi.

--- a/bodhi/tests/client/test_bindings.py
+++ b/bodhi/tests/client/test_bindings.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2008-2019 Red Hat, Inc. and others.
 #
 # This file is part of Bodhi.

--- a/bodhi/tests/utils.py
+++ b/bodhi/tests/utils.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright © 2018 Red Hat, Inc.
 #
 # This file is part of Bodhi.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-#
 # bodhi documentation build configuration file, created by
 # sphinx-quickstart on Sat Aug 10 09:29:50 2013.
 #


### PR DESCRIPTION
Now that we are purely Python 3, UTF-8 is the default encoding for
source code and we no longer need these encoding headers.

Signed-off-by: Randy Barlow <randy@electronsweatshop.com>