### PR TITLE
Remove two more uses of six.

### DIFF
--- a/devel/ci/Dockerfile-f30
+++ b/devel/ci/Dockerfile-f30
@@ -44,7 +44,6 @@ RUN dnf install --disablerepo rawhide-modular -y \
     python3-pytest-cov \
     python3-responses \
     python3-simplemediawiki \
-    python3-six \
     python3-sqlalchemy \
     python3-sqlalchemy_schemadisplay \
     python3-waitress \

--- a/devel/ci/integration/tests/fixtures/bodhi.py
+++ b/devel/ci/integration/tests/fixtures/bodhi.py
@@ -17,10 +17,10 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 import os
+from configparser import ConfigParser
 from uuid import uuid4
 
 import pytest
-from six.moves.configparser import ConfigParser
 
 from ..utils import make_db_and_user, edit_file
 


### PR DESCRIPTION
Now that we are purely Python 3, we don't need six anymore.

Signed-off-by: Randy Barlow <randy@electronsweatshop.com>