### PR TITLE
use psycopg2-binary to fix build failures

### DIFF
--- a/devel/ci/cico.pipeline
+++ b/devel/ci/cico.pipeline
@@ -49,7 +49,7 @@ def configure_node = {
     onmyduffynode 'systemctl start docker'
     // To run the integration testsuite
     onmyduffynode 'python3.6 -m ensurepip'
-    onmyduffynode 'python3.6 -m pip install \'pytest<4.0\' pytest-cov conu munch psycopg2'
+    onmyduffynode 'python3.6 -m pip install \'pytest<4.0\' pytest-cov conu munch psycopg2-binary'
 }
 
 


### PR DESCRIPTION
#3131 fails with https://ci.centos.org/job/bodhi-pipeline/job/PR-3131/2/consoleFull:

```
04:50:27  Collecting psycopg2
04:50:27    Downloading https://files.pythonhosted.org/packages/c7/ca/75236b17f1b951950ffc55d657c5aa408d3d0327a1b6c4c0f7cb16ef7e7b/psycopg2-2.8.tar.gz (367kB)
04:50:27      Complete output from command python setup.py egg_info:
04:50:27      running egg_info
04:50:27      creating pip-egg-info/psycopg2.egg-info
04:50:27      writing pip-egg-info/psycopg2.egg-info/PKG-INFO
04:50:27      writing dependency_links to pip-egg-info/psycopg2.egg-info/dependency_links.txt
04:50:27      writing top-level names to pip-egg-info/psycopg2.egg-info/top_level.txt
04:50:27      writing manifest file 'pip-egg-info/psycopg2.egg-info/SOURCES.txt'
04:50:27      
04:50:27      Error: pg_config executable not found.
04:50:27      
04:50:27      pg_config is required to build psycopg2 from source.  Please add the directory
04:50:27      containing pg_config to the $PATH or specify the full executable path with the
04:50:27      option:
04:50:27      
04:50:27          python setup.py build_ext --pg-config /path/to/pg_config build ...
04:50:27      
04:50:27      or with the pg_config option in 'setup.cfg'.
04:50:27      
04:50:27      If you prefer to avoid building psycopg2 from source, please install the PyPI
04:50:27      'psycopg2-binary' package instead.
04:50:27      
04:50:27      For further information please check the 'doc/src/install.rst' file (also at
04:50:27      <http://initd.org/psycopg/docs/install.html>).
```