### PR TITLE
document that response is intentionally truncated

### DIFF
--- a/bodhi/server/config.py
+++ b/bodhi/server/config.py
@@ -227,9 +227,11 @@ class BodhiConfig(dict):
             'value': None,
             'validator': _validate_none_or(str)},
         'admin_groups': {
+            # Defined in and tied to the Fedora Account System (limited to 16 characters)
             'value': ['proventesters', 'security_respons', 'bodhiadmin', 'sysadmin-main'],
             'validator': _generate_list_validator()},
         'admin_packager_groups': {
+            # Defined in and tied to the Fedora Account System (limited to 16 characters)
             'value': ['provenpackager', 'releng', 'security_respons'],
             'validator': _generate_list_validator()},
         'authtkt.secret': {
@@ -346,6 +348,7 @@ class BodhiConfig(dict):
             'value': 'https://apps.fedoraproject.org/notifications/',
             'validator': str},
         'important_groups': {
+            # Defined in and tied to the Fedora Account System (limited to 16 characters)
             'value': ['proventesters', 'provenpackager,' 'releng', 'security_respons', 'packager',
                       'bodhiadmin'],
             'validator': _generate_list_validator()},

--- a/production.ini
+++ b/production.ini
@@ -256,6 +256,8 @@ use = egg:bodhi-server
 # fedora_epel_test_announce_list = epel-devel@lists.fedoraproject.org
 
 # Superuser groups
+#
+# Defined in and tied to the Fedora Account System (limited to 16 characters)
 # admin_groups = proventesters security_respons bodhiadmin sysadmin-main
 
 # Users that we don't want to show up in the "leaderboard(s)"
@@ -457,9 +459,13 @@ fedora_epel.mandatory_days_in_testing = 14
 # When a user logs in, bodhi will look for any of these groups and associate #
 # them with the user. They will then appear as the users effective principals in
 # the format "group:groupname" and can be used in Pyramid ACE's.
+#
+# Defined in and tied to the Fedora Account System (limited to 16 characters)
 # important_groups = proventesters provenpackager releng security_respons packager bodhiadmin
 
 # Groups that can push updates for any package
+#
+# Defined in and tied to the Fedora Account System (limited to 16 characters)
 # admin_packager_groups = provenpackager releng security_respons
 
 # User must be a member of this group to submit updates


### PR DESCRIPTION
This is because the group names come from the Fedora Account System
which is limited to 16 characters.

https://community.aegirproject.org/developing/architecture/unix-group-limitations/index.html

Signed-off-by: Josh Soref <jsoref@users.noreply.github.com>

split from #3131 because `security_respons` is essentially set in stone.