### PR TITLE
Do not warm up the home page cache in CI.

### DIFF
--- a/devel/ci/integration/tests/fixtures/bodhi.py
+++ b/devel/ci/integration/tests/fixtures/bodhi.py
@@ -99,6 +99,9 @@ def bodhi_container(
         "pyramid.debug_routematch": "false",
         "authtkt.secure": "true",
         "authtkt.timeout": "1209600",
+        # Building a cache for every test takes a lot of time, so let's configure the Bodhi server
+        # not to warm the cache.
+        "warm_cache_on_start": "false",
     }
     with edit_file(container, "/etc/bodhi/production.ini") as config_path:
         config = ConfigParser()


### PR DESCRIPTION
The home page cache takes a lot of time to build, and running this
in CI takes a lot of time as a result. This commit configures Bodhi
not to warm the cache for the home page upon process start, and as
a result the integration tests run about 58% faster on my laptop.

Signed-off-by: Randy Barlow <randy@electronsweatshop.com>