### PR TITLE
Emit a log message when blocking an update API request.

### DIFF
--- a/bodhi/server/services/updates.py
+++ b/bodhi/server/services/updates.py
@@ -190,6 +190,9 @@ def set_request(request):
     if action == UpdateRequest.stable:
         settings = request.registry.settings
         result, reason = update.check_requirements(request.db, settings)
+        log.info(
+            f'Unable to set request for {update.alias} to {action} due to failed requirements: '
+            f'{reason}')
         if not result:
             request.errors.add('body', 'request',
                                'Requirement not met %s' % reason)


### PR DESCRIPTION
I recently would have benefitted from a log message being emitted
when an update was blocked from setting its request due to a test
gating decision. This commit adds such a log.

Signed-off-by: Randy Barlow <randy@electronsweatshop.com>