### PR TITLE
Drop the submitter field from serialized updates.

### DIFF
--- a/bodhi/messages/schemas/base.py
+++ b/bodhi/messages/schemas/base.py
@@ -161,7 +161,6 @@ class UpdateV1(typing.NamedTuple):
     Attributes:
         alias: The alias of the update.
         builds: A list of builds associated with the update.
-        submitter: The id of the user who submitted the update.
     """
 
     alias: str

--- a/bodhi/server/models.py
+++ b/bodhi/server/models.py
@@ -3472,9 +3472,6 @@ class Update(Base):
         result = super(Update, self).__json__(request=request)
         # Duplicate alias as updateid for backwards compat with bodhi1
         result['updateid'] = result['alias']
-        # Also, put the update submitter's name in the same place we put
-        # it for bodhi1 to make the messaging schema compat much more simple.
-        result['submitter'] = result['user']['name']
         # Include the karma total in the results
         result['karma'] = self.karma
         # Also, the Update content_type (derived from the builds content_types)

--- a/bodhi/tests/server/services/test_updates.py
+++ b/bodhi/tests/server/services/test_updates.py
@@ -1659,7 +1659,6 @@ class TestUpdatesService(BaseTestCase):
         self.assertEqual(up['status'], u'pending')
         self.assertEqual(up['request'], u'testing')
         self.assertEqual(up['user']['name'], u'guest')
-        self.assertEqual(up['submitter'], u'guest')
         self.assertEqual(up['release']['name'], u'F17')
         self.assertEqual(up['type'], u'bugfix')
         self.assertEqual(up['content_type'], u'rpm')

--- a/docs/user/release_notes.rst
+++ b/docs/user/release_notes.rst
@@ -60,6 +60,9 @@ Backwards incompatible changes
   need information that is not included in the supported schema, please work with the Bodhi project
   to get the schema adjusted accordingly. Bodhi's messages are now documented in
   :doc:`../server_api/index`.
+* All messages and API responses that serialize updates no longer have a ``submitter`` field. This
+  was redundant with the included ``user.name`` field, and was only in place for compatibility with
+  Bodhi 1 which was EOL many years ago.
 
 
 Dependency changes


### PR DESCRIPTION
Bodhi has been adding a non-existing field, submitter, to
serialized versions of updates for compatibility with Bodhi 1.
Bodhi 1 went EOL a long time ago, and this data is redundant with
the update.user.name field that also appears in all serialized
updates.

Signed-off-by: Randy Barlow <randy@electronsweatshop.com>