### PR TITLE
Allow downloading of debuginfo packages from updates

### DIFF
--- a/bodhi/client/__init__.py
+++ b/bodhi/client/__init__.py
@@ -675,6 +675,8 @@ def comment(update, text, karma, user, password, url, openid_api, **kwargs):
 @click.option('--arch',
               help=('Specify arch of packages to download, "all" will retrieve packages from all '
                     'architectures'))
+@click.option('--debuginfo', is_flag=True, default=False,
+              help=('Include debuginfo packages'))
 @click.option('--updateid', help='Download update(s) by ID(s) (comma-separated list)')
 @click.option('--builds', help='Download update(s) by build NVR(s) (comma-separated list)')
 @url_option
@@ -688,18 +690,21 @@ def download(url, **kwargs):
     Download the builds for an update.
 
     Args:
-        staging (bool): Whether to use the staging server or not.
-        arch (unicode): Requested architecture of packages to download.
-                        "all" will retrieve packages from all architectures.
-        url (unicode): The URL of a Bodhi server to create the update on. Ignored if staging is
-                       True.
-        kwargs (dict): Other keyword arguments passed to us by click.
+        staging (bool):   Whether to use the staging server or not.
+        arch (unicode):   Requested architecture of packages to download.
+                          "all" will retrieve packages from all architectures.
+        debuginfo (bool): Whether to include debuginfo packages.
+        url (unicode):    The URL of a Bodhi server to create the update on. Ignored if staging is
+                          True.
+        kwargs (dict):    Other keyword arguments passed to us by click.
     """
     client = bindings.BodhiClient(base_url=url, staging=kwargs['staging'])
     requested_arch = kwargs['arch']
+    debuginfo = kwargs['debuginfo']
 
     del(kwargs['staging'])
     del(kwargs['arch'])
+    del(kwargs['debuginfo'])
     # At this point we need to have reduced the kwargs dict to only our
     # query options (updateid or builds)
     if not any(kwargs.values()):
@@ -720,6 +725,9 @@ def download(url, **kwargs):
             # Not sure if we need a check for > expecteds, I don't
             # *think* that should ever be possible for these opts.
 
+            args = ['koji', 'download-build']
+            if debuginfo:
+                args.append('--debuginfo')
             for update in resp.updates:
                 click.echo("Downloading packages from {0}".format(update['alias']))
                 for build in update['builds']:
@@ -727,14 +735,14 @@ def download(url, **kwargs):
                     # expose this in any usable way, and we don't want
                     # to rewrite it here.
                     if requested_arch is None:
-                        args = ('koji', 'download-build', '--arch=noarch',
-                                '--arch={0}'.format(platform.machine()), build['nvr'])
+                        args.extend(['--arch=noarch',
+                                     '--arch={0}'.format(platform.machine()), build['nvr']])
                     else:
                         if u'all' in requested_arch:
-                            args = ('koji', 'download-build', build['nvr'])
+                            args.append(build['nvr'])
                         if u'all' not in requested_arch:
-                            args = ('koji', 'download-build', '--arch=noarch',
-                                    '--arch={0}'.format(requested_arch), build['nvr'])
+                            args.extend(['--arch=noarch',
+                                         '--arch={0}'.format(requested_arch), build['nvr']])
                     ret = subprocess.call(args)
                     if ret:
                         click.echo("WARNING: download of {0} failed!".format(build['nvr']))

--- a/bodhi/tests/client/test___init__.py
+++ b/bodhi/tests/client/test___init__.py
@@ -122,9 +122,9 @@ class TestDownload(unittest.TestCase):
             bindings_client, 'updates/', verb='GET',
             params={'builds': u'nodejs-grunt-wrap-0.3.0-2.fc25'})
         self.assertEqual(bindings_client.base_url, 'http://localhost:6543/')
-        call.assert_called_once_with((
+        call.assert_called_once_with([
             'koji', 'download-build', '--arch=noarch', '--arch={}'.format(platform.machine()),
-            'nodejs-grunt-wrap-0.3.0-2.fc25'))
+            'nodejs-grunt-wrap-0.3.0-2.fc25'])
 
     @mock.patch('bodhi.client.bindings.BodhiClient.csrf',
                 mock.MagicMock(return_value='a_csrf_token'))
@@ -144,9 +144,9 @@ class TestDownload(unittest.TestCase):
         self.assertEqual(result.exit_code, 0)
         self.assertEqual(result.output,
                          'Downloading packages from FEDORA-2017-c95b33872d\n')
-        call.assert_called_once_with((
+        call.assert_called_once_with([
             'koji', 'download-build', '--arch=noarch', '--arch=x86_64',
-            'nodejs-grunt-wrap-0.3.0-2.fc25'))
+            'nodejs-grunt-wrap-0.3.0-2.fc25'])
 
     @mock.patch('bodhi.client.bindings.BodhiClient.csrf',
                 mock.MagicMock(return_value='a_csrf_token'))
@@ -166,8 +166,29 @@ class TestDownload(unittest.TestCase):
         self.assertEqual(result.exit_code, 0)
         self.assertEqual(result.output,
                          'Downloading packages from FEDORA-2017-c95b33872d\n')
-        call.assert_called_once_with((
-            'koji', 'download-build', 'nodejs-grunt-wrap-0.3.0-2.fc25'))
+        call.assert_called_once_with([
+            'koji', 'download-build', 'nodejs-grunt-wrap-0.3.0-2.fc25'])
+
+    @mock.patch('bodhi.client.bindings.BodhiClient.csrf',
+                mock.MagicMock(return_value='a_csrf_token'))
+    @mock.patch('bodhi.client.bindings.BodhiClient.send_request',
+                return_value=client_test_data.EXAMPLE_QUERY_MUNCH, autospec=True)
+    @mock.patch('bodhi.client.subprocess.call', return_value=0)
+    def test_debuginfo_flag(self, call, send_request):
+        """
+        Assert correct behavior with --debuginfo flag.
+        """
+        runner = testing.CliRunner()
+
+        result = runner.invoke(
+            client.download,
+            ['--builds', 'nodejs-grunt-wrap-0.3.0-2.fc25', '--arch', 'all', '--debuginfo'])
+
+        self.assertEqual(result.exit_code, 0)
+        self.assertEqual(result.output,
+                         'Downloading packages from FEDORA-2017-c95b33872d\n')
+        call.assert_called_once_with([
+            'koji', 'download-build', '--debuginfo', 'nodejs-grunt-wrap-0.3.0-2.fc25'])
 
     @mock.patch('bodhi.client.bindings.BodhiClient.csrf',
                 mock.MagicMock(return_value='a_csrf_token'))
@@ -221,9 +242,9 @@ class TestDownload(unittest.TestCase):
         self.assertEqual(result.output,
                          ('WARNING: Some builds not found!\nDownloading packages '
                           'from FEDORA-2017-c95b33872d\n'))
-        call.assert_called_once_with((
+        call.assert_called_once_with([
             'koji', 'download-build', '--arch=noarch', '--arch={}'.format(platform.machine()),
-            'nodejs-grunt-wrap-0.3.0-2.fc25'))
+            'nodejs-grunt-wrap-0.3.0-2.fc25'])
 
     @mock.patch('bodhi.client.bindings.BodhiClient.csrf',
                 mock.MagicMock(return_value='a_csrf_token'))
@@ -245,9 +266,9 @@ class TestDownload(unittest.TestCase):
         self.assertEqual(result.output,
                          ('Downloading packages from FEDORA-2017-c95b33872d\n'
                           'WARNING: download of nodejs-grunt-wrap-0.3.0-2.fc25 failed!\n'))
-        call.assert_called_once_with((
+        call.assert_called_once_with([
             'koji', 'download-build', '--arch=noarch', '--arch={}'.format(platform.machine()),
-            'nodejs-grunt-wrap-0.3.0-2.fc25'))
+            'nodejs-grunt-wrap-0.3.0-2.fc25'])
 
 
 class TestComposeInfo(unittest.TestCase):

--- a/devel/ci/integration/tests/test_bodhi_cli.py
+++ b/devel/ci/integration/tests/test_bodhi_cli.py
@@ -324,4 +324,4 @@ def test_updates_download(bodhi_container, db_container):
     for update in updates:
         assert "Downloading packages from {}".format(update['alias']) in result.output
     for build_id in builds:
-        assert "TESTING CALL /usr/bin/koji download-build {}".format(build_id) in result.output
+        assert re.search(f"TESTING CALL /usr/bin/koji download-build.*{build_id}", result.output)

--- a/docs/user/man_pages/bodhi.rst
+++ b/docs/user/man_pages/bodhi.rst
@@ -185,6 +185,10 @@ The ``updates`` command allows users to interact with bodhi updates.
     Download update(s) given by ID(s) or NVR(s). One of ``--updateid`` or
     ``builds`` is required. The download subcommand supports the following options:
 
+    ``--debuginfo``
+
+        Include debuginfo packages when downloading.
+
     ``--updateid <ids>``
 
         A comman-separated list of update IDs you would like to download.


### PR DESCRIPTION
This isn't currently possible, but sometimes is useful, so add
--debuginfo to allow it.

Signed-off-by: Adam Williamson <awilliam@redhat.com>