### PR TITLE
Build the integration test containers in parallel.

### DIFF
--- a/devel/ci/cico.pipeline
+++ b/devel/ci/cico.pipeline
@@ -99,6 +99,7 @@ def bodhi_ci = { String release, String command, String context, String args ->
  */
 def test_release = { String release ->
     retry_with_sleep({ bodhi_ci(release, 'build', 'build', '') })
+    retry_with_sleep({ bodhi_ci(release, 'integration-build', 'integration-build', '') })
 
     parallel(
         docs: {bodhi_ci(release, 'docs', 'docs', '--no-build --no-init')},
@@ -168,7 +169,6 @@ node('bodhi') {
         def releases = ['f28', 'f29', 'f30', 'pip', 'rawhide']
         for (release in releases) {
             try {
-                retry_with_sleep({ bodhi_ci(release, 'integration-build', 'integration-build', '') })
                 bodhi_ci(release, 'integration', 'integration', '--no-build --no-init')
             } catch(error) {
                 failed = error


### PR DESCRIPTION
I recently altered our Jenkins job such that it would not run the
integration tests in parallel. This was to avoid putting so much
load on our Duffy nodes such as to cause the tests to timeout.
However, I also made it so that it does not build the containers
used by the integration tests in parallel anymore.

This commit adjusts the Jenkins job to again run the builds in
parallel.

Signed-off-by: Randy Barlow <randy@electronsweatshop.com>