### PR TITLE
We don't need to workaround a docker bug anymore.

### DIFF
--- a/devel/ci/cico.pipeline
+++ b/devel/ci/cico.pipeline
@@ -44,8 +44,6 @@ def synctoduffynode(rsyncpath) {
 def configure_node = {
     onmyduffynode 'yum -y install epel-release'
     onmyduffynode 'yum install -y docker python36-click python36-pip python36-requests rsync'
-    // Workaround https://bugzilla.redhat.com/show_bug.cgi?id=1655214
-    onmyduffynode 'yum downgrade -y docker-1.13.1-75.git8633870.el7.centos.x86_64 docker-client-1.13.1-75.git8633870.el7.centos.x86_64 docker-common-1.13.1-75.git8633870.el7.centos.x86_64'
     onmyduffynode 'systemctl start docker'
     // To run the integration testsuite
     onmyduffynode 'python3.6 -m pip install \'pytest<4.0\' pytest-cov conu munch psycopg2-binary'


### PR DESCRIPTION
The CI tests didn't use the latest docker from CentOS 7 due to a
bug we needed to work around a while ago. This bug is now fixed so
we should not need to downgrade anymore.

Signed-off-by: Randy Barlow <randy@electronsweatshop.com>