### PR TITLE
If an integration test fails, keep going.

### DIFF
--- a/devel/ci/cico.pipeline
+++ b/devel/ci/cico.pipeline
@@ -158,10 +158,18 @@ node('bodhi') {
             rawhide: {test_release('rawhide')},
         )
 
+        def failed = false
         def releases = ['f28', 'f29', 'f30', 'pip', 'rawhide']
         for (release in releases) {
-            bodhi_ci(release, 'integration-build', 'integration-build', '')
-            bodhi_ci(release, 'integration', 'integration', '--no-build --no-init')
+            try {
+                bodhi_ci(release, 'integration-build', 'integration-build', '')
+                bodhi_ci(release, 'integration', 'integration', '--no-build --no-init')
+            } catch(error) {
+                failed = error
+            }
+        }
+        if (failed) {
+            throw failed
         }
     } catch (e) {
         currentBuild.result = "FAILURE"


### PR DESCRIPTION
We recently worked around a CI load issue by running the
integration tests in serial rather than in parallel. However, we
introduced a regression in that a failure in one release causes
Jenkins to halt, rather than proceeding to test the other releases.

This commit makes it such that the CI will proceed even if one
fails so we get all of the results.

Signed-off-by: Randy Barlow <randy@electronsweatshop.com>