### PR TITLE
Do not check gpg signatures in pip integration.

### DIFF
--- a/devel/ci/integration/bodhi/Dockerfile-pip
+++ b/devel/ci/integration/bodhi/Dockerfile-pip
@@ -9,8 +9,10 @@ LABEL \
 RUN curl -o /etc/yum.repos.d/infra-tags.repo https://infrastructure.fedoraproject.org/cgit/ansible.git/plain/files/common/fedora-infra-tags.repo
 RUN dnf upgrade -y
 
-# Install Bodhi deps (that were not needed by the unittests container)
-RUN dnf install -y \
+# Install Bodhi deps (that were not needed by the unittests container). We use --nogpgcheck due to
+# https://bugzilla.redhat.com/show_bug.cgi?id=1699396. This is OK since this is CI and not
+# production.
+RUN dnf install --nogpgcheck -y \
     httpd \
     intltool \
     python3-koji \


### PR DESCRIPTION
There is a bizarre bug in dnf's gpg check code[0] that is causing
our pip integration container build from succeeding. Since this is
testing and not production, let's just configure dnf not to check
gpg signatures for now until the issue is resolved. The issue will
be resolved when Fedora 29 stable has the same version of koji as
the f29-infra repo, or if dnf fixes the issue.

[0] https://bugzilla.redhat.com/show_bug.cgi?id=1699396

Signed-off-by: Randy Barlow <randy@electronsweatshop.com>