### PR TITLE
CI: Retry on build failures.

### DIFF
--- a/devel/ci/cico.pipeline
+++ b/devel/ci/cico.pipeline
@@ -98,7 +98,7 @@ def bodhi_ci = { String release, String command, String context, String args ->
  * @param release The release to test.
  */
 def test_release = { String release ->
-    bodhi_ci(release, 'build', 'build', '')
+    retry_with_sleep({ bodhi_ci(release, 'build', 'build', '') })
 
     parallel(
         docs: {bodhi_ci(release, 'docs', 'docs', '--no-build --no-init')},
@@ -168,7 +168,7 @@ node('bodhi') {
         def releases = ['f28', 'f29', 'f30', 'pip', 'rawhide']
         for (release in releases) {
             try {
-                bodhi_ci(release, 'integration-build', 'integration-build', '')
+                retry_with_sleep({ bodhi_ci(release, 'integration-build', 'integration-build', '') })
                 bodhi_ci(release, 'integration', 'integration', '--no-build --no-init')
             } catch(error) {
                 failed = error


### PR DESCRIPTION
CI build failures are often due to network issues and not
necessarily due to problems in Bodhi. This commits adjusts the CI
system to try again on build failures up to 4 times with a 60
second sleep in between. This should make our CI a little more
reliable. The con is that real build failures will take longer to
be reported since they will be tried many times.

Signed-off-by: Randy Barlow <randy@electronsweatshop.com>