### PR TITLE
Refactor and rename the met_testing_requirements function.

### DIFF
--- a/bodhi/server/models.py
+++ b/bodhi/server/models.py
@@ -2508,7 +2508,7 @@ class Update(Base):
                 # If we haven't met the stable karma requirements, check if it
                 # has met the mandatory time-in-testing requirements
                 if self.mandatory_days_in_testing:
-                    if not self.met_testing_requirements and \
+                    if not self.has_stable_comment and \
                        not self.meets_testing_requirements:
                         if self.release.id_prefix == "FEDORA-EPEL":
                             flash_notes = config.get('not_yet_tested_epel_msg')
@@ -3321,28 +3321,17 @@ class Update(Base):
         return self.days_in_testing >= num_days
 
     @property
-    def met_testing_requirements(self):
+    def has_stable_comment(self):
         """
-        Return True if the update has already been found to meet requirements in the past.
+        Return whether Bodhi has commented on the update that the requirements have been met.
 
-        Return whether or not this update has already met the testing
-        requirements and bodhi has commented on the update that the
-        requirements have been met. This is used to determine whether bodhi
-        should add the comment about the Update's eligibility to be pushed,
-        as we only want Bodhi to add the comment once.
-
-        If this release does not have a mandatory testing requirement, then
-        simply return True.
+        This is used to determine whether bodhi should add the comment
+        about the Update's eligibility to be pushed, as we only want Bodhi
+        to add the comment once.
 
         Returns:
             bool: See description above for what the bool might mean.
         """
-        min_num_days = self.mandatory_days_in_testing
-        if min_num_days:
-            if not self.meets_testing_requirements:
-                return False
-        else:
-            return True
         for comment in self.comments_since_karma_reset:
             if comment.user.name == 'bodhi' and \
                comment.text.startswith('This update has reached') and \

--- a/bodhi/server/scripts/approve_testing.py
+++ b/bodhi/server/scripts/approve_testing.py
@@ -81,8 +81,8 @@ def main(argv=sys.argv):
                 print('%s doesn\'t have mandatory days in testing' % update.release.name)
                 continue
 
-            # If this has already met testing requirements, skip it
-            if update.met_testing_requirements:
+            # If this update was already commented, skip it
+            if update.has_stable_comment:
                 continue
 
             # Approval message when testing based on karma threshold

--- a/bodhi/tests/server/test_models.py
+++ b/bodhi/tests/server/test_models.py
@@ -3065,9 +3065,9 @@ class TestUpdate(ModelTest):
         self.assertEqual(self.obj.request, UpdateRequest.stable)
         self.assertEqual(self.obj.status, UpdateStatus.pending)
 
-    def test_met_testing_requirements_at_7_days_after_bodhi_comment(self):
+    def test_has_stable_comment_at_7_days_after_bodhi_comment(self):
         """
-        Ensure a correct True return value from Update.met_testing_requirements() after an update
+        Ensure a correct True return value from Update.has_stable_comment() after an update
         has been in testing for 7 days and after bodhi has commented about it.
         """
         self.obj.status = UpdateStatus.testing
@@ -3084,11 +3084,11 @@ class TestUpdate(ModelTest):
 
         # met_testing_requirement() should return True since Bodhi has commented on the Update to
         # say that it can now be pushed to stable.
-        self.assertEqual(self.obj.met_testing_requirements, True)
+        self.assertEqual(self.obj.has_stable_comment, True)
 
-    def test_met_testing_requirements_at_7_days_before_bodhi_comment(self):
+    def test_has_stable_comment_at_7_days_before_bodhi_comment(self):
         """
-        Ensure a correct False return value from Update.met_testing_requirements() after an update
+        Ensure a correct False return value from Update.has_stable_comment() after an update
         has been in testing for 7 days but before bodhi has commented about it.
         """
         self.obj.status = UpdateStatus.testing
@@ -3101,12 +3101,7 @@ class TestUpdate(ModelTest):
         self.assertEqual(self.obj.meets_testing_requirements, True)
 
         # Since bodhi hasn't added the testing_approval_message yet, this should be False.
-        self.assertEqual(self.obj.met_testing_requirements, False)
-
-    def test_met_testing_requirements_no_mandatory_days_in_testing(self):
-        """met_testing_requirements() should return True if no mandatory days in testing."""
-        with mock.patch.dict(config, {'fedora.mandatory_days_in_testing': 0}):
-            self.assertTrue(self.obj.met_testing_requirements)
+        self.assertEqual(self.obj.has_stable_comment, False)
 
     def test_meets_testing_requirements_with_non_autokarma_update_below_stable_karma(self):
         """
@@ -3145,9 +3140,9 @@ class TestUpdate(ModelTest):
         update.comment(self.db, 'testing', author='enemy', karma=-1)
         self.assertEqual(update.meets_testing_requirements, False)
 
-    def test_met_testing_requirements_with_karma_after_bodhi_comment(self):
+    def test_has_stable_comment_with_karma_after_bodhi_comment(self):
         """
-        Ensure a correct True return value from Update.met_testing_requirements() after a
+        Ensure a correct True return value from Update.has_stable_comment() after a
         non-autokarma update has reached the karma requirement and after bodhi has commented about
         it.
         """
@@ -3168,11 +3163,11 @@ class TestUpdate(ModelTest):
 
         # met_testing_requirement() should return True since Bodhi has commented on the Update to
         # say that it can now be pushed to stable.
-        self.assertEqual(self.obj.met_testing_requirements, True)
+        self.assertEqual(self.obj.has_stable_comment, True)
 
-    def test_met_testing_requirements_with_karma_before_bodhi_comment(self):
+    def test_has_stable_comment_with_karma_before_bodhi_comment(self):
         """
-        Ensure a correct False return value from Update.met_testing_requirements() after a
+        Ensure a correct False return value from Update.has_stable_comment() after a
         non-autokarma update has reached the karma requirement but before bodhi has commented about
         it.
         """
@@ -3190,7 +3185,7 @@ class TestUpdate(ModelTest):
 
         # met_testing_requirement() should return False since Bodhi has not yet commented on the
         # Update to say that it can now be pushed to stable.
-        self.assertEqual(self.obj.met_testing_requirements, False)
+        self.assertEqual(self.obj.has_stable_comment, False)
 
     def test_set_request_obsolete(self):
         req = DummyRequest(user=DummyUser())


### PR DESCRIPTION
The met_testing_requirements function is really only used to check
if bodhi has already commented on the update that the requirements
have been met. This commit renames the function and remove duplicated
logic.

Signed-off-by: Clement Verna <cverna@tutanota.com>