### PR TITLE
Install psycopg2 from EPEL instead of pip.

### DIFF
--- a/devel/ci/cico.pipeline
+++ b/devel/ci/cico.pipeline
@@ -43,10 +43,10 @@ def synctoduffynode(rsyncpath) {
  */
 def configure_node = {
     onmyduffynode 'yum -y install epel-release'
-    onmyduffynode 'yum install -y docker python36-click python36-pip python36-requests rsync'
+    onmyduffynode 'yum install -y docker python36-click python36-pip python36-psycopg2 python36-requests rsync'
     onmyduffynode 'systemctl start docker'
     // To run the integration testsuite
-    onmyduffynode 'python3.6 -m pip install \'pytest<4.0\' pytest-cov conu munch psycopg2-binary'
+    onmyduffynode 'python3.6 -m pip install \'pytest<4.0\' pytest-cov conu munch'
 }
 
 


### PR DESCRIPTION
Signed-off-by: Randy Barlow <randy@electronsweatshop.com>