### PR TITLE
Handle possible duplicate messages in the consumers

### DIFF
--- a/bodhi/server/consumers/composer.py
+++ b/bodhi/server/consumers/composer.py
@@ -178,6 +178,9 @@ class ComposerHandler(object):
         If there are any security updates in the push, then those repositories
         will be executed before all others.
 
+        Duplicate messages: if a requested compose is already pending or has
+        already started, it will be skipped.
+
         Args:
             message: The message we are processing. This is how we know what compose jobs to run.
         """
@@ -236,6 +239,10 @@ class ComposerHandler(object):
                 composes = [Compose.from_dict(db, c) for c in msg['composes']]
             else:
                 raise ValueError('Unable to process message: {}'.format(msg))
+
+            # Filter out composes that are pending or have started, for example in
+            # case of duplicate messages.
+            composes = [c for c in composes if c.state == ComposeState.requested]
 
             for c in composes:
                 # Acknowledge that we've received the command to run these composes.

--- a/bodhi/server/consumers/signed.py
+++ b/bodhi/server/consumers/signed.py
@@ -77,6 +77,8 @@ class SignedHandler(object):
 
         The message can contain additional keys.
 
+        Duplicate messages: this method is idempotent.
+
         Args:
             message: The incoming message in the format described above.
         """
@@ -98,6 +100,10 @@ class SignedHandler(object):
 
             if build.release.pending_testing_tag != tag:
                 log.info("Tag is not pending_testing tag, skipping")
+                return
+
+            if build.signed:
+                log.info("Build was already marked as signed (maybe a duplicate message)")
                 return
 
             # This build was moved into the pending_testing tag for the applicable release, which

--- a/bodhi/server/consumers/updates.py
+++ b/bodhi/server/consumers/updates.py
@@ -76,6 +76,10 @@ class UpdatesHandler(object):
         """
         Process the given message, updating relevant bugs and test cases.
 
+        Duplicate messages: if the server delivers the message multiple times,
+        the bugs and test cases are simply re-fetched and updated, so nothing
+        bad happens.
+
         Args:
             message: A message about a new or edited update.
         """

--- a/bodhi/tests/server/consumers/test_composer.py
+++ b/bodhi/tests/server/consumers/test_composer.py
@@ -354,6 +354,14 @@ That was the actual one''' % compose_dir
 
         self.assertEqual(str(exc.exception), 'No row was found for one()')
 
+    def test__get_composes_duplicate(self):
+        """Test _get_composes() when a duplicate message is received."""
+        msg = self._make_msg().body
+        composes = self.handler._get_composes(msg)
+        self.assertEqual(len(composes), 1)
+        composes = self.handler._get_composes(msg)
+        self.assertEqual(len(composes), 0)
+
     @mock.patch(**mock_taskotron_results)
     @mock.patch('bodhi.server.consumers.composer.PungiComposerThread._wait_for_pungi')
     @mock.patch('bodhi.server.consumers.composer.PungiComposerThread._sanity_check_repo')

--- a/bodhi/tests/server/consumers/test_signed.py
+++ b/bodhi/tests/server/consumers/test_signed.py
@@ -57,6 +57,7 @@ class TestSignedHandlerConsume(unittest.TestCase):
     def test_consume(self, mock_build_model):
         """Assert that messages marking the build as signed updates the database"""
         build = mock_build_model.get.return_value
+        build.signed = False
         build.release.pending_testing_tag = self.sample_message.body["msg"]["tag"]
 
         self.handler(self.sample_message)
@@ -68,6 +69,7 @@ class TestSignedHandlerConsume(unittest.TestCase):
         Assert that messages whose tag don't match the pending testing tag don't update the DB
         """
         build = mock_build_model.get.return_value
+        build.signed = False
         build.release.pending_testing_tag = "some tag that isn't pending testing"
 
         self.handler(self.sample_message)
@@ -79,6 +81,7 @@ class TestSignedHandlerConsume(unittest.TestCase):
         Assert that messages about builds that haven't been assigned a release don't update the DB
         """
         build = mock_build_model.get.return_value
+        build.signed = False
         build.release = None
 
         self.handler(self.sample_message)
@@ -92,3 +95,16 @@ class TestSignedHandlerConsume(unittest.TestCase):
 
         self.handler(self.sample_message)
         mock_log.info.assert_called_with('Build was not submitted, skipping')
+
+    @mock.patch('bodhi.server.consumers.signed.log')
+    @mock.patch('bodhi.server.consumers.signed.Build')
+    def test_consume_duplicate(self, mock_build_model, mock_log):
+        """Assert that the handler is idempotent."""
+        build = mock_build_model.get.return_value
+        build.release.pending_testing_tag = self.sample_message.body["msg"]["tag"]
+        build.signed = True
+
+        self.handler(self.sample_message)
+        mock_log.info.assert_called_with(
+            "Build was already marked as signed (maybe a duplicate message)")
+        self.assertEqual(mock_log.info.call_count, 2)


### PR DESCRIPTION
Fixes #3069

In AMQP and thus Fedora Messaging, messages can be delivered multiple times in the event of a network issue or a crash, for example. This changeset ensures that the consumers are idempotent or will deduplicate messages.