### PR TITLE
Disable libvirt qemu user sessions

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -73,6 +73,10 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
         # your development guest becoming corrupted (in which case you should only need to do a
         # vagrant destroy and vagrant up to get a new one).
         domain.volume_cache = "unsafe"
+
+        # Bodhi should not use user sessions since it requires network customization
+        # See https://bugzilla.redhat.com/show_bug.cgi?id=1701755
+        domain.qemu_use_session = false
     end
  end
 end


### PR DESCRIPTION
Starting from F30, libvirt defaults to use user sessions for QEMU. This will prevent Bodhi VM to work since we require network customization.
This PR will disable qemu_use_session and restores the previous state.

See https://bugzilla.redhat.com/show_bug.cgi?id=1701755

Signed-off-by: Mattia Verga <mattia.verga@tiscali.it>