### PR TITLE
Add markdown for gcc and sourceware bug trackers

### DIFF
--- a/bodhi/server/ffmarkdown.py
+++ b/bodhi/server/ffmarkdown.py
@@ -53,7 +53,8 @@ def bug_url(tracker, idx):
 
     Args:
         tracker (basestring): Which bug tracker is being referenced. May be any of 'fedora',
-            'gnome', 'kde', 'mozilla', 'pear', 'perl', 'php', 'python', 'rh', or 'rhbz'.
+            'gcc', 'gnome', 'kde', 'mozilla', 'pear', 'perl', 'php', 'python', 'rh', 'rhbz'
+            or 'sourceware'.
         idx (basestring or int): The bug number.
     Returns:
         basestring: The URL of the given bug.
@@ -61,8 +62,9 @@ def bug_url(tracker, idx):
         KeyError: If the given tracker is not supported by this function.
     """
     try:
-        return {
+        trackers = {
             'fedora': "https://bugzilla.redhat.com/show_bug.cgi?id=%s",
+            'gcc': "https://gcc.gnu.org/bugzilla/show_bug.cgi?id=%s",
             'gnome': "https://bugzilla.gnome.org/show_bug.cgi?id=%s",
             'kde': "https://bugs.kde.org/show_bug.cgi?id=%s",
             'mozilla': "https://bugzilla.mozilla.org/show_bug.cgi?id=%s",
@@ -71,7 +73,10 @@ def bug_url(tracker, idx):
             'php': "https://bugs.php.net/bug.php?id=%s",
             'python': "https://bugs.python.org/issue%s",
             'rh': "https://bugzilla.redhat.com/show_bug.cgi?id=%s",
-            'rhbz': "https://bugzilla.redhat.com/show_bug.cgi?id=%s"}[tracker.lower()] % idx
+            'rhbz': "https://bugzilla.redhat.com/show_bug.cgi?id=%s",
+            'sourceware': "https://sourceware.org/bugzilla/show_bug.cgi?id=%s"}
+
+        return trackers[tracker.lower()] % idx
 
     except KeyError:
         return None

--- a/bodhi/server/ffmarkdown.py
+++ b/bodhi/server/ffmarkdown.py
@@ -68,7 +68,7 @@ def bug_url(tracker, idx):
             'gnome': "https://bugzilla.gnome.org/show_bug.cgi?id=%s",
             'kde': "https://bugs.kde.org/show_bug.cgi?id=%s",
             'mozilla': "https://bugzilla.mozilla.org/show_bug.cgi?id=%s",
-            'pear': "http://pear.php.net/bugs/bug.php?id=%s",
+            'pear': "https://pear.php.net/bugs/bug.php?id=%s",
             'perl': "https://rt.cpan.org/Public/Bug/Display.html?id=%s",
             'php': "https://bugs.php.net/bug.php?id=%s",
             'python': "https://bugs.python.org/issue%s",

--- a/bodhi/server/templates/fragments.html
+++ b/bodhi/server/templates/fragments.html
@@ -222,11 +222,13 @@ __bold__
               <p>The supported bug tracker prefixes are: (these are all case-insensitive)</p>
               <ul>
                 <li><code>Fedora</code>, <code>RHBZ</code> and <code>RH</code> (all point to the Red Hat Bugzilla)</li>
+                <li><code>GCC</code></li>
                 <li><code>GNOME</code></li>
                 <li><code>KDE</code></li>
                 <li><code>PEAR</code></li>
                 <li><code>PHP</code></li>
                 <li><code>Python</code></li>
+                <li><code>SOURCEWARE</code></li>
               </ul>
               <hr/>
               <p>And you can refer to <strong>other users</strong> by prefixing their username with the <code>@</code> symbol.</p>


### PR DESCRIPTION
Add markdown for gcc and sourceware bug trackers.
Fixes #3129 

Signed-off-by: Mattia Verga <mattia.verga@tiscali.it>