### PR TITLE
Add a RateLimiter log filter and document it.

### DIFF
--- a/bodhi/server/__init__.py
+++ b/bodhi/server/__init__.py
@@ -17,7 +17,7 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 """Initialize the Bodhi server."""
 from collections import defaultdict
-import logging
+import logging as python_logging
 
 from cornice.validators import DEFAULT_FILTERS
 from dogpile.cache import make_region
@@ -33,7 +33,7 @@ from bodhi.server import bugs, buildsys
 from bodhi.server.config import config as bodhi_config
 
 
-log = logging.getLogger(__name__)
+log = python_logging.getLogger(__name__)
 
 
 #

--- a/bodhi/server/consumers/composer.py
+++ b/bodhi/server/consumers/composer.py
@@ -48,6 +48,7 @@ from bodhi.messages.schemas import compose as compose_schemas, update as update_
 from bodhi.server import bugs, initialize_db, buildsys, notifications, mail
 from bodhi.server.config import config, validate_path
 from bodhi.server.exceptions import BodhiException
+from bodhi.server.logging import setup as setup_logging
 from bodhi.server.metadata import UpdateInfoMetadata
 from bodhi.server.models import (Compose, ComposeState, Update, UpdateRequest, UpdateType, Release,
                                  UpdateStatus, ReleaseState, ContentType)
@@ -150,6 +151,8 @@ class ComposerHandler(object):
         Raises:
             ValueError: If pungi.cmd is set to a path that does not exist.
         """
+        setup_logging()
+
         if not db_factory:
             initialize_db(config)
             self.db_factory = transactional_session_maker()

--- a/bodhi/server/consumers/signed.py
+++ b/bodhi/server/consumers/signed.py
@@ -28,6 +28,7 @@ import fedora_messaging
 
 from bodhi.server import initialize_db
 from bodhi.server.config import config
+from bodhi.server.logging import setup as setup_logging
 from bodhi.server.models import Build
 from bodhi.server.util import transactional_session_maker
 
@@ -43,6 +44,7 @@ class SignedHandler(object):
 
     def __init__(self):
         """Initialize the SignedHandler."""
+        setup_logging()
         initialize_db(config)
         self.db_factory = transactional_session_maker()
 

--- a/bodhi/server/consumers/updates.py
+++ b/bodhi/server/consumers/updates.py
@@ -41,6 +41,7 @@ import fedora_messaging
 from bodhi.server import initialize_db, util, bugs as bug_module
 from bodhi.server.config import config
 from bodhi.server.exceptions import BodhiException
+from bodhi.server.logging import setup as setup_logging
 from bodhi.server.models import Bug, Update, UpdateType
 
 
@@ -63,6 +64,7 @@ class UpdatesHandler(object):
 
     def __init__(self, *args, **kwargs):
         """Initialize the UpdatesHandler."""
+        setup_logging()
         initialize_db(config)
         self.db_factory = util.transactional_session_maker()
 

--- a/bodhi/server/logging.py
+++ b/bodhi/server/logging.py
@@ -1,0 +1,107 @@
+# Copyright © 2019 Red Hat, Inc.
+#
+# This file is part of Bodhi.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+"""Utilities for logging in Bodhi."""
+
+import logging
+
+from pyramid import paster
+import yaml
+
+from bodhi.server import config
+
+
+def setup():
+    """Set up logging from our config file."""
+    pyramid_includes = config.config.get('pyramid.includes', '').split('\n')
+    if 'pyramid_sawing' in pyramid_includes:
+        # This Bodhi deployment is using pyramid_sawing to configure logging. This means that we
+        # cannot use paster.setup_logging() because the main config file doesn't have the logging
+        # settings. Let's read the main config file to find out where the logging settings are.
+        logging_config = config.config['pyramid_sawing.file']
+        with open(logging_config) as logging_config_file:
+            logging_config = yaml.safe_load(logging_config_file.read())
+        logging.config.dictConfig(logging_config)
+    else:
+        paster.setup_logging(config.get_configfile())
+
+
+class RateLimiter(logging.Filter):
+    """
+    Log filter that rate-limits logs based on time.
+
+    The rate limit is applied to records by filename and line number.
+
+    Filters can be applied to handlers and loggers. Configuring this via
+    dictConfig is possible, but has somewhat odd syntax::
+
+        log_config = {
+            "filters": {
+                "60_second_filter": {
+                    "()": "fedmsg_migration_tools.filters.RateLimiter",
+                    "rate": "60"
+                }
+            }
+            "handlers": {
+                "rate_limited": {
+                    "filters": ["60_second_filter"],
+                    ...
+                }
+            }
+            "loggers": {
+                "fedmsg_migration_tools": {
+                    "filters": ["60_second_filter"],
+                    ...
+                }
+            }
+        }
+
+    This was shamelessly stolen from
+    https://github.com/fedora-infra/fedmsg-migration-tools/blob/0cafc8f/fedmsg_migration_tools/filters.py
+    which is also licensed GPLv2+.
+
+    Attributes:
+        rate: How often, in seconds, to allow records. Defaults to hourly.
+    """
+
+    def __init__(self, rate: int = 3600):
+        """
+        Initialize the log filter.
+
+        Args:
+            rate: How often, in seconds, to allow records. Defaults to hourly.
+        """
+        self.rate = rate
+        self._sent = {}
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        """
+        Record call sites and filter based on time.
+
+        Args:
+            The log record we are filtering on.
+        Returns:
+            True if the record should be emitted, False otherwise.
+        """
+        key = "{}:{}".format(record.pathname, record.lineno)
+        try:
+            if self.rate > record.created - self._sent[key]:
+                return False
+        except KeyError:
+            pass
+        self._sent[key] = record.created
+        return True

--- a/bodhi/server/scripts/expire_overrides.py
+++ b/bodhi/server/scripts/expire_overrides.py
@@ -18,11 +18,12 @@ import logging
 import os
 import sys
 
-from pyramid.paster import get_appsettings, setup_logging
+from pyramid.paster import get_appsettings
 
 from ..buildsys import setup_buildsystem
 from ..models import BuildrootOverride
 from bodhi.server import Session, initialize_db
+from bodhi.server.logging import setup as setup_logging
 
 
 def usage(argv):
@@ -50,7 +51,7 @@ def main(argv=sys.argv):
 
     config_uri = argv[1]
 
-    setup_logging(config_uri)
+    setup_logging()
     log = logging.getLogger(__name__)
 
     settings = get_appsettings(config_uri)

--- a/bodhi/server/scripts/initializedb.py
+++ b/bodhi/server/scripts/initializedb.py
@@ -1,3 +1,7 @@
+# Copyright © 2013-2019 Red Hat, Inc. and others.
+#
+# This file is part of Bodhi.
+#
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
 # as published by the Free Software Foundation; either version 2
@@ -16,10 +20,11 @@
 import os
 import sys
 
-from pyramid.paster import get_appsettings, setup_logging
+from pyramid.paster import get_appsettings
 
 from ..models import Base
 from bodhi.server import initialize_db
+from bodhi.server.logging import setup as setup_logging
 
 
 def usage(argv):
@@ -47,7 +52,7 @@ def main(argv=sys.argv):
     if len(argv) != 2:
         usage(argv)
     config_uri = argv[1]
-    setup_logging(config_uri)
+    setup_logging()
     settings = get_appsettings(config_uri)
     engine = initialize_db(settings)
     Base.metadata.bind = engine

--- a/bodhi/server/scripts/untag_branched.py
+++ b/bodhi/server/scripts/untag_branched.py
@@ -30,11 +30,12 @@ import logging
 
 from datetime import datetime, timedelta
 
-from pyramid.paster import get_appsettings, setup_logging
+from pyramid.paster import get_appsettings
 
 from ..models import Release, ReleaseState, Update, UpdateStatus
 
 from bodhi.server import buildsys, Session, initialize_db
+from bodhi.server.logging import setup as setup_logging
 
 
 def usage(argv):
@@ -62,7 +63,7 @@ def main(argv=sys.argv):
 
     config_uri = argv[1]
 
-    setup_logging(config_uri)
+    setup_logging()
     log = logging.getLogger(__name__)
 
     settings = get_appsettings(config_uri)

--- a/bodhi/tests/server/consumers/test_composer.py
+++ b/bodhi/tests/server/consumers/test_composer.py
@@ -290,6 +290,15 @@ That was the actual one''' % compose_dir
 
         set_bugtracker.assert_called_once_with()
 
+    @mock.patch('bodhi.server.consumers.composer.setup_logging')
+    def test___init___sets_logging(self, setup_logging):
+        """
+        Assert that Handler.__init__() calls bodhi.server.log.setup().
+        """
+        ComposerHandler(db_factory=self.db_factory, compose_dir=self.tempdir)
+
+        setup_logging.assert_called_once_with()
+
     @mock.patch.dict('bodhi.server.config.config', {
         'pungi.cmd': '/does/not/exist',
         'compose_dir': '/does/not/exist',

--- a/bodhi/tests/server/consumers/test_signed.py
+++ b/bodhi/tests/server/consumers/test_signed.py
@@ -53,6 +53,13 @@ class TestSignedHandlerConsume(unittest.TestCase):
         )
         self.handler = signed.SignedHandler()
 
+    @mock.patch('bodhi.server.consumers.signed.setup_logging')
+    def test___init___sets_up_logging(self, setup_logging):
+        """Assert that __init__() sets up logging."""
+        signed.SignedHandler()
+
+        setup_logging.assert_called_once_with()
+
     @mock.patch('bodhi.server.consumers.signed.Build')
     def test_consume(self, mock_build_model):
         """Assert that messages marking the build as signed updates the database"""

--- a/bodhi/tests/server/consumers/test_updates.py
+++ b/bodhi/tests/server/consumers/test_updates.py
@@ -308,6 +308,13 @@ class TestUpdatesHandlerInit(unittest.TestCase):
 
         self.assertEqual(h.handle_bugs, False)
 
+    @mock.patch('bodhi.server.consumers.updates.setup_logging')
+    def test_sets_up_logging(self, setup_logging):
+        """Assert that __init__() sets up logging."""
+        updates.UpdatesHandler()
+
+        setup_logging.assert_called_once_with()
+
     @mock.patch('bodhi.server.consumers.updates.bug_module.set_bugtracker')
     def test_typical_config(self, set_bugtracker):
         """

--- a/bodhi/tests/server/scripts/test_initializedb.py
+++ b/bodhi/tests/server/scripts/test_initializedb.py
@@ -34,7 +34,7 @@ class TestMain(unittest.TestCase):
         """Assert correct behavior when the right arguments are supplied."""
         initializedb.main(argv=['initializedb', '/etc/bodhi/production.ini'])
 
-        setup_logging.assert_called_once_with('/etc/bodhi/production.ini')
+        setup_logging.assert_called_once_with()
         get_appsettings.assert_called_once_with('/etc/bodhi/production.ini')
         initialize_db.assert_called_once_with(get_appsettings.return_value)
         self.assertEqual(initializedb.Base.metadata.bind, initialize_db.return_value)

--- a/bodhi/tests/server/scripts/test_untag_branched.py
+++ b/bodhi/tests/server/scripts/test_untag_branched.py
@@ -52,7 +52,7 @@ class TestMain(BaseTestCase):
 
         untag_branched.main(['untag_branched', 'some_config_path'])
 
-        setup_logging.assert_called_once_with('some_config_path')
+        setup_logging.assert_called_once_with()
         initialize_db.assert_called_once_with({'some': 'settings'})
         get_appsettings.assert_called_once_with('some_config_path')
         # Nothing should have been untagged
@@ -83,7 +83,7 @@ class TestMain(BaseTestCase):
 
         untag_branched.main(['untag_branched', 'some_config_path'])
 
-        setup_logging.assert_called_once_with('some_config_path')
+        setup_logging.assert_called_once_with()
         initialize_db.assert_called_once_with({'some': 'settings'})
         get_appsettings.assert_called_once_with('some_config_path')
         # Nothing should have been untagged
@@ -115,7 +115,7 @@ class TestMain(BaseTestCase):
 
         untag_branched.main(['untag_branched', 'some_config_path'])
 
-        setup_logging.assert_called_once_with('some_config_path')
+        setup_logging.assert_called_once_with()
         initialize_db.assert_called_once_with({'some': 'settings'})
         get_appsettings.assert_called_once_with('some_config_path')
         # Nothing should have been untagged
@@ -151,7 +151,7 @@ class TestMain(BaseTestCase):
 
         untag_branched.main(['untag_branched', 'some_config_path'])
 
-        setup_logging.assert_called_once_with('some_config_path')
+        setup_logging.assert_called_once_with()
         initialize_db.assert_called_once_with({'some': 'settings'})
         get_appsettings.assert_called_once_with('some_config_path')
         # Nothing should have been untagged
@@ -189,7 +189,7 @@ class TestMain(BaseTestCase):
 
         untag_branched.main(['untag_branched', 'some_config_path'])
 
-        setup_logging.assert_called_once_with('some_config_path')
+        setup_logging.assert_called_once_with()
         initialize_db.assert_called_once_with({'some': 'settings'})
         get_appsettings.assert_called_once_with('some_config_path')
         # Nothing should have been untagged
@@ -223,7 +223,7 @@ class TestMain(BaseTestCase):
 
         untag_branched.main(['untag_branched', 'some_config_path'])
 
-        setup_logging.assert_called_once_with('some_config_path')
+        setup_logging.assert_called_once_with()
         initialize_db.assert_called_once_with({'some': 'settings'})
         get_appsettings.assert_called_once_with('some_config_path')
         # Nothing should have been untagged

--- a/bodhi/tests/server/test_logging.py
+++ b/bodhi/tests/server/test_logging.py
@@ -1,0 +1,110 @@
+# Copyright © 2019 Red Hat, Inc.
+#
+# This file is part of Bodhi.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+"""Test bodhi.server.logging."""
+
+import logging
+import unittest
+
+from bodhi.server import logging as bodhi_logging
+
+
+test_log = logging.Logger(__name__)
+
+
+class TestSetup(unittest.TestCase):
+    """Test the setup() function."""
+
+    @unittest.mock.patch(
+        'bodhi.server.logging.config.config',
+        {'pyramid.includes': 'some_plugin\npyramid_sawing\nsome_other_plugin',
+         'pyramid_sawing.file': '/some/file'})
+    @unittest.mock.patch('bodhi.server.logging.logging.config.dictConfig')
+    def test_with_sawing(self, dictConfig):
+        """Test for when the user is using pyramid_sawing."""
+        with unittest.mock.patch('builtins.open',
+                                 unittest.mock.mock_open(read_data='some: data')) as mock_open:
+            bodhi_logging.setup()
+
+        mock_open.assert_called_once_with('/some/file')
+        dictConfig.assert_called_once_with({'some': 'data'})
+
+    @unittest.mock.patch.dict('bodhi.server.logging.config.config',
+                              {'pyramid.includes': 'some_plugin\nsome_other_plugin'})
+    @unittest.mock.patch('bodhi.server.logging.config.get_configfile',
+                         unittest.mock.MagicMock(return_value='/test/file'))
+    @unittest.mock.patch('bodhi.server.logging.paster.setup_logging')
+    def test_without_sawing(self, setup_logging):
+        """Test for when the user is not using pyramid_sawing."""
+        bodhi_logging.setup()
+
+        setup_logging.assert_called_once_with('/test/file')
+
+
+class TestRateLimiter(unittest.TestCase):
+    """
+    Test the RateLimiter class.
+
+    These tests were stolen from
+    https://github.com/fedora-infra/fedmsg-migration-tools/blob/0cafc8f5/fedmsg_migration_tools/tests/test_filters.py
+    """
+
+    def test_filter_new_record(self):
+        """Assert a new record is not limited."""
+        record = test_log.makeRecord(
+            "test_name", logging.INFO, "/my/file.py", 3, "beep boop", tuple(), None)
+        rate_filter = bodhi_logging.RateLimiter()
+
+        self.assertTrue(rate_filter.filter(record))
+
+    def test_filter_false(self):
+        """Assert if the filename:lineno entry exists and is new, it's filtered out."""
+        record = test_log.makeRecord(
+            "test_name", logging.INFO, "/my/file.py", 3, "beep boop", tuple(), None)
+        rate_filter = bodhi_logging.RateLimiter(rate=2)
+        rate_filter._sent["/my/file.py:3"] = record.created - 1
+
+        self.assertFalse(rate_filter.filter(record))
+
+    def test_rate_is_used(self):
+        """Assert custom rates are respected."""
+        record = test_log.makeRecord(
+            "test_name", logging.INFO, "/my/file.py", 3, "beep boop", tuple(), None)
+        rate_filter = bodhi_logging.RateLimiter(rate=2)
+        rate_filter._sent["/my/file.py:3"] = record.created - 2
+
+        self.assertTrue(rate_filter.filter(record))
+
+    def test_rate_limited(self):
+        """Assert the first call is allowed and the subsequent one is not."""
+        record = test_log.makeRecord(
+            "test_name", logging.INFO, "/my/file.py", 3, "beep boop", tuple(), None)
+        rate_filter = bodhi_logging.RateLimiter(rate=60)
+
+        self.assertTrue(rate_filter.filter(record))
+        self.assertFalse(rate_filter.filter(record))
+
+    def test_different_lines(self):
+        """Assert rate limiting is line-dependent."""
+        record1 = test_log.makeRecord(
+            "test_name", logging.INFO, "/my/file.py", 3, "beep boop", tuple(), None)
+        record2 = test_log.makeRecord(
+            "test_name", logging.INFO, "/my/file.py", 4, "beep boop", tuple(), None)
+        rate_filter = bodhi_logging.RateLimiter()
+
+        self.assertTrue(rate_filter.filter(record1))
+        self.assertTrue(rate_filter.filter(record2))

--- a/devel/ci/Dockerfile-f28
+++ b/devel/ci/Dockerfile-f28
@@ -38,6 +38,7 @@ RUN dnf install --disablerepo rawhide-modular -y \
     python3-pyramid-mako \
     python3-pytest \
     python3-pytest-cov \
+    python3-pyyaml \
     python3-responses \
     python3-simplemediawiki \
     python3-sqlalchemy \

--- a/devel/ci/Dockerfile-f29
+++ b/devel/ci/Dockerfile-f29
@@ -34,6 +34,7 @@ RUN dnf install --disablerepo rawhide-modular -y \
     python3-pyramid-mako \
     python3-pytest \
     python3-pytest-cov \
+    python3-pyyaml \
     python3-responses \
     python3-simplemediawiki \
     python3-sqlalchemy \

--- a/docs/user/release_notes.rst
+++ b/docs/user/release_notes.rst
@@ -78,6 +78,7 @@ Dependency changes
 * ``bodhi-server`` now depends on ``bodhi-messages``.
 * kitchen is no longer required.
 * hawkey is no longer required.
+* PyYAML is now a required dependency (:issue:`3174`).
 * Twisted is now required (:issue:`3145`).
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,6 +19,7 @@ pyramid_fas_openid
 pyramid_mako
 python-bugzilla
 python-fedora
+PyYAML
 simplemediawiki
 sqlalchemy
 waitress


### PR DESCRIPTION
In order to send crash e-mails to admins with Bodhi 4, we need a
way to rate limit the e-mails so we don't send too many repeat
messages about the same problem. This commit introduces
bodhi.server.logging.RateLimiter, which can be used with Python's
logging system to filter messages via the SMTPHandler.

Unfortunately, it is not possible to use logging filters with
Python's configparser logging configs, which is what Pyramid uses
for logging configuration. Due to this, this commit also adds
documentation describing how deployments can use pyramid_sawing to
move the logging configuration into a YAML file. It also documents
the RateLimiter filter. This allows deployments to use the log
filter with Python's built-in SMTPHandler if they don't mind using
a plugin.

This commit also adjusts all places that were configuring logging
to use a new bodhi.server.logging.setup() function that is able to
use the pyramid_sawing YAML file if it is configured, or is able
to use the regular Pyramid INI configuration if the plugin is not
being used. This way there is one way to configure logging in
Bodhi across all processes.

fixes #969

Signed-off-by: Randy Barlow <randy@electronsweatshop.com>