### PR TITLE
Switch log call to let the API format a string.

### DIFF
--- a/bodhi/client/bindings.py
+++ b/bodhi/client/bindings.py
@@ -946,5 +946,5 @@ class BodhiClient(OpenIdBaseClient):
                     if build['owner_name'] == self.username:
                         builds.append(build)
             except Exception:
-                log.exception('Unable to query candidate builds for %s' % release)
+                log.exception('Unable to query candidate builds for %s', release)
         return builds

--- a/bodhi/tests/client/test_bindings.py
+++ b/bodhi/tests/client/test_bindings.py
@@ -1548,7 +1548,7 @@ class TestBodhiClient_candidates(unittest.TestCase):
              mock.call('f26-updates-testing', latest=True)])
         client.send_request.assert_called_once_with('releases/', params={}, verb='GET')
         exception.assert_called_once_with(
-            "Unable to query candidate builds for {'candidate_tag': 'f26-updates-testing'}")
+            "Unable to query candidate builds for %s", {'candidate_tag': 'f26-updates-testing'})
 
     @mock.patch('bodhi.client.bindings.BodhiClient._load_cookies', mock.MagicMock())
     @mock.patch('bodhi.client.bindings.BodhiClient.get_koji_session')


### PR DESCRIPTION
It's best to let the log API format strings. This way if the log
level is set to a level that won't emit the log, we don't spend
time formatting it.

Signed-off-by: Randy Barlow <randy@electronsweatshop.com>