### PR TITLE
Give bodhi-ci diff_cover a -Z flag.

### DIFF
--- a/devel/ci/bodhi-ci
+++ b/devel/ci/bodhi-ci
@@ -128,6 +128,9 @@ releases_option = click.option(
           "Acceptable values: {}".format(', '.join(RELEASES))))
 tty_option = click.option('--tty/--no-tty', default=True, help='Allocate a pseudo-TTY.',
                           callback=_set_global)
+z_option = click.option(
+    '-Z', default=False, callback=_set_global, is_flag=True,
+    help="Use the container runtime's Z flag when bind mounting the .git folder")
 
 container_runtime = 'docker'
 failfast = False
@@ -136,6 +139,7 @@ init = True
 # _set_global().
 no_build = False
 tty = False
+z = False
 
 
 @click.group()
@@ -204,8 +208,9 @@ def clean(concurrency, container_runtime, init, release, tty):
 @no_build_option
 @releases_option
 @tty_option
+@z_option
 def diff_cover(archive, archive_path, concurrency, container_runtime, no_build, failfast, init,
-               release, tty):
+               release, tty, z):
     """Run the diff cover test."""
     _run_jobs(_build_jobs_list('diff_cover', concurrency, release, archive=archive,
                                archive_path=archive_path))
@@ -612,7 +617,11 @@ class Job(object):
             args.extend(['-v', '{}:/results:z'.format(self.archive_dir)])
 
         if include_git:
-            args.extend(['-v', f"{os.path.join(PROJECT_PATH, '.git')}:/bodhi/.git:ro,z"])
+            mount_flags = ['ro']
+            if z:
+                mount_flags.append('Z')
+            args.extend([
+                '-v', f"{os.path.join(PROJECT_PATH, '.git')}:/bodhi/.git:{','.join(mount_flags)}"])
 
         args.append(self._container_image)
         args.extend(self._command)

--- a/devel/ci/cico.pipeline
+++ b/devel/ci/cico.pipeline
@@ -120,7 +120,7 @@ def test_release = { String release ->
         },
         unit: {
             bodhi_ci(release, 'unit', 'unit', '--no-build --no-init')
-            bodhi_ci(release, 'diff_cover', 'diff-cover', '--no-build --no-init')
+            bodhi_ci(release, 'diff_cover', 'diff-cover', '--no-build --no-init -Z')
         }
     )
 }


### PR DESCRIPTION
We recently started sharing the .git folder into the container with
a bind mount for the diff_cover container. We used the Z flag on
the docker bind mount so that the container would have the right
SELinux labeling in the container. Unfortunately, the Z flag also
caused the container to fail to be able to read the .git folder in
the Vagrant guest.

This commit adds a -Z flag so that the tests in CentOS CI can run
with the flag, but running in the Vagrant guest will not use it.
This way the tests work in both environments.

fixes #3166

Signed-off-by: Randy Barlow <randy@electronsweatshop.com>