### PR TITLE
Replace the call to hawkey with a call to DNF in repo sanity check

### DIFF
--- a/bootstrap.py
+++ b/bootstrap.py
@@ -113,7 +113,7 @@ def link_system_libs():
                 '_sqlitecache', 'psycopg2', 'krbVmodule', 'deltarpm',
                 '_deltarpmmodule', 'fedora_cert', 'libxml2', 'libxml2mod',
                 'librepo', 'createrepo_c', 'dnf', 'gpg', 'gpgme', 'lzma',
-                'hawkey', 'yum'):
+                'dnf', 'yum'):
         _link_system_lib(mod)
 
 

--- a/devel/ci/Dockerfile-f28
+++ b/devel/ci/Dockerfile-f28
@@ -13,7 +13,6 @@ RUN dnf install --disablerepo rawhide-modular -y \
     gcc \
     git \
     python3-createrepo_c \
-    python3-hawkey \
     python3-koji \
     make \
     python3-alembic \

--- a/devel/ci/Dockerfile-f29
+++ b/devel/ci/Dockerfile-f29
@@ -14,7 +14,6 @@ RUN dnf install --disablerepo rawhide-modular -y \
     git \
     python3-bugzilla \
     python3-createrepo_c \
-    python3-hawkey \
     python3-koji \
     make \
     python3-alembic \

--- a/devel/ci/Dockerfile-f30
+++ b/devel/ci/Dockerfile-f30
@@ -23,7 +23,6 @@ RUN dnf install --disablerepo rawhide-modular -y \
     python3-dogpile-cache \
     python3-fedora \
     python3-feedgen \
-    python3-hawkey \
     python3-jinja2 \
     python3-koji \
     python3-libcomps \

--- a/devel/ci/Dockerfile-pip
+++ b/devel/ci/Dockerfile-pip
@@ -9,7 +9,6 @@ RUN dnf install -y \
     findutils \
     git \
     python3-createrepo_c \
-    python3-hawkey \
     python3-koji \
     createrepo_c \
     gcc \

--- a/devel/ci/Dockerfile-rawhide
+++ b/devel/ci/Dockerfile-rawhide
@@ -22,7 +22,6 @@ RUN dnf install --disablerepo rawhide-modular -y \
     python3-dogpile-cache \
     python3-fedora \
     python3-feedgen \
-    python3-hawkey \
     python3-jinja2 \
     python3-koji \
     python3-libcomps \

--- a/docs/user/release_notes.rst
+++ b/docs/user/release_notes.rst
@@ -77,6 +77,7 @@ Dependency changes
 * six is no longer required for the client or server (:issue:`2759`).
 * ``bodhi-server`` now depends on ``bodhi-messages``.
 * kitchen is no longer required.
+* hawkey is no longer required.
 
 
 Server upgrade instructions


### PR DESCRIPTION
libdnf/hawkey silently dropped the API we were using to do repo sanity checks.
So instead, let's just shell out to DNF and make it their problem.

Signed-off-by: Patrick Uiterwijk <patrick@puiterwijk.org>