### PR TITLE
Add an index to comments.update_id.

### DIFF
--- a/bodhi/server/migrations/versions/19e28e9851a2_index_comment_update_id.py
+++ b/bodhi/server/migrations/versions/19e28e9851a2_index_comment_update_id.py
@@ -1,0 +1,40 @@
+# Copyright © Red Hat, Inc.
+#
+# This file is part of Bodhi.
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+"""
+Index the update_id column on the comments table.
+
+Revision ID: 19e28e9851a2
+Revises: 7ba286412ad4
+Create Date: 2019-04-30 22:29:42.553574
+"""
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = '19e28e9851a2'
+down_revision = '7ba286412ad4'
+
+
+def upgrade():
+    """Add an index on comments.update_id."""
+    op.create_index(op.f('ix_comments_update_id'), 'comments', ['update_id'], unique=False)
+
+
+def downgrade():
+    """Drop the index on comments.update_id."""
+    op.drop_index(op.f('ix_comments_update_id'), table_name='comments')

--- a/bodhi/server/models.py
+++ b/bodhi/server/models.py
@@ -3809,7 +3809,7 @@ class Comment(Base):
     text = Column(UnicodeText, nullable=False)
     timestamp = Column(DateTime, default=datetime.utcnow)
 
-    update_id = Column(Integer, ForeignKey('updates.id'))
+    update_id = Column(Integer, ForeignKey('updates.id'), index=True)
     user_id = Column(Integer, ForeignKey('users.id'))
 
     def url(self):


### PR DESCRIPTION
Many queries will pull in update comments, and it was discovered
that the comments table's update_id column was not indexed. This
means that the comments table was being scanned repeatedly when
updates were being retrieved from the database.

This commit lowered the time to query for all updates from a given
user from 5638.934 ms to 14.911 ms in the Vagrant environment,
just 0.264% of the previous time to run the query.

re #3062

Signed-off-by: Randy Barlow <randy@electronsweatshop.com>