### PR TITLE
Remove a workaround for an old dnf bug to workaround a new dnf bug.

### DIFF
--- a/devel/ci/Dockerfile-f29
+++ b/devel/ci/Dockerfile-f29
@@ -1,9 +1,6 @@
 FROM registry.fedoraproject.org/fedora:29
 LABEL maintainer="Randy Barlow <bowlofeggs@fedoraproject.org>"
 
-# Work around a severe dnf/libsolv/glibc issue: https://pagure.io/releng/issue/7125
-# This was suggested in a BZ comment: https://bugzilla.redhat.com/show_bug.cgi?id=1483553#c78
-RUN dnf upgrade -y libsolv || echo "We are not trying to test dnf upgrade, so ignoring dnf failure."
 # The echo works around https://bugzilla.redhat.com/show_bug.cgi?id=1483553 and any other future dnf
 # upgrade bugs.
 RUN dnf upgrade -y || echo "We are not trying to test dnf upgrade, so ignoring dnf failure."


### PR DESCRIPTION
This commit removes a workaround for a dnf Bug our CI used to hit,
in order to work around a new dnf bug we just started hitting
today[0]. I do not know why removing this line fixes the current
issue, but it does and we don't need this line anymore anyway.

[0] https://bugzilla.redhat.com/show_bug.cgi?id=1705265

Signed-off-by: Randy Barlow <randy@electronsweatshop.com>