### PR TITLE
z instead of Z on the .git folder for diff-cover

### DIFF
--- a/devel/ci/bodhi-ci
+++ b/devel/ci/bodhi-ci
@@ -612,7 +612,7 @@ class Job(object):
             args.extend(['-v', '{}:/results:z'.format(self.archive_dir)])
 
         if include_git:
-            args.extend(['-v', f"{os.path.join(PROJECT_PATH, '.git')}:/bodhi/.git:ro,Z"])
+            args.extend(['-v', f"{os.path.join(PROJECT_PATH, '.git')}:/bodhi/.git:ro,z"])
 
         args.append(self._container_image)
         args.extend(self._command)


### PR DESCRIPTION
This commit adjusts our Docker bind mount to use the z flag instead
of the Z flag. It is possible that multiple containers run at the
same time with the same content, so the shared label is more
sensible.

Signed-off-by: Randy Barlow <randy@electronsweatshop.com>