### PR TITLE
Use greenwave subject_identifier to store missing tests in the UI.

### DIFF
--- a/bodhi/server/templates/update.html
+++ b/bodhi/server/templates/update.html
@@ -54,16 +54,16 @@ ${update.type} update for ${update.beautify_title(amp=True) | n}
     var handle_unsatisfied_requirements = function(data){
         $.each(data['unsatisfied_requirements'], function(i, requirement) {
             if (requirement.type == 'test-result-missing') {
-                if (missing_tests[requirement.item] === undefined)
-                    missing_tests[requirement.item] = [];
-                missing_tests[requirement.item].push(requirement);
+                if (missing_tests[requirement.subject_identifier] === undefined)
+                    missing_tests[requirement.subject_identifier] = [];
+                missing_tests[requirement.subject_identifier].push(requirement);
             }
             // the user may have already specified this in the required taskotron tests
             if ($.inArray(requirement.testcase, requirements) == -1) {
                 requirements.push(requirement.testcase);
             }
             $('#failed_requirements').append('<li class="list-group-item">' + requirement.testcase + '</li>');
-            
+
             // there is at least one unsatisfied requirement, so show the button to be able to waive.
             $('#waive').show();
         });


### PR DESCRIPTION
This commmit makes use of the subject_identifier (build nvr) in
greenwave response to store the related missing tests.
The missing tests are then displayed in the list of automated test on
the UI.

Signed-off-by: Clement Verna <cverna@tutanota.com>