### PR TITLE
Stop producing bodhi-dequeue-stable.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -225,7 +225,6 @@ setup(
     [console_scripts]
     initialize_bodhi_db = bodhi.server.scripts.initializedb:main
     bodhi-clean-old-composes = bodhi.server.scripts.clean_old_composes:clean_up
-    bodhi-dequeue-stable = bodhi.server.scripts.dequeue_stable:dequeue_stable
     bodhi-push = bodhi.server.push:push
     bodhi-expire-overrides = bodhi.server.scripts.expire_overrides:main
     bodhi-untag-branched = bodhi.server.scripts.untag_branched:main


### PR DESCRIPTION
The batching feature was dropped in Bodhi 4.0.0, and the code
backing the bodhi-dequeue-stable CLI was removed, but we forgot to
remove it from the setup.py so the CLI still gets generated.

This commit removes the CLI from setup.py.

Signed-off-by: Randy Barlow <randy@electronsweatshop.com>