### PR TITLE
API: Create/edit updates from Koji tags

### DIFF
--- a/bodhi/server/buildsys.py
+++ b/bodhi/server/buildsys.py
@@ -381,10 +381,19 @@ class DevBuildsys:
     @multicall_enabled
     def listTagged(self, tag: str, *args, **kw) -> typing.List[typing.Any]:
         """List updates tagged with teh given tag."""
+        latest = kw.get('latest', False)
         builds = []
-        for build in [self.getBuild(),
+
+        all_builds = [self.getBuild(),
                       self.getBuild(other=True),
-                      self.getBuild(other=True, testing=True)]:
+                      self.getBuild(other=True, testing=True)]
+
+        if latest:
+            # Delete all older builds which aren't the latest for their tag.
+            # Knowing which these are is simpler than trying to rpmvercmp.
+            del all_builds[0]
+
+        for build in all_builds:
             if build['nvr'] in self.__untag__:
                 log.debug('Pruning koji build %s' % build['nvr'])
                 continue

--- a/bodhi/server/migrations/versions/d3f8bd499ecd_add_from_tag_column_to_updates.py
+++ b/bodhi/server/migrations/versions/d3f8bd499ecd_add_from_tag_column_to_updates.py
@@ -1,0 +1,41 @@
+# Copyright (c) 2019 Red Hat, Inc.
+#
+# This file is part of Bodhi.
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+"""
+Add from_tag column to updates.
+
+Revision ID: d3f8bd499ecd
+Revises: c60d95eef4f1
+Create Date: 2019-05-14 15:10:54.769789
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'd3f8bd499ecd'
+down_revision = 'c60d95eef4f1'
+
+
+def upgrade():
+    """Add the from_tag column to the updates table."""
+    op.add_column('updates', sa.Column('from_tag', sa.UnicodeText(), nullable=True))
+
+
+def downgrade():
+    """Drop the from_tag column from the updates table."""
+    op.drop_column('updates', 'from_tag')

--- a/bodhi/server/models.py
+++ b/bodhi/server/models.py
@@ -1666,6 +1666,8 @@ class Update(Base):
             Greenwave integration was not enabled when the update was created.
         compose (Compose): The :class:`Compose` that this update is currently being composed in. The
             update is locked if this is defined.
+        from_tag (str): The koji tag from which the list of builds was
+            originally populated (if any).
     """
 
     __tablename__ = 'updates'
@@ -1738,6 +1740,9 @@ class Update(Base):
 
     # Greenwave
     test_gating_status = Column(TestGatingStatus.db_type(), default=None, nullable=True)
+
+    # Koji tag, if any, from which the list of builds was populated initially.
+    from_tag = Column(UnicodeText, nullable=True)
 
     def __init__(self, *args, **kwargs):
         """

--- a/bodhi/server/schemas.py
+++ b/bodhi/server/schemas.py
@@ -171,6 +171,11 @@ class SaveUpdateSchema(CSRFProtectedSchema, colander.MappingSchema):
     builds = Builds(colander.Sequence(accept_scalar=True),
                     preparer=[util.splitter])
 
+    from_tag = colander.SchemaNode(
+        colander.String(),
+        missing=None,
+    )
+
     bugs = Bugs(colander.Sequence(accept_scalar=True), missing=None, preparer=[util.splitter])
 
     display_name = colander.SchemaNode(

--- a/bodhi/tests/server/base.py
+++ b/bodhi/tests/server/base.py
@@ -199,7 +199,8 @@ class BaseTestCaseMixin:
             app = self.app
         return app.get('/csrf', headers={'Accept': 'application/json'}).json_body['csrf_token']
 
-    def get_update(self, builds='bodhi-2.0-1.fc17', stable_karma=3, unstable_karma=-3):
+    def get_update(self, builds='bodhi-2.0-1.fc17', from_tag=None,
+                   stable_karma=3, unstable_karma=-3):
         """
         Return a dict describing an update.
 
@@ -207,15 +208,11 @@ class BaseTestCaseMixin:
 
         Args:
             builds (str): A comma-separated list of NVRs to include in the update.
+            from_tag (str): A tag from which to fill the list of builds.
             stable_karma (int): The stable karma threshold to use on the update.
             unstable_karma (int): The unstable karma threshold to use on the update.
         """
-        if isinstance(builds, list):
-            builds = ','.join(builds)
-        if not isinstance(builds, str):
-            builds = builds.encode('utf-8')
-        return {
-            'builds': builds,
+        update = {
             'bugs': '',
             'notes': 'this is a test update',
             'type': 'bugfix',
@@ -227,6 +224,18 @@ class BaseTestCaseMixin:
             'require_testcases': True,
             'csrf_token': self.get_csrf_token(),
         }
+
+        if builds:
+            if isinstance(builds, list):
+                builds = ','.join(builds)
+            if not isinstance(builds, str):
+                builds = builds.encode('utf-8')
+            update['builds'] = builds
+
+        if from_tag:
+            update['from_tag'] = from_tag
+
+        return update
 
     def _teardown_method(self):
         """Roll back all the changes from the test and clean up the session."""

--- a/bodhi/tests/server/views/test_generic.py
+++ b/bodhi/tests/server/views/test_generic.py
@@ -340,21 +340,17 @@ class TestGenericViews(base.BaseTestCase):
 
         res = self.app.get('/latest_candidates', {'package': 'TurboGears'})
         body = res.json_body
-        self.assertEqual(len(body), 2)
-        self.assertEqual(body[0]['nvr'], 'TurboGears-1.0.2.2-2.fc17')
-        self.assertEqual(body[0]['id'], 16058)
-        self.assertEqual(body[1]['nvr'], 'TurboGears-1.0.2.2-3.fc17')
-        self.assertEqual(body[1]['id'], 16059)
+        self.assertEqual(len(body), 1)
+        self.assertEqual(body[0]['nvr'], 'TurboGears-1.0.2.2-3.fc17')
+        self.assertEqual(body[0]['id'], 16059)
 
         res = self.app.get('/latest_candidates', {'package': 'TurboGears', 'testing': True})
         body = res.json_body
-        self.assertEqual(len(body), 3)
-        self.assertEqual(body[0]['nvr'], 'TurboGears-1.0.2.2-2.fc17')
-        self.assertEqual(body[0]['id'], 16058)
-        self.assertEqual(body[1]['nvr'], 'TurboGears-1.0.2.2-3.fc17')
-        self.assertEqual(body[1]['id'], 16059)
-        self.assertEqual(body[2]['nvr'], 'TurboGears-1.0.2.2-4.fc17')
-        self.assertEqual(body[2]['id'], 16060)
+        self.assertEqual(len(body), 2)
+        self.assertEqual(body[0]['nvr'], 'TurboGears-1.0.2.2-3.fc17')
+        self.assertEqual(body[0]['id'], 16059)
+        self.assertEqual(body[1]['nvr'], 'TurboGears-1.0.2.2-4.fc17')
+        self.assertEqual(body[1]['id'], 16060)
 
     def test_version(self):
         res = self.app.get('/api_version')


### PR DESCRIPTION
This PR contains code to let users submit new updates or edit existing ones for a Koji (side) tag, i.e. it would pull the latest builds in the tag into the update and remember the tag with the update. For editing (not fully implemented yet), it would work like this: if the list of submitted builds is non-empty, do things just as before, if it is empty, consult Koji again for a list of builds.

NB: it uses the first two commits from PR#3168, so it would be good if this one would be merged first.