### PR TITLE
Do not crash the updates handler upon messages.

### DIFF
--- a/bodhi/messages/schemas/update.py
+++ b/bodhi/messages/schemas/update.py
@@ -256,15 +256,33 @@ class UpdateEditV1(UpdateMessage):
                 'type': 'string',
                 'description': 'The user who edited the update',
             },
+            'new_bugs': {
+                'type': 'array',
+                'description': 'An array of bug ids that have been added to the update',
+                'items': {
+                    'type': 'integer',
+                    'description': 'A Bugzilla bug ID'
+                }
+            },
             'update': UpdateV1.schema(),
         },
-        'required': ['agent', 'update'],
+        'required': ['agent', 'new_bugs', 'update'],
         'definitions': {
             'build': BuildV1.schema(),
         }
     }
 
     topic = "bodhi.update.edit"
+
+    @property
+    def new_bugs(self) -> typing.Iterable[int]:
+        """
+        Return an iterable of the new bugs that have been added to the update.
+
+        Returns:
+            A list of Bugzilla bug IDs.
+        """
+        return self.body['new_bugs']
 
     @property
     def summary(self) -> str:

--- a/bodhi/tests/messages/schemas/test_update.py
+++ b/bodhi/tests/messages/schemas/test_update.py
@@ -520,6 +520,7 @@ class UpdateMessageTests(unittest.TestCase):
                 "9c9f7784935381befc302fe3c814f9136e7a33953d0318761669b8643f4df55c"
                 "?s=64&d=retro"
             ),
+            "new_bugs": [1708925, 1706626],
             "usernames": ["ralph"],
             "packages": ["tzdata"],
             'update': UpdateV1('FEDORA-2019-7dbbb74a13', [BuildV1('tzdata-2014i-1.fc19')],
@@ -527,6 +528,7 @@ class UpdateMessageTests(unittest.TestCase):
         }
         msg = UpdateEditV1(
             body={
+                "new_bugs": [1708925, 1706626],
                 "update": {
                     "close_bugs": True,
                     "pushed": False,


### PR DESCRIPTION
The updates handler was crashing in staging because it was
expecting the old fedmsg but was receiving a fedora-messaging
Message. This commit adjusts the handler to use Bodhi's new
Message objects. It also adds a new field to the schema of one
since the updates handler was using that field.

fixes #3233

Signed-off-by: Randy Barlow <randy@electronsweatshop.com>