### PR TITLE
Do not send fedora-messages in the unit tests

### DIFF
--- a/bodhi/tests/server/consumers/test_composer.py
+++ b/bodhi/tests/server/consumers/test_composer.py
@@ -2011,25 +2011,26 @@ testmodule:master:20172:2
             with mock_sends(*[base_schemas.BodhiMessage] * 3):
                 self.handler(self._make_msg())
 
-        with self.db_factory() as session:
-            up = session.query(Update).one()
+        with mock_sends(*[base_schemas.BodhiMessage] * 3):
+            with self.db_factory() as session:
+                up = session.query(Update).one()
 
-            # Ensure the update is still locked and in testing
-            self.assertEqual(up.locked, True)
-            self.assertEqual(up.status, UpdateStatus.pending)
-            self.assertEqual(up.request, UpdateRequest.testing)
+                # Ensure the update is still locked and in testing
+                self.assertEqual(up.locked, True)
+                self.assertEqual(up.status, UpdateStatus.pending)
+                self.assertEqual(up.request, UpdateRequest.testing)
 
-            # Have the update reach the stable karma threshold
-            self.assertEqual(up.karma, 1)
-            up.comment(session, "foo", 1, 'foo')
-            self.assertEqual(up.karma, 2)
-            self.assertEqual(up.request, UpdateRequest.testing)
-            up.comment(session, "foo", 1, 'bar')
-            self.assertEqual(up.karma, 3)
-            self.assertEqual(up.request, UpdateRequest.testing)
-            up.comment(session, "foo", 1, 'biz')
-            self.assertEqual(up.request, UpdateRequest.testing)
-            self.assertEqual(up.karma, 4)
+                # Have the update reach the stable karma threshold
+                self.assertEqual(up.karma, 1)
+                up.comment(session, "foo", 1, 'foo')
+                self.assertEqual(up.karma, 2)
+                self.assertEqual(up.request, UpdateRequest.testing)
+                up.comment(session, "foo", 1, 'bar')
+                self.assertEqual(up.karma, 3)
+                self.assertEqual(up.request, UpdateRequest.testing)
+                up.comment(session, "foo", 1, 'biz')
+                self.assertEqual(up.request, UpdateRequest.testing)
+                self.assertEqual(up.karma, 4)
 
         # finish push and unlock updates
         msg = self._make_msg()
@@ -2037,14 +2038,15 @@ testmodule:master:20172:2
         with mock_sends(*[base_schemas.BodhiMessage] * 6):
             self.handler(msg)
 
-        with self.db_factory() as session:
-            up = session.query(Update).one()
-            up.comment(session, "foo", 1, 'baz')
-            self.assertEqual(up.karma, 5)
+        with mock_sends(*[base_schemas.BodhiMessage] * 2):
+            with self.db_factory() as session:
+                up = session.query(Update).one()
+                up.comment(session, "foo", 1, 'baz')
+                self.assertEqual(up.karma, 5)
 
-            # Ensure the composer set the autokarma once the push is done
-            self.assertEqual(up.locked, False)
-            self.assertEqual(up.request, UpdateRequest.stable)
+                # Ensure the composer set the autokarma once the push is done
+                self.assertEqual(up.locked, False)
+                self.assertEqual(up.request, UpdateRequest.stable)
 
     @mock.patch(**mock_taskotron_results)
     @mock.patch('bodhi.server.consumers.composer.PungiComposerThread._wait_for_pungi')

--- a/bodhi/tests/server/test_models.py
+++ b/bodhi/tests/server/test_models.py
@@ -2732,7 +2732,7 @@ class TestUpdate(ModelTest):
         self.assertEqual(update.karma, 2)
         self.assertEqual(update.request, None)
         # Let's flush out any messages that have been sent.
-        self.db.commit()
+        self.db.info['messages'] = []
         expected_message_0 = update_schemas.UpdateCommentV1.from_dict(
             {'comment': self.obj['comments'][0], 'agent': 'biz'})
         expected_message_1 = update_schemas.UpdateKarmaThresholdV1.from_dict(
@@ -2795,7 +2795,7 @@ class TestUpdate(ModelTest):
         self.assertEqual(update.status, UpdateStatus.testing)
         self.assertEqual(update.karma, -2)
         # Let's flush out any messages that have been sent.
-        self.db.commit()
+        self.db.info['messages'] = []
         expected_message_0 = update_schemas.UpdateCommentV1.from_dict(
             {'comment': self.obj['comments'][0], 'agent': 'biz'})
         expected_message_1 = update_schemas.UpdateKarmaThresholdV1.from_dict(


### PR DESCRIPTION
We recently started to notice a significant time increase in
running Bodhi's unit tests with fedora-messaging >= 1.6.1. It
turned out that that version added more retry logic when it could
not publish messages, and that many of our unit tests were
attempting to publish messages. This caused the tests to go from
about 3 minutes to over an hour.

This commit adds mocks to all the places that were attempting to
publish messages.

fixes #3241

Signed-off-by: Randy Barlow <randy@electronsweatshop.com>