### PR TITLE
Remove duplicate permission dict for RabbitMQ host.

### DIFF
--- a/devel/ansible/roles/bodhi/tasks/rabbitmq.yml
+++ b/devel/ansible/roles/bodhi/tasks/rabbitmq.yml
@@ -42,8 +42,4 @@
         configure_priv: .*
         read_priv: .*
         write_priv: .*
-      - vhost: /
-        configure_priv: .*
-        read_priv: .*
-        write_priv: .*
     state: present


### PR DESCRIPTION
This made provisioning the Vagrant box fail lately:

```
TASK [bodhi : Create a guest user in RabbitMQ] *********************************
fatal: [bodhi]: FAILED! => {"changed": false, "msg": "Error parsing permissions: You can't have two permission dicts for the same vhost"}
```