### PR TITLE
Message consuming and sending now works in Vagrant

### DIFF
--- a/devel/ansible/roles/bodhi/files/.bashrc
+++ b/devel/ansible/roles/bodhi/files/.bashrc
@@ -11,12 +11,12 @@ fi
 shopt -s expand_aliases
 alias bci="sudo -E /home/vagrant/bodhi/devel/ci/bodhi-ci"
 alias bdocs="make -C /home/vagrant/bodhi/docs clean && make -C /home/vagrant/bodhi/docs html && make -C /home/vagrant/bodhi/docs man"
-alias blog="sudo journalctl -u bodhi"
-alias brestart="sudo systemctl restart bodhi && echo 'The Application is running on http://localhost:6543'"
-alias bstart="sudo systemctl start bodhi && echo 'The Application is running on http://localhost:6543'"
-alias bstop="sudo systemctl stop bodhi"
+alias blog="sudo journalctl -u bodhi -u fm-consumer@config"
+alias brestart="sudo systemctl restart bodhi && sudo systemctl restart fm-consumer@config && echo 'The Application is running on http://localhost:6543'"
+alias bstart="sudo systemctl start bodhi && sudo systemctl start fm-consumer@config && echo 'The Application is running on http://localhost:6543'"
+alias bstop="sudo systemctl stop bodhi && sudo systemctl stop fm-consumer@config"
 alias bteststyle="flake8-3 && pydocstyle bodhi && bci mypy"
-alias bfedmsg="sudo journalctl -u print-messages"
+alias bmessages="sudo journalctl -u print-messages"
 
 
 function bresetdb {

--- a/devel/ansible/roles/bodhi/tasks/main.yml
+++ b/devel/ansible/roles/bodhi/tasks/main.yml
@@ -178,7 +178,7 @@
 - name: Copy the fedora-messaging configuration file bodhi.toml
   copy:
       src: bodhi.toml
-      dest: /etc/fedora-messaging/bodhi.toml
+      dest: /etc/fedora-messaging/config.toml
       owner: root
       group: root
       mode: 644
@@ -197,7 +197,7 @@
 
 - name: Start and enable the bodhi consumer service
   service:
-      name: fm-consumer@bodhi
+      name: fm-consumer@config
       state: started
       enabled: yes
 


### PR DESCRIPTION
This commit allows us to produce and consumer AMQP messages in
the Vagrant development environment, and makes the shell aliases
such that they interact with the fm-consumer process.

Signed-off-by: Randy Barlow <randy@electronsweatshop.com>