### PR TITLE
Add a missing f for a format string

### DIFF
--- a/bodhi/server/push.py
+++ b/bodhi/server/push.py
@@ -128,7 +128,7 @@ def push(username, yes, **kwargs):
 
                 if not update.signed:
                     click.echo(
-                        'Warning: {update.get_title()} has unsigned builds and has been skipped')
+                        f'Warning: {update.get_title()} has unsigned builds and has been skipped')
                     continue
 
                 updates.append(update)

--- a/bodhi/tests/server/test_push.py
+++ b/bodhi/tests/server/test_push.py
@@ -1021,6 +1021,9 @@ class TestPush(base.BaseTestCase):
                     expected_message.body['composes'] = [
                         python_paste_deploy.compose.__json__(composer=True)]
 
+        self.assertIn(
+            f'Warning: {python_nose.get_title()} has unsigned builds and has been skipped',
+            result.output)
         self.assertEqual(result.exception, None)
         self.assertEqual(result.exit_code, 0)
         python_nose = self.db.query(models.Build).filter_by(


### PR DESCRIPTION
nirik reported that Bodhi was printing this warning:

Warning: {update.get_title()} has unsigned builds and has been skipped

It turns out that we forgot to put the f in front of a format
string, so the template wasn't getting rendered.

This commit fixes that and adds an assertion that the warning is
rendered correctly.

Signed-off-by: Randy Barlow <randy@electronsweatshop.com>