### PR TITLE
Use flake8-import-order to enforce PEP-8 imports

### DIFF
--- a/bodhi/client/__init__.py
+++ b/bodhi/client/__init__.py
@@ -26,11 +26,11 @@ import traceback
 import re
 import functools
 
+from fedora.client import AuthError, openidproxyclient
 import click
 import munch
 
 from bodhi.client import bindings
-from fedora.client import AuthError, openidproxyclient
 
 
 log = logging.getLogger(__name__)

--- a/bodhi/client/bindings.py
+++ b/bodhi/client/bindings.py
@@ -35,16 +35,15 @@ import re
 import textwrap
 import typing
 
+from fedora.client import AuthError, OpenIdBaseClient, FedoraClientError, ServerError
 try:
     import dnf
 except ImportError:  # pragma: no cover
     # dnf is not available on EL 7.
     dnf = None  # pragma: no cover
+import fedora.client.openidproxyclient
 import koji
 import requests.exceptions
-
-from fedora.client import AuthError, OpenIdBaseClient, FedoraClientError, ServerError
-import fedora.client.openidproxyclient
 
 if typing.TYPE_CHECKING:  # pragma: no cover
     import munch  # noqa: 401

--- a/bodhi/server/bugs.py
+++ b/bodhi/server/bugs.py
@@ -17,11 +17,11 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 """Defines utilities for accessing Bugzilla."""
 
+from collections import namedtuple
 from xmlrpc import client as xmlrpc_client
 import logging
 import typing
 
-from collections import namedtuple
 import bugzilla
 
 from bodhi.server.config import config

--- a/bodhi/server/migrations/env.py
+++ b/bodhi/server/migrations/env.py
@@ -16,7 +16,7 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 """Define the environment for Alembic migrations to run in."""
-from __future__ import with_statement
+
 from logging.config import fileConfig
 import logging
 

--- a/bodhi/server/models.py
+++ b/bodhi/server/models.py
@@ -24,7 +24,6 @@ import hashlib
 import json
 import os
 import re
-import rpm
 import time
 import typing
 import uuid
@@ -38,6 +37,7 @@ from sqlalchemy.orm.exc import NoResultFound
 from sqlalchemy.orm.properties import RelationshipProperty
 from sqlalchemy.types import SchemaType, TypeDecorator, Enum
 import requests.exceptions
+import rpm
 
 from bodhi.messages.schemas import (buildroot_override as override_schemas,
                                     errata as errata_schemas, update as update_schemas)

--- a/bodhi/server/scripts/approve_testing.py
+++ b/bodhi/server/scripts/approve_testing.py
@@ -28,10 +28,10 @@ import logging
 
 from pyramid.paster import get_appsettings
 
-from ..models import Update, UpdateStatus
-from ..config import config
 from bodhi.messages.schemas import update as update_schemas
 from bodhi.server import Session, initialize_db, notifications
+from ..models import Update, UpdateStatus
+from ..config import config
 
 
 logger = logging.getLogger('approve-testing')

--- a/bodhi/server/scripts/clean_old_composes.py
+++ b/bodhi/server/scripts/clean_old_composes.py
@@ -17,10 +17,10 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 """Cleans up old composes that are left over in compose_dir."""
 import collections
-
-import click
 import os
 import shutil
+
+import click
 
 from bodhi.server import config
 

--- a/bodhi/server/scripts/expire_overrides.py
+++ b/bodhi/server/scripts/expire_overrides.py
@@ -20,10 +20,10 @@ import sys
 
 from pyramid.paster import get_appsettings
 
-from ..buildsys import setup_buildsystem
-from ..models import BuildrootOverride
 from bodhi.server import Session, initialize_db
 from bodhi.server.logging import setup as setup_logging
+from ..buildsys import setup_buildsystem
+from ..models import BuildrootOverride
 
 
 def usage(argv):

--- a/bodhi/server/scripts/initializedb.py
+++ b/bodhi/server/scripts/initializedb.py
@@ -22,9 +22,9 @@ import sys
 
 from pyramid.paster import get_appsettings
 
-from ..models import Base
 from bodhi.server import initialize_db
 from bodhi.server.logging import setup as setup_logging
+from ..models import Base
 
 
 def usage(argv):

--- a/bodhi/server/scripts/untag_branched.py
+++ b/bodhi/server/scripts/untag_branched.py
@@ -24,18 +24,16 @@ those stable updates with the testing tags for 1 day before untagging.
 https://github.com/fedora-infra/bodhi/issues/576
 """
 
+from datetime import datetime, timedelta
 import os
 import sys
 import logging
 
-from datetime import datetime, timedelta
-
 from pyramid.paster import get_appsettings
-
-from ..models import Release, ReleaseState, Update, UpdateStatus
 
 from bodhi.server import buildsys, Session, initialize_db
 from bodhi.server.logging import setup as setup_logging
+from ..models import Release, ReleaseState, Update, UpdateStatus
 
 
 def usage(argv):

--- a/bodhi/server/security.py
+++ b/bodhi/server/security.py
@@ -16,8 +16,8 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 """A collection of authentication and authorization functions and classes."""
-from cornice.errors import Errors
 
+from cornice.errors import Errors
 from pyramid.security import (Allow, ALL_PERMISSIONS, DENY_ALL)
 from pyramid.security import remember, forget
 from pyramid.httpexceptions import HTTPFound

--- a/bodhi/server/services/overrides.py
+++ b/bodhi/server/services/overrides.py
@@ -23,7 +23,6 @@ from datetime import datetime
 from cornice import Service
 from cornice.validators import colander_body_validator, colander_querystring_validator
 from pyramid.exceptions import HTTPNotFound
-
 from sqlalchemy import func, distinct
 from sqlalchemy.sql import or_
 

--- a/bodhi/server/util.py
+++ b/bodhi/server/util.py
@@ -24,7 +24,6 @@ import functools
 import hashlib
 import json
 import os
-import pkg_resources
 import re
 import socket
 import subprocess
@@ -40,6 +39,7 @@ import libcomps
 import libravatar
 import librepo
 import markdown
+import pkg_resources
 import requests
 import rpm
 

--- a/bodhi/server/validators.py
+++ b/bodhi/server/validators.py
@@ -28,6 +28,7 @@ import koji
 import pyramid.threadlocal
 import rpm
 
+from bodhi.server.config import config
 from . import log
 from .models import (
     Build,
@@ -55,7 +56,6 @@ from .util import (
     tokenize,
     taskotron_results,
 )
-from bodhi.server.config import config
 
 
 csrf_error_message = """CSRF tokens do not match.  This happens if you have

--- a/bodhi/tests/server/consumers/test_composer.py
+++ b/bodhi/tests/server/consumers/test_composer.py
@@ -38,12 +38,10 @@ from bodhi.messages.schemas import (
     composer as composer_schemas, errata as errata_schemas, update as update_schemas)
 from bodhi.server import buildsys, exceptions, log, push
 from bodhi.server.config import config
-
 from bodhi.server.consumers.composer import (
     checkpoint, ComposerHandler, ComposerThread, ContainerComposerThread,
     FlatpakComposerThread, RPMComposerThread, ModuleComposerThread,
     PungiComposerThread)
-
 from bodhi.server.exceptions import LockedUpdateException
 from bodhi.server.models import (
     Build, BuildrootOverride, Compose, ComposeState, ContainerBuild, FlatpakBuild,

--- a/bodhi/tests/server/consumers/test_updates.py
+++ b/bodhi/tests/server/consumers/test_updates.py
@@ -21,9 +21,8 @@ from unittest import mock
 import copy
 import unittest
 
-import sqlalchemy
-
 from fedora_messaging.api import Message
+import sqlalchemy
 
 from bodhi.messages.schemas.update import UpdateEditV1, UpdateRequestTestingV1
 from bodhi.server import config, exceptions, models, util

--- a/devel/ansible/roles/bodhi/tasks/main.yml
+++ b/devel/ansible/roles/bodhi/tasks/main.yml
@@ -36,6 +36,7 @@
       - python3-dogpile-cache
       - python3-fedora
       - python3-flake8
+      - python3-flake8-import-order
       - python3-ipdb
       - python3-koji
       - python3-librepo

--- a/devel/ci/Dockerfile-pip
+++ b/devel/ci/Dockerfile-pip
@@ -33,6 +33,7 @@ RUN pip-3 install \
     cornice_sphinx \
     diff-cover \
     flake8 \
+    flake8-import-order \
     responses \
     pydocstyle \
     pytest \

--- a/devel/ci/integration/tests/test_bodhi.py
+++ b/devel/ci/integration/tests/test_bodhi.py
@@ -20,7 +20,7 @@ import math
 
 import psycopg2
 
-from tests.utils import read_file
+from .utils import read_file
 
 
 def test_get_root(bodhi_container, db_container):

--- a/devel/ci/integration/tests/test_bodhi_cli.py
+++ b/devel/ci/integration/tests/test_bodhi_cli.py
@@ -21,12 +21,11 @@ import json
 import re
 import textwrap
 
+from conu import ConuException
+from munch import Munch
 import requests
 import psycopg2
 import pytest
-
-from conu import ConuException
-from munch import Munch
 
 from .utils import replace_file
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,6 +16,9 @@ show-source = True
 max-line-length = 100
 exclude = .git,.tox,dist,*egg,build,tools
 ignore = E712,W503
+# Configure flake8-import-order
+application-import-names = bodhi
+import-order-style = pep8
 
 [init_catalog]
 domain = bodhi

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
-from setuptools import setup, find_packages
 import os
+
+from setuptools import setup, find_packages
 import setuptools.command.egg_info
 
 


### PR DESCRIPTION
PEP-8 specifies that imports should be grouped into three sections:
stdlib, third party libs, and then application imports. flake8
itself does not enforce this, and so until now we have manually
checked this in pull requests.

This commit adds a flake8 plugin called flake8-import-order to
enforce this part of PEP-8.

Signed-off-by: Randy Barlow <randy@electronsweatshop.com>