### PR TITLE
Correct grammar on a comment that Bodhi writes

### DIFF
--- a/bodhi/server/models.py
+++ b/bodhi/server/models.py
@@ -3555,7 +3555,7 @@ class Update(Base):
         if value != old:
             target.comment(
                 Session(),
-                f"This update test gating status has been changed to '{value}'.",
+                f"This update's test gating status has been changed to '{value}'.",
                 author="bodhi",
             )
 

--- a/bodhi/tests/server/scripts/test_check_policies.py
+++ b/bodhi/tests/server/scripts/test_check_policies.py
@@ -123,7 +123,7 @@ class TestCheckPolicies(BaseTestCase):
             update = self.db.query(models.Update).filter(models.Update.id == update.id).one()
             self.assertEqual(update.test_gating_status, models.TestGatingStatus.failed)
             # Check for the comment
-            expected_comment = "This update test gating status has been changed to 'failed'."
+            expected_comment = "This update's test gating status has been changed to 'failed'."
             self.assertEqual(update.comments[-1].text, expected_comment)
 
         expected_query = {
@@ -203,7 +203,7 @@ class TestCheckPolicies(BaseTestCase):
         mock_greenwave.assert_called_once_with(config['greenwave_api_url'] + '/decision',
                                                expected_query)
         # Check for the comment
-        expected_comment = "This update test gating status has been changed to 'failed'."
+        expected_comment = "This update's test gating status has been changed to 'failed'."
         self.assertEqual(update.comments[-1].text, expected_comment)
 
     @patch.dict(config, [('greenwave_api_url', 'http://domain.local')])
@@ -225,7 +225,7 @@ class TestCheckPolicies(BaseTestCase):
             update = self.db.query(models.Update).filter(models.Update.id == update.id).one()
             self.assertEqual(update.test_gating_status, models.TestGatingStatus.ignored)
             # Check for the comment
-            expected_comment = "This update test gating status has been changed to 'ignored'."
+            expected_comment = "This update's test gating status has been changed to 'ignored'."
             self.assertEqual(update.comments[-1].text, expected_comment)
 
         expected_query = {

--- a/bodhi/tests/server/services/test_updates.py
+++ b/bodhi/tests/server/services/test_updates.py
@@ -5280,7 +5280,7 @@ class TestWaiveTestResults(BaseTestCase):
         # The test gating status should have been reset to waiting.
         self.assertEqual(up.test_gating_status, TestGatingStatus.waiting)
         # Check for the comment multiple ways
-        expected_comment = "This update test gating status has been changed to 'waiting'."
+        expected_comment = "This update's test gating status has been changed to 'waiting'."
         self.assertEqual(res.json_body["update"]['comments'][-1]['text'], expected_comment)
         self.assertEqual(up.comments[-1].text, expected_comment)
 
@@ -5375,7 +5375,7 @@ class TestWaiveTestResults(BaseTestCase):
         # The test gating status should have been reset to waiting.
         self.assertEqual(up.test_gating_status, TestGatingStatus.waiting)
         # Check for the comment multiple ways
-        expected_comment = "This update test gating status has been changed to 'waiting'."
+        expected_comment = "This update's test gating status has been changed to 'waiting'."
         self.assertEqual(res.json_body["update"]['comments'][-1]['text'], expected_comment)
         self.assertEqual(up.comments[-1].text, expected_comment)
 
@@ -5458,7 +5458,7 @@ class TestWaiveTestResults(BaseTestCase):
         # The test gating status should have been reset to waiting.
         self.assertEqual(up.test_gating_status, TestGatingStatus.waiting)
         # Check for the comment multiple ways
-        expected_comment = "This update test gating status has been changed to 'waiting'."
+        expected_comment = "This update's test gating status has been changed to 'waiting'."
         self.assertEqual(res.json_body["update"]['comments'][-1]['text'], expected_comment)
         self.assertEqual(up.comments[-1].text, expected_comment)
 
@@ -5557,7 +5557,7 @@ class TestWaiveTestResults(BaseTestCase):
         # The test gating status should have been updated to waiting.
         self.assertEqual(up.test_gating_status, TestGatingStatus.waiting)
         # Check for the comment multiple ways
-        expected_comment = "This update test gating status has been changed to 'waiting'."
+        expected_comment = "This update's test gating status has been changed to 'waiting'."
         self.assertEqual(res.json_body["update"]['comments'][-1]['text'], expected_comment)
         self.assertEqual(up.comments[-1].text, expected_comment)
 

--- a/bodhi/tests/server/test_models.py
+++ b/bodhi/tests/server/test_models.py
@@ -3804,7 +3804,7 @@ class TestUpdate(ModelTest):
             self.obj.waive_test_results('foo', 'this is not true!')
 
         # Check for the comment
-        expected_comment = "This update test gating status has been changed to 'waiting'."
+        expected_comment = "This update's test gating status has been changed to 'waiting'."
         self.assertEqual(self.obj.comments[-1].text, expected_comment)
 
         expected_calls = []
@@ -3872,7 +3872,7 @@ class TestUpdate(ModelTest):
                 '{}/waivers/'.format(config.get('waiverdb_api_url')), wdata)
 
         # Check for the comment
-        expected_comment = "This update test gating status has been changed to 'waiting'."
+        expected_comment = "This update's test gating status has been changed to 'waiting'."
         self.assertEqual(update.comments[-1].text, expected_comment)
 
     def test_comment_on_test_gating_status_change(self):
@@ -3883,7 +3883,7 @@ class TestUpdate(ModelTest):
         self.obj.test_gating_status = TestGatingStatus.waiting
 
         # Check for the comment about test_gating_status change
-        expected_comment = "This update test gating status has been changed to 'waiting'."
+        expected_comment = "This update's test gating status has been changed to 'waiting'."
         self.assertEqual(self.obj.comments[0].text, expected_comment)
         self.assertEqual(len(self.obj.comments), 1)
 


### PR DESCRIPTION
Bodhi had a grammatical error in the message it writes when an
update's test_gating_status field changes. This commit corrects
that error.

Signed-off-by: Randy Barlow <randy@electronsweatshop.com>