### PR TITLE
Avoid sphinx >= 2.1 in the pip CI test

### DIFF
--- a/devel/ci/Dockerfile-pip
+++ b/devel/ci/Dockerfile-pip
@@ -37,6 +37,7 @@ RUN pip-3 install \
     pydocstyle \
     pytest \
     pytest-cov \
+    "sphinx<2.1" \
     sqlalchemy_schemadisplay \
     webtest
 


### PR DESCRIPTION
Sphinx 2.1.0 does not work with cornice_sphinx[0]. This is causing
our CI to fail, but fixing it is not easy. For now, we are going
to install an older Sphinx until we can figure out what to do to
work with Sphinx >= 2.1.0.

re #3300

[0] https://github.com/Cornices/cornice.ext.sphinx/issues/22

Signed-off-by: Randy Barlow <randy@electronsweatshop.com>