### PR TITLE
Correct a message type causing missing coverage

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -9,7 +9,7 @@ omit =
 
 [report]
 precision = 2
-fail_under = 99.2
+fail_under = 99.3
 exclude_lines =
     pragma: no cover
     class DevBuildsys

--- a/bodhi/tests/server/consumers/test_updates.py
+++ b/bodhi/tests/server/consumers/test_updates.py
@@ -228,12 +228,11 @@ class TestUpdatesHandlerConsume(base.BaseTestCase):
         h = updates.UpdatesHandler()
         h.db_factory = base.TransactionalSessionMaker(self.Session)
         update = models.Build.query.filter_by(nvr='bodhi-2.0-1.fc17').one().update
-        message = UpdateEditV1(
+        message = UpdateRequestTestingV1(
             body={
                 'update': {'alias': update.alias, 'builds': [{'nvr': 'bodhi-2.0-1.fc17'}],
                            'user': {'name': 'brodhi'}, 'status': str(update.status),
-                           'request': str(update.request)},
-                'new_bugs': [12345]})
+                           'request': str(update.request)}})
 
         h(message)
 


### PR DESCRIPTION
I noticed today that we were missing test coverage on one line and
one jump in the updates handler. It turned out that when I
converted the codebase to use Fedora Messages, I had accidentally
chosen the incorrect type for one of the messages and this resulted
in missing coverage on a line and a jump.

This commit corrects that error and raises coverage again to 100%
in the updates handler.

Signed-off-by: Randy Barlow <randy@electronsweatshop.com>