### PR TITLE
Do not ask for_original_spec_nvr results from greenwave.

### DIFF
--- a/bodhi/server/models.py
+++ b/bodhi/server/models.py
@@ -1884,9 +1884,6 @@ class Update(Base):
         """
         # See discussion on https://pagure.io/greenwave/issue/34 for why we use these subjects.
         subject = [{'item': build.nvr, 'type': 'koji_build'} for build in self.builds]
-        # Additionally add some subject entries for "CI"
-        # https://pagure.io/greenwave/issue/61
-        subject.extend([{'original_spec_nvr': build.nvr} for build in self.builds])
         subject.append({'item': self.alias, 'type': 'bodhi_update'})
         return subject
 

--- a/bodhi/server/templates/update.html
+++ b/bodhi/server/templates/update.html
@@ -212,9 +212,6 @@ ${update.type} update for ${update.beautify_title(amp=True) | n}
         // seem to break anything
         var arch = result.data.arch;
         var item = result.data.item;
-        if (item === undefined && testcase.startsWith('org.centos.prod.ci.pipeline')){
-            item = result.data.original_spec_nvr[0] + '#' + result.data.rev;
-        }
         var submit_time = new Date(result.submit_time);
 
         if (latest[item] === undefined)

--- a/bodhi/tests/server/consumers/test_updates.py
+++ b/bodhi/tests/server/consumers/test_updates.py
@@ -163,9 +163,6 @@ class TestUpdatesHandlerConsume(base.BaseTestCase):
                      'item': {'item': 'bodhi-2.0-1.fc17', 'type': 'koji_build'},
                      'type': 'test-result-missing', 'scenario': None},
                     {'testcase': 'dist.rpmdeplint',
-                     'item': {'original_spec_nvr': 'bodhi-2.0-1.fc17'},
-                     'type': 'test-result-missing', 'scenario': None},
-                    {'testcase': 'dist.rpmdeplint',
                      'item': {'item': update.alias, 'type': 'bodhi_update'},
                      'type': 'test-result-missing', 'scenario': None}]}
             mock_greenwave.return_value = greenwave_response
@@ -199,9 +196,6 @@ class TestUpdatesHandlerConsume(base.BaseTestCase):
                 'unsatisfied_requirements': [
                     {'testcase': 'dist.rpmdeplint',
                      'item': {'item': 'bodhi-2.0-1.fc17', 'type': 'koji_build'},
-                     'type': 'test-result-missing', 'scenario': None},
-                    {'testcase': 'dist.rpmdeplint',
-                     'item': {'original_spec_nvr': 'bodhi-2.0-1.fc17'},
                      'type': 'test-result-missing', 'scenario': None},
                     {'testcase': 'dist.rpmdeplint',
                      'item': {'item': update.alias, 'type': 'bodhi_update'},

--- a/bodhi/tests/server/scripts/test_check_policies.py
+++ b/bodhi/tests/server/scripts/test_check_policies.py
@@ -54,7 +54,6 @@ class TestCheckPolicies(BaseTestCase):
             'product_version': 'fedora-17', 'decision_context': 'bodhi_update_push_stable',
             'subject': [
                 {'item': 'bodhi-2.0-1.fc17', 'type': 'koji_build'},
-                {'original_spec_nvr': 'bodhi-2.0-1.fc17'},
                 {'item': 'FEDORA-{}-a3bbe1a8f2'.format(datetime.datetime.utcnow().year),
                  'type': 'bodhi_update'}],
             'verbose': True
@@ -87,7 +86,6 @@ class TestCheckPolicies(BaseTestCase):
             'product_version': 'fedora-17', 'decision_context': 'bodhi_update_push_testing',
             'subject': [
                 {'item': 'bodhi-2.0-1.fc17', 'type': 'koji_build'},
-                {'original_spec_nvr': 'bodhi-2.0-1.fc17'},
                 {'item': 'FEDORA-{}-a3bbe1a8f2'.format(datetime.datetime.utcnow().year),
                  'type': 'bodhi_update'}],
             'verbose': True,
@@ -112,9 +110,6 @@ class TestCheckPolicies(BaseTestCase):
                      'item': {'item': 'glibc-1.0-1.f26', 'type': 'koji_build'},
                      'type': 'test-result-missing', 'scenario': None},
                     {'testcase': 'dist.rpmdeplint',
-                     'item': {'original_spec_nvr': 'glibc-1.0-1.f26'},
-                     'type': 'test-result-missing', 'scenario': None},
-                    {'testcase': 'dist.rpmdeplint',
                      'item': {'item': update.alias, 'type': 'bodhi_update'},
                      'type': 'test-result-missing', 'scenario': None}]}
             mock_greenwave.return_value = greenwave_response
@@ -130,7 +125,6 @@ class TestCheckPolicies(BaseTestCase):
             'product_version': 'fedora-17', 'decision_context': 'bodhi_update_push_stable',
             'subject': [
                 {'item': 'bodhi-2.0-1.fc17', 'type': 'koji_build'},
-                {'original_spec_nvr': 'bodhi-2.0-1.fc17'},
                 {'item': 'FEDORA-{}-a3bbe1a8f2'.format(datetime.datetime.utcnow().year),
                  'type': 'bodhi_update'}],
             'verbose': True
@@ -163,7 +157,6 @@ class TestCheckPolicies(BaseTestCase):
             'product_version': 'fedora-17', 'decision_context': 'bodhi_update_push_stable',
             'subject': [
                 {'item': 'bodhi-2.0-1.fc17', 'type': 'koji_build'},
-                {'original_spec_nvr': 'bodhi-2.0-1.fc17'},
                 {'item': 'FEDORA-{}-a3bbe1a8f2'.format(datetime.datetime.utcnow().year),
                  'type': 'bodhi_update'}],
             'verbose': True
@@ -195,7 +188,6 @@ class TestCheckPolicies(BaseTestCase):
         expected_query = {
             'product_version': 'fedora-17', 'decision_context': 'bodhi_update_push_stable',
             'subject': [{'item': 'bodhi-2.0-1.fc17', 'type': 'koji_build'},
-                        {'original_spec_nvr': 'bodhi-2.0-1.fc17'},
                         {'item': 'FEDORA-{}-a3bbe1a8f2'.format(datetime.datetime.utcnow().year),
                          'type': 'bodhi_update'}],
             'verbose': True
@@ -232,7 +224,6 @@ class TestCheckPolicies(BaseTestCase):
             'product_version': 'fedora-17', 'decision_context': 'bodhi_update_push_stable',
             'subject': [
                 {'item': 'bodhi-2.0-1.fc17', 'type': 'koji_build'},
-                {'original_spec_nvr': 'bodhi-2.0-1.fc17'},
                 {'item': 'FEDORA-{}-a3bbe1a8f2'.format(datetime.datetime.utcnow().year),
                  'type': 'bodhi_update'}],
             'verbose': True

--- a/bodhi/tests/server/services/test_updates.py
+++ b/bodhi/tests/server/services/test_updates.py
@@ -5252,7 +5252,6 @@ class TestWaiveTestResults(BaseTestCase):
                 'decision_context': 'bodhi_update_push_testing',
                 'subject': [
                     {'item': 'bodhi-2.0-1.fc17', 'type': 'koji_build'},
-                    {'original_spec_nvr': 'bodhi-2.0-1.fc17'},
                     {'item': up.alias, 'type': 'bodhi_update'}
                 ],
                 'verbose': True,
@@ -5331,7 +5330,6 @@ class TestWaiveTestResults(BaseTestCase):
                 'decision_context': 'bodhi_update_push_testing',
                 'subject': [
                     {'item': 'bodhi-2.0-1.fc17', 'type': 'koji_build'},
-                    {'original_spec_nvr': 'bodhi-2.0-1.fc17'},
                     {'item': up.alias, 'type': 'bodhi_update'}
                 ],
                 'verbose': True,
@@ -5430,7 +5428,6 @@ class TestWaiveTestResults(BaseTestCase):
                 'decision_context': 'bodhi_update_push_testing',
                 'subject': [
                     {'item': 'bodhi-2.0-1.fc17', 'type': 'koji_build'},
-                    {'original_spec_nvr': 'bodhi-2.0-1.fc17'},
                     {'item': up.alias, 'type': 'bodhi_update'}
                 ],
                 'verbose': True,
@@ -5513,7 +5510,6 @@ class TestWaiveTestResults(BaseTestCase):
                 'decision_context': 'bodhi_update_push_testing',
                 'subject': [
                     {'item': 'bodhi-2.0-1.fc17', 'type': 'koji_build'},
-                    {'original_spec_nvr': 'bodhi-2.0-1.fc17'},
                     {'item': up.alias, 'type': 'bodhi_update'}
                 ],
                 'verbose': True,
@@ -5612,7 +5608,6 @@ class TestWaiveTestResults(BaseTestCase):
                 'decision_context': 'bodhi_update_push_testing',
                 'subject': [
                     {'item': 'bodhi-2.0-1.fc17', 'type': 'koji_build'},
-                    {'original_spec_nvr': 'bodhi-2.0-1.fc17'},
                     {'item': up.alias, 'type': 'bodhi_update'}
                 ],
                 'verbose': True,
@@ -5766,7 +5761,6 @@ class TestGetTestResults(BaseTestCase):
                 'decision_context': 'bodhi_update_push_testing',
                 'subject': [
                     {'item': 'bodhi-2.0-1.fc17', 'type': 'koji_build'},
-                    {'original_spec_nvr': 'bodhi-2.0-1.fc17'},
                     {'item': update.alias, 'type': 'bodhi_update'}
                 ],
                 'verbose': True,
@@ -5809,7 +5803,6 @@ class TestGetTestResults(BaseTestCase):
                 'decision_context': 'bodhi_update_push_testing',
                 'subject': [
                     {'item': 'bodhi-2.0-1.fc17', 'type': 'koji_build'},
-                    {'original_spec_nvr': 'bodhi-2.0-1.fc17'},
                     {'item': update.alias, 'type': 'bodhi_update'}
                 ],
                 'verbose': True,
@@ -5851,7 +5844,6 @@ class TestGetTestResults(BaseTestCase):
                 'decision_context': 'bodhi_update_push_testing',
                 'subject': [
                     {'item': 'bodhi-2.0-1.fc17', 'type': 'koji_build'},
-                    {'original_spec_nvr': 'bodhi-2.0-1.fc17'},
                     {'item': update.alias, 'type': 'bodhi_update'}
                 ],
                 'verbose': True,
@@ -5885,7 +5877,6 @@ class TestGetTestResults(BaseTestCase):
                 'decision_context': 'bodhi_update_push_testing',
                 'subject': [
                     {'item': 'bodhi-2.0-1.fc17', 'type': 'koji_build'},
-                    {'original_spec_nvr': 'bodhi-2.0-1.fc17'},
                     {'item': update.alias, 'type': 'bodhi_update'}
                 ],
                 'verbose': True,

--- a/bodhi/tests/server/test_models.py
+++ b/bodhi/tests/server/test_models.py
@@ -1828,7 +1828,6 @@ class TestUpdateUpdateTestGatingStatus(BaseTestCase):
             'https://greenwave-web-greenwave.app.os.fedoraproject.org/api/v1.0/decision',
             data={"product_version": "fedora-17", "decision_context": "bodhi_update_push_testing",
                   "subject": [{"item": f"{update.builds[0].nvr}", "type": "koji_build"},
-                              {"original_spec_nvr": f"{update.builds[0].nvr}"},
                               {"item": f"{update.alias}", "type": "bodhi_update"}],
                   "verbose": True},
             headers={'Content-Type': 'application/json'}, timeout=60)
@@ -1873,7 +1872,6 @@ class TestUpdateUpdateTestGatingStatus(BaseTestCase):
             'https://greenwave-web-greenwave.app.os.fedoraproject.org/api/v1.0/decision',
             data={"product_version": "fedora-17", "decision_context": "bodhi_update_push_testing",
                   "subject": [{"item": f"{update.builds[0].nvr}", "type": "koji_build"},
-                              {"original_spec_nvr": f"{update.builds[0].nvr}"},
                               {"item": f"{update.alias}", "type": "bodhi_update"}],
                   "verbose": True},
             headers={'Content-Type': 'application/json'}, timeout=60)
@@ -2127,7 +2125,6 @@ class TestUpdate(ModelTest):
         self.assertEqual(
             self.obj.greenwave_subject,
             [{'item': 'TurboGears-1.0.8-3.fc11', 'type': 'koji_build'},
-             {'original_spec_nvr': 'TurboGears-1.0.8-3.fc11'},
              {'item': self.obj.alias, 'type': 'bodhi_update'}])
 
     def test_greenwave_subject_json(self):
@@ -2138,7 +2135,6 @@ class TestUpdate(ModelTest):
         self.assertEqual(
             json.loads(subject),
             [{'item': 'TurboGears-1.0.8-3.fc11', 'type': 'koji_build'},
-             {'original_spec_nvr': 'TurboGears-1.0.8-3.fc11'},
              {'item': self.obj.alias, 'type': 'bodhi_update'}])
 
     def test_mandatory_days_in_testing_critpath(self):

--- a/devel/ci/integration/tests/test_bodhi_cli.py
+++ b/devel/ci/integration/tests/test_bodhi_cli.py
@@ -423,9 +423,6 @@ def test_updates_query_details(bodhi_container, db_container, greenwave_containe
                 {"item": b, "type": "koji_build"}
                 for b in update.builds
             ] + [
-                {"original_spec_nvr": b}
-                for b in update.builds
-            ] + [
                 {"item": update.alias, "type": "bodhi_update"}
             ],
             "verbose": True,


### PR DESCRIPTION
Greenwave already takes care of getting the tests results for original_spec_nvr
in resultsdb, hence bodhi does not need to ask for it.
See greenwave code (https://pagure.io/greenwave/blob/master/f/greenwave/resources.py#_95)

This will have for effect to improve the performance of bodhi's
requests to greenwave.

Signed-off-by: Clement Verna <cverna@tutanota.com>