### PR TITLE
Avoid NACK loops in the automatic updates consumer

### DIFF
--- a/bodhi/server/scripts/approve_testing.py
+++ b/bodhi/server/scripts/approve_testing.py
@@ -35,7 +35,6 @@ from ..config import config
 
 
 logger = logging.getLogger('approve-testing')
-logging.basicConfig(level=logging.ERROR)
 
 
 def usage(argv):
@@ -65,6 +64,8 @@ def main(argv=sys.argv):
     Args:
         argv (list): A list of command line arguments. Defaults to sys.argv.
     """
+    logging.basicConfig(level=logging.ERROR)
+
     if len(argv) != 2:
         usage(argv)
 


### PR DESCRIPTION
The first commit contains an otherwise unrelated fix which is needed for the reworked unit tests to be able to verify that the expected log messages are issued.