### PR TITLE
Retry on koji.AuthError with backoff

### DIFF
--- a/bodhi/server/buildsys.py
+++ b/bodhi/server/buildsys.py
@@ -24,6 +24,7 @@ import typing
 import os
 from functools import wraps
 
+import backoff
 import koji
 
 if typing.TYPE_CHECKING:  # pragma: no cover
@@ -525,6 +526,7 @@ class DevBuildsys:
             return headers
 
 
+@backoff.on_exception(backoff.expo, koji.AuthError, max_time=600)
 def koji_login(config: 'BodhiConfig', authenticate: bool) -> koji.ClientSession:
     """
     Login to Koji and return the session.

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,6 +25,9 @@ domain = bodhi
 input_file = bodhi/server/locale/bodhi.pot
 output_dir = bodhi/server/locale
 
+[mypy-backoff.*]
+ignore_missing_imports = True
+
 [mypy-bugzilla.*]
 ignore_missing_imports = True
 


### PR DESCRIPTION
Bodhi will now retry for up to 10 minutes if it receives
koji.AuthError.

fixes #1201

Signed-off-by: Randy Barlow <randy@electronsweatshop.com>