### PR TITLE
Fix downloading packages for updates with multiple builds

### DIFF
--- a/bodhi/client/__init__.py
+++ b/bodhi/client/__init__.py
@@ -741,10 +741,19 @@ def download(url, **kwargs):
             resp = client.query(**{attr: value})
             if len(resp.updates) == 0:
                 click.echo(f"WARNING: No {attr} found!")
-            elif len(resp.updates) < expecteds:
-                click.echo(f"WARNING: Some {attr} not found!")
-            # Not sure if we need a check for > expecteds, I don't
-            # *think* that should ever be possible for these opts.
+            else:
+                if attr == 'updateid':
+                    resp_no = len(resp.updates)
+                else:
+                    # attr == 'builds', add up number of builds for each returned update
+                    resp_no = functools.reduce(
+                        lambda x, y: x + len(y.get('builds', [])), resp.updates, 0
+                    )
+
+                if resp_no < expecteds:
+                    click.echo(f"WARNING: Some {attr} not found!")
+                # Not sure if we need a check for > expecteds, I don't
+                # *think* that should ever be possible for these opts.
 
             args = ['koji', 'download-build']
             if debuginfo:

--- a/bodhi/client/__init__.py
+++ b/bodhi/client/__init__.py
@@ -755,12 +755,12 @@ def download(url, **kwargs):
                 # Not sure if we need a check for > expecteds, I don't
                 # *think* that should ever be possible for these opts.
 
-            args = ['koji', 'download-build']
-            if debuginfo:
-                args.append('--debuginfo')
             for update in resp.updates:
                 click.echo(f"Downloading packages from {update['alias']}")
                 for build in update['builds']:
+                    args = ['koji', 'download-build']
+                    if debuginfo:
+                        args.append('--debuginfo')
                     # subprocess is icky, but koji module doesn't
                     # expose this in any usable way, and we don't want
                     # to rewrite it here.

--- a/bodhi/tests/client/test___init__.py
+++ b/bodhi/tests/client/test___init__.py
@@ -272,6 +272,33 @@ class TestDownload(unittest.TestCase):
             'koji', 'download-build', '--arch=noarch', '--arch={}'.format(platform.machine()),
             'nodejs-grunt-wrap-0.3.0-2.fc25'])
 
+    @mock.patch('bodhi.client.bindings.BodhiClient.csrf',
+                mock.MagicMock(return_value='a_csrf_token'))
+    @mock.patch('bodhi.client.bindings.BodhiClient.send_request',
+                return_value=client_test_data.EXAMPLE_QUERY_MUNCH, autospec=True)
+    @mock.patch('bodhi.client.subprocess.call', return_value=0)
+    def test_updateid(self, call, send_request):
+        """
+        Assert correct behavior with the --updateid flag.
+        """
+        runner = testing.CliRunner()
+
+        result = runner.invoke(
+            client.download,
+            ['--updateid', 'FEDORA-2017-c95b33872d', '--url', 'http://localhost:6543'])
+
+        self.assertEqual(result.exit_code, 0)
+        self.assertEqual(result.output,
+                         'Downloading packages from FEDORA-2017-c95b33872d\n')
+        bindings_client = send_request.mock_calls[0][1][0]
+        send_request.assert_called_once_with(
+            bindings_client, 'updates/', verb='GET',
+            params={'updateid': 'FEDORA-2017-c95b33872d'})
+        self.assertEqual(bindings_client.base_url, 'http://localhost:6543/')
+        call.assert_called_once_with([
+            'koji', 'download-build', '--arch=noarch', '--arch={}'.format(platform.machine()),
+            'nodejs-grunt-wrap-0.3.0-2.fc25'])
+
 
 class TestComposeInfo(unittest.TestCase):
     """

--- a/bodhi/tests/client/test___init__.py
+++ b/bodhi/tests/client/test___init__.py
@@ -101,6 +101,14 @@ class TestDownload(unittest.TestCase):
     """
     Test the download() function.
     """
+
+    EXAMPLE_QUERY_MUNCH_MULTI_BUILDS = copy.deepcopy(client_test_data.EXAMPLE_QUERY_MUNCH)
+    EXAMPLE_QUERY_MUNCH_MULTI_BUILDS.updates[0]['builds'].append({
+        'epoch': 0,
+        'nvr': 'nodejs-pants-0.3.0-2.fc25',
+        'signed': True
+    })
+
     @mock.patch('bodhi.client.bindings.BodhiClient.csrf',
                 mock.MagicMock(return_value='a_csrf_token'))
     @mock.patch('bodhi.client.bindings.BodhiClient.send_request',
@@ -191,6 +199,30 @@ class TestDownload(unittest.TestCase):
                          'Downloading packages from FEDORA-2017-c95b33872d\n')
         call.assert_called_once_with([
             'koji', 'download-build', '--debuginfo', 'nodejs-grunt-wrap-0.3.0-2.fc25'])
+
+    @mock.patch('bodhi.client.bindings.BodhiClient.csrf',
+                mock.MagicMock(return_value='a_csrf_token'))
+    @mock.patch('bodhi.client.bindings.BodhiClient.send_request',
+                return_value=EXAMPLE_QUERY_MUNCH_MULTI_BUILDS, autospec=True)
+    @mock.patch('bodhi.client.subprocess.call', return_value=0)
+    def test_multiple_builds(self, call, send_request):
+        """
+        Assert correct behavior with multiple builds.
+        """
+        runner = testing.CliRunner()
+
+        result = runner.invoke(
+            client.download,
+            ['--builds', 'nodejs-pants-0.3.0-2.fc25,nodejs-grunt-wrap-0.3.0-2.fc25',
+             '--arch', 'all'])
+
+        self.assertEqual(result.exit_code, 0)
+        self.assertEqual(result.output,
+                         'Downloading packages from FEDORA-2017-c95b33872d\n')
+        call.assert_any_call([
+            'koji', 'download-build', 'nodejs-pants-0.3.0-2.fc25'])
+        call.assert_any_call([
+            'koji', 'download-build', 'nodejs-grunt-wrap-0.3.0-2.fc25'])
 
     @mock.patch('bodhi.client.bindings.BodhiClient.csrf',
                 mock.MagicMock(return_value='a_csrf_token'))


### PR DESCRIPTION
I inadvertently broke this in #3148 - sorry. I tried to make
the handling of the args list cleaner in that commit, but
overlooked that initializing it outside of the `for build in`
loop meant it'd just keep getting appended to, it doesn't get
recreated for each build - so by the time you get to the second
build in an update, you're trying to do something like:

koji download-build foo-1.0-1 bar-1.0-1

which isn't allowed (that's why we run one command per build in
the first place, life would be easier if Koji let us pass it
multiple NVRs...)

Fix this simply by (re)initializing `args` inside the loop, not
outside it.

Signed-off-by: Adam Williamson <awilliam@redhat.com>