### PR TITLE
Convert the BRO schema to use f-strings

### DIFF
--- a/bodhi/messages/schemas/buildroot_override.py
+++ b/bodhi/messages/schemas/buildroot_override.py
@@ -57,7 +57,7 @@ class BuildrootOverrideMessage(BodhiMessage):
         Returns:
             A relevant URL.
         """
-        return "https://bodhi.fedoraproject.org/overrides/{nvr}".format(nvr=self.build.nvr)
+        return f"https://bodhi.fedoraproject.org/overrides/{self.build.nvr}"
 
     @property
     def packages(self) -> typing.Iterable[str]:


### PR DESCRIPTION
This converts bodhi.messages.schemas.buildroot_overrides to use
f-strings instead of format().

Signed-off-by: Randy Barlow <randy@electronsweatshop.com>