### PR TITLE
Make stable_days field in update form to use mandatory_days_in_testing

### DIFF
--- a/bodhi/server/templates/new_update.html
+++ b/bodhi/server/templates/new_update.html
@@ -277,13 +277,13 @@ ${update.notes}
                       % endif
                     ></dd>
 
-                  <dt data-toggle="tooltip" title="This is the number of days an update needs to spend in testing to be automatically pushed to stable.">
+                  <dt data-toggle="tooltip" title="This is the number of days an update needs to spend in testing to be automatically pushed to stable. If empty it will be set to the minimum number of days set for the Release.">
                   Stable days</dt>
-                  <dd> <input type="number" name="stable_days" min="1"
+                  <dd> <input type="number" name="stable_days" placeholder="auto"
                       % if update:
-                      value="${update.stable_days}"
+                      min="${update.mandatory_days_in_testing}" value="${update.stable_days}"
                       % elif not update:
-                      value=""
+                      min="0" value=""
                       % endif
                     ></dd>
 


### PR DESCRIPTION
This will make the "stable days" field fo the new update form to display an "auto" placeholder when creating a new update, while when editing an existing update the minimum accepted value will be the mandatory_days_in_testing for that update.

It was quite confusing for me to have "Auto-request stable based on time" flagged and "Stable days" with an empty value (zero?). This should make things clearer.

Signed-off-by: Mattia Verga <mattia.verga@tiscali.it>