### PR TITLE
Authorize null mandatory days in testing

### DIFF
--- a/bodhi/server/models.py
+++ b/bodhi/server/models.py
@@ -858,10 +858,10 @@ class Release(Base):
         name = self.name.lower().replace('-', '')
         status = config.get('%s.status' % name, None)
         if status:
-            days = int(config.get(
-                '%s.%s.mandatory_days_in_testing' % (name, status)))
-            if days:
-                return days
+            days = config.get(
+                '%s.%s.mandatory_days_in_testing' % (name, status))
+            if days is not None:
+                return int(days)
         days = config.get('%s.mandatory_days_in_testing' %
                           self.id_prefix.lower().replace('-', '_'))
         if days is None:

--- a/bodhi/tests/server/test_models.py
+++ b/bodhi/tests/server/test_models.py
@@ -710,6 +710,11 @@ class TestRelease(ModelTest):
         """Test mandatory_days_in_testing() with a value that is truthy."""
         self.assertEqual(self.obj.mandatory_days_in_testing, 42)
 
+    @mock.patch.dict(config, {'f11.current.mandatory_days_in_testing': 0, 'f11.status': 'current'})
+    def test_mandatory_days_in_testing_status_0_days(self):
+        """Test mandatory_days_in_testing() with a value that is 0."""
+        self.assertEqual(self.obj.mandatory_days_in_testing, 0)
+
     def test_setting_prefix(self):
         """Assert correct return value from the setting_prefix property."""
         self.assertEqual(self.obj.setting_prefix, 'f11')


### PR DESCRIPTION
This PR has 2 commits, the first commit makes sure that we can set a specific release mandatory days to 0 and the second one protect the code from trying to cast `None` to an integer.