### PR TITLE
approve_testing needs to setup the buildsystem.

### DIFF
--- a/bodhi/server/scripts/approve_testing.py
+++ b/bodhi/server/scripts/approve_testing.py
@@ -29,7 +29,7 @@ import logging
 from pyramid.paster import get_appsettings
 
 from bodhi.messages.schemas import update as update_schemas
-from bodhi.server import Session, initialize_db, notifications
+from bodhi.server import Session, initialize_db, notifications, buildsys
 from ..models import Update, UpdateStatus, UpdateRequest
 from ..config import config
 
@@ -72,6 +72,7 @@ def main(argv=sys.argv):
     settings = get_appsettings(argv[1])
     initialize_db(settings)
     db = Session()
+    buildsys.setup_buildsystem(config)
 
     try:
         testing = db.query(Update).filter_by(status=UpdateStatus.testing,


### PR DESCRIPTION
Since the approve_testing script now can requests a build to be move stable
it needs the buildsystem to be setup so that bodhi can update the build
tags in koji. This is done in the update.set_request method via the
add_tag method.

Signed-off-by: Clement Verna <cverna@tutanota.com>