### PR TITLE
Add the greenwave topic to the fedora-messaging routing keys.

### DIFF
--- a/devel/ansible/roles/bodhi/files/bodhi.toml
+++ b/devel/ansible/roles/bodhi/files/bodhi.toml
@@ -21,6 +21,7 @@ routing_keys = [
     "org.fedoraproject.*.buildsys.tag",
     "org.fedoraproject.*.bodhi.update.request.testing",
     "org.fedoraproject.*.bodhi.update.edit",
+    "org.fedoraproject.*.greenwave.decision.update",
 ]
 
 [tls]

--- a/devel/ci/integration/bodhi/fedora-messaging.toml
+++ b/devel/ci/integration/bodhi/fedora-messaging.toml
@@ -10,6 +10,7 @@ routing_keys = [
     "org.fedoraproject.*.buildsys.tag",
     "org.fedoraproject.*.bodhi.update.request.testing",
     "org.fedoraproject.*.bodhi.update.edit",
+    "org.fedoraproject.*.greenwave.decision.update",
 ]
 
 [client_properties]


### PR DESCRIPTION
This commit makes sure that we have the greenwave.decision.update
topic in the fedora-messaging configuration used in the vagrant box

Signed-off-by: Clement Verna <cverna@tutanota.com>