### PR TITLE
Work around Fedora Infra RPM repo key import issue

### DIFF
--- a/devel/ci/integration/bodhi/Dockerfile-f29
+++ b/devel/ci/integration/bodhi/Dockerfile-f29
@@ -7,6 +7,9 @@ LABEL \
 
 # For integration testing we're using the infrastructure repo
 RUN curl -o /etc/yum.repos.d/infra-tags.repo https://infrastructure.fedoraproject.org/cgit/ansible.git/plain/files/common/fedora-infra-tags.repo
+# work around https://bugzilla.redhat.com/show_bug.cgi?id=1699396
+RUN rpm --import "$(awk -F= '{if ($0 ~ "gpgkey *=") {print $2;}}' < /etc/yum.repos.d/infra-tags.repo)"
+
 RUN dnf upgrade -y
 
 # Install Bodhi deps (that were not needed by the unittests container)

--- a/devel/ci/integration/bodhi/Dockerfile-f30
+++ b/devel/ci/integration/bodhi/Dockerfile-f30
@@ -7,6 +7,9 @@ LABEL \
 
 # For integration testing we're using the infrastructure repo
 RUN curl -o /etc/yum.repos.d/infra-tags.repo https://infrastructure.fedoraproject.org/cgit/ansible.git/plain/files/common/fedora-infra-tags.repo
+# work around https://bugzilla.redhat.com/show_bug.cgi?id=1699396
+RUN rpm --import "$(awk -F= '{if ($0 ~ "gpgkey *=") {print $2;}}' < /etc/yum.repos.d/infra-tags.repo)"
+
 RUN dnf upgrade -y
 
 # Install Bodhi deps (that were not needed by the unittests container)

--- a/devel/ci/integration/bodhi/Dockerfile-pip
+++ b/devel/ci/integration/bodhi/Dockerfile-pip
@@ -7,6 +7,9 @@ LABEL \
 
 # For integration testing we're using the infrastructure repo
 RUN curl -o /etc/yum.repos.d/infra-tags.repo https://infrastructure.fedoraproject.org/cgit/ansible.git/plain/files/common/fedora-infra-tags.repo
+# work around https://bugzilla.redhat.com/show_bug.cgi?id=1699396
+RUN rpm --import "$(awk -F= '{if ($0 ~ "gpgkey *=") {print $2;}}' < /etc/yum.repos.d/infra-tags.repo)"
+
 RUN dnf upgrade -y
 
 # Install Bodhi deps (that were not needed by the unittests container)

--- a/devel/ci/integration/bodhi/Dockerfile-rawhide
+++ b/devel/ci/integration/bodhi/Dockerfile-rawhide
@@ -7,6 +7,9 @@ LABEL \
 
 # For integration testing we're using the infrastructure repo
 RUN curl -o /etc/yum.repos.d/infra-tags.repo https://infrastructure.fedoraproject.org/cgit/ansible.git/plain/files/common/fedora-infra-tags.repo
+# work around https://bugzilla.redhat.com/show_bug.cgi?id=1699396
+RUN rpm --import "$(awk -F= '{if ($0 ~ "gpgkey *=") {print $2;}}' < /etc/yum.repos.d/infra-tags.repo)"
+
 RUN dnf upgrade -y
 
 # Install Bodhi deps (that were not needed by the unittests container)


### PR DESCRIPTION
This is an obscure and hard to debug (therefore unfixed) problem in DNF
which caused installing Fedora Infrastructure RPM packages to fail in CI
containters. It's documented at:

https://bugzilla.redhat.com/show_bug.cgi?id=1699396

Thanks to Brian Stinson for the suggested workaround!

Signed-off-by: Nils Philippsen <nils@redhat.com>