### PR TITLE
Automatically create the rawhide updates in a TESTING state

### DIFF
--- a/bodhi/server/consumers/automatic_updates.py
+++ b/bodhi/server/consumers/automatic_updates.py
@@ -28,7 +28,7 @@ import fedora_messaging
 
 from bodhi.server import buildsys
 from bodhi.server.models import Build, ContentType, Package, Release
-from bodhi.server.models import Update, UpdateRequest, UpdateType, User
+from bodhi.server.models import Update, UpdateStatus, UpdateType, User
 from bodhi.server.util import transactional_session_maker
 
 
@@ -141,10 +141,15 @@ class AutomaticUpdateHandler:
                 stable_karma=3,
                 unstable_karma=-3,
                 user=user,
+                status=UpdateStatus.testing,
             )
 
-            log.debug("Setting request for new update.")
-            update.set_request(dbsession, UpdateRequest.testing, owner_name)
+            # Comment on the update that it was automatically created.
+            update.comment(
+                dbsession,
+                str("This update was automatically created"),
+                author="bodhi",
+            )
 
             log.debug("Adding new update to the database.")
             dbsession.add(update)


### PR DESCRIPTION
For updates that are automatically created for rawhide there is no
need to have them go through the PENDING state. We can just directly
create them in the TESTING state, let them be tested by CI and let
the approve_testing cron job move them to STABLE once they have
passed their CI.

Signed-off-by: Pierre-Yves Chibon <pingou@pingoured.fr>