### PR TITLE
Mark the update as stable if they are not meant to go through testing

### DIFF
--- a/bodhi/server/scripts/approve_testing.py
+++ b/bodhi/server/scripts/approve_testing.py
@@ -103,6 +103,11 @@ def main(argv=sys.argv):
                 if update.autotime and update.days_in_testing >= update.stable_days:
                     print(f"Automatically marking {update.alias} as stable")
                     update.set_request(db=db, action=UpdateRequest.stable, username="bodhi")
+                    # For updates that are not included in composes run by bodhi itself,
+                    # mark them as stable
+                    if not update.release.composed_by_bodhi:
+                        update.status = UpdateStatus.stable
+                        update.request = None
 
                 db.commit()
 


### PR DESCRIPTION
In regular releases we have:
- pending-testing
- testing
- pending-stable
- stable

For the rawhide release in Fedora, we have:
- testing
- stable
Updates that are in testing and whose gating status is "green", are
pushed to stable via the approve_testing script. On "regular"
releases they will go from testing to pending-stable, on "rawhide"
we want them to go from testing to stable directly since the compose
process that normally moves the build from pending-stable to stable
is not run by bodhi in rawhide.

This commit also adds a comment precising that setting
mandatory_days_in_testing to 0 on a non-rawhide release may lead to
unexpected behaviour in this part of the code, since non-rawhide
releases are composed within bodhi and thus having the updates marked
as stable outside of the compose process may leads to some issues.

Signed-off-by: Pierre-Yves Chibon <pingou@pingoured.fr>