### PR TITLE
Change the tag flow in bodhi for rawhide.

### DIFF
--- a/bodhi/server/consumers/automatic_updates.py
+++ b/bodhi/server/consumers/automatic_updates.py
@@ -100,7 +100,7 @@ class AutomaticUpdateHandler:
 
         with self.db_factory() as dbsession:
             rel = dbsession.query(Release).filter_by(create_automatic_updates=True,
-                                                     candidate_tag=btag).first()
+                                                     pending_testing_tag=btag).first()
             if not rel:
                 log.debug(f"Ignoring build being tagged into {btag!r}, no release configured for "
                           "automatic updates for it found.")

--- a/bodhi/tests/server/consumers/test_automatic_updates.py
+++ b/bodhi/tests/server/consumers/test_automatic_updates.py
@@ -50,7 +50,7 @@ class TestAutomaticUpdateHandler(base.BasePyTestCase):
             'name': 'colord',
             'tag_id': 214,
             'instance': 's390',
-            'tag': 'f17-updates-candidate',
+            'tag': 'f17-updates-testing-pending',
             'user': 'sharkcz',
             'version': '1.3.4',
             'owner': 'sharkcz',


### PR DESCRIPTION
The first flow we thought of was:
- builds are picked from the candidate_tag
- once un-gated, they are pushed into the pending_stable_tag

However, by doing this we realized we wanted/needed a different
flow for two reasons:
- rawhide does not have the notion of "pending", the builds are
  directly in testing. So the updates we create for rawhide are
  directly in the testing status.
- we want builds to the signed before they are tested so the CI
  system really tests what is being shipped.

So we're changing the flow to be:
- builds are picked from pending_testing_tag (where they are pushed
  by robotsignatory)
- once un-gated, they are pushed into the pending_stable_tag (where
  something will push them into their stable tag)
  -> The update are marked as stable at the time their builds are
     pushed into the pending_stable_tag for rawhide.

Signed-off-by: Pierre-Yves Chibon <pingou@pingoured.fr>