### PR TITLE
Go to stable directly for rawhide-like releases.

### DIFF
--- a/bodhi/server/scripts/approve_testing.py
+++ b/bodhi/server/scripts/approve_testing.py
@@ -107,6 +107,9 @@ def main(argv=sys.argv):
                     # For updates that are not included in composes run by bodhi itself,
                     # mark them as stable
                     if not update.release.composed_by_bodhi:
+                        update.add_tag(update.release.stable_tag)
+                        update.remove_tag(update.release.pending_testing_tag)
+                        update.remove_tag(update.release.pending_stable_tag)
                         update.status = UpdateStatus.stable
                         update.date_stable = datetime.datetime.utcnow()
                         update.request = None


### PR DESCRIPTION
For releases that do not go through testing and aren't composed by
bodhi, go to stable directly.
This means, move the update's build into update.release.stable_tag and
remove the update.release.pending_testing_tag (where the update was when
it was picked up) and update.release.pending_stable_tag which was just
added when the update was marked pending stable.

Signed-off-by: Pierre-Yves Chibon <pingou@pingoured.fr>