### PR TITLE
Get gating status from Greenwave for created updates

### DIFF
--- a/bodhi/server/consumers/automatic_updates.py
+++ b/bodhi/server/consumers/automatic_updates.py
@@ -146,8 +146,10 @@ class AutomaticUpdateHandler:
             if config.get('test_gating.required'):
                 log.debug(
                     'Test gating required is enforced, marking the update as '
-                    'waiting on test gating')
+                    'waiting on test gating and updating it from Greenwave to '
+                    'get the real status.')
                 update.test_gating_status = TestGatingStatus.waiting
+                update.update_test_gating_status()
 
             # Comment on the update that it was automatically created.
             update.comment(


### PR DESCRIPTION
This should let us do the right thing if no tests are required for this
update, i.e. Greenwave won't send us any updates either.

Signed-off-by: Nils Philippsen <nils@redhat.com>