### PR TITLE
Ensure correct order of automatic update comments

### DIFF
--- a/bodhi/server/consumers/automatic_updates.py
+++ b/bodhi/server/consumers/automatic_updates.py
@@ -143,13 +143,6 @@ class AutomaticUpdateHandler:
                 user=user,
                 status=UpdateStatus.testing,
             )
-            if config.get('test_gating.required'):
-                log.debug(
-                    'Test gating required is enforced, marking the update as '
-                    'waiting on test gating and updating it from Greenwave to '
-                    'get the real status.')
-                update.test_gating_status = TestGatingStatus.waiting
-                update.update_test_gating_status()
 
             # Comment on the update that it was automatically created.
             update.comment(
@@ -157,6 +150,14 @@ class AutomaticUpdateHandler:
                 str("This update was automatically created"),
                 author="bodhi",
             )
+
+            if config.get('test_gating.required'):
+                log.debug(
+                    'Test gating required is enforced, marking the update as '
+                    'waiting on test gating and updating it from Greenwave to '
+                    'get the real status.')
+                update.test_gating_status = TestGatingStatus.waiting
+                update.update_test_gating_status()
 
             log.debug("Adding new update to the database.")
             dbsession.add(update)

--- a/bodhi/tests/server/consumers/test_automatic_updates.py
+++ b/bodhi/tests/server/consumers/test_automatic_updates.py
@@ -133,6 +133,23 @@ class TestAutomaticUpdateHandler(base.BasePyTestCase):
         expected_username = base.buildsys.DevBuildsys._build_data['owner_name']
         assert update.user and update.user.name == expected_username
 
+        # check comments and their order
+        if gated == 'error':
+            final_status = 'greenwave_failed'
+        elif gated:
+            final_status = 'failed'
+        else:
+            final_status = 'ignored'
+
+        expected_comments = [
+            "This update was automatically created",
+            "This update's test gating status has been changed to 'waiting'.",
+            f"This update's test gating status has been changed to '{final_status}'.",
+        ]
+
+        assert (expected_comments == [c.text for c in update.comments])
+
+        # check for log records, warning or higher
         if gated == 'error':
             warn_higher_records = [r for r in caplog.records if r.levelno >= logging.WARNING]
             assert len(warn_higher_records) == 1


### PR DESCRIPTION
Previously, gating status was checked before the comment about creating
the update was added. Because the timestamp of comments defaults to
datetime.utcnow() (evaluated when the object is created), this caused
the creation comment to be sorted after the two comments concerning the
test gating status.

fixes: #3401

Signed-off-by: Nils Philippsen <nils@redhat.com>