### PR TITLE
Use current feedgen API

### DIFF
--- a/bodhi/server/renderers.py
+++ b/bodhi/server/renderers.py
@@ -103,7 +103,7 @@ def rss(info):
                 'title': operator.itemgetter('alias'),
                 'link': linker('update', 'id', 'alias'),
                 'description': operator.itemgetter('notes'),
-                'pubdate': lambda obj: utc.localize(obj['date_submitted']),
+                'pubDate': lambda obj: utc.localize(obj['date_submitted']),
             },
             'users': {
                 'title': operator.itemgetter('name'),
@@ -114,13 +114,13 @@ def rss(info):
                 'title': operator.itemgetter('rss_title'),
                 'link': linker('comment', 'id', 'id'),
                 'description': operator.itemgetter('text'),
-                'pubdate': lambda obj: utc.localize(obj['timestamp']),
+                'pubDate': lambda obj: utc.localize(obj['timestamp']),
             },
             'overrides': {
                 'title': operator.itemgetter('nvr'),
                 'link': linker('override', 'nvr', 'nvr'),
                 'description': operator.itemgetter('notes'),
-                'pubdate': lambda obj: utc.localize(obj['submission_date']),
+                'pubDate': lambda obj: utc.localize(obj['submission_date']),
             },
         }
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ cornice>=3.1.0
 dogpile.cache
 pyasn1-modules  # Due to an unfortunate dash in its name, installs break if pyasn1 is installed first
 fedora_messaging
-feedgen
+feedgen>=0.7.0
 jinja2
 markdown
 psycopg2


### PR DESCRIPTION
Use FeedGenerator.pubDate() rather than .pubdate() which is deprecated
and might go away in 0.8. The new name was introduced in feedgen 0.7.0,
as we don't support Fedora < 29, this is safe to require.

Signed-off-by: Nils Philippsen <nils@redhat.com>