### PR TITLE
When automatically creating an update, obsolete the pending ones

### DIFF
--- a/bodhi/server/consumers/automatic_updates.py
+++ b/bodhi/server/consumers/automatic_updates.py
@@ -151,6 +151,10 @@ class AutomaticUpdateHandler:
                 author="bodhi",
             )
 
+            # Obsolete all the updates that are in pending and having this
+            # build
+            update.obsolete_older_updates(dbsession, status=UpdateStatus.pending)
+
             if config.get('test_gating.required'):
                 log.debug(
                     'Test gating required is enforced, marking the update as '


### PR DESCRIPTION
If an update is automatically created, there could still be one
that was manually created by the user and which is laying around
in a "Pending" state (the one automatically created being created
in a "Testing" state).
So to not have these updates laying around doing nothing forever,
we can just obsolete them.

But we do not want to obsolete the ones in Testing as the new build
may fail CI while the old one passes and thus would land in the
rawhide buildroot.

Signed-off-by: Pierre-Yves Chibon <pingou@pingoured.fr>