### PR TITLE
Handle situation where there is an existing update but in Pending

### DIFF
--- a/bodhi/tests/server/consumers/test_automatic_updates.py
+++ b/bodhi/tests/server/consumers/test_automatic_updates.py
@@ -27,7 +27,7 @@ import pytest
 from bodhi.server.config import config
 from bodhi.server.consumers.automatic_updates import AutomaticUpdateHandler
 from bodhi.server.models import (
-    Build, Release, TestGatingStatus, Update, UpdateStatus, UpdateType, User
+    Build, Release, TestGatingStatus, Update, UpdateRequest, UpdateStatus, UpdateType, User
 )
 from bodhi.tests.server import base
 
@@ -275,3 +275,120 @@ class TestAutomaticUpdateHandler(base.BasePyTestCase):
 
         assert (f"Build, active update for {self.sample_nvr} exists already, skipping."
                 in caplog.messages)
+
+    def test_existing_pending_update(self, caplog):
+        """
+        Ensure an update is moved to testing if a matching pending one exists.
+        """
+        caplog.set_level(logging.DEBUG)
+
+        self.handler(self.sample_message)
+        update = self.db.query(Update).filter(
+            Update.builds.any(Build.nvr == self.sample_nvr)
+        ).first()
+        # Check it was created in testing
+        assert update.status == UpdateStatus.testing
+        # Move it back to Pending as if the user has manually created it
+        update.status = UpdateStatus.pending
+        update.request = UpdateRequest.testing
+        self.db.add(update)
+        self.db.flush()
+
+        caplog.clear()
+
+        self.handler(self.sample_message)
+
+        assert (f"Build, active update for {self.sample_nvr} exists already in "
+                "Pending, moving it along." in caplog.messages)
+
+        update = self.db.query(Update).filter(
+            Update.builds.any(Build.nvr == self.sample_nvr)
+        ).first()
+        assert update.status == UpdateStatus.testing
+        assert update.request is None
+
+    @mock.patch.dict(config, [('test_gating.required', True),
+                              ('greenwave_api_url', 'http://domain.local')])
+    @pytest.mark.parametrize('gated', (True, False, 'error'))
+    def test_existing_pending_update_with_gating(self, caplog, gated):
+        """
+        Ensure an update is moved to testing if a matching pending one exists.
+
+        Contrary to test_existing_pending_update(), this test runs with test
+        gating required, i.e. simulates querying Greenwave for the gating
+        status.
+        """
+        def _call_handler():
+            """ Call the handler to process the sample message. """
+            with mock.patch('bodhi.server.models.util.greenwave_api_post') as mock_greenwave:
+                if gated == 'error':
+                    mock_greenwave.side_effect = RuntimeError("Boo!")
+                else:
+                    if gated:
+                        greenwave_response = {
+                            'policies_satisfied': False,
+                            'summary': "1 of 1 required test results missing",
+                        }
+                    else:
+                        greenwave_response = {
+                            'policies_satisfied': True,
+                            'summary': "no tests are required",
+                        }
+                    mock_greenwave.return_value = greenwave_response
+                self.handler(self.sample_message)
+
+                # Quick sanity checks
+                assert mock_greenwave.call_count == 1
+
+            update = self.db.query(Update).filter(
+                Update.builds.any(Build.nvr == self.sample_nvr)
+            ).first()
+            if gated == 'error':
+                assert update.test_gating_status == TestGatingStatus.greenwave_failed
+            elif gated:
+                assert update.test_gating_status == TestGatingStatus.failed
+            else:
+                assert update.test_gating_status == TestGatingStatus.ignored
+            return update
+
+        # First run
+        caplog.set_level(logging.DEBUG)
+        update = _call_handler()
+
+        # Double-check how it was created in the first run
+        assert update.status == UpdateStatus.testing
+
+        # Move it back to Pending as if the user had manually created it
+        update.status = UpdateStatus.pending
+        update.request = UpdateRequest.testing
+        self.db.add(update)
+        self.db.flush()
+
+        caplog.clear()
+
+        # Second run
+        update = _call_handler()
+
+        assert (f"Build, active update for {self.sample_nvr} exists already in "
+                "Pending, moving it along." in caplog.messages)
+
+        assert update.status == UpdateStatus.testing
+        assert update.request is None
+
+        # check comments and their order
+        if gated == 'error':
+            final_status = 'greenwave_failed'
+        elif gated:
+            final_status = 'failed'
+        else:
+            final_status = 'ignored'
+
+        expected_comments = [
+            "This update was automatically created",
+            "This update's test gating status has been changed to 'waiting'.",
+            f"This update's test gating status has been changed to '{final_status}'.",
+            "This update's test gating status has been changed to 'waiting'.",
+            f"This update's test gating status has been changed to '{final_status}'.",
+        ]
+
+        assert (expected_comments == [c.text for c in update.comments])


### PR DESCRIPTION
If the user manually creates the bodhi update for a release for which the
update should have been automatically created, that update will stay in
a Pending state with nothing moving it forward.
When we finally receive the message from koji about a build being tagged
in the tag of interest, we will discard it since there is already an
update for it.
This results in the update being basically stuck in bodhi.

With this commit, if are notified of a build tagged in a koji tag of
interest, we will check if there is an existing update and if there is
one that is in "Pending" state, we will move it to "Testing" and check
its gating status, effectively allowing to move the update to the next
stage from where it can be picked by the regular workflow.

Fixes https://github.com/fedora-infra/bodhi/issues/3414

Signed-off-by: Pierre-Yves Chibon <pingou@pingoured.fr>