### PR TITLE
Ensure pip is available in integration tests

### DIFF
--- a/devel/ci/integration/bodhi/Dockerfile-f29
+++ b/devel/ci/integration/bodhi/Dockerfile-f29
@@ -17,6 +17,7 @@ RUN dnf install -y \
     httpd \
     intltool \
     python3-mod_wsgi \
+    python3-pip \
     skopeo \
     /usr/bin/koji
 

--- a/devel/ci/integration/bodhi/Dockerfile-f30
+++ b/devel/ci/integration/bodhi/Dockerfile-f30
@@ -17,6 +17,7 @@ RUN dnf install -y \
     httpd \
     intltool \
     python3-mod_wsgi \
+    python3-pip \
     skopeo \
     /usr/bin/koji
 

--- a/devel/ci/integration/bodhi/Dockerfile-pip
+++ b/devel/ci/integration/bodhi/Dockerfile-pip
@@ -19,6 +19,7 @@ RUN dnf install -y \
     python3-koji \
     /usr/bin/koji \
     python3-mod_wsgi \
+    python3-pip \
     python3-dnf \
     skopeo
 

--- a/devel/ci/integration/bodhi/Dockerfile-rawhide
+++ b/devel/ci/integration/bodhi/Dockerfile-rawhide
@@ -20,6 +20,7 @@ RUN dnf install -y \
     httpd \
     intltool \
     python3-mod_wsgi \
+    python3-pip \
     skopeo \
     /usr/bin/koji
 


### PR DESCRIPTION
Apparently, python3-pip was pulled in via some dependency before recent
changes in Rawhide.

Signed-off-by: Nils Philippsen <nils@redhat.com>