### PR TITLE
Only send an email for the comments added when CI fails

### DIFF
--- a/bodhi/server/models.py
+++ b/bodhi/server/models.py
@@ -3066,7 +3066,8 @@ class Update(Base):
         return
 
     def comment(self, session, text, karma=0, author=None, karma_critpath=0,
-                bug_feedback=None, testcase_feedback=None, check_karma=True):
+                bug_feedback=None, testcase_feedback=None, check_karma=True,
+                email_notification=True):
         """Add a comment to this update.
 
         If the karma reaches the 'stable_karma' value, then request that this update be marked
@@ -3178,7 +3179,8 @@ class Update(Base):
                 people.add(comment.user.email)
             else:
                 people.add(comment.user.name)
-        mail.send(people, 'comment', self, sender=None, agent=author)
+        if email_notification:
+            mail.send(people, 'comment', self, sender=None, agent=author)
         return comment, caveats
 
     def unpush(self, db):
@@ -3706,6 +3708,9 @@ class Update(Base):
         """
         Place comment on the update when ``test_gating_status`` changes.
 
+        Only notify the users by email if the new status is in ``failed`` or
+        ``greenwave_failed``.
+
         Args:
             target (Update): The compose that has had a change to its state attribute.
             value (EnumSymbol): The new value of the test_gating_status.
@@ -3714,10 +3719,15 @@ class Update(Base):
                 transition.
         """
         if value != old:
+            notify = value in [
+                TestGatingStatus.greenwave_failed,
+                TestGatingStatus.failed,
+            ]
             target.comment(
                 Session(),
                 f"This update's test gating status has been changed to '{value}'.",
                 author="bodhi",
+                email_notification=notify,
             )
 
 

--- a/bodhi/tests/server/test_models.py
+++ b/bodhi/tests/server/test_models.py
@@ -4146,7 +4146,8 @@ class TestUpdate(ModelTest):
         expected_comment = "This update's test gating status has been changed to 'waiting'."
         self.assertEqual(update.comments[-1].text, expected_comment)
 
-    def test_comment_on_test_gating_status_change(self):
+    @mock.patch('bodhi.server.models.mail')
+    def test_comment_on_test_gating_status_change(self, mail):
         """Assert that Bodhi will leave comment only when test_gating_status changes."""
         # Let's make sure that update has no comments.
         self.assertEqual(len(self.obj.comments), 0)
@@ -4163,6 +4164,37 @@ class TestUpdate(ModelTest):
 
         # We should have still only one comment about test_gating_status change.
         self.assertEqual(len(self.obj.comments), 1)
+
+        # Check that no email were sent:
+        self.assertEqual(mail.send.call_count, 0)
+
+    @mock.patch('bodhi.server.models.mail')
+    def test_comment_on_test_gating_status_change_email(self, mail):
+        """Assert that Bodhi will leave comment only when test_gating_status changes."""
+        # Let's make sure that update has no comments.
+        self.assertEqual(len(self.obj.comments), 0)
+
+        # Check that no email were sent:
+        self.assertEqual(mail.send.call_count, 0)
+
+        self.obj.test_gating_status = TestGatingStatus.failed
+
+        # Check that one email was sent:
+        self.assertEqual(mail.send.call_count, 1)
+
+        # Check for the comment about test_gating_status change
+        expected_comment = "This update's test gating status has been changed to 'failed'."
+        self.assertEqual(self.obj.comments[0].text, expected_comment)
+        self.assertEqual(len(self.obj.comments), 1)
+
+        # Let's set test_gating_status to 'waiting' once again.
+        self.obj.test_gating_status = TestGatingStatus.waiting
+
+        # Check that still only one email was sent:
+        self.assertEqual(mail.send.call_count, 1)
+
+        # We should have two comments, one for each test_gating_status change
+        self.assertEqual(len(self.obj.comments), 2)
 
 
 class TestUser(ModelTest):


### PR DESCRIPTION
Relates to https://github.com/fedora-infra/bodhi/issues/3431

Signed-off-by: Pierre-Yves Chibon <pingou@pingoured.fr>