### PR TITLE
Ignore the compose decision in the greenwave consumer.

### DIFF
--- a/bodhi/server/consumers/greenwave.py
+++ b/bodhi/server/consumers/greenwave.py
@@ -56,6 +56,11 @@ class GreenwaveHandler:
             log.debug("Couldn't find subject_identifier in Greenwave message")
             return
 
+        subject_type = msg.get("subject_type")
+        if subject_type == "compose":
+            log.debug("Not requesting a decision for a compose")
+            return
+
         with self.db_factory():
 
             build = Build.get(subject_identifier)

--- a/bodhi/tests/server/consumers/test_greenwave.py
+++ b/bodhi/tests/server/consumers/test_greenwave.py
@@ -34,7 +34,7 @@ class TestGreenwaveHandler(BaseTestCase):
         super().setUp()
         self.sample_message = Message(
             topic="org.fedoraproject.prod.greenwave.decision.update",
-            body={"subject_identifier": "bodhi-2.0-1.fc17"},
+            body={"subject_identifier": "bodhi-2.0-1.fc17", "subject_type": "koji_build"},
         )
         self.handler = greenwave.GreenwaveHandler()
 
@@ -94,3 +94,12 @@ class TestGreenwaveHandler(BaseTestCase):
         self.handler(self.sample_message)
         self.assertEqual(mock_log.debug.call_count, 1)
         mock_log.debug.assert_called_with("Couldn't find build notapackage-2.0-1.fc17 in DB")
+
+    @mock.patch('bodhi.server.consumers.greenwave.log')
+    def test_greenwave_compose_subject_type(self, mock_log):
+        """ Assert that the consumer ignores messages with subject_type equal to compose """
+
+        self.sample_message.body["subject_type"] = "compose"
+        self.handler(self.sample_message)
+        self.assertEqual(mock_log.debug.call_count, 1)
+        mock_log.debug.assert_called_with("Not requesting a decision for a compose")


### PR DESCRIPTION
Fixes #3425

Signed-off-by: Clement Verna <cverna@tutanota.com>