### PR TITLE
add option to vagrant provisioning to use stg infra

### DIFF
--- a/devel/ansible/roles/bodhi/tasks/configure_stg.yml
+++ b/devel/ansible/roles/bodhi/tasks/configure_stg.yml
@@ -1,0 +1,42 @@
+---
+- name: change config to use the koji buildsystem
+  ini_file:
+    path: /home/vagrant/bodhi/development.ini
+    section: app:main
+    option: buildsystem
+    value: koji
+
+- name: change config to use the stg kojihub
+  ini_file:
+    path: /home/vagrant/bodhi/development.ini
+    section: app:main
+    option: koji_hub
+    value: https://koji.stg.fedoraproject.org/kojihub
+
+- name: change config to use the stg koji
+  ini_file:
+    path: /home/vagrant/bodhi/development.ini
+    section: app:main
+    option: koji_web_url
+    value: https://koji.stg.fedoraproject.org/koji/
+
+- name: change config to use the stg kerberos
+  ini_file:
+    path: /home/vagrant/bodhi/development.ini
+    section: app:main
+    option: krb_principal
+    value: "{{ staging_fas }}@STG.FEDORAPROJECT.ORG"
+
+- name: change config to use the pagure for acls
+  ini_file:
+    path: /home/vagrant/bodhi/development.ini
+    section: app:main
+    option: acl_system
+    value: pagure
+
+- name: change config to use stg pagure for acls
+  ini_file:
+    path: /home/vagrant/bodhi/development.ini
+    section: app:main
+    option: pagure_url
+    value: https://src.stg.fedoraproject.org/

--- a/devel/ansible/roles/bodhi/tasks/main.yml
+++ b/devel/ansible/roles/bodhi/tasks/main.yml
@@ -144,6 +144,10 @@
   args:
       creates: /home/vagrant/bodhi/development.ini
 
+- name: Change development.ini to make bodhi use the staging infrastructure
+  import_tasks: configure_stg.yml
+  when: (staging_fas is defined) and use_staging_infra
+
 - name: Creates /etc/bodhi directory
   file:
     path: /etc/bodhi


### PR DESCRIPTION
This adds an option when provisioning the bodhi devel
envrionment with vagrant to set up the config to use
the fedora staging infra.

to use this option, the box is provisioned with

    vagrant --use-staging up

note that talking to koji stg requires a krb ticket, so
before starting bodhi, get a new ticket with:

    kinit <fasusername>@STG.FEDORAPROJECT.ORG