### PR TITLE
mark updates not composed by bodhi as pushed when stable

### DIFF
--- a/bodhi/server/scripts/approve_testing.py
+++ b/bodhi/server/scripts/approve_testing.py
@@ -120,6 +120,8 @@ def main(argv=sys.argv):
                         update.status = UpdateStatus.stable
                         update.date_stable = datetime.datetime.utcnow()
                         update.request = None
+                        update.date_pushed = datetime.datetime.utcnow()
+                        update.pushed = True
 
                 db.commit()
 

--- a/bodhi/tests/server/scripts/test_approve_testing.py
+++ b/bodhi/tests/server/scripts/test_approve_testing.py
@@ -679,6 +679,8 @@ class TestMain(BasePyTestCase):
         assert update.request is None
         assert update.date_stable is not None
         assert update.status == models.UpdateStatus.stable
+        assert update.pushed
+        assert update.date_pushed is not None
         # First pass, it adds f17=updatest-pending, then since we're pushing
         # to stable directly, it adds f17-updates (the stable tag) then
         # removes f17-updates-testing-pending and f17-updates-pending


### PR DESCRIPTION
when an update is composed by bodhi, composer.py marked
the update as pushed. However, in the case of an update
that is not composed_by_bodhi, (e.g an automatically
created rawhide update), the update's pushed boolean would
always remain false. The update.html template uses the
pushed boolean to help decide what action buttons to show,
and consequently, an automatically created rawhide update
that is in stable would still show the push to testing buttons
at the top of this page (#3451)

This commit changes the approve_testing.py script to update the
update's pushed boolean, and the date pushed boolean when an
update that is not composed by bodhi is marked as stable.

Resolves: #3451
