### PR TITLE
Ignore the VS Code local settings directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ htmlcov/
 composer/
 nosetests.xml
 virtenv
+.vscode


### PR DESCRIPTION
This folder is where VS Code store its local config file, which contains the path to the Python executable and other local stuff.