### PR TITLE
Create additional side tags on multi build tag

### DIFF
--- a/bodhi/server/buildsys.py
+++ b/bodhi/server/buildsys.py
@@ -126,6 +126,7 @@ class DevBuildsys:
         cls.__added__ = []
         cls.__tagged__ = {}
         cls.__rpms__ = []
+        cls.__tags__ = []
 
     def multiCall(self):
         """Emulate Koji's multiCall."""
@@ -487,7 +488,7 @@ class DevBuildsys:
                  'parent_id': 6438, 'maxdepth': None, 'noconfig': False, 'child_id': 6441,
                  'nextdepth': None, 'filter': [], 'currdepth': 4}]
 
-    def addTag(self, tag: str, **opts):
+    def createTag(self, tag: str, **opts):
         """Emulate tag adding."""
         if 'parent' not in opts:
             raise ValueError('No parent in tag options')

--- a/bodhi/server/models.py
+++ b/bodhi/server/models.py
@@ -982,6 +982,34 @@ class Release(Base):
         """
         return config.get(f'{self.setting_prefix}.status', None)
 
+    def get_testing_side_tag(self, from_tag: str) -> str:
+        """
+        Return the testing side tag for this ``Release``.
+
+        Args:
+            from_tag: Name of side tag from which ``Update`` was created.
+
+        Returns:
+            Testing side tag used in koji.
+        """
+        side_tag_postfix = config.get(
+            f'{self.setting_prefix}.koji-testing-side-tag', "-testing")
+        return from_tag + side_tag_postfix
+
+    def get_pending_signing_side_tag(self, from_tag: str) -> str:
+        """
+        Return the testing side tag for this ``Release``.
+
+        Args:
+            from_tag: Name of side tag from which ``Update`` was created.
+
+        Returns:
+            Testing side tag used in koji.
+        """
+        side_tag_postfix = config.get(
+            f'{self.setting_prefix}.koji-pending-signing-side-tag', "-pending-signing")
+        return from_tag + side_tag_postfix
+
 
 class TestCase(Base):
     """

--- a/bodhi/server/services/updates.py
+++ b/bodhi/server/services/updates.py
@@ -26,7 +26,7 @@ from sqlalchemy import func, distinct
 from sqlalchemy.sql import or_
 from requests import RequestException, Timeout as RequestsTimeout
 
-from bodhi.server import log, security
+from bodhi.server import log, security, buildsys
 from bodhi.server.exceptions import BodhiException, LockedUpdateException
 from bodhi.server.models import (
     Update,
@@ -440,6 +440,8 @@ def new_update(request):
     empty, the list of builds will be filled with the latest builds in this
     Koji tag. This is done by validate_from_tag() because the list of builds
     needs to be available in validate_acls().
+    Ensure that related tags ``from_tag``-pending-signing and ``from_tag``-testing
+    exists and if not create them in Koji.
 
     Args:
         request (pyramid.request): The current request.
@@ -492,8 +494,8 @@ def new_update(request):
         # the builds as signed.
         request.db.commit()
 
-        # After we commit the transaction, we need to get the builds and releases again, since they
-        # were tied to the previous session that has now been terminated.
+        # After we commit the transaction, we need to get the builds and releases again,
+        # since they were tied to the previous session that has now been terminated.
         builds = []
         releases = set()
         for nvr in build_nvrs:
@@ -536,6 +538,24 @@ def new_update(request):
 
             if len(releases) > 1:
                 result = dict(updates=updates)
+
+            if from_tag:
+                koji = buildsys.get_session()
+                for update in updates:
+                    # Validate that <koji_tag>-pending-signing and <koji-tag>-testing exists,
+                    # if not create them
+                    side_tag_pending_signing = update.release.get_pending_signing_side_tag(
+                        from_tag)
+                    side_tag_testing = update.release.get_testing_side_tag(from_tag)
+                    if not koji.getTag(side_tag_pending_signing):
+                        koji.createTag(side_tag_pending_signing, parent=from_tag)
+                    if not koji.getTag(side_tag_testing):
+                        koji.createTag(side_tag_testing, parent=from_tag)
+
+                    to_tag = side_tag_pending_signing
+                    # Move every new build to <from_tag>-pending-signing tag
+                    update.add_tag(to_tag)
+
     except LockedUpdateException as e:
         log.warning(str(e))
         request.errors.add('body', 'builds', "%s" % str(e))

--- a/bodhi/tests/server/test_models.py
+++ b/bodhi/tests/server/test_models.py
@@ -753,6 +753,36 @@ class TestRelease(ModelTest):
         model.Release.clear_all_releases_cache()
         self.assertIsNone(model.Release._all_releases)
 
+    @mock.patch.dict(config, {'f11.koji-pending-signing-side-tag': '-pending-signing-test'})
+    def test_get_pending_signing_side_tag_found(self):
+        """
+        Assert that correct side tag is returned.
+        """
+        self.assertEqual(
+            self.obj.get_pending_signing_side_tag("side-tag"), "side-tag-pending-signing-test")
+
+    def test_get_pending_signing_side_tag_not_found(self):
+        """
+        Assert that default side tag is returned.
+        """
+        self.assertEqual(
+            self.obj.get_pending_signing_side_tag("side-tag"), "side-tag-pending-signing")
+
+    @mock.patch.dict(config, {'f11.koji-testing-side-tag': '-testing-test'})
+    def test_get_testing_side_tag_found(self):
+        """
+        Assert that correct side tag is returned.
+        """
+        self.assertEqual(
+            self.obj.get_testing_side_tag("side-tag"), "side-tag-testing-test")
+
+    def test_get_testing_side_tag_not_found(self):
+        """
+        Assert that default side tag is returned.
+        """
+        self.assertEqual(
+            self.obj.get_testing_side_tag("side-tag"), "side-tag-testing")
+
 
 class TestReleaseCritpathMinKarma(BaseTestCase):
     """Tests for the Release.critpath_min_karma property."""


### PR DESCRIPTION
Create new side tags from initial side tag and move builds to newly
created sidetag.

Closes #3473

Signed-off-by: Michal Konečný <mkonecny@redhat.com>