### PR TITLE
determine a release for builds in a sidetag update

### DIFF
--- a/bodhi/server/__init__.py
+++ b/bodhi/server/__init__.py
@@ -129,6 +129,21 @@ def get_buildinfo(request):
     return defaultdict(dict)
 
 
+def get_from_tag_inherited(request):
+    """
+    Return a list, defaulting to empty.
+
+    A per-request cache populated by the validators and shared with the views
+    to store the list of inherited tags of a sidetag.
+
+    Args:
+        request (pyramid.request.Request): The current web request. Unused.
+    Returns:
+        list: A cache populated by the validators and used by the views.
+    """
+    return list()
+
+
 def get_releases(request):
     """
     Return a defaultdict describing all Releases keyed by state.
@@ -251,6 +266,7 @@ def main(global_config, testing=None, session=None, **settings):
     config.add_request_method(get_koji, 'koji', reify=True)
     config.add_request_method(get_cacheregion, 'cache', reify=True)
     config.add_request_method(get_buildinfo, 'buildinfo', reify=True)
+    config.add_request_method(get_from_tag_inherited, 'from_tag_inherited', reify=True)
     config.add_request_method(get_releases, 'releases', reify=True)
 
     # Templating

--- a/bodhi/server/buildsys.py
+++ b/bodhi/server/buildsys.py
@@ -185,6 +185,14 @@ class DevBuildsys:
         if 'youdontknowme' in build:
             return None
 
+        if 'gnome-backgrounds-3.0-1.fc17' in build:
+            return {'name': 'gnome-backgrounds',
+                    'nvr': 'gnome-backgrounds-3.0-1.fc17',
+                    'package_name': 'gnome-backgrounds',
+                    'release': '1.fc17',
+                    'tag_name': 'f17-build-side-7777',
+                    'version': '3.0'}
+
         theid = 16058
         if other and not testing:
             theid = 16059
@@ -382,6 +390,8 @@ class DevBuildsys:
     def listTagged(self, tag: str, *args, **kw) -> typing.List[typing.Any]:
         """List updates tagged with teh given tag."""
         latest = kw.get('latest', False)
+        if tag == 'f17-build-side-7777':
+            return [self.getBuild(build="gnome-backgrounds-3.0-1.fc17")]
         builds = []
 
         all_builds = [self.getBuild(),
@@ -444,9 +454,38 @@ class DevBuildsys:
             else:
                 return None
 
+        # hardcode a side-tag response
+        if taginfo == 'f17-build-side-7777':
+            return {'maven_support': False, 'locked': False, 'name': 'f17-build-side-7777',
+                    'extra': {'sidetag_user': 'dudemcpants', 'sidetag': True},
+                    'perm': None, 'perm_id': None, 'arches': None, 'maven_include_all': False,
+                    'id': 7777}
+
         return {'maven_support': False, 'locked': False, 'name': taginfo,
                 'perm': None, 'id': 246, 'arches': None,
                 'maven_include_all': False, 'perm_id': None}
+
+    def getFullInheritance(self, taginfo, **kw):
+        """
+        Return a tag inheritance.
+
+        Args:
+            taginfo (int or str): The tag. does not impact the output
+        Returns:
+            list: A list of dicts of tag information
+        """
+        return [{'intransitive': False, 'name': 'f17-build', 'pkg_filter': '', 'priority': 0,
+                 'parent_id': 6448, 'maxdepth': None, 'noconfig': False, 'child_id': 7715,
+                 'nextdepth': None, 'filter': [], 'currdepth': 1},
+                {'intransitive': False, 'name': 'f17-override', 'pkg_filter': '', 'priority': 0,
+                 'parent_id': 6447, 'maxdepth': None, 'noconfig': False, 'child_id': 6448,
+                 'nextdepth': None, 'filter': [], 'currdepth': 2},
+                {'intransitive': False, 'name': 'f17-updates', 'pkg_filter': '', 'priority': 0,
+                 'parent_id': 6441, 'maxdepth': None, 'noconfig': False, 'child_id': 6447,
+                 'nextdepth': None, 'filter': [], 'currdepth': 3},
+                {'intransitive': False, 'name': 'f17', 'pkg_filter': '', 'priority': 0,
+                 'parent_id': 6438, 'maxdepth': None, 'noconfig': False, 'child_id': 6441,
+                 'nextdepth': None, 'filter': [], 'currdepth': 4}]
 
     def addTag(self, tag: str, **opts):
         """Emulate tag adding."""

--- a/bodhi/server/services/updates.py
+++ b/bodhi/server/services/updates.py
@@ -416,11 +416,11 @@ def query_updates(request):
               error_handler=bodhi.server.services.errors.json_handler,
               validators=(
                   colander_body_validator,
+                  validate_from_tag,
                   validate_build_nvrs,
                   validate_builds,
                   validate_build_tags,
                   validate_build_uniqueness,
-                  validate_from_tag,
                   validate_builds_or_from_tag_exist,
                   validate_acls,
                   validate_enums,

--- a/bodhi/server/validators.py
+++ b/bodhi/server/validators.py
@@ -133,8 +133,8 @@ def cache_tags(request, build):
         request.errors.add('body', 'builds',
                            'Invalid koji build: %s' % build)
     # This might end up setting tags to None. That is expected, and indicates it failed.
-    request.buildinfo[build]['tags'] = tags
-    return tags
+    request.buildinfo[build]['tags'] = tags + request.from_tag_inherited
+    return tags + request.from_tag_inherited
 
 
 def cache_release(request, build):
@@ -313,6 +313,10 @@ def validate_build_tags(request, **kwargs):
         release = update.release
     else:
         valid_tags = tag_types['candidate']
+
+    from_tag = request.validated.get('from_tag')
+    if from_tag:
+        valid_tags.append(from_tag)
 
     for build in request.validated.get('builds') or []:
         valid = False
@@ -1278,10 +1282,16 @@ def validate_from_tag(request: pyramid.request.Request, **kwargs: dict):
 
     if koji_tag:
         koji_client = buildsys.get_session()
+        taginfo = koji_client.getTag(koji_tag)
+
+        # add all the inherited tags of a sidetag to from_tag_inherited
+        if taginfo and taginfo['extra']['sidetag']:
+            for tag in koji_client.getFullInheritance(koji_tag):
+                request.from_tag_inherited.append(tag['name'])
 
         if request.validated.get('builds'):
             # Builds were specified explicitly, verify that the tag exists in Koji.
-            if not koji_client.getTag(koji_tag):
+            if not taginfo:
                 request.errors.add('body', 'from_tag', "The supplied from_tag doesn't exist.")
                 return
 

--- a/bodhi/tests/server/services/test_updates.py
+++ b/bodhi/tests/server/services/test_updates.py
@@ -285,13 +285,13 @@ class TestNewUpdate(BaseTestCase):
         # We don't want the new update to obsolete the existing one.
         self.db.delete(Update.query.one())
 
-        update = self.get_update(builds=None, from_tag='f17-updates-candidate')
+        update = self.get_update(builds=None, from_tag='f17-build-side-7777')
         with fml_testing.mock_sends(update_schemas.UpdateRequestTestingV1):
             r = self.app.post_json('/updates/', update)
 
         up = r.json_body
-        self.assertEqual(up['title'], 'TurboGears-1.0.2.2-3.fc17')
-        self.assertEqual(up['builds'][0]['nvr'], 'TurboGears-1.0.2.2-3.fc17')
+        self.assertEqual(up['title'], 'gnome-backgrounds-3.0-1.fc17')
+        self.assertEqual(up['builds'][0]['nvr'], 'gnome-backgrounds-3.0-1.fc17')
         self.assertEqual(up['status'], 'pending')
         self.assertEqual(up['request'], 'testing')
         self.assertEqual(up['user']['name'], 'guest')
@@ -312,7 +312,7 @@ class TestNewUpdate(BaseTestCase):
                        f'FEDORA-{YEAR + 1}-033713b73b'))
         self.assertEqual(up['karma'], 0)
         self.assertEqual(up['requirements'], 'rpmlint')
-        self.assertEqual(up['from_tag'], 'f17-updates-candidate')
+        self.assertEqual(up['from_tag'], 'f17-build-side-7777')
 
     @mock.patch(**mock_valid_requirements)
     def test_koji_config_url(self, *args):
@@ -2908,7 +2908,7 @@ class TestUpdatesService(BaseTestCase):
         # We don't want an existing buildroot override to clutter the messages.
         self.db.delete(BuildrootOverride.query.one())
 
-        update = self.get_update(from_tag='f17-updates-candidate')
+        update = self.get_update(from_tag='f17-build-side-7777')
         with fml_testing.mock_sends(update_schemas.UpdateRequestTestingV1):
             r = self.app.post_json('/updates/', update)
 

--- a/bodhi/tests/server/test_validators.py
+++ b/bodhi/tests/server/test_validators.py
@@ -725,7 +725,7 @@ class TestValidateFromTag(BasePyTestCase):
         self.request = mock.Mock()
         self.request.db = self.db
         self.request.errors = Errors()
-        self.request.validated = {'from_tag': 'f17-updates-candidate'}
+        self.request.validated = {'from_tag': 'f17-build-side-7777'}
 
     # Successful validations
 


### PR DESCRIPTION
Previously, when trying to create an update from a side tag,
it would fail, as bodhi was unable to determine the release
for build(s) for that sidetag.

This commit adds code to the validate_from_tag validator to
pull the inheritance data from koji of a sidetag, and puts it
into a new per-request cache item in the request (`from_tag_inherited`)
One or more of the tags in a sidetags inhertiance structure will match
with one of the tags defined in the Bodhi Release.

Then, when validating all the builds to determine the releases, this
list is added to the regular tags to help determine the bodhi release
of the build.

Fixes: #3480
Signed-off-by: Ryan Lerch <rlerch@redhat.com>