### PR TITLE
Clear side and aux tags on move to stable

### DIFF
--- a/bodhi/server/buildsys.py
+++ b/bodhi/server/buildsys.py
@@ -17,12 +17,12 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 """Define tools for interacting with the build system and a fake build system for development."""
 
-from threading import Lock
 import logging
 import time
 import typing
 import os
 from functools import wraps
+from threading import Lock
 
 import backoff
 import koji
@@ -504,9 +504,19 @@ class DevBuildsys:
         opts['perm_id'] = 1
         self.__tags__.append((tag, opts))
 
-    def deleteTag(self, tagid):
+    def deleteTag(self, tagid: typing.Union[str, int]):
         """Emulate tag deletion."""
-        del self.__tags__[tagid]
+        if isinstance(tagid, str):
+            for tid, tinfo in self.__tags__:
+                if tagid == tid:
+                    self.__tags__.remove((tid, tinfo))
+                    return
+        else:
+            del self.__tags__[tagid]
+
+    def removeSideTag(self, sidetag):
+        """Emulate side tag and build target deletion."""
+        pass
 
     def getRPMHeaders(self, rpmID: str,
                       headers: typing.Any) -> typing.Union[typing.Mapping[str, str], None]:

--- a/bodhi/server/models.py
+++ b/bodhi/server/models.py
@@ -3769,19 +3769,22 @@ class Update(Base):
         ``greenwave_failed``.
 
         Args:
-            target (Update): The compose that has had a change to its state attribute.
+            target (InstanceState): The state of the instance that has had a
+                change to its test_gating_status attribute.
             value (EnumSymbol): The new value of the test_gating_status.
             old (EnumSymbol): The old value of the test_gating_status
             initiator (sqlalchemy.orm.attributes.Event): The event object that is initiating this
                 transition.
         """
+        instance = target.object
+
         if value != old:
             notify = value in [
                 TestGatingStatus.greenwave_failed,
                 TestGatingStatus.failed,
             ]
-            target.comment(
-                Session(),
+            instance.comment(
+                target.session,
                 f"This update's test gating status has been changed to '{value}'.",
                 author="bodhi",
                 email_notification=notify,
@@ -3823,6 +3826,7 @@ event.listen(
     'set',
     Update.comment_on_test_gating_status_change,
     active_history=True,
+    raw=True,
 )
 
 

--- a/bodhi/server/scripts/approve_testing.py
+++ b/bodhi/server/scripts/approve_testing.py
@@ -22,12 +22,12 @@ The script is responsible for commenting on updates after they reach the mandato
 spent in the testing repository.
 """
 
-import datetime
 import os
 import sys
 import logging
 
 from pyramid.paster import get_appsettings
+from sqlalchemy import func
 
 from bodhi.messages.schemas import update as update_schemas
 from bodhi.server import Session, initialize_db, notifications, buildsys
@@ -110,18 +110,44 @@ def main(argv=sys.argv):
 
                 if update.autotime and update.days_in_testing >= update.stable_days:
                     print(f"Automatically marking {update.alias} as stable")
-                    update.set_request(db=db, action=UpdateRequest.stable, username="bodhi")
+                    # For now only rawhide update can be created using side tag
+                    # Do not add the release.pending_stable_tag if the update
+                    # was created from a side tag.
+                    if update.release.composed_by_bodhi:
+                        update.set_request(db=db, action=UpdateRequest.stable, username="bodhi")
                     # For updates that are not included in composes run by bodhi itself,
                     # mark them as stable
-                    if not update.release.composed_by_bodhi:
+                    else:
+                        # Single and Multi build update
                         update.add_tag(update.release.stable_tag)
-                        update.remove_tag(update.release.pending_testing_tag)
-                        update.remove_tag(update.release.pending_stable_tag)
                         update.status = UpdateStatus.stable
-                        update.date_stable = datetime.datetime.utcnow()
                         update.request = None
-                        update.date_pushed = datetime.datetime.utcnow()
                         update.pushed = True
+                        update.date_stable = update.date_pushed = func.current_timestamp()
+                        update.comment(db, "This update has been submitted for stable by bodhi",
+                                       author=u'bodhi')
+
+                        # Multi build update
+                        if update.from_tag:
+                            # Merging the side tag should happen here
+                            pending_signing_tag = update.release.get_pending_signing_side_tag(
+                                update.from_tag)
+                            testing_tag = update.release.get_testing_side_tag(update.from_tag)
+
+                            update.remove_tag(pending_signing_tag)
+                            update.remove_tag(testing_tag)
+                            update.remove_tag(update.from_tag)
+
+                            koji = buildsys.get_session()
+                            koji.deleteTag(pending_signing_tag)
+                            koji.deleteTag(testing_tag)
+
+                            # Removes the tag and the build target from koji.
+                            koji.removeSideTag(update.from_tag)
+                        else:
+                            # Single build update
+                            update.remove_tag(update.release.pending_testing_tag)
+                            update.remove_tag(update.release.pending_stable_tag)
 
                 db.commit()
 

--- a/bodhi/tests/server/scripts/test_approve_testing.py
+++ b/bodhi/tests/server/scripts/test_approve_testing.py
@@ -683,15 +683,19 @@ class TestMain(BasePyTestCase):
         assert update.status == models.UpdateStatus.testing
         assert update.date_stable is None
 
+    @pytest.mark.parametrize('from_side_tag', (None, 'f17-build-side-1234'))
     @patch.dict(config, [('fedora.mandatory_days_in_testing', 0)])
     @patch('bodhi.server.models.Update.add_tag')
     @patch('bodhi.server.models.Update.remove_tag')
     @patch('bodhi.server.models.mail')
     def test_autotime_update_zero_day_in_testing_no_gated_gets_pushed_to_rawhide(
-            self, mail, remove_tag, add_tag):
+            self, mail, remove_tag, add_tag, from_side_tag):
         """
         Ensure that an autotime update with 0 mandatory_days_in_testing that meets
         the test requirements gets pushed to stable in rawhide.
+
+        Test for normal updates and such from a side tags, where it and its
+        auxiliary tags need to be removed.
         """
         update = self.db.query(models.Update).all()[0]
         update.autokarma = False
@@ -702,13 +706,15 @@ class TestMain(BasePyTestCase):
         update.stable_days = 0
         update.date_testing = datetime.utcnow() - timedelta(days=0)
         update.status = models.UpdateStatus.testing
+        update.from_tag = from_side_tag
         # Clear pending messages
         self.db.info['messages'] = []
+
         self.db.commit()
 
         with patch('bodhi.server.scripts.approve_testing.initialize_db'):
             with patch('bodhi.server.scripts.approve_testing.get_appsettings', return_value=''):
-                with fml_testing.mock_sends(api.Message, api.Message):
+                with fml_testing.mock_sends(api.Message):
                     approve_testing.main(['nosetests', 'some_config.ini'])
 
         assert update.request is None
@@ -716,14 +722,24 @@ class TestMain(BasePyTestCase):
         assert update.status == models.UpdateStatus.stable
         assert update.pushed
         assert update.date_pushed is not None
-        # First pass, it adds f17=updatest-pending, then since we're pushing
-        # to stable directly, it adds f17-updates (the stable tag) then
-        # removes f17-updates-testing-pending and f17-updates-pending
-        assert remove_tag.call_args_list == \
-            [call('f17-updates-testing-pending'), call('f17-updates-pending')]
 
-        assert add_tag.call_args_list == \
-            [call('f17-updates-pending'), call('f17-updates')]
+        if not from_side_tag:
+            # First pass, it adds f17=updates-pending, then since we're pushing
+            # to stable directly, it adds f17-updates (the stable tag) then
+            # removes f17-updates-testing-pending and f17-updates-pending
+            assert remove_tag.call_args_list == \
+                [call('f17-updates-testing-pending'), call('f17-updates-pending')]
+
+            assert add_tag.call_args_list == \
+                [call('f17-updates')]
+        else:
+            assert remove_tag.call_args_list == \
+                [call(f'{from_side_tag}-pending-signing'), call(f'{from_side_tag}-testing'),
+                 call(from_side_tag)]
+
+            assert add_tag.call_args_list == \
+                [call('f17-updates')]
+
         assert mail.send.call_count == 1
 
     @patch.dict(config, [('fedora.mandatory_days_in_testing', 0)])


### PR DESCRIPTION
This implements what's missing for #3476, i.e. re-/untagging the builds and removing the side tag and its auxiliary tags (-pending-signing and -testing).

~~I haven't gotten around to writing tests for it yet, and~~ the pattern for the aux tags (`<sidetag>-pending-signing` and `<sidetag>-testing`) is hardcoded, not configurable (not sure if we need this). ~~This is why it has the WIP label, which can be removed once more testing and lookovers went over this than I can do before going on vacation tomorrow.~~

The first two commits are for (IMO) minor cleanups and test out well in unit tests (integration tests still ongoing). ~~I'll see if I can add some tests for it before going on vacation.~~ Please "do the needful" while I'm away, but look at it thoroughly because my eyes are beginning to glaze over. :wink: