### PR TITLE
Check if it is safe to tag a multi build update in stable.

### DIFF
--- a/bodhi/server/scripts/approve_testing.py
+++ b/bodhi/server/scripts/approve_testing.py
@@ -119,6 +119,18 @@ def main(argv=sys.argv):
                     # mark them as stable
                     else:
                         # Single and Multi build update
+                        conflicting_builds = update.find_conflicting_builds()
+                        if conflicting_builds:
+                            builds_str = str.join(", ", conflicting_builds)
+                            update.comment(
+                                db,
+                                "This update cannot be pushed to stable. "
+                                f"These builds {builds_str} have a more recent "
+                                f"build in koji's {update.release.stable_tag} tag.",
+                                author="bodhi")
+                            db.commit()
+                            continue
+
                         update.add_tag(update.release.stable_tag)
                         update.status = UpdateStatus.stable
                         update.request = None


### PR DESCRIPTION
This commit add the logic to check if a multi build update
has builds that conflicts with the stable tag. To do that we
are checking for each package present in the update if a more
recent build exists in the stable tag. If that is the case we
consider that this package build is conflicting and the update
will not be pushed to stable.

If none of the build present in the update are conflicting then
we proceed with pushing the update to stable.

Signed-off-by: Clement Verna <cverna@tutanota.com>