### PR TITLE
turn off autokarma and autotime for automatic updates

### DIFF
--- a/bodhi/server/consumers/automatic_updates.py
+++ b/bodhi/server/consumers/automatic_updates.py
@@ -156,6 +156,7 @@ class AutomaticUpdateHandler:
                 type=UpdateType.unspecified,
                 stable_karma=3,
                 unstable_karma=-3,
+                autokarma=False,
                 user=user,
                 status=UpdateStatus.testing,
             )

--- a/bodhi/tests/server/consumers/test_automatic_updates.py
+++ b/bodhi/tests/server/consumers/test_automatic_updates.py
@@ -85,6 +85,7 @@ class TestAutomaticUpdateHandler(base.BasePyTestCase):
         assert update is not None
         assert update.type == UpdateType.unspecified
         assert update.status == UpdateStatus.testing
+        assert update.autokarma == False
         assert update.test_gating_status is None
 
         expected_username = base.buildsys.DevBuildsys._build_data['owner_name']


### PR DESCRIPTION
having autokarma and autotime does not really make
much sense for automatic updates, so this turns it off.

Additionally, the recently merged UI refresh hides some
items if they are turned off, making the ui cleaner for
the user.

Fixes: #3424

Signed-off-by: Ryan Lerch <rlerch@redhat.com>