### PR TITLE
add automatic_updates_blacklist

### DIFF
--- a/bodhi/server/config.py
+++ b/bodhi/server/config.py
@@ -247,6 +247,10 @@ class BodhiConfig(dict):
         'authtkt.timeout': {
             'value': 86400,
             'validator': int},
+        'automatic_updates_blacklist': {
+            # List of users to not create automatic updates from
+            'value': ['releng'],
+            'validator': _generate_list_validator()},
         'badge_ids': {
             'value': [],
             'validator': _generate_list_validator('|')},

--- a/bodhi/server/consumers/automatic_updates.py
+++ b/bodhi/server/consumers/automatic_updates.py
@@ -91,6 +91,11 @@ class AutomaticUpdateHandler:
             log.debug(f"Koji build info for {bnvr} doesn't contain 'owner_name'.")
             return
 
+        if kbuildinfo['owner_name'] in config.get('automatic_updates_blacklist'):
+            log.debug(f"{bnvr} owned by {kbuildinfo['owner_name']} who is listed in "
+                      "automatic_updates_blacklist, skipping.")
+            return
+
         # some APIs want the Koji build info, some others want the same
         # wrapped in a larger (request?) structure
         rbuildinfo = {


### PR DESCRIPTION
adds a new config item, automatic_updates_blacklist, which is
a list of users to not process auto updates from

fixes: #3445 

Signed-off-by: Ryan Lerch <rlerch@redhat.com>