### PR TITLE
Unify rawhide simple build update with multi build update.

### DIFF
--- a/bodhi/tests/server/consumers/test_automatic_updates.py
+++ b/bodhi/tests/server/consumers/test_automatic_updates.py
@@ -25,11 +25,10 @@ from fedora_messaging.api import Message
 from fedora_messaging.testing import mock_sends
 import pytest
 
-from bodhi.messages.schemas import update as update_schemas
 from bodhi.server.config import config
 from bodhi.server.consumers.automatic_updates import AutomaticUpdateHandler
 from bodhi.server.models import (
-    Build, Release, TestGatingStatus, Update, UpdateRequest, UpdateStatus, UpdateType, User
+    Build, Release, Update, UpdateRequest, UpdateStatus, UpdateType, User
 )
 from bodhi.tests.server import base
 
@@ -53,7 +52,7 @@ class TestAutomaticUpdateHandler(base.BasePyTestCase):
             'name': 'colord',
             'tag_id': 214,
             'instance': 's390',
-            'tag': 'f17-updates-testing-pending',
+            'tag': 'f17-updates-candidate',
             'user': 'sharkcz',
             'version': '1.3.4',
             'owner': 'sharkcz',
@@ -73,8 +72,7 @@ class TestAutomaticUpdateHandler(base.BasePyTestCase):
         caplog.set_level(logging.DEBUG)
 
         # process the message
-        with mock_sends(update_schemas.UpdateReadyForTestingV1):
-            self.handler(self.sample_message)
+        self.handler(self.sample_message)
 
         # check if the update exists...
         update = self.db.query(Update).filter(
@@ -84,7 +82,7 @@ class TestAutomaticUpdateHandler(base.BasePyTestCase):
         # ...and some of its properties
         assert update is not None
         assert update.type == UpdateType.unspecified
-        assert update.status == UpdateStatus.testing
+        assert update.status == UpdateStatus.pending
         assert update.autokarma == False
         assert update.test_gating_status is None
 
@@ -102,8 +100,7 @@ class TestAutomaticUpdateHandler(base.BasePyTestCase):
         caplog.set_level(logging.DEBUG)
 
         # Run the handler to create the build & update, then remove the update.
-        with mock_sends(update_schemas.UpdateReadyForTestingV1):
-            self.handler(self.sample_message)
+        self.handler(self.sample_message)
         build = self.db.query(Build).filter_by(nvr=self.sample_nvr).one()
         update = build.update
         build.update = None  # satisfy foreign key constraint
@@ -111,8 +108,7 @@ class TestAutomaticUpdateHandler(base.BasePyTestCase):
 
         # Now test with the same message again which should encounter the
         # build already existing in the database.
-        with mock_sends(update_schemas.UpdateReadyForTestingV1):
-            self.handler(self.sample_message)
+        self.handler(self.sample_message)
 
         # check if the update exists...
         update = self.db.query(Update).filter(
@@ -122,7 +118,7 @@ class TestAutomaticUpdateHandler(base.BasePyTestCase):
         # ...and some of its properties
         assert update is not None
         assert update.type == UpdateType.unspecified
-        assert update.status == UpdateStatus.testing
+        assert update.status == UpdateStatus.pending
         assert update.test_gating_status is None
 
         expected_username = base.buildsys.DevBuildsys._build_data['owner_name']
@@ -130,91 +126,16 @@ class TestAutomaticUpdateHandler(base.BasePyTestCase):
 
         assert not any(r.levelno >= logging.WARNING for r in caplog.records)
 
-    @mock.patch.dict(config, [('test_gating.required', True),
-                              ('greenwave_api_url', 'http://domain.local')])
-    @pytest.mark.parametrize('gated', (True, False, 'error'))
-    def test_consume_with_gating(self, caplog, gated):
-        """Assert that messages about tagged builds create an update with the expected gating status.
-        """
-        caplog.set_level(logging.DEBUG)
-
-        # process the message
-        with mock.patch('bodhi.server.models.util.greenwave_api_post') as mock_greenwave:
-            if gated == 'error':
-                mock_greenwave.side_effect = RuntimeError("Boo!")
-            else:
-                if gated:
-                    greenwave_response = {
-                        'policies_satisfied': False,
-                        'summary': "1 of 1 required test results missing",
-                    }
-                else:
-                    greenwave_response = {
-                        'policies_satisfied': True,
-                        'summary': "no tests are required",
-                    }
-                mock_greenwave.return_value = greenwave_response
-            with mock_sends(update_schemas.UpdateReadyForTestingV1):
-                self.handler(self.sample_message)
-
-        # check if the update exists...
-        update = self.db.query(Update).filter(
-            Update.builds.any(Build.nvr == self.sample_nvr)
-        ).first()
-
-        # ...and some of its properties
-        assert update is not None
-        assert update.type == UpdateType.unspecified
-        assert update.status == UpdateStatus.testing
-        if gated == 'error':
-            assert update.test_gating_status == TestGatingStatus.greenwave_failed
-        elif gated:
-            assert update.test_gating_status == TestGatingStatus.failed
-        else:
-            assert update.test_gating_status == TestGatingStatus.ignored
-
-        expected_username = base.buildsys.DevBuildsys._build_data['owner_name']
-        assert update.user and update.user.name == expected_username
-
-        # check comments and their order
-        if gated == 'error':
-            final_status = 'greenwave_failed'
-        elif gated:
-            final_status = 'failed'
-        else:
-            final_status = 'ignored'
-
-        expected_comments = [
-            "This update was automatically created",
-            "This update's test gating status has been changed to 'waiting'.",
-            f"This update's test gating status has been changed to '{final_status}'.",
-        ]
-
-        assert (expected_comments == [c.text for c in update.comments])
-
-        # check for log records, warning or higher
-        if gated == 'error':
-            warn_higher_records = [r for r in caplog.records if r.levelno >= logging.WARNING]
-            assert len(warn_higher_records) == 1
-            log_record = warn_higher_records[0]
-            assert log_record.levelno == logging.ERROR
-            assert log_record.message == "Boo!"
-        else:
-            assert not any(r.levelno >= logging.WARNING for r in caplog.records)
-
     def test_existing_pending_update(self, caplog):
         """
-        Ensure an update is moved to testing if a matching pending one exists.
+        Ensure an update is not created if a matching pending one exists.
         """
         caplog.set_level(logging.DEBUG)
 
-        with mock_sends(update_schemas.UpdateReadyForTestingV1):
-            self.handler(self.sample_message)
+        self.handler(self.sample_message)
         update = self.db.query(Update).filter(
             Update.builds.any(Build.nvr == self.sample_nvr)
         ).first()
-        # Check it was created in testing
-        assert update.status == UpdateStatus.testing
         # Move it back to Pending as if the user has manually created it
         update.status = UpdateStatus.pending
         update.request = UpdateRequest.testing
@@ -225,106 +146,10 @@ class TestAutomaticUpdateHandler(base.BasePyTestCase):
 
         caplog.clear()
 
-        with mock_sends(update_schemas.UpdateReadyForTestingV1):
-            self.handler(self.sample_message)
+        self.handler(self.sample_message)
 
-        assert (f"Build, active update for {self.sample_nvr} exists already in "
-                "Pending, moving it along." in caplog.messages)
-
-        update = self.db.query(Update).filter(
-            Update.builds.any(Build.nvr == self.sample_nvr)
-        ).first()
-        assert update.status == UpdateStatus.testing
-        assert update.request is None
-
-    @mock.patch.dict(config, [('test_gating.required', True),
-                              ('greenwave_api_url', 'http://domain.local')])
-    @pytest.mark.parametrize('gated', (True, False, 'error'))
-    def test_existing_pending_update_with_gating(self, caplog, gated):
-        """
-        Ensure an update is moved to testing if a matching pending one exists.
-
-        Contrary to test_existing_pending_update(), this test runs with test
-        gating required, i.e. simulates querying Greenwave for the gating
-        status.
-        """
-        def _call_handler():
-            """ Call the handler to process the sample message. """
-            with mock.patch('bodhi.server.models.util.greenwave_api_post') as mock_greenwave:
-                if gated == 'error':
-                    mock_greenwave.side_effect = RuntimeError("Boo!")
-                else:
-                    if gated:
-                        greenwave_response = {
-                            'policies_satisfied': False,
-                            'summary': "1 of 1 required test results missing",
-                        }
-                    else:
-                        greenwave_response = {
-                            'policies_satisfied': True,
-                            'summary': "no tests are required",
-                        }
-                    mock_greenwave.return_value = greenwave_response
-                with mock_sends(update_schemas.UpdateReadyForTestingV1):
-                    self.handler(self.sample_message)
-
-                # Quick sanity checks
-                assert mock_greenwave.call_count == 1
-
-            update = self.db.query(Update).filter(
-                Update.builds.any(Build.nvr == self.sample_nvr)
-            ).first()
-            if gated == 'error':
-                assert update.test_gating_status == TestGatingStatus.greenwave_failed
-            elif gated:
-                assert update.test_gating_status == TestGatingStatus.failed
-            else:
-                assert update.test_gating_status == TestGatingStatus.ignored
-            return update
-
-        # First run
-        caplog.set_level(logging.DEBUG)
-        update = _call_handler()
-
-        # Double-check how it was created in the first run
-        assert update.status == UpdateStatus.testing
-
-        # Move it back to Pending as if the user had manually created it
-        update.status = UpdateStatus.pending
-        update.request = UpdateRequest.testing
-        self.db.add(update)
-        self.db.flush()
-        # Clear pending messages
-        self.db.info['messages'] = []
-
-        caplog.clear()
-
-        # Second run
-        update = _call_handler()
-
-        assert (f"Build, active update for {self.sample_nvr} exists already in "
-                "Pending, moving it along." in caplog.messages)
-
-        assert update.status == UpdateStatus.testing
-        assert update.request is None
-
-        # check comments and their order
-        if gated == 'error':
-            final_status = 'greenwave_failed'
-        elif gated:
-            final_status = 'failed'
-        else:
-            final_status = 'ignored'
-
-        expected_comments = [
-            "This update was automatically created",
-            "This update's test gating status has been changed to 'waiting'.",
-            f"This update's test gating status has been changed to '{final_status}'.",
-            "This update's test gating status has been changed to 'waiting'.",
-            f"This update's test gating status has been changed to '{final_status}'.",
-        ]
-
-        assert (expected_comments == [c.text for c in update.comments])
+        assert (f"Build, active update for {self.sample_nvr} exists already, skipping."
+                in caplog.messages)
 
     # The following tests cover lesser-travelled code paths.
 
@@ -392,8 +217,7 @@ class TestAutomaticUpdateHandler(base.BasePyTestCase):
         self.db.query(User).filter_by(name=expected_username).delete()
         self.db.flush()
 
-        with mock_sends(update_schemas.UpdateReadyForTestingV1):
-            self.handler(self.sample_message)
+        self.handler(self.sample_message)
 
         assert(f"Creating bodhi user for '{expected_username}'."
                in caplog.messages)
@@ -412,8 +236,7 @@ class TestAutomaticUpdateHandler(base.BasePyTestCase):
         self.db.flush()
 
         with mock.patch('bodhi.server.models.handle_update'):
-            with mock_sends(update_schemas.UpdateReadyForTestingV1):
-                self.handler(self.sample_message)
+            self.handler(self.sample_message)
 
         assert(f"Creating bodhi user for '{expected_username}'."
                not in caplog.messages)
@@ -437,8 +260,7 @@ class TestAutomaticUpdateHandler(base.BasePyTestCase):
         """Assert that duplicate messages ignore existing build/update."""
         caplog.set_level(logging.DEBUG)
 
-        with mock_sends(update_schemas.UpdateReadyForTestingV1):
-            self.handler(self.sample_message)
+        self.handler(self.sample_message)
 
         caplog.clear()
 


### PR DESCRIPTION
This commits changes how bodhi automatically creates single build
updates for rawhide. Instead of creating the update directly in the
testing status it creates it in pending. The update is then moved in
testing when the build is signed.
Once the update is moved to testing bodhi sends a fedora-messaging
message to trigger the CI tests. Results of these tests will be received
by the greenwave consumer.

Fixes #3513

Signed-off-by: Clement Verna <cverna@tutanota.com>