### PR TITLE
sign new builds to <sidetag>-pending-signing

### DIFF
--- a/bodhi/server/models.py
+++ b/bodhi/server/models.py
@@ -2365,7 +2365,12 @@ class Update(Base):
 
             # Add the pending_signing_tag to all new builds
             for build in new_builds:
-                if up.release.pending_signing_tag:
+                if up.from_tag:
+                    # this is a sidetag based update. use the sidetag pending signing tag
+                    side_tag_pending_signing = up.release.get_pending_signing_side_tag(up.from_tag)
+                    koji.tagBuild(side_tag_pending_signing, build)
+                elif up.release.pending_signing_tag:
+                    # Add the release's pending_signing_tag to all new builds
                     koji.tagBuild(up.release.pending_signing_tag, build)
                 else:
                     # EL6 doesn't have these, and that's okay...

--- a/bodhi/tests/server/services/test_updates.py
+++ b/bodhi/tests/server/services/test_updates.py
@@ -3014,6 +3014,12 @@ class TestUpdatesService(BaseTestCase):
         self.assertEqual(self.db.query(RpmBuild).filter_by(nvr='bodhi-2.0.0-2.fc17').first(),
                          None)
 
+        # check that the added build was tagged in koji
+        koji_session = buildsys.get_session()
+        self.assertIn(('f17-build-side-7777-pending-signing',
+                       'bodhi-2.0.0-3.fc17'),
+                      koji_session.__added__)
+
     @mock.patch(**mock_valid_requirements)
     def test_edit_testing_update_with_new_builds(self, *args):
         nvr = 'bodhi-2.0.0-2.fc17'


### PR DESCRIPTION
When creating a new update from a side tag, each of the
builds in the update are tagged in koji with
<sidetag>-pending-signing. However, when editing an update,
updated builds were trying to be signed with the regular
pending signing tag for the release (rather than the sidetag tags)

This commit now signs the builds with the correct sidetag koji tag
when editing a sidetag update.

fixes: #3485
Signed-off-by: Ryan Lerch <rlerch@redhat.com>