### PR TITLE
remove critpath_karma from the UI

### DIFF
--- a/bodhi/server/models.py
+++ b/bodhi/server/models.py
@@ -4141,6 +4141,7 @@ class Comment(Base):
     Attributes:
         karma (int): The karma associated with this comment. Defaults to 0.
         karma_critpath (int): The critpath karma associated with this comment. Defaults to 0.
+            **DEPRECATED** no longer used in the UI
         text (str): The text of the comment.
         timestamp (datetime.datetime): The time the comment was created. Defaults to
             the return value of datetime.utcnow().

--- a/bodhi/server/templates/fragments.html
+++ b/bodhi/server/templates/fragments.html
@@ -85,7 +85,7 @@ ${statusmap[status]}\
             ${comment.user.name}
           </a>
           % if comment.text:
-            % if comment.karma or comment.karma_critpath or comment.bug_feedback or any([True for feedback in comment.unique_testcase_feedback if feedback.karma]):
+            % if comment.karma or comment.bug_feedback or any([True for feedback in comment.unique_testcase_feedback if feedback.karma]):
               commented &amp; provided feedback
             % else:
               commented
@@ -104,12 +104,6 @@ ${statusmap[status]}\
             </a>
           </div>
           <div class="col-auto">
-        % if comment.karma_critpath:
-        <span class="font-size-09 font-weight-bold">${karma(comment.karma_critpath, optional_text="critpath")}</span>
-        % endif
-        %if comment.karma and comment.karma_critpath:
-        <span class="px-2 font-size-09">|</span>
-        %endif
         % if comment.karma:
         <span class="font-size-09 font-weight-bold"> ${karma(comment.karma, optional_text="karma")}</span>
         % endif

--- a/bodhi/server/templates/update.html
+++ b/bodhi/server/templates/update.html
@@ -256,16 +256,6 @@ if can_edit:
                         <div class="col font-size-09"><strong>Karma:</strong> Is the update generally functional?</div>
                       </div>
                     </div>
-                    % if update.critpath:
-                    <div class="list-group-item py-1">
-                      <div class="row">
-                        <div class="col-auto min-width-35"><input type="radio" name="karma_critpath" value="-1"></div>
-                        <div class="col-auto min-width-35"><input type="radio" name="karma_critpath" value="0" checked></div>
-                        <div class="col-auto min-width-35"><input type="radio" name="karma_critpath" value="1"></div>
-                        <div class="col font-size-09"><strong>Critical Path:</strong> Does the system's basic functionality continue to work after this update?</div>
-                      </div>
-                    </div>
-                    % endif
                     % if update.bugs:
                     <div class="list-group-item bg-light py-1">
                       <div class="row">


### PR DESCRIPTION
for a long time, there has been a critpath_karma field
in an updates comments that users could use on critical path
updates. However, it was not used by bodhi to do anything.

This PR removes the critpath_karma from the ui, but leaves
everything else for now. see #2194 for more information.

Additionally, the bodhi cli never had support for changing
the critpath_karma.

Fixes: #2194
Fixes: #2183

Signed-off-by: Ryan Lerch <rlerch@redhat.com>