### PR TITLE
Disable comments on updates when update is pushed and stable

### DIFF
--- a/bodhi/server/services/comments.py
+++ b/bodhi/server/services/comments.py
@@ -33,6 +33,7 @@ from bodhi.server.validators import (
     validate_update_owner,
     validate_ignore_user,
     validate_comment_id,
+    validate_comments_open,
     validate_username,
     validate_bug_feedback,
     validate_testcase_feedback,
@@ -193,6 +194,7 @@ def query_comments(request):
                    validate_update,
                    validate_bug_feedback,
                    validate_testcase_feedback,
+                   validate_comments_open,
                ))
 def new_comment(request):
     """

--- a/bodhi/server/templates/update.html
+++ b/bodhi/server/templates/update.html
@@ -205,9 +205,13 @@ if can_edit:
               % endfor
             </div>
           </div>
-
-
-          % if request.user:
+          <hr/>
+          % if request.user and update.status.value == "stable" and update.pushed == True:
+          <div class="alert alert-secondary bg-light mt-5 text-center text-muted">
+            <h5 class="mb-0 mt-2 font-weight-bold">Comments and Feedback are Closed</h5>
+            <p><small>this update has been pushed to stable</small></p>
+          </div>
+          % elif request.user:
           <form id="new_comment" role="form"
           action="javascript:form.submit();">
           <input type="hidden" name="csrf_token" value="${request.session.get_csrf_token()}"/>
@@ -313,15 +317,15 @@ if can_edit:
             </div>
           </form>
           % else:
-          <div class="col-md-12">
-              <p>
-              % if request.matched_route:
-                Please <a href="${request.route_url('login') + '?came_from=' + request.current_route_url()}">login</a> to add feedback.
-              % else:
-                Please <a href="${request.route_url('login')}">login</a> to add feedback.
-              % endif
-              </p>
-            </div>
+          <div class="alert alert-secondary bg-light mt-5 text-center text-muted">
+            <p>
+            % if request.matched_route:
+              Please <a href="${request.route_url('login') + '?came_from=' + request.current_route_url()}">login</a> to add feedback.
+            % else:
+              Please <a href="${request.route_url('login')}">login</a> to add feedback.
+            % endif
+            </p>
+          </div>
           %endif
 
 

--- a/bodhi/server/validators.py
+++ b/bodhi/server/validators.py
@@ -917,6 +917,23 @@ def _conditionally_get_update(request):
 
 
 @postschema_validator
+def validate_comments_open(request, **kwargs):
+    """
+    Ensure that a comment cannot be added to a stable, pushed update.
+
+    Args:
+        request (pyramid.request.Request): The current request.
+        kwargs (dict): The kwargs of the related service definition. Unused.
+    """
+    update = _conditionally_get_update(request)
+
+    if update.status == UpdateStatus.stable and update.pushed:
+        request.errors.add("body", "comment",
+                           "Comments are Closed on this update. It has been "
+                           "pushed to stable")
+
+
+@postschema_validator
 def validate_bug_feedback(request, **kwargs):
     """
     Ensure that bug feedback references bugs associated with the given update.

--- a/bodhi/tests/server/services/test_comments.py
+++ b/bodhi/tests/server/services/test_comments.py
@@ -651,3 +651,32 @@ class TestCommentsService(base.BaseTestCase):
         # Ensure that the request did not change .. don't trigger something.
         self.assertEqual(up.status.value, UpdateStatus.testing.value)
         self.assertEqual(up.request.value, UpdateRequest.stable.value)
+
+    def test_no_comment_on_stable_pushed_update(self):
+        """ Make sure you cannot comment on stable, pushed updates """
+        up = self.db.query(Build).filter_by(nvr=up2).one().update
+        up.status = UpdateStatus.stable
+        up.request = None
+        up.pushed = True
+        self.assertEqual(len(up.comments), 0)
+        self.assertEqual(up.karma, 0)
+        self.db.info['messages'] = []
+        self.db.flush()
+
+        # check the webui deosnt show the comment form
+        htmlres = self.app.get(f'/updates/{up.alias}', headers={'Accept': 'text/html'})
+        self.assertIn("Comments and Feedback are Closed", htmlres.text)
+        self.assertIn("this update has been pushed to stable", htmlres.text)
+        self.assertNotIn('<form id="new_comment"', htmlres.text)
+
+        # check that we can't actually submit a comment
+        comment = self.make_comment(up2, karma=1)
+        with fml_testing.mock_sends():
+            res = self.app.post_json('/comments/', comment, status=400)
+
+        print(res)
+        self.assertEqual(res.json_body['errors'][0]['description'],
+                         "Comments are Closed on this update. It has been pushed to stable")
+        up = self.db.query(Build).filter_by(nvr=up2).one().update
+        self.assertEqual(len(up.comments), 0)
+        self.assertEqual(up.karma, 0)


### PR DESCRIPTION
This disables the update comments if the update is in status
stable, and pushed is True.

Fixes: #2050

Signed-off-by: Ryan Lerch <rlerch@redhat.com>