### PR TITLE
Add API call to retrigger update tests

### DIFF
--- a/bodhi/messages/schemas/update.py
+++ b/bodhi/messages/schemas/update.py
@@ -584,6 +584,10 @@ class UpdateReadyForTestingV1(UpdateMessage):
         'required': ['update'],
         'definitions': {
             'build': BuildV1.schema(),
+        },
+        're-trigger': {
+            'type': 'bool',
+            'description': 'This flag is True if the message is sent to re-trigger tests'
         }
     }
 

--- a/bodhi/server/models.py
+++ b/bodhi/server/models.py
@@ -3854,7 +3854,7 @@ class Update(Base):
             # the message now. This method will be called again at the end of __init__
             return
         message = update_schemas.UpdateReadyForTestingV1.from_dict(
-            message={'update': target, 'agent': 'bodhi'}
+            message={'update': target, 'agent': 'bodhi', 're-trigger': False}
         )
         # This method is called before the new attribute value is actually set,
         # so the message needs to be updated.

--- a/bodhi/server/schemas.py
+++ b/bodhi/server/schemas.py
@@ -823,3 +823,9 @@ class GetTestResultsSchema(CSRFProtectedSchema, colander.MappingSchema):
         colander.Sequence(accept_scalar=True),
         missing=None,
     )
+
+
+class TriggerTestsSchema(CSRFProtectedSchema, colander.MappingSchema):
+    """An API schema for bodhi.server.services.updates.trigger_tests()."""
+
+    pass


### PR DESCRIPTION
This commit adds API call which will publish bodhi.update.status.testing
message to re-trigger tests again.

This should help with implementation of #3284, #3285, #3286, #3287
and #3288.

Signed-off-by: Michal Konečný <mkonecny@redhat.com>