### PR TITLE
fix html validation errors and warnings

### DIFF
--- a/bodhi/server/templates/fragments.html
+++ b/bodhi/server/templates/fragments.html
@@ -99,7 +99,7 @@ ${statusmap[status]}\
           <div class="col font-size-09">
           % if comment.user:
           <a href="${request.route_url('user', name=comment.user.name)}" class="font-weight-bold notblue">
-            <img src="${util.avatar(comment.user.name, size=16)}"/>
+            <img src="${util.avatar(comment.user.name, size=16)}" alt="User Icon"/>
             ${comment.user.name}
           </a>
           % if comment.text:
@@ -182,7 +182,7 @@ ${statusmap[status]}\
                   ${util.type2icon(update['type'])|n}
                   <div class="media-body ml-2">
                       <div class="font-weight-bold">
-                        <a href="${request.route_url('update', id=update['alias'])}"">
+                        <a href="${request.route_url('update', id=update['alias'])}">
                         ${update.beautify_title(amp=True,nvr=True) | n}
                         </a>
                       </div>

--- a/bodhi/server/templates/home.html
+++ b/bodhi/server/templates/home.html
@@ -92,7 +92,7 @@
                 % for tester, count in top_testers:
                 <div class="list-group-item">
                     <a href="${request.route_url('user', name=tester['name'])}">
-                      <img class="rounded-circle" src="${self.util.avatar(tester['name'], size=24)}"/>
+                      <img class="rounded-circle" src="${self.util.avatar(tester['name'], size=24)}" alt="User Icon"/>
                       ${tester['name']}
                     </a>
                   <div class="float-right">${str(count)} comments</div>
@@ -106,7 +106,7 @@
               % for tester, count in top_packagers:
               <div class="list-group-item">
                   <a href="${request.route_url('user', name=tester['name'])}">
-                    <img class="rounded-circle" src="${self.util.avatar(tester['name'], size=24)}"/>
+                    <img class="rounded-circle" src="${self.util.avatar(tester['name'], size=24)}" alt="User Icon"/>
                     ${tester['name']}
                   </a>
                 <div class="float-right">${str(count)} updates</div>
@@ -117,4 +117,3 @@
   </div>
 
   </div>
-</div>

--- a/bodhi/server/templates/master.html
+++ b/bodhi/server/templates/master.html
@@ -57,7 +57,7 @@
         <div class="row">
           <div class="col-sm-6">
             <a href="${request.route_url('home')}">
-              <img src="${request.static_url('bodhi:server/static/img/bodhi-logo.png')}" alt="Fedora Update System" id="kojiLogo" height="40px">
+              <img src="${request.static_url('bodhi:server/static/img/bodhi-logo.png')}" alt="Fedora Update System" height="40">
             </a>
           </div>
           <div class="col-sm-6">
@@ -93,7 +93,7 @@
                         % endif
                           <a class="nav-link dropdown-toggle" href="javascript:void(0)" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">
                             <span class="glyphicon glyphicon-user"></span>
-                            <img src="${self.util.avatar(request.user.name, size=24)}"/>
+                            <img src="${self.util.avatar(request.user.name, size=24)}" alt="User Icon"/>
                           </a>
                           <div class="dropdown-menu">
                               <a class="dropdown-item" href="${request.route_url('home')}">
@@ -200,7 +200,7 @@
       </div>
     </div>
 
-    <script type="text/javascript">
+    <script>
       var settings = {
           bz_products: ["${ '","'.join(config['bz_products']) | n }"],
           bz_server_rest: "${config['bz_server_rest']}"

--- a/bodhi/server/templates/metrics.html
+++ b/bodhi/server/templates/metrics.html
@@ -14,7 +14,7 @@
 <%block name="javascript">
 ${parent.javascript()}
 <script src="${request.static_url('bodhi:server/static/vendor/chartjs/Chart-0.2.0.min.js')}"></script>
-<script type="text/javascript">
+<script>
   $(document).ready(function(){
       $("<div id='tooltip'></div>").css({
         position: "absolute",

--- a/bodhi/server/templates/update.html
+++ b/bodhi/server/templates/update.html
@@ -43,7 +43,7 @@ if can_edit:
 <div class="container">
 <div class="row">
   <div class="col-md-12">
-    <h3>
+    <div class="h3">
       <div class="row">
         <div class="col">
             <div class="media">
@@ -57,21 +57,21 @@ if can_edit:
             </div>
                 <div class="media-body ml-0">
                     <div class="font-weight-bold">
-                      <a href="${request.route_url('update', id=update['alias'])}"">
+                      <a href="${request.route_url('update', id=update['alias'])}">
                       ${update.beautify_title(amp=True,nvr=True) | n}
                       </a>
                     </div>
-                    <h5 class="mt-1">
+                    <div class="h5 mt-1">
                         ${update.alias} created by <a href="${request.route_url('user', name=update['user']['name'])}"> ${update['user']['name']}</a>
                         <span title="${update['date_submitted']} UTC"> ${self.util.age(update['date_submitted'], True)}</span> ago 
                         for <a href="${request.route_url('release', name=update['release']['name'])}">${update['release']['long_name']}
-                        </a></small>
-                      </h5>
+                        </a>
+                      </div>
                 </div>
             </div>
 
         </div>
-        <div class="col-xs-auto">
+        <div class="col-x-auto">
             % if can_edit and (not update.locked and update.status.value != 'stable'):
               <a id='edit' href="javascript:void(0)" class="btn btn-outline-primary border-0 btn-sm"><span class="fa fa-fw fa-pencil-square-o"></span> Edit</a>
             % elif can_edit and update.locked and update.date_locked:
@@ -81,7 +81,7 @@ if can_edit:
             </a>
             % endif
             % if actions:
-              <span class="dropdown" id="updatebuttons">
+              <div class="dropdown d-inline" id="updatebuttons">
                 <button class="btn btn-${self.fragments.status_context(update.status.value)} dropdown-toggle btn-sm" type="button" id="statusActions" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                     ${self.fragments.status_text(update)}
                 </button>
@@ -99,7 +99,7 @@ if can_edit:
                     <a class="dropdown-item" id="stable" href="javascript:void(0)">Push to Stable</a>
                   %endif
                 </div>
-              </span>
+              </div>
             % else:
               <span class="btn btn-sm btn-${self.fragments.status_context(update.status.value)}">
                   ${self.fragments.status_text(update)}
@@ -107,7 +107,7 @@ if can_edit:
             % endif
         </div>
       </div>
-    </h3>
+    </div>
   </div>
 </div>
 <ul class="nav nav-tabs pt-2" role="tablist">
@@ -212,7 +212,7 @@ if can_edit:
             <p><small>this update has been pushed to stable</small></p>
           </div>
           % elif request.user:
-          <form id="new_comment" role="form"
+          <form id="new_comment"
           action="javascript:form.submit();">
           <input type="hidden" name="csrf_token" value="${request.session.get_csrf_token()}"/>
           <input type="hidden" name="update" value="${update.alias}"/>
@@ -327,18 +327,12 @@ if can_edit:
             </p>
           </div>
           %endif
-
-
-
-
-
-
         </div>
         <div class="col-3 font-size-09">
-          <div>
-              <h5 class="d-flex align-items-center font-weight-bold border-bottom">
+            <div class="mt-3">
+              <div class="h5 d-flex align-items-center font-weight-bold border-bottom">
                   <div class="py-2 text-uppercase font-size-09">Metadata</div>
-              </h5>
+              </div>
               
               % if update.type:
               <div class="pb-1">
@@ -393,10 +387,9 @@ if can_edit:
               </div>
               % endif
             </div>
-          
               % if request.registry.settings.get('test_gating.required'):
               <div class="mt-3">
-                  <h5 class="d-flex align-items-center font-weight-bold border-bottom">
+                  <div class="h5 d-flex align-items-center font-weight-bold border-bottom">
                       <div class="py-2 text-uppercase font-size-09">
                           % if request.registry.settings.get('test_gating.url'):
                           <a class="notblue" href="${request.registry.settings.get('test_gating.url')}" title="More information about test gating">
@@ -406,7 +399,7 @@ if can_edit:
                           Test Gating
                         % endif
                       </div>
-                  </h5>
+                    </div>
               <div class="pb-1">
                 <div>
                   % if can_edit and self.util.can_waive_test_results(update):
@@ -419,16 +412,10 @@ if can_edit:
               </div>
               </div>
               % endif
-
-
-
-
-
-
               <div class="mt-3">
-                  <h5 class="d-flex align-items-center font-weight-bold border-bottom">
+                  <div class="h5 d-flex align-items-center font-weight-bold border-bottom">
                       <div class="py-2 text-uppercase font-size-09">Builds</div> <span class="badge badge-secondary badge-pill ml-auto">${len(update.builds)}</span>
-                  </h5>
+                  </div>
 
               % for build in update.builds:
               <%
@@ -444,18 +431,10 @@ if can_edit:
               % endfor
 
               </div>
-
-
-
-
-
-
-
-
               <div class="mt-3">
-                  <h5 class="d-flex align-items-center font-weight-bold border-bottom">
+                  <div class="h5 d-flex align-items-center font-weight-bold border-bottom">
                       <div class="py-2 text-uppercase font-size-09">Settings</div>
-                  </h5>
+                  </div>
 
 
               % if update.unstable_karma:
@@ -497,24 +476,18 @@ if can_edit:
               </div>
               % endif
               </div>
-
               <div class="mt-3">
-                  <h5 class="d-flex align-items-center font-weight-bold border-bottom">
+                  <div class="h5 d-flex align-items-center font-weight-bold border-bottom">
                       <div class="py-2 text-uppercase font-size-09">Dates</div>
-                  </h5>
-                <div>
-                  <table class="table table-sm">
-                      <div class="pb-1">
-                          <div class="row">
-                            <div class="col font-weight-bold text-muted">submitted</div>
-                            <div class="col-xs-auto font-weight-bold">
-                                  <span class="text-muted font-weight-bold" data-toggle='tooltip' title='${(update.date_submitted).strftime("%Y-%m-%d %H:%M:%S")} (UTC)'>
-                                      ${self.util.age(update.date_submitted)}
-                                  </span>
-                            </div>
-                          </div>
+                  </div>
+                    <div class="row">
+                      <div class="col font-weight-bold text-muted">submitted</div>
+                      <div class="col-xs-auto font-weight-bold">
+                            <span class="text-muted font-weight-bold" data-toggle='tooltip' title='${(update.date_submitted).strftime("%Y-%m-%d %H:%M:%S")} (UTC)'>
+                                ${self.util.age(update.date_submitted)}
+                            </span>
                       </div>
-                      <div class="pb-1">
+                    </div>
 
                     % if update.date_testing:
                     <div class="row">
@@ -525,7 +498,6 @@ if can_edit:
                           </span>
                         </div>
                       </div>
-                    </div>
                     % endif
 
                     % if update.date_stable:
@@ -537,7 +509,6 @@ if can_edit:
                           </span>
                         </div>
                       </div>
-                    </div>
                     % endif
 
                     % if update.days_to_stable and update.status.value == 'testing':
@@ -549,29 +520,30 @@ if can_edit:
                           </span>
                         </div>
                       </div>
-                    </div>
                     % endif
 
                     % if update.date_modified:
-                    <tr>
-                      <td>modified</td>
-                      <td class="text-muted">
-                        <span data-toggle='tooltip' title='${(update.date_modified).strftime("%Y-%m-%d %H:%M:%S")} (UTC)'>${self.util.age(update.date_modified)}</span>
-                      </td>
-                    </tr>
+                    <div class="row">
+                      <div class="col font-weight-bold text-muted">modified</div>
+                        <div class="col-xs-auto font-weight-bold">
+                          <span data-toggle='tooltip' title='${(update.date_modified).strftime("%Y-%m-%d %H:%M:%S")} (UTC)' class="text-muted font-weight-bold">
+                              ${self.util.age(update.date_modified)}
+                          </span>
+                        </div>
+                      </div>
                     % endif
 
-                    % if update.date_approved:
-                    <tr>
-                      <td>approved</td>
-                      <td class="text-muted">
-                        <span data-toggle='tooltip' title='${(update.date_approved).strftime("%Y-%m-%d %H:%M:%S")} (UTC)'>${self.util.age(update.date_approved)}</span>
-                      </td>
-                    </tr>
+                    % if update.date_modified:
+                    <div class="row">
+                      <div class="col font-weight-bold text-muted">approved</div>
+                        <div class="col-xs-auto font-weight-bold">
+                          <span data-toggle='tooltip' title='${(update.date_approved).strftime("%Y-%m-%d %H:%M:%S")} (UTC)' class="text-muted font-weight-bold">
+                              ${self.util.age(update.date_approved)}
+                          </span>
+                        </div>
+                      </div>
                     % endif
-                  </table>
-                </div>
-          </div>
+              </div>
         </div>
       </div>
     </div>
@@ -664,13 +636,8 @@ if can_edit:
     </table>
   </div>
     % endif
-
   </div>
-
-
-<div class="row">
-
-</div>
+</div> <!-- end container -->
 
 % if self.util.can_waive_test_results(update):
 <div class="modal fade" id="waive_test_results" tabindex="-1" role="dialog" aria-labelledby="waiveModalLabel" aria-hidden="true">
@@ -702,11 +669,9 @@ if can_edit:
       </div>
     </div>
     </form>
-  </div>
 </div>
 % endif
 
-</div> <!-- end container -->
 
 <%block name="javascript">
 ${parent.javascript()}
@@ -714,7 +679,7 @@ ${parent.javascript()}
 <script src="${request.static_url('bodhi:server/static/vendor/messenger/js/messenger-theme-flat.js')}"></script>
 <script src="${request.static_url('bodhi:server/static/js/forms.js')}"></script>
 <script src="${request.static_url('bodhi:server/static/vendor/moment/moment.min.js')}"></script>
-<script type="text/javascript">
+<script>
   $(document).ready(function() {
     // Some handy lookups that map taskotron states to bootstrap CSS classes.
     var classes = {
@@ -1041,7 +1006,7 @@ ${parent.javascript()}
   });
 </script>
 
-<script type="text/javascript">
+<script>
 $(document).ready(function() {
     var messenger = Messenger({theme: 'flat'});
     var update_id = '${update.alias}';
@@ -1124,7 +1089,7 @@ $(document).ready(function() {
 });
 </script>
 
-<script type="text/javascript">
+<script>
 var form;
 $(document).ready(function(){
   CommentsForm = function() {};
@@ -1206,7 +1171,7 @@ $(document).ready(function(){
 });
 </script>
 
-<script type="text/javascript">
+<script>
 $(document).ready(function(){
     var button = document.getElementById('copybutton')
 

--- a/bodhi/server/templates/updates.html
+++ b/bodhi/server/templates/updates.html
@@ -15,15 +15,19 @@ ${parent.css()}
 <link href="${request.static_url('bodhi:server/static/vendor/selectize/selectize.bootstrap3-0.12.3.css') }" rel="stylesheet" />
 <link rel="alternate" type="application/atom+xml" title="New Updates" href="${request.route_url('updates_rss') + '?' + request.query_string}"/>
 </%block>
-<div class="subheader py-3">
-  <div class="container">
-    <div class="row">
-      <div class="col-md-12">
-        <h2>Updates</h2>
+<div class="subheader">
+    <div class="container py-4">
+      <div class="row">
+        <div class="col">
+            <h3 class="font-weight-bold m-0 d-flex align-items-center">Updates
+                % if request.user:
+                <a class="btn btm-sm font-weight-bold btn-outline-primary ml-auto" href="${request.route_url('new_update')}"><i class="fa fa-plus pr-2"></i>New Update</a>
+                % endif
+            </h3>
+        </div>
       </div>
     </div>
   </div>
-</div>
 <div class="container pt-4">
   <div class="row">
     <div class="col-md-12">
@@ -94,9 +98,9 @@ ${parent.css()}
                   </div>
 
               </div>
-              <input name="search" type="text" autocomplete='off' class="form-control" id="updates-search" aria-describedby="basic-addon3" value="${searchterm}" placeholder="search">
+              <input name="search" type="text" autocomplete='off' class="form-control" id="updates-search" value="${searchterm}" placeholder="search">
             </div>
-            <div class="dropdown-menu dropdown-menu-right p-3" style="min-width:400px; max-width: 400px" aria-labelledby="dropdownMenuButton" id="filters-dropdown">
+            <div class="dropdown-menu dropdown-menu-right p-3" style="min-width:400px; max-width: 400px" id="filters-dropdown">
                 % for param, values in parameters.items():
                   % for i, value in enumerate(values):
                     % if (param in allValidParams) and (param not in visibleParams):
@@ -106,11 +110,11 @@ ${parent.css()}
               % endfor
               <div class="form-group row mb-1 filter-group">
                   <div class="col-3 align-self-center">
-                  <label for="type" class="col-auto align-self-center pl-1 pr-0 m-0">Status:</label>
+                  <label for="updatestatus" class="col-auto align-self-center pl-1 pr-0 m-0">Status:</label>
                   </div>
                   <div class="col-8 pl-1">
                       <select id="updatestatus" name="status" multiple="multiple">
-                          <option value=""></option>
+                          <option value="">&nbsp;</option>
                           % for value in statuses:
                           <option value="${value}"
                           % if 'status' in parameters and value in parameters['status']:
@@ -127,11 +131,11 @@ ${parent.css()}
 
               <div class="form-group row mb-1 filter-group">
                   <div class="col-3 align-self-center">
-                  <label for="releases" class="col-auto align-self-center pl-1 pr-0 m-0">Releases:</label>
+                  <label for="updatereleases" class="col-auto align-self-center pl-1 pr-0 m-0">Releases:</label>
                   </div>
                   <div class="col-8 pl-1">
                       <select id="updatereleases" name="releases" multiple="multiple">
-                          <option value=""></option>
+                          <option value=""><&nbsp;/option>
                           % for rstatus in ['current', 'pending', "archived"]:
                             <optgroup label="${rstatus}">
                             % for value in releases[rstatus]:
@@ -152,11 +156,11 @@ ${parent.css()}
               
               <div class="form-group row mb-1 filter-group">
                   <div class="col-3 align-self-center">
-                  <label for="type" class="col-auto align-self-center pl-1 pr-0 m-0">Type:</label>
+                  <label for="updatetypes" class="col-auto align-self-center pl-1 pr-0 m-0">Type:</label>
                   </div>
                   <div class="col-8 pl-1">
                       <select id="updatetypes" name="type" class="custom-select">
-                          <option value=""></option>
+                          <option value="">&nbsp;</option>
                           % for value in types:
                           <option value="${value}"
                           % if 'type' in parameters and parameters['type'][0] == value:
@@ -172,11 +176,11 @@ ${parent.css()}
               </div>
               <div class="form-group row mb-1 filter-group">
                   <div class="col-3 align-self-center">
-                  <label for="severity" class="col-auto align-self-center pl-1 pr-0 m-0">Severity:</label>
+                  <label for="updateseverity" class="col-auto align-self-center pl-1 pr-0 m-0">Severity:</label>
                   </div>
                   <div class="col-8 pl-1">
                       <select id="updateseverity" name="severity" class="custom-select">
-                          <option value=""></option>
+                          <option value="">&nbsp;</option>
                           % for value in severities:
                           <option value="${value}"
                           % if 'severity' in parameters and parameters['severity'][0] == value:
@@ -192,14 +196,10 @@ ${parent.css()}
               </div>
               <div class="form-group row mb-1 filter-group">
                   <div class="col-3 align-self-center">
-                  <label for="user" class="col-auto align-self-center pl-1 pr-0 m-0">User:</label>
+                  <label for="updateuser" class="col-auto align-self-center pl-1 pr-0 m-0">User:</label>
                   </div>
                   <div class="col-8 pl-1">
-                      <input type="text" id="updateuser" name="user" class="form-control"
-                      % if 'user' in parameters:
-                          value="${parameters['user'][0]}"
-                      % endif>
-                    </input>
+                      <input type="text" id="updateuser" name="user" class="form-control" ${"value="+parameters['user'][0] if 'user' in parameters else ""}/>
                   </div>
                   <div class="col-1 pl-0 pr-1 pt-1">
                     <i class="fa fa-times fa-fw text-muted clear-button" data-clear="updateuser"></i>

--- a/bodhi/server/templates/user.html
+++ b/bodhi/server/templates/user.html
@@ -6,10 +6,10 @@
     <div class="float-left">
       % if request.user and user['name'] == request.user.name:
         <a href="https://www.libravatar.org/openid/login/?openid_identifier=${request.user.openid}">
-          <img class="img-thumbnail" src="${self.util.avatar(user['name'], size=128)}" width="128px" height="128px"/>
+          <img class="img-thumbnail" src="${self.util.avatar(user['name'], size=128)}" width="128px" height="128px" alt="User Icon"/>
         </a>
       % else:
-        <img class="img-thumbnail" src="${self.util.avatar(user['name'], size=128)}"/>
+        <img class="img-thumbnail" src="${self.util.avatar(user['name'], size=128)}" alt="User Icon"/>
       % endif
     </div>
     <div class="float-left" style="margin-left: 15px">


### PR DESCRIPTION
This fixes a bunch of different html errors and warnings,
including:

* remove stray div from home.html
* logo in master.html
    * change height attribute "40px" to "40"
    * remove the kojilogo id from the logo
* add alt tags to avatar images
* remove unneeded type="text/javascript" from <script> tags
* remove extra double quotation mark " from fragments.html and
  update.html
* update.html
    * remove a stray /small closing tag
    * remove instances of h3 and h5 that had nested divs and replace
      with div with the bootstrap .h3 / .h5 classes
    * remove unneeded role="form" from the new comment form
    * remove div inside of span in the updatebuttons dropdown
    * convert the last two dates items (modified and approved) from the
      old table format, and remove the table.
    * remove many wrongly closed div tags
* updates.html
    * fix empty options failing the validator
    * fix issues with form labels

Signed-off-by: Ryan Lerch <rlerch@redhat.com>