### PR TITLE
fix typo in markup for releases filter selectbox

### DIFF
--- a/bodhi/server/templates/updates.html
+++ b/bodhi/server/templates/updates.html
@@ -135,7 +135,7 @@ ${parent.css()}
                   </div>
                   <div class="col-8 pl-1">
                       <select id="updatereleases" name="releases" multiple="multiple">
-                          <option value=""><&nbsp;/option>
+                          <option value="">&nbsp;</option>
                           % for rstatus in ['current', 'pending', "archived"]:
                             <optgroup label="${rstatus}">
                             % for value in releases[rstatus]:


### PR DESCRIPTION
a typo in the markup for the releases filer selectbox made the text "/option>"
show in the selectbox. This commit fixes this issue

Signed-off-by: Ryan Lerch <rlerch@redhat.com>