### PR TITLE
Reconcile Update.{get_title,beautify_title}()

### DIFF
--- a/bodhi/server/mail.py
+++ b/bodhi/server/mail.py
@@ -427,7 +427,7 @@ def send(to: typing.Iterable[str], msg_type: str, update: 'Update',
             "X-Bodhi-Update-Release": update.release.name,
             "X-Bodhi-Update-Status": update.status.description,
             "X-Bodhi-Update-Builds": ",".join([b.nvr for b in update.builds]),
-            "X-Bodhi-Update-Title": update.beautify_title(nvr=True),
+            "X-Bodhi-Update-Title": update.get_title(nvr=True, beautify=True),
             "X-Bodhi-Update-Pushed": update.pushed,
             "X-Bodhi-Update-Submitter": update.user.name,
         }
@@ -445,7 +445,7 @@ def send(to: typing.Iterable[str], msg_type: str, update: 'Update',
 
     subject_template = '[Fedora Update] %s[%s] %s'
     for person in to:
-        subject = subject_template % (critpath, msg_type, update.beautify_title(nvr=True))
+        subject = subject_template % (critpath, msg_type, update.get_title(nvr=True, beautify=True))
         fields = MESSAGES[msg_type]['fields'](agent, update)
         body = MESSAGES[msg_type]['body'] % fields
         send_mail(sender, person, subject, body, headers=headers)

--- a/bodhi/server/models.py
+++ b/bodhi/server/models.py
@@ -2573,7 +2573,8 @@ class Update(Base):
         """
         return self.get_title()
 
-    def get_title(self, delim=' ', limit=None, after_limit='…'):
+    def get_title(self, delim=' ', limit=None, after_limit='…',
+                  beautify=False, nvr=False, amp=False):
         """
         Return a title for the update based on the :class:`Builds <Build>` it is associated with.
 
@@ -2583,13 +2584,42 @@ class Update(Base):
                 number. If ``None`` (the default), no limit is used.
             after_limit (str): If a limit is set, use this string after the limit is reached.
                 Defaults to '…'.
+            beautify (bool): If provided, the returned string will be human
+                readable, i.e. 3 or more builds will take the form "package1,
+                package2 and XXX more".
+            nvr (bool): If specified, the title will include name, version and
+                release information in package labels.
+            amp (bool): If specified, it will replace the word 'and' with an
+                ampersand, '&'.
         Returns:
             str: A title for this update.
         """
-        all_nvrs = [x.nvr for x in self.builds]
-        nvrs = all_nvrs[:limit]
-        builds = delim.join(sorted(nvrs)) + (after_limit if limit and len(all_nvrs) > limit else "")
-        return builds
+        if beautify:
+            if self.display_name:
+                return self.display_name
+
+            def build_label(build):
+                return build.nvr if nvr else build.package.name
+
+            if len(self.builds) > 2:
+                title = ", ".join([build_label(build) for build in self.builds[:2]])
+
+                if amp:
+                    title += ", & "
+                else:
+                    title += ", and "
+                title += str(len(self.builds) - 2)
+                title += " more"
+
+                return title
+            else:
+                return " and ".join([build_label(build) for build in self.builds])
+        else:
+            all_nvrs = [x.nvr for x in self.builds]
+            nvrs = all_nvrs[:limit]
+            builds = delim.join(sorted(nvrs)) + \
+                (after_limit if limit and len(all_nvrs) > limit else "")
+            return builds
 
     def get_bugstring(self, show_titles=False):
         """
@@ -2661,41 +2691,6 @@ class Update(Base):
                     elif feedback.karma < 0:
                         bad += 1
         return bad * -1, good
-
-    def beautify_title(self, amp=False, nvr=False):
-        """
-        Return a human readable title for this update.
-
-        This is used mostly in subject of a update notification email and
-        displaying the title in html. If there are 3 or more builds per title
-        the title be:
-
-            "package1, package, 2 and XXX more"
-
-        If the "amp" parameter is specified it will replace the "and" with an
-        "&" entity.
-
-        If the "nvr" parameter is specified it will include name, version and
-        release information in package labels.
-        """
-        if self.display_name:
-            return self.display_name
-
-        def build_label(build):
-            return build.nvr if nvr else build.package.name
-
-        if len(self.builds) > 2:
-            title = ", ".join([build_label(build) for build in self.builds[:2]])
-
-            if amp:
-                title += ", & "
-            else:
-                title += ", and "
-            title += str(len(self.builds) - 2)
-            title += " more"
-            return title
-        else:
-            return " and ".join([build_label(build) for build in self.builds])
 
     def set_request(self, db, action, username):
         """
@@ -4106,7 +4101,8 @@ class Compose(Base):
             list: A list of dictionaries with keys 'alias' and 'title', indexing each update alias
                 and title associated with this Compose.
         """
-        return [{'alias': u.alias, 'title': u.beautify_title(nvr=True)} for u in self.updates]
+        return [{'alias': u.alias,
+                'title': u.get_title(nvr=True, beautify=True)} for u in self.updates]
 
     def __json__(self, request=None, exclude=None, include=None, composer=False):
         """

--- a/bodhi/server/templates/fragments.html
+++ b/bodhi/server/templates/fragments.html
@@ -183,7 +183,7 @@ ${statusmap[status]}\
                   <div class="media-body ml-2">
                       <div class="font-weight-bold">
                         <a href="${request.route_url('update', id=update['alias'])}">
-                        ${update.beautify_title(amp=True,nvr=True) | h}
+                        ${update.get_title(amp=True,nvr=True,beautify=True) | h}
                         </a>
                       </div>
                       <div class="line-height-1">

--- a/bodhi/server/templates/update.html
+++ b/bodhi/server/templates/update.html
@@ -11,7 +11,7 @@
 <%block name="pagetitle">
   ${update.alias}
 &mdash;
-${update.type} update for ${update.beautify_title(amp=True) | h}
+${update.type} update for ${update.get_title(amp=True,beautify=True) | h}
 &mdash; Fedora Updates System
 </%block>
 
@@ -58,7 +58,7 @@ if can_edit and update.release.composed_by_bodhi:
                 <div class="media-body ml-0">
                     <div class="font-weight-bold">
                       <a href="${request.route_url('update', id=update['alias'])}">
-                      ${update.beautify_title(amp=True,nvr=True) | h}
+                      ${update.get_title(amp=True,nvr=True,beautify=True) | h}
                       </a>
                     </div>
                     <div class="h5 mt-1">

--- a/bodhi/tests/server/services/test_composes.py
+++ b/bodhi/tests/server/services/test_composes.py
@@ -135,7 +135,7 @@ class TestComposeGet(base.BaseTestCase):
 
         self.assertTrue(compose.state.description in response)
         self.assertTrue('{} {}'.format(compose.release.name, compose.request.value) in response)
-        self.assertTrue(update.beautify_title(amp=True, nvr=True) in response)
+        self.assertTrue(update.get_title(amp=True, nvr=True, beautify=True) in response)
 
     def test_with_compose_json(self):
         """Assert correct behavior from the json renderer when there is a compose."""

--- a/bodhi/tests/server/test_models.py
+++ b/bodhi/tests/server/test_models.py
@@ -613,7 +613,7 @@ class TestCompose(BasePyTestCase):
         update = compose.updates[0]
 
         assert compose.update_summary == (
-            [{'alias': update.alias, 'title': update.beautify_title(nvr=True)}])
+            [{'alias': update.alias, 'title': update.get_title(nvr=True, beautify=True)}])
 
     def test___json___composer_flag(self):
         """The composer flag should reduce the number of serialized fields."""
@@ -2934,32 +2934,33 @@ class TestUpdate(ModelTest):
     def test_title(self):
         assert self.obj.title == 'TurboGears-1.0.8-3.fc11'
 
-    def test_beautify_title_display_name(self):
-        """If the user has set a display_name on the update, beautify_title() should use that."""
+    def test_get_title_display_name(self):
+        """If the user has set a display_name on the update, get_title() should use that."""
         update = self.get_update()
         update.display_name = 'some human made title'
 
-        assert update.beautify_title() == 'some human made title'
+        assert update.get_title(beautify=True) == 'some human made title'
 
-    def test_beautify_title(self):
+    def test_get_title_with_beautify(self):
         update = self.get_update()
         rpm_build = update.builds[0]
-        assert update.beautify_title() == 'TurboGears'
-        assert update.beautify_title(nvr=True) == 'TurboGears-1.0.8-3.fc11'
+        assert update.get_title(beautify=True) == 'TurboGears'
+        assert update.get_title(nvr=True, beautify=True) == 'TurboGears-1.0.8-3.fc11'
 
         update.builds.append(rpm_build)
-        assert update.beautify_title() == 'TurboGears and TurboGears'
-        assert update.beautify_title(nvr=True) == (
+        assert update.get_title(beautify=True) == 'TurboGears and TurboGears'
+        assert update.get_title(nvr=True, beautify=True) == (
             'TurboGears-1.0.8-3.fc11 and TurboGears-1.0.8-3.fc11')
 
         update.builds.append(rpm_build)
-        assert update.beautify_title(), 'TurboGears, TurboGears == and 1 more'
-        assert update.beautify_title(nvr=True) == (
+        assert update.get_title(beautify=True), 'TurboGears, TurboGears == and 1 more'
+        assert update.get_title(nvr=True, beautify=True) == (
             'TurboGears-1.0.8-3.fc11, TurboGears-1.0.8-3.fc11, and 1 more')
 
         p = html.parser.HTMLParser()
-        assert p.unescape(update.beautify_title(amp=True)) == 'TurboGears, TurboGears, & 1 more'
-        assert p.unescape(update.beautify_title(amp=True, nvr=True)) == (
+        assert p.unescape(update.get_title(amp=True, beautify=True)) == (
+            'TurboGears, TurboGears, & 1 more')
+        assert p.unescape(update.get_title(amp=True, nvr=True, beautify=True)) == (
             'TurboGears-1.0.8-3.fc11, TurboGears-1.0.8-3.fc11, & 1 more')
 
     def test_pkg_str(self):


### PR DESCRIPTION
As per https://github.com/fedora-infra/bodhi/issues/3114
Reconcile the two functions into one. The beautification now depends on
a boolean within get_title and otherwise nothing else changes.

Signed-off-by: Stephen Coady <scoady@redhat.com>