### PR TITLE
Reload update page when commenting

### DIFF
--- a/bodhi/server/templates/update.html
+++ b/bodhi/server/templates/update.html
@@ -1101,9 +1101,7 @@ $(document).ready(function(){
       url: this.url + "../comments/" + data.comment.id,
       dataType: "html",
       success: function(html) {
-        $("#comments").append(html);
-        $(".list-group-item").removeClass("list-group-item-success");
-        $(".list-group-item").removeClass("list-group-item-danger");
+        window.location.reload(true);
       },
       error: function(html) {
         // TODO -- handle this


### PR DESCRIPTION
Previously, when adding a comment to an update, the javascript
dynamically added the comment to the bottom of the list, but did not
update the karma. In this commit, we just reload the entire page rather
than fuss with adding the information correctly after the async comment
form returns a success.

Fixes: #3502
Signed-off-by: Ryan Lerch <rlerch@redhat.com>