### PR TITLE
Fix rendering of border on active testers on home.html

### DIFF
--- a/bodhi/server/templates/home.html
+++ b/bodhi/server/templates/home.html
@@ -88,7 +88,7 @@
   <div class="row py-4">
     <div class="col-6">
         <h5 class="font-weight-bold">Active Testers</h5>
-            <div class="list-group list-group-flush">
+            <div class="list-group">
                 % for tester, count in top_testers:
                 <div class="list-group-item">
                     <a href="${request.route_url('user', name=tester['name'])}">


### PR DESCRIPTION
Previously, the active testers box on the homepage was rendered without
a border. (the active packagers box to the right is how it should
display) this commit fixes this issue.

![Screenshot from 2019-10-08 16-14-42](https://user-images.githubusercontent.com/592259/66371690-3d7f9780-e9e7-11e9-9dfa-c932536b2e37.png)


Signed-off-by: Ryan Lerch <rlerch@redhat.com>