### PR TITLE
add new version_hash property to Update model

### DIFF
--- a/bodhi/server/models.py
+++ b/bodhi/server/models.py
@@ -1758,7 +1758,7 @@ class Update(Base):
 
     __tablename__ = 'updates'
     __exclude_columns__ = ('id', 'user_id', 'release_id')
-    __include_extras__ = ('meets_testing_requirements', 'url', 'title')
+    __include_extras__ = ('meets_testing_requirements', 'url', 'title', 'version_hash')
     __get_by__ = ('alias',)
 
     autokarma = Column(Boolean, default=True, nullable=False)
@@ -1853,6 +1853,18 @@ class Update(Base):
 
         if self.status == UpdateStatus.testing:
             self._ready_for_testing(self, self.status, None, None)
+
+    @property
+    def version_hash(self):
+        """
+        Return a SHA1 hash of the Builds NVRs.
+
+        Returns:
+            str: a SHA1 hash of the builds NVRs.
+        """
+        nvrs = [x.nvr for x in self.builds]
+        builds = " ".join(sorted(nvrs))
+        return hashlib.sha1(str(builds).encode('utf-8')).hexdigest()
 
     @property
     def side_tag_locked(self):

--- a/bodhi/tests/server/services/test_updates.py
+++ b/bodhi/tests/server/services/test_updates.py
@@ -1754,6 +1754,8 @@ class TestUpdatesService(BaseTestCase):
         res = self.app.get(f'/updates/{update.alias}', headers={'Accept': 'application/json'})
 
         self.assertEqual(res.json_body['update']['title'], 'bodhi-2.0-1.fc17')
+        version_hash = "19504edccbed061be0b47741238859a94d973138"
+        self.assertEqual(res.json_body['update']['version_hash'], version_hash)
         self.assertIn('application/json', res.headers['Content-Type'])
 
     def test_get_single_update_jsonp(self):


### PR DESCRIPTION
This adds a new version_hash property to the Update model, which is a
SHA1 hash of all the builds in an update.

Fixes: #3497

Signed-off-by: Ryan Lerch <rlerch@redhat.com>