### PR TITLE
Move multi build update that failed to merge in rawhide to pending.

### DIFF
--- a/bodhi/server/scripts/approve_testing.py
+++ b/bodhi/server/scripts/approve_testing.py
@@ -128,6 +128,9 @@ def main(argv=sys.argv):
                                 f"These builds {builds_str} have a more recent "
                                 f"build in koji's {update.release.stable_tag} tag.",
                                 author="bodhi")
+                            update.status = UpdateStatus.pending
+                            update.request = None
+                            update.remove_tag(update.release.get_testing_side_tag(update.from_tag))
                             db.commit()
                             continue
 

--- a/bodhi/tests/server/scripts/test_approve_testing.py
+++ b/bodhi/tests/server/scripts/test_approve_testing.py
@@ -930,6 +930,7 @@ class TestMain(BasePyTestCase):
         update.date_testing = datetime.utcnow() - timedelta(days=8)
         update.status = models.UpdateStatus.testing
         update.release.composed_by_bodhi = False
+        update.from_tag = 'f17-build-side-1234'
 
         # Clear pending messages
         self.db.info['messages'] = []
@@ -940,7 +941,7 @@ class TestMain(BasePyTestCase):
                 with fml_testing.mock_sends(api.Message):
                     approve_testing.main(['nosetests', 'some_config.ini'])
 
-        assert update.status == models.UpdateStatus.testing
+        assert update.status == models.UpdateStatus.pending
 
         bodhi = self.db.query(models.User).filter_by(name='bodhi').one()
         cmnts = self.db.query(models.Comment).filter_by(update_id=update.id, user_id=bodhi.id)

--- a/news/3514.feature
+++ b/news/3514.feature
@@ -1,0 +1,1 @@
+Move multi build update that failed to merge in rawhide to pending.


### PR DESCRIPTION
This commit move a multi build rawhide update that was tested but failed
to merge in rawhide (more recent build found in rawhide buildroot)
to pending.
Once in pending the maintainer needs to edit the update to either
add a new build or remove a conflicting build.
On the edit action bodhi checks if all the builds in the update are
signed and moved the update back to testing. If the build are not signed
we wait in pending until we receive the signed message from koji.

Fixes #3514

Signed-off-by: Clement Verna <cverna@tutanota.com>