### PR TITLE
FIxes and updates for new updates form and update page

### DIFF
--- a/bodhi/server/templates/new_update.html
+++ b/bodhi/server/templates/new_update.html
@@ -357,16 +357,17 @@ ${update.notes}
             % if update:
             <input type="hidden" name="edited" value="${update.alias}">
             % endif
-
-            <button id="submit" class="btn btn-success">
-              % if update:
-              <span class="indicator fa fa-edit" data-spinclass="indicator fa fa-spinner fa-spin"></span>
-              Save
-              % else:
-              <span class="indicator fa fa-save" data-spinclass="indicator fa fa-spinner fa-spin"></span>
-              Submit
-              % endif
-            </button>
+            <div class="d-flex flex-row flex-row-reverse pt-3">
+              <button id="submit" class="btn btn-primary">
+                % if update:
+                <span class="indicator fa fa-edit" data-spinclass="indicator fa fa-spinner fa-spin"></span>
+                Save
+                % else:
+                <span class="indicator fa fa-save" data-spinclass="indicator fa fa-spinner fa-spin"></span>
+                Submit
+                % endif
+              </button>
+            </div>
 
   </div>
 </div></div></div>

--- a/bodhi/server/templates/new_update.html
+++ b/bodhi/server/templates/new_update.html
@@ -7,22 +7,19 @@ ${parent.css()}
 <link href="${request.static_url('bodhi:server/static/vendor/selectize/selectize.bootstrap3-0.12.3.css') }" rel="stylesheet" />
 </%block>
 
-<div class="subheader pt-3">
-    <div class="container">
+<div class="subheader">
+    <div class="container py-4">
       <div class="row">
-        <div class="col-md-12">
-          % if not update:
-            <h2 class="float-left">New Update</span>
-          % else:
-            <h2 class="float-left">Edit
-              ${update.alias}
-            </h2>
-          % endif
+        <div class="col">
+            <h3 class="font-weight-bold m-0"><a href="${request.route_url('updates')}">Updates</a>
+                <span class="text-muted"> / </span> 
+                Create New Update
+            </h3>
         </div>
       </div>
     </div>
   </div>
-<div class="container">
+<div class="container pt-4">
   <div id='js-warning' class="col-md-10 col-md-offset-1 mt-3">
     <div class="alert alert-warning">
         <h3>

--- a/bodhi/server/templates/update.html
+++ b/bodhi/server/templates/update.html
@@ -533,7 +533,7 @@ if can_edit:
                       </div>
                     % endif
 
-                    % if update.date_modified:
+                    % if update.date_approved:
                     <div class="row">
                       <div class="col font-weight-bold text-muted">approved</div>
                         <div class="col-xs-auto font-weight-bold">


### PR DESCRIPTION
1. allow a comma seperated list of builds to be pasted in newupdate  …
In the old version of the new update form, multiple builds could be
added at once with a comma separating them. This restores this
functionality in the new new update form.

2. fix 500 error updates with a modified date but not approved date  …
this fixes a copy-paste error that would cause some updates to return a
500 error if they had a date_modified but no date_approved. fixes: #3545

3. style new update subheader to match everything else

4. add some padding and style to the submit update button 