### PR TITLE
Add changelog entry to update notes for automatic updates

### DIFF
--- a/bodhi/server/consumers/automatic_updates.py
+++ b/bodhi/server/consumers/automatic_updates.py
@@ -30,7 +30,7 @@ from bodhi.server import buildsys
 from bodhi.server.config import config
 from bodhi.server.models import Build, ContentType, Package, Release
 from bodhi.server.models import Update, UpdateStatus, UpdateType, User
-from bodhi.server.util import transactional_session_maker
+from bodhi.server.util import generate_changelog, transactional_session_maker
 
 log = logging.getLogger('bodhi')
 
@@ -139,10 +139,21 @@ class AutomaticUpdateHandler:
                 dbsession.add(user)
 
             log.debug(f"Creating new update for {bnvr}.")
+            changelog = generate_changelog(build)
+            if changelog:
+                notes = f"""Automatic update for {bnvr}.
+
+##### **Changelog**
+
+```
+{changelog}
+```"""
+            else:
+                notes = f"Automatic update for {bnvr}."
             update = Update(
                 release=rel,
                 builds=[build],
-                notes=f"Automatic update for {bnvr}.",
+                notes=notes,
                 type=UpdateType.unspecified,
                 stable_karma=3,
                 unstable_karma=-3,

--- a/news/3192.feature
+++ b/news/3192.feature
@@ -1,0 +1,1 @@
+Automatically created updates (e.g. Fedora Rawhide single package updates) now include a changelog entry in the update notes.


### PR DESCRIPTION
This abstracts out the code in mail.py that generates the changelog entry, and puts it in util.py so we can use it in other places. Then, this new abstraction is used to add a changelog entry to the updates notes of automatic updates.

Fixes: #3192