### PR TITLE
Move the --user and --password arguments in a group with --openid-api

### DIFF
--- a/news/PR3550.feature
+++ b/news/PR3550.feature
@@ -1,0 +1,1 @@
+Add --user and --password to all actions of the bodhi CLI supporting --openid-api (for example: waive and trigger)


### PR DESCRIPTION
This way action which allow to set the --openid-api arguments will not
forget to add the --user and --password ones (as did the waive and
request-tests).
This commit also fixes the waive and request-tests action so they allow
logging in from the CLI via the --user and --password arguments as do
other actions requiring to be logged in.

Signed-off-by: Pierre-Yves Chibon <pingou@pingoured.fr>