### PR TITLE
Fix hint in 79ce9f0

### DIFF
--- a/apache/bodhi.conf
+++ b/apache/bodhi.conf
@@ -1,4 +1,4 @@
-Alias /static/BODHI_VERSION /usr/lib/python3.7/site-packages/bodhi/server/static/
+Alias /static/vBODHI_VERSION /usr/lib/python3.7/site-packages/bodhi/server/static/
 
 WSGIDaemonProcess bodhi user=bodhi group=bodhi display-name=bodhi processes=2 threads=2
 WSGISocketPrefix run/wsgi


### PR DESCRIPTION
As pointed out in a comment, there's a missing `v`.