### PR TITLE
fix overrides list on public user profile page

### DIFF
--- a/bodhi/server/templates/overrides.html
+++ b/bodhi/server/templates/overrides.html
@@ -8,10 +8,12 @@ def inherit(context):
 
 <%namespace name="fragments" file="fragments.html"/>
 
+% if chrome:
 <%block name="css">
 ${parent.css()}
 <link rel="alternate" type="application/atom+xml" title="New Buildroot Overrides" href="${request.route_url('overrides_rss') + '?' + request.query_string}"/>
 </%block>
+% endif
 
 % if chrome:
 <div class="subheader">


### PR DESCRIPTION
previously, the user public profile page was not showing the list of
buildroot overrides. This was due to the overrides.html returning a
block that should only be returned when rendering the page as a whole,
rather than the fragment used in this case. This fixes this issue.

Fixes: #3567

Signed-off-by: Ryan Lerch <rlerch@redhat.com>