### PR TITLE
Don't upgrade packages when building containers for CI

### DIFF
--- a/devel/ci/Dockerfile-f29
+++ b/devel/ci/Dockerfile-f29
@@ -1,9 +1,6 @@
 FROM registry.fedoraproject.org/fedora:29
 LABEL maintainer="Randy Barlow <bowlofeggs@fedoraproject.org>"
 
-# The echo works around https://bugzilla.redhat.com/show_bug.cgi?id=1483553 and any other future dnf
-# upgrade bugs.
-RUN dnf upgrade -y || echo "We are not trying to test dnf upgrade, so ignoring dnf failure."
 RUN dnf install --disablerepo rawhide-modular -y \
     createrepo_c \
     fedora-messaging \

--- a/devel/ci/Dockerfile-f30
+++ b/devel/ci/Dockerfile-f30
@@ -1,7 +1,6 @@
 FROM registry.fedoraproject.org/fedora:30
 LABEL maintainer="Randy Barlow <bowlofeggs@fedoraproject.org>"
 
-RUN dnf upgrade -y
 RUN dnf install --disablerepo rawhide-modular -y \
     createrepo_c \
     fedora-messaging \

--- a/devel/ci/Dockerfile-f31
+++ b/devel/ci/Dockerfile-f31
@@ -1,7 +1,6 @@
 FROM registry.fedoraproject.org/fedora:31
 LABEL maintainer="Randy Barlow <bowlofeggs@fedoraproject.org>"
 
-RUN dnf upgrade -y
 RUN dnf install -y \
     createrepo_c \
     fedora-messaging \

--- a/devel/ci/Dockerfile-pip
+++ b/devel/ci/Dockerfile-pip
@@ -4,9 +4,6 @@ LABEL maintainer="Randy Barlow <bowlofeggs@fedoraproject.org>"
 # This works around https://bugzilla.redhat.com/show_bug.cgi?id=1705265
 RUN dnf install -y dnf-plugin-ovl
 
-# The echo works around https://bugzilla.redhat.com/show_bug.cgi?id=1483553 and any other future dnf
-# upgrade bugs.
-RUN dnf upgrade -y || echo "We are not trying to test dnf upgrade, so ignoring dnf failure."
 RUN dnf install -y \
     createrepo_c \
     findutils \

--- a/devel/ci/Dockerfile-rawhide
+++ b/devel/ci/Dockerfile-rawhide
@@ -1,7 +1,6 @@
 FROM registry.fedoraproject.org/fedora:rawhide
 LABEL maintainer="Randy Barlow <bowlofeggs@fedoraproject.org>"
 
-RUN dnf upgrade -y
 RUN dnf install --disablerepo rawhide-modular -y \
     createrepo_c \
     fedora-messaging \

--- a/devel/ci/integration/bodhi/Dockerfile-f29
+++ b/devel/ci/integration/bodhi/Dockerfile-f29
@@ -10,8 +10,6 @@ RUN curl -o /etc/yum.repos.d/infra-tags.repo https://infrastructure.fedoraprojec
 # work around https://bugzilla.redhat.com/show_bug.cgi?id=1699396
 RUN rpm --import "$(awk -F= '{if ($0 ~ "gpgkey *=") {print $2;}}' < /etc/yum.repos.d/infra-tags.repo)"
 
-RUN dnf upgrade -y
-
 # Install Bodhi deps (that were not needed by the unittests container)
 RUN dnf install -y \
     httpd \

--- a/devel/ci/integration/bodhi/Dockerfile-f30
+++ b/devel/ci/integration/bodhi/Dockerfile-f30
@@ -10,8 +10,6 @@ RUN curl -o /etc/yum.repos.d/infra-tags.repo https://infrastructure.fedoraprojec
 # work around https://bugzilla.redhat.com/show_bug.cgi?id=1699396
 RUN rpm --import "$(awk -F= '{if ($0 ~ "gpgkey *=") {print $2;}}' < /etc/yum.repos.d/infra-tags.repo)"
 
-RUN dnf upgrade -y
-
 # Install Bodhi deps (that were not needed by the unittests container)
 RUN dnf install -y \
     httpd \

--- a/devel/ci/integration/bodhi/Dockerfile-f31
+++ b/devel/ci/integration/bodhi/Dockerfile-f31
@@ -13,8 +13,6 @@ RUN rpm --import "$(awk -F= '{if ($0 ~ "gpgkey *=") {print $2;}}' \
         < /etc/yum.repos.d/infra-tags.repo)" && \
     echo skip_if_unavailable=True >> /etc/yum.repos.d/infra-tags.repo
 
-RUN dnf upgrade -y
-
 # Install Bodhi deps (that were not needed by the unittests container)
 RUN dnf install -y \
     httpd \

--- a/devel/ci/integration/bodhi/Dockerfile-pip
+++ b/devel/ci/integration/bodhi/Dockerfile-pip
@@ -10,8 +10,6 @@ RUN curl -o /etc/yum.repos.d/infra-tags.repo https://infrastructure.fedoraprojec
 # work around https://bugzilla.redhat.com/show_bug.cgi?id=1699396
 RUN rpm --import "$(awk -F= '{if ($0 ~ "gpgkey *=") {print $2;}}' < /etc/yum.repos.d/infra-tags.repo)"
 
-RUN dnf upgrade -y
-
 # Install Bodhi deps (that were not needed by the unittests container)
 RUN dnf install -y \
     httpd \

--- a/devel/ci/integration/bodhi/Dockerfile-rawhide
+++ b/devel/ci/integration/bodhi/Dockerfile-rawhide
@@ -13,8 +13,6 @@ RUN rpm --import "$(awk -F= '{if ($0 ~ "gpgkey *=") {print $2;}}' \
         < /etc/yum.repos.d/infra-tags.repo)" && \
     echo skip_if_unavailable=True >> /etc/yum.repos.d/infra-tags.repo
 
-RUN dnf upgrade -y
-
 # Install Bodhi deps (that were not needed by the unittests container)
 RUN dnf install -y \
     httpd \


### PR DESCRIPTION
There's currently an update that breaks our CI containers, don't upgrade packages when building them.
Also, according to Clément, upgrading packages in containers is a bad practice.