### PR TITLE
set update.pushed to true when moved to testing in the signed consumer

### DIFF
--- a/bodhi/server/consumers/signed.py
+++ b/bodhi/server/consumers/signed.py
@@ -118,6 +118,7 @@ class SignedHandler(object):
                 build.update.status = UpdateStatus.testing
                 build.update.date_testing = func.current_timestamp()
                 build.update.request = None
+                build.update.pushed = True
 
                 if config.get("test_gating.required"):
                     log.debug('Test gating is required, marking the update as waiting on test '

--- a/bodhi/tests/server/consumers/test_signed.py
+++ b/bodhi/tests/server/consumers/test_signed.py
@@ -183,6 +183,7 @@ class TestSignedHandlerConsume(base.BasePyTestCase):
         update.status = UpdateStatus.pending
         update.release.composed_by_bodhi = False
         update.builds[0].signed = False
+        update.pushed = False
 
         self.db.commit()
         with mock.patch('bodhi.server.models.util.greenwave_api_post') as mock_greenwave:
@@ -196,4 +197,5 @@ class TestSignedHandlerConsume(base.BasePyTestCase):
         assert update.builds[0].signed is True
         assert update.builds[0].update.request is None
         assert update.status == UpdateStatus.testing
+        assert update.pushed is True
         assert update.test_gating_status == TestGatingStatus.passed

--- a/news/3625.bug
+++ b/news/3625.bug
@@ -1,0 +1,1 @@
+Added build.update.pushed = True for the signed consumer so that it can be unpushed.


### PR DESCRIPTION
Added build.update.pushed = True for the signed consumer so that it can be unpushed. See https://github.com/fedora-infra/bodhi/issues/3625

Signed-off-by: Stephen Coady <scoady@redhat.com>