### PR TITLE
Change the message sent when an update is ready to be tested

### DIFF
--- a/bodhi/server/services/updates.py
+++ b/bodhi/server/services/updates.py
@@ -712,7 +712,7 @@ def trigger_tests(request):
         request.errors.add('body', 'request', 'Update is not in testing status')
     else:
         message = update_schemas.UpdateReadyForTestingV1.from_dict(
-            message={'update': update, 'agent': 'bodhi', 're-trigger': True}
+            message=update._build_group_test_message()
         )
         notifications.publish(message)
 

--- a/bodhi/tests/messages/schemas/test_update.py
+++ b/bodhi/tests/messages/schemas/test_update.py
@@ -166,9 +166,9 @@ class UpdateMessageTests(unittest.TestCase):
 
     def test_ready_for_testing_v1(self):
         expected = {
-            "topic": "bodhi.update.status.testing",
+            "topic": "bodhi.update.status.testing.koji-build-group.build.complete",
             "summary": (
-                "eclipseo's golang-github-SAP-go-hdb-0.14.1-1.fc29 t… bodhi update "
+                "BaseOS CI's libselinux-2.8-6.fc29.x86_64 libsepol-2.… bodhi update "
                 "is ready for testing"
             ),
             "app_icon": "https://apps.fedoraproject.org/img/icons/bodhi.png",
@@ -178,27 +178,43 @@ class UpdateMessageTests(unittest.TestCase):
                 "20652954adacfd9f6e26536bbcf3b5fbc850dc61f8a2e67c5bfbc6e345032976"
                 "?s=64&d=retro"
             ),
-            "usernames": ["eclipseo", 'mohanboddu'],
-            "packages": ["golang-github-SAP-go-hdb", 'texworks'],
-            'update': UpdateV1(
-                'FEDORA-2019-d64d0caab3',
-                [BuildV1('golang-github-SAP-go-hdb-0.14.1-1.fc29'),
-                 BuildV1('texworks-0.6.3-1.fc29')],
-                UserV1('eclipseo'), 'testing', None, ReleaseV1('F29'))
+            "usernames": ["mohanboddu", "plautrba"],
+            "packages": ["libselinux", "libsepol"],
         }
         msg = UpdateReadyForTestingV1(
             body={
-                "update": {
-                    "alias": "FEDORA-2019-d64d0caab3",
-                    "builds": [{"nvr": "golang-github-SAP-go-hdb-0.14.1-1.fc29"},
-                               {'nvr': 'texworks-0.6.3-1.fc29'}],
-                    "title": "fedmsg-0.2.7-2.el6",
-                    'release': {"name": "F29"},
-                    'request': None,
-                    "status": "testing",
-                    "user": {"name": "eclipseo"}
+                "contact": {
+                    "name": "BaseOS CI",
+                    "team": "BaseOS",
+                    "url": "https://somewhere.com",
+                    "docs": "https://somewhere.com/user-documentation",
+                    "irc": "#baseosci",
+                    "email": "baseos-ci@somewhere.com"
                 },
-                'agent': 'mohanboddu'
+                "artifact": {
+                    "type": "rpm-build-group",
+                    "id": "FEDORA-2019-d64d0caab3",
+                    "repository": "https://bodhi.fp.o/updates/FEDORA-2019-d64d0caab3",
+                    "builds":
+                        [{
+                            "type": "koji-build",
+                            "id": 14546276,
+                            "issuer": "plautrba",
+                            "component": "libselinux",
+                            "nvr": "libselinux-2.8-6.fc29.x86_64",
+                            "scratch": False,
+                        }, {
+                            "type": "koji-build",
+                            "id": 14546277,
+                            "issuer": "plautrba",
+                            "component": "libsepol",
+                            "nvr": "libsepol-2.8-3.fc29.x86_64",
+                            "scratch": False,
+                        }]
+                },
+                "generated_at": "2019-10-22 13:08:10.222602",
+                "version": "0.2.2",
+                "agent": "mohanboddu",
             }
         )
         check_message(msg, expected)

--- a/bodhi/tests/server/services/test_schemas.py
+++ b/bodhi/tests/server/services/test_schemas.py
@@ -62,8 +62,8 @@ class TestMessageSchemasV1CollectionGet(base.BaseTestCase):
                 'bodhi.compose.sync.done', 'bodhi.compose.sync.wait',
                 'bodhi.errata.publish', 'bodhi.repo.done', 'bodhi.update.comment',
                 'bodhi.update.complete.stable', 'bodhi.update.complete.testing',
-                'bodhi.update.status.testing', 'bodhi.update.karma.threshold.reach',
-                'bodhi.update.edit', 'bodhi.update.eject',
+                'bodhi.update.status.testing.koji-build-group.build.complete',
+                'bodhi.update.karma.threshold.reach', 'bodhi.update.edit', 'bodhi.update.eject',
                 'bodhi.update.request.obsolete', 'bodhi.update.request.revoke',
                 'bodhi.update.request.stable', 'bodhi.update.request.testing',
                 'bodhi.update.request.unpush', 'bodhi.update.requirements_met.stable']))

--- a/bodhi/tests/server/test_models.py
+++ b/bodhi/tests/server/test_models.py
@@ -4044,7 +4044,7 @@ class TestUpdate(ModelTest):
         package = model.Package(name='testmodule',
                                 type=model.ContentType.module)
         self.db.add(package)
-        build = model.ModuleBuild(nvr='testmodule-master-2',
+        build = model.ModuleBuild(nvr='testmodule-master-2.fc18',
                                   release=release, signed=True,
                                   package=package)
         self.db.add(build)
@@ -4093,11 +4093,11 @@ class TestUpdate(ModelTest):
         package = model.Package(name='testmodule',
                                 type=model.ContentType.module)
         self.db.add(package)
-        build1 = model.ModuleBuild(nvr='testmodule-master-1',
+        build1 = model.ModuleBuild(nvr='testmodule-master-1.fc18',
                                    release=release, signed=True,
                                    package=package)
         self.db.add(build1)
-        build2 = model.ModuleBuild(nvr='testmodule-master-2',
+        build2 = model.ModuleBuild(nvr='testmodule-master-2.fc18',
                                    release=release, signed=True,
                                    package=package)
         self.db.add(build2)
@@ -4302,10 +4302,10 @@ class TestUpdate(ModelTest):
             self.obj.status = UpdateStatus.testing
             msg = self.db.info['messages'][0]
             self.db.commit()
-        assert msg.body["update"]["status"] == "testing"
-        assert msg.body["update"]["release"]["name"] == "F11"
-        version_hash = "1202d60656e76b6882b1e9dcaeca8d8563c10797"
-        assert msg.body["update"]["version_hash"] == version_hash
+        assert msg.body["artifact"]["builds"][0]["component"] == "TurboGears"
+        assert msg.body["artifact"]["id"].startswith("FEDORA-")
+        assert msg.body["artifact"]["type"] == "rpm-build-group"
+        assert msg.packages == ['TurboGears']
 
     def test_create_with_status_testing(self):
         """Test that creating an update with the status set to testing sends a message."""
@@ -4318,10 +4318,10 @@ class TestUpdate(ModelTest):
             assert len(self.db.info['messages']) == 1
             msg = self.db.info['messages'][0]
             self.db.commit()
-        assert msg.body["update"]["status"] == "testing"
-        assert msg.body["update"]["release"]["name"] == "F11"
-        version_hash = "2432c3a8561de717e916cf551f855af422447615"
-        assert msg.body["update"]["version_hash"] == version_hash
+        assert msg.body["artifact"]["builds"][0]["component"] == "TurboGears"
+        assert msg.body["artifact"]["id"].startswith("FEDORA-")
+        assert msg.body["artifact"]["type"] == "rpm-build-group"
+        assert msg.packages == ['TurboGears']
 
 
 class TestUser(ModelTest):


### PR DESCRIPTION
This commit changes the content of the message sent when an update is
ready to be tested by a CI system to match the schema already used by
the Fedora CI system.

More information about the request can be found at:
https://pagure.io/fedora-ci/general/issue/70

Signed-off-by: Pierre-Yves Chibon <pingou@pingoured.fr>