### PR TITLE
Migrate messages/schemas/ tests to PyTest

### DIFF
--- a/bodhi/tests/messages/schemas/test_base.py
+++ b/bodhi/tests/messages/schemas/test_base.py
@@ -18,20 +18,18 @@
 """This test module contains tests for bodhi.messages.schemas.base."""
 
 import json
-import unittest
+
+import pytest
 
 from bodhi.messages.schemas import base
 
 
-class FedMsgEncoderTests(unittest.TestCase):
+class TestFedMsgEncoder:
     """Tests for the custom JSON encode ``FedMsgEncoder``."""
 
     def test_default(self):
         """Assert normal types are encoded the same way as the default encoder."""
-        self.assertEqual(
-            json.dumps('a string'),
-            json.dumps('a string', cls=base.FedMsgEncoder)
-        )
+        assert json.dumps('a string') == json.dumps('a string', cls=base.FedMsgEncoder)
 
     def test_default_obj_with_json(self):
         """Assert classes with a ``__json__`` function encode as the return of ``__json__``."""
@@ -40,15 +38,9 @@ class FedMsgEncoderTests(unittest.TestCase):
             def __json__(self):
                 return {'my': 'json'}
 
-        self.assertEqual(
-            {'my': 'json'},
-            base.FedMsgEncoder().default(JsonClass())
-        )
+        assert {'my': 'json'} == base.FedMsgEncoder().default(JsonClass())
 
     def test_default_other(self):
         """Fallback to the superclasses' default."""
-        self.assertRaises(
-            TypeError,
-            base.FedMsgEncoder().default,
-            object()
-        )
+        with pytest.raises(TypeError):
+            base.FedMsgEncoder().default(object())

--- a/bodhi/tests/messages/schemas/test_buildroot_override.py
+++ b/bodhi/tests/messages/schemas/test_buildroot_override.py
@@ -15,15 +15,13 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 """Unit tests for the buildroot_override message schemas."""
 
-import unittest
-
 from bodhi.messages.schemas import base
 from bodhi.messages.schemas.buildroot_override import (BuildrootOverrideTagV1,
                                                        BuildrootOverrideUntagV1)
 from bodhi.tests.messages.utils import check_message
 
 
-class BuildrootOverrideMessageTests(unittest.TestCase):
+class TestBuildrootOverrideMessage:
     """A set of unit tests for classes in :py:mod:`bodhi_messages.schemas.buildroot_override`"""
 
     def test_tag_v1(self):

--- a/bodhi/tests/messages/schemas/test_compose.py
+++ b/bodhi/tests/messages/schemas/test_compose.py
@@ -15,7 +15,6 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 """Unit tests for the compose message schemas."""
 
-import unittest
 
 from bodhi.messages.schemas.compose import (
     ComposeComposingV1,
@@ -28,7 +27,7 @@ from bodhi.messages.schemas.compose import (
 from bodhi.tests.messages.utils import check_message
 
 
-class ComposeMessageTests(unittest.TestCase):
+class TestComposeMessage:
     """A set of unit tests for classes in :py:mod:`bodhi_messages.schemas.compose`"""
 
     def test_composing_v1(self):

--- a/bodhi/tests/messages/schemas/test_errata.py
+++ b/bodhi/tests/messages/schemas/test_errata.py
@@ -15,13 +15,12 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 """Unit tests for the errata message schemas."""
 
-import unittest
 
 from bodhi.messages.schemas.errata import BuildV1, ErrataPublishV1, ReleaseV1, UpdateV1, UserV1
 from bodhi.tests.messages.utils import check_message
 
 
-class ErrataMessageTests(unittest.TestCase):
+class TestErrataMessage:
     """A set of unit tests for classes in :py:mod:`bodhi_messages.schemas.errata`"""
 
     def test_publish_v1(self):


### PR DESCRIPTION
Migrate the following 4 files to PyTest:

* Migrate messages/schemas/test_buildroot_override.py to PyTest  (Fixes #3602)
* Migrate messages/schemas/test_base.py to PyTest  (Fixes: #3604)
* Migrate messages/schemas/test_errata.py to PyTest  (Fixes: #3607)
* Migrate messages/schemas/test_compose.py to PyTest  (Fixes: #3603)