### PR TITLE
Migrate server/test__init__.py to PyTest

### DIFF
--- a/bodhi/tests/server/test___init__.py
+++ b/bodhi/tests/server/test___init__.py
@@ -18,7 +18,6 @@
 """This test suite contains tests for bodhi.server.__init__."""
 from unittest import mock
 import collections
-import unittest
 
 from pyramid import authentication, authorization, testing
 import munch
@@ -30,7 +29,7 @@ from bodhi.server.views import generic
 from bodhi.tests.server import base
 
 
-class TestExceptionFilter(unittest.TestCase):
+class TestExceptionFilter:
     """Test the exception_filter() function."""
     @mock.patch('bodhi.server.log.exception')
     def test_exception(self, exception):
@@ -40,7 +39,7 @@ class TestExceptionFilter(unittest.TestCase):
         # The second argument is not used.
         response = server.exception_filter(request_response, None)
 
-        self.assertIs(response, request_response)
+        assert response == request_response
         exception.assert_called_once_with(
             "Unhandled exception raised:  {}".format(repr(request_response)))
 
@@ -52,23 +51,23 @@ class TestExceptionFilter(unittest.TestCase):
         # The second argument is not used.
         response = server.exception_filter(request_response, None)
 
-        self.assertIs(response, request_response)
-        self.assertEqual(exception.call_count, 0)
+        assert response == request_response
+        assert exception.call_count == 0
 
 
-class TestGetBuildinfo(unittest.TestCase):
+class TestGetBuildinfo:
     """Test get_buildinfo()."""
     def test_get_buildinfo(self):
         """get_buildinfo() should return an empty defaultdict."""
         # The argument isn't used, so we'll just pass None.
         bi = server.get_buildinfo(None)
 
-        self.assertTrue(isinstance(bi, collections.defaultdict))
-        self.assertEqual(bi, {})
-        self.assertEqual(bi['made_up_key'], {})
+        assert isinstance(bi, collections.defaultdict)
+        assert bi == {}
+        assert bi['made_up_key'] == {}
 
 
-class TestGetCacheregion(unittest.TestCase):
+class TestGetCacheregion:
     """Test get_cacheregion()."""
     @mock.patch.dict('bodhi.server.bodhi_config', {'some': 'config'}, clear=True)
     @mock.patch('bodhi.server.make_region')
@@ -78,11 +77,11 @@ class TestGetCacheregion(unittest.TestCase):
         region = server.get_cacheregion(None)
 
         make_region.assert_called_once_with()
-        self.assertEqual(region, make_region.return_value)
+        assert region is make_region.return_value
         region.configure_from_config.assert_called_once_with({'some': 'config'}, 'dogpile.cache.')
 
 
-class TestGetKoji(unittest.TestCase):
+class TestGetKoji:
     """Test get_koji()."""
     @mock.patch('bodhi.server.buildsys.get_session')
     def test_get_koji(self, get_session):
@@ -90,10 +89,10 @@ class TestGetKoji(unittest.TestCase):
         # The argument is not used, so set it to None.
         k = server.get_koji(None)
 
-        self.assertIs(k, get_session.return_value)
+        assert k is get_session.return_value
 
 
-class TestGetReleases(base.BaseTestCase):
+class TestGetReleases(base.BasePyTestCase):
     """Test the get_releases() function."""
     def test_get_releases(self):
         """Assert correct return value from get_releases()."""
@@ -101,10 +100,10 @@ class TestGetReleases(base.BaseTestCase):
 
         releases = server.get_releases(request)
 
-        self.assertEqual(releases, models.Release.all_releases())
+        assert releases == models.Release.all_releases()
 
 
-class TestGetUser(base.BaseTestCase):
+class TestGetUser(base.BasePyTestCase):
     """Test get_user()."""
     def test_authenticated(self):
         """Assert that a munch gets returned for an authenticated user."""
@@ -125,9 +124,9 @@ class TestGetUser(base.BaseTestCase):
 
         user = server.get_user(Request())
 
-        self.assertEqual(user['groups'], [{'name': 'packager'}])
-        self.assertEqual(user['name'], 'guest')
-        self.assertTrue(isinstance(user, munch.Munch))
+        assert user['groups'] == [{'name': 'packager'}]
+        assert user['name'] == 'guest'
+        assert isinstance(user, munch.Munch)
 
     def test_unauthenticated(self):
         """Assert that None gets returned for an unauthenticated user."""
@@ -146,10 +145,10 @@ class TestGetUser(base.BaseTestCase):
 
         user = server.get_user(Request())
 
-        self.assertIsNone(user)
+        assert user is None
 
 
-class TestGroupfinder(base.BaseTestCase):
+class TestGroupfinder(base.BasePyTestCase):
     """Test the groupfinder() function."""
 
     def test_no_user(self):
@@ -160,17 +159,17 @@ class TestGroupfinder(base.BaseTestCase):
         # The first argument isn't used, so just set it to None.
         groups = server.groupfinder(None, request)
 
-        self.assertEqual(groups, ['group:packager'])
+        assert groups == ['group:packager']
 
     def test_user(self):
         """Test with a user."""
         request = testing.DummyRequest(user=None)
 
         # The first argument isn't used, so just set it to None.
-        self.assertIsNone(server.groupfinder(None, request))
+        assert server.groupfinder(None, request) is None
 
 
-class TestMain(base.BaseTestCase):
+class TestMain(base.BasePyTestCase):
     """
     Assert correct behavior from the main() function.
     """
@@ -184,17 +183,17 @@ class TestMain(base.BaseTestCase):
             server.main({}, **self.app_settings)
 
         policy = set_authentication_policy.mock_calls[0][1][0]
-        self.assertTrue(isinstance(policy, authentication.AuthTktAuthenticationPolicy))
-        self.assertEqual(policy.callback, server.groupfinder)
-        self.assertEqual(policy.cookie.hashalg, 'sha512')
-        self.assertEqual(policy.cookie.max_age, 10)
-        self.assertEqual(policy.cookie.secure, True)
-        self.assertEqual(policy.cookie.secret, 'hunter2')
-        self.assertEqual(policy.cookie.timeout, 10)
+        assert isinstance(policy, authentication.AuthTktAuthenticationPolicy)
+        assert policy.callback == server.groupfinder
+        assert policy.cookie.hashalg == 'sha512'
+        assert policy.cookie.max_age == 10
+        assert policy.cookie.secure == True
+        assert policy.cookie.secret == 'hunter2'
+        assert policy.cookie.timeout == 10
         set_authentication_policy.assert_called_once_with(policy)
         # Ensure that the ACLAuthorizationPolicy was used
         policy = set_authorization_policy.mock_calls[0][1][0]
-        self.assertTrue(isinstance(policy, authorization.ACLAuthorizationPolicy))
+        assert isinstance(policy, authorization.ACLAuthorizationPolicy)
         set_authorization_policy.assert_called_once_with(policy)
 
     @mock.patch('bodhi.server.Configurator.set_authentication_policy')
@@ -206,17 +205,17 @@ class TestMain(base.BaseTestCase):
             server.main({}, **self.app_settings)
 
         policy = set_authentication_policy.mock_calls[0][1][0]
-        self.assertTrue(isinstance(policy, authentication.AuthTktAuthenticationPolicy))
-        self.assertEqual(policy.callback, server.groupfinder)
-        self.assertEqual(policy.cookie.hashalg, 'sha512')
-        self.assertEqual(policy.cookie.max_age, 86400)
-        self.assertEqual(policy.cookie.secure, True)
-        self.assertEqual(policy.cookie.secret, 'hunter2')
-        self.assertEqual(policy.cookie.timeout, 86400)
+        assert isinstance(policy, authentication.AuthTktAuthenticationPolicy)
+        assert policy.callback == server.groupfinder
+        assert policy.cookie.hashalg == 'sha512'
+        assert policy.cookie.max_age == 86400
+        assert policy.cookie.secure == True
+        assert policy.cookie.secret == 'hunter2'
+        assert policy.cookie.timeout == 86400
         set_authentication_policy.assert_called_once_with(policy)
         # Ensure that the ACLAuthorizationPolicy was used
         policy = set_authorization_policy.mock_calls[0][1][0]
-        self.assertTrue(isinstance(policy, authorization.ACLAuthorizationPolicy))
+        assert isinstance(policy, authorization.ACLAuthorizationPolicy)
         set_authorization_policy.assert_called_once_with(policy)
 
     def test_calls_session_remove(self):
@@ -242,7 +241,7 @@ class TestMain(base.BaseTestCase):
 
         server.main({}, testing='guest', session=self.db, **self.app_settings)
 
-        self.assertEqual(config['test'], 'setting')
+        assert config['test'] == 'setting'
 
     @mock.patch.dict(
         'bodhi.server.config.config',
@@ -253,20 +252,20 @@ class TestMain(base.BaseTestCase):
         _generate_home_page_stats.return_value = 5
         # Let's pull invalidate off of the mock so that main() will decorate it again as a cache.
         del _generate_home_page_stats.invalidate
-        self.assertFalse(hasattr(_generate_home_page_stats, 'invalidate'))
+        assert not hasattr(_generate_home_page_stats, 'invalidate')
 
         server.main({}, testing='guest', session=self.db)
 
         # main() should have given it a cache, which would give it an invalidate attribute.
-        self.assertTrue(hasattr(generic._generate_home_page_stats, 'invalidate'))
-        self.assertEqual(generic._generate_home_page_stats(), 5)
+        assert hasattr(generic._generate_home_page_stats, 'invalidate')
+        assert generic._generate_home_page_stats() == 5
         # Changing the return value of the mock should not affect the return value since it is
         # cached.
         _generate_home_page_stats.return_value = 7
-        self.assertEqual(generic._generate_home_page_stats(), 5)
+        assert generic._generate_home_page_stats() == 5
         # If we invalidate the cache, we should see the new return value.
         generic._generate_home_page_stats.invalidate()
-        self.assertEqual(generic._generate_home_page_stats(), 7)
+        assert generic._generate_home_page_stats() == 7
 
     @mock.patch.dict('bodhi.server.config.config', {'warm_cache_on_start': True})
     def test_warms_up_releases_cache(self):
@@ -277,4 +276,4 @@ class TestMain(base.BaseTestCase):
         server.main({}, testing='guest', session=self.db)
 
         # The cache should have a release in it now - let's just spot check it
-        self.assertEqual(models.Release._all_releases['current'][0]['name'], 'F17')
+        assert models.Release._all_releases['current'][0]['name'] == 'F17'


### PR DESCRIPTION
Removes unittest.TestCase dependency

Fixes #3591

Signed-off-by: Michal Konečný <mkonecny@redhat.com>