### PR TITLE
Add and Remove the pending signing tag for a rawhide single build upd…

### DIFF
--- a/bodhi/server/consumers/automatic_updates.py
+++ b/bodhi/server/consumers/automatic_updates.py
@@ -169,6 +169,8 @@ class AutomaticUpdateHandler:
                 author="bodhi",
             )
 
+            update.add_tag(update.release.pending_signing_tag)
+
             log.debug("Adding new update to the database.")
             dbsession.add(update)
 

--- a/bodhi/server/scripts/approve_testing.py
+++ b/bodhi/server/scripts/approve_testing.py
@@ -163,6 +163,7 @@ def main(argv=sys.argv):
                             # Single build update
                             update.remove_tag(update.release.pending_testing_tag)
                             update.remove_tag(update.release.pending_stable_tag)
+                            update.remove_tag(update.release.pending_signing_tag)
 
                 db.commit()
 

--- a/bodhi/tests/server/__init__.py
+++ b/bodhi/tests/server/__init__.py
@@ -101,7 +101,7 @@ def populate(db):
         dist_tag='f17', stable_tag='f17-updates',
         testing_tag='f17-updates-testing',
         candidate_tag='f17-updates-candidate',
-        pending_signing_tag='f17-updates-testing-signing',
+        pending_signing_tag='f17-updates-signing-pending',
         pending_testing_tag='f17-updates-testing-pending',
         pending_stable_tag='f17-updates-pending',
         override_tag='f17-override',

--- a/bodhi/tests/server/scripts/test_approve_testing.py
+++ b/bodhi/tests/server/scripts/test_approve_testing.py
@@ -728,7 +728,8 @@ class TestMain(BasePyTestCase):
             # to stable directly, it adds f17-updates (the stable tag) then
             # removes f17-updates-testing-pending and f17-updates-pending
             assert remove_tag.call_args_list == \
-                [call('f17-updates-testing-pending'), call('f17-updates-pending')]
+                [call('f17-updates-testing-pending'), call('f17-updates-pending'),
+                 call('f17-updates-signing-pending')]
 
             assert add_tag.call_args_list == \
                 [call('f17-updates')]

--- a/bodhi/tests/server/scripts/test_untag_branched.py
+++ b/bodhi/tests/server/scripts/test_untag_branched.py
@@ -110,7 +110,7 @@ class TestMain(BaseTestCase):
         update.date_stable = datetime.utcnow() - timedelta(days=2)
         update.status = models.UpdateStatus.stable
         # The pending_signing tag is present so it should be removed.
-        koji.listTags.return_value = [{'name': 'f17-updates-testing-signing'}, {'name': 'f17'}]
+        koji.listTags.return_value = [{'name': 'f17-updates-signing-pending'}, {'name': 'f17'}]
         self.db.flush()
 
         untag_branched.main(['untag_branched', 'some_config_path'])
@@ -119,7 +119,7 @@ class TestMain(BaseTestCase):
         initialize_db.assert_called_once_with({'some': 'settings'})
         get_appsettings.assert_called_once_with('some_config_path')
         # Nothing should have been untagged
-        koji.untagBuild.assert_called_once_with('f17-updates-testing-signing', 'bodhi-2.0-1.fc17')
+        koji.untagBuild.assert_called_once_with('f17-updates-signing-pending', 'bodhi-2.0-1.fc17')
         # An error should have been logged about the stable tag missing
         self.assertEqual(log.error.call_count, 0)
         # The Release name should have been logged and a message should have been logged about
@@ -127,7 +127,7 @@ class TestMain(BaseTestCase):
         self.assertEqual(
             log.info.mock_calls,
             [call(release.name),
-             call('Removing f17-updates-testing-signing from bodhi-2.0-1.fc17')])
+             call('Removing f17-updates-signing-pending from bodhi-2.0-1.fc17')])
         koji.listTags.assert_called_once_with('bodhi-2.0-1.fc17')
 
     @patch('bodhi.server.models.buildsys.get_session')
@@ -183,7 +183,7 @@ class TestMain(BaseTestCase):
         update.status = models.UpdateStatus.stable
         # Since the stable tag is not present, none of these should be removed.
         koji.listTags.return_value = [
-            {'name': 'f17-updates-testing'}, {'name': 'f17-updates-testing-signing'},
+            {'name': 'f17-updates-testing'}, {'name': 'f17-updates-signing-pending'},
             {'name': 'f17-updates-testing-pending'}]
         self.db.flush()
 
@@ -197,7 +197,7 @@ class TestMain(BaseTestCase):
         # An error should have been logged about the stable tag missing
         log.error.assert_called_once_with(
             ("bodhi-2.0-1.fc17 not tagged as stable ['f17-updates-testing', "
-             "'f17-updates-testing-signing', 'f17-updates-testing-pending']"))
+             "'f17-updates-signing-pending', 'f17-updates-testing-pending']"))
         # The Release name should have been logged
         log.info.assert_called_once_with(release.name)
         koji.listTags.assert_called_once_with('bodhi-2.0-1.fc17')

--- a/bodhi/tests/server/test_push.py
+++ b/bodhi/tests/server/test_push.py
@@ -662,7 +662,7 @@ class TestPush(base.BaseTestCase):
                         return_value=base.TransactionalSessionMaker(self.Session)):
             # Note: this IS the signing-pending tag
             with mock.patch('bodhi.server.buildsys.DevBuildsys.listTags',
-                            return_value=[{'name': 'f17-updates-testing-signing'}]):
+                            return_value=[{'name': 'f17-updates-signing-pending'}]):
                 with mock.patch('bodhi.server.push.compose_task') as compose_task:
                     result = cli.invoke(push.push, ['--username', 'bowlofeggs'], input='y')
                     compose_task.delay.assert_not_called()
@@ -1090,7 +1090,7 @@ class TestPush(base.BaseTestCase):
                         return_value=base.TransactionalSessionMaker(self.Session)):
             # Note: this IS the signing-pending tag
             with mock.patch('bodhi.server.buildsys.DevBuildsys.listTags',
-                            return_value=[{'name': 'f17-updates-testing-signing'}]):
+                            return_value=[{'name': 'f17-updates-signing-pending'}]):
                 with mock.patch('bodhi.server.push.compose_task') as compose_task:
                     result = cli.invoke(push.push, ['--username', 'bowlofeggs'],
                                         input='y')


### PR DESCRIPTION
…ate.

Now that we are using the pending status for single build update
we need to use the pending signing tag for robosignatory.

This commit also update the tests to use a more realistic tag name.

Signed-off-by: Clement Verna <cverna@tutanota.com>