### PR TITLE
Add side tag to update view

### DIFF
--- a/bodhi/server/templates/update.html
+++ b/bodhi/server/templates/update.html
@@ -414,7 +414,11 @@ if can_edit:
               % endif
               <div class="mt-3">
                   <div class="h5 d-flex align-items-center font-weight-bold border-bottom">
-                      <div class="py-2 text-uppercase font-size-09">Builds</div> <span class="badge badge-secondary badge-pill ml-auto">${len(update.builds)}</span>
+                      <div class="py-2 text-uppercase font-size-09">Builds</div>
+                       <span class="badge badge-secondary badge-pill ml-1">${len(update.builds)}</span>
+                      % if request.user and update.from_tag:
+                      <span class="badge badge-light badge-pill ml-auto border" title="Builds from the Side Tag: ${update.from_tag}" data-toggle="tooltip"><i class="fa fa-tag pr-1"></i> ${update.from_tag}</span>
+                      % endif
                   </div>
 
               % for build in update.builds:

--- a/bodhi/tests/server/services/test_updates.py
+++ b/bodhi/tests/server/services/test_updates.py
@@ -330,6 +330,10 @@ class TestNewUpdate(BaseTestCase):
         self.assertEqual(up['requirements'], 'rpmlint')
         self.assertEqual(up['from_tag'], 'f17-build-side-7777')
 
+        # check that the sidetag gets displayed on the update page
+        resp = self.app.get(f"/updates/{up['alias']}", headers={'Accept': 'text/html'})
+        assert 'title="Builds from the Side Tag: f17-build-side-7777' in resp
+
         koji_session = buildsys.get_session()
         expected_pending_signing = ('f17-build-side-7777-signing-pending',
                                     {'parent': 'f17-build-side-7777',


### PR DESCRIPTION
If an update is from a side-tag (i.e. update.from_tag has something in
it), then we show the side tag at the top of the Builds section on the
right side of the Update page.
Fixes #3642

![Screenshot from 2019-10-28 17-28-42](https://user-images.githubusercontent.com/592259/67659606-78eb0180-f9a8-11e9-865d-61f074a5e742.png)

