### PR TITLE
Do not request testing status for side tag updates.

### DIFF
--- a/bodhi/server/models.py
+++ b/bodhi/server/models.py
@@ -2256,8 +2256,9 @@ class Update(Base):
                                f"release value of {up.mandatory_days_in_testing} days"
             })
 
-        log.debug("Setting request for new update.")
-        up.set_request(db, req, request.user.name)
+        if not data.get("from_tag"):
+            log.debug("Setting request for new update.")
+            up.set_request(db, req, request.user.name)
 
         log.debug("Adding new update to the db.")
         db.add(up)
@@ -2402,7 +2403,7 @@ class Update(Base):
         del(data['bugs'])
 
         req = data.pop("request", None)
-        if req is not None:
+        if req is not None and not data.get("from_tag"):
             up.set_request(db, req, request.user.name)
 
         for key, value in data.items():

--- a/bodhi/tests/server/services/test_updates.py
+++ b/bodhi/tests/server/services/test_updates.py
@@ -302,15 +302,14 @@ class TestNewUpdate(BaseTestCase):
         self.db.commit()
 
         update = self.get_update(builds=None, from_tag='f17-build-side-7777')
-        with fml_testing.mock_sends(update_schemas.UpdateRequestTestingV1), mock.patch(
-                'bodhi.server.buildsys.DevBuildsys.getTag', self.mock_getTag):
+        with mock.patch('bodhi.server.buildsys.DevBuildsys.getTag', self.mock_getTag):
             r = self.app.post_json('/updates/', update)
 
         up = r.json_body
         self.assertEqual(up['title'], 'gnome-backgrounds-3.0-1.fc17')
         self.assertEqual(up['builds'][0]['nvr'], 'gnome-backgrounds-3.0-1.fc17')
         self.assertEqual(up['status'], 'pending')
-        self.assertEqual(up['request'], 'testing')
+        self.assertEqual(up['request'], None)
         self.assertEqual(up['user']['name'], 'guest')
         self.assertEqual(up['release']['name'], 'F17')
         self.assertEqual(up['type'], 'bugfix')
@@ -350,7 +349,6 @@ class TestNewUpdate(BaseTestCase):
                              'arches': None,
                              'maven_include_all': False,
                              'perm_id': 1})
-
         self.assertIn(expected_pending_signing, koji_session.__tags__)
         self.assertIn(expected_testing, koji_session.__tags__)
         self.assertIn(('f17-build-side-7777-signing-pending',
@@ -3017,8 +3015,7 @@ class TestUpdatesService(BaseTestCase):
         self.db.delete(BuildrootOverride.query.one())
 
         update = self.get_update(from_tag='f17-build-side-7777')
-        with fml_testing.mock_sends(update_schemas.UpdateRequestTestingV1):
-            r = self.app.post_json('/updates/', update)
+        r = self.app.post_json('/updates/', update)
 
         update['edited'] = r.json['alias']
         update['builds'] = 'bodhi-2.0.0-3.fc17'
@@ -3030,7 +3027,7 @@ class TestUpdatesService(BaseTestCase):
         up = r.json_body
         self.assertEqual(up['title'], 'bodhi-2.0.0-3.fc17')
         self.assertEqual(up['status'], 'pending')
-        self.assertEqual(up['request'], 'testing')
+        self.assertEqual(up['request'], None)
         self.assertEqual(up['user']['name'], 'guest')
         self.assertEqual(up['release']['name'], 'F17')
         self.assertEqual(up['type'], 'bugfix')


### PR DESCRIPTION
If an update is created/edited with a side tag let's not request the testing status
since the request automatically tag the builds in the fxx-updates-testing-pending tag
instead of the dedicated testing-pending side tag.

Signed-off-by: Clement Verna <cverna@tutanota.com>

#Fixes #3656.