### PR TITLE
Make sure to remove the candidate tag for rawhide updates.

### DIFF
--- a/bodhi/server/scripts/approve_testing.py
+++ b/bodhi/server/scripts/approve_testing.py
@@ -164,6 +164,7 @@ def main(argv=sys.argv):
                             update.remove_tag(update.release.pending_testing_tag)
                             update.remove_tag(update.release.pending_stable_tag)
                             update.remove_tag(update.release.pending_signing_tag)
+                            update.remove_tag(update.release.candidate_tag)
 
                 db.commit()
 

--- a/bodhi/tests/server/scripts/test_approve_testing.py
+++ b/bodhi/tests/server/scripts/test_approve_testing.py
@@ -729,7 +729,7 @@ class TestMain(BasePyTestCase):
             # removes f17-updates-testing-pending and f17-updates-pending
             assert remove_tag.call_args_list == \
                 [call('f17-updates-testing-pending'), call('f17-updates-pending'),
-                 call('f17-updates-signing-pending')]
+                 call('f17-updates-signing-pending'), call('f17-updates-candidate')]
 
             assert add_tag.call_args_list == \
                 [call('f17-updates')]


### PR DESCRIPTION
This commit makes sure that we remove the candidate tag of a rawhide
update when it is pushed to stable.

Signed-off-by: Clement Verna <cverna@tutanota.com>