### PR TITLE
remove unneeded z-index:999 from masthead

### DIFF
--- a/bodhi/server/static/css/site.css
+++ b/bodhi/server/static/css/site.css
@@ -405,7 +405,6 @@ padding-bottom: 2em;
 .masthead{
     border-bottom: 1px solid #ccc;
     box-shadow: 0 0 10px 2px #ddd;
-    z-index: 999;
     position: relative;
 }
 


### PR DESCRIPTION
Remove the z-index:999 rule from the masthead element in site.css that
was causing the search results to be partially hidden.

Fixes: #3652
Signed-off-by: Ryan Lerch <rlerch@redhat.com>