### PR TITLE
newupdateform: dont show candidate builds already in updates

### DIFF
--- a/bodhi/server/static/js/update_form.js
+++ b/bodhi/server/static/js/update_form.js
@@ -200,7 +200,7 @@ $(document).ready(function() {
                     $builds_search_selectize.disable()
                 }
                 $.ajax({
-                    url: '/latest_candidates?prefix=' + encodeURIComponent(query),
+                    url: '/latest_candidates?hide_existing=true&prefix=' + encodeURIComponent(query),
                     type: 'GET',
                     error: function() {
                         messenger.post({


### PR DESCRIPTION
previously the builds chooser in the new update form showed builds
that were already in updates. if a user chose one of these builds, the
form validation would fail. this filters out these builds so the user
can't be set up to fail.

Fixes: #3649

Signed-off-by: Ryan Lerch <rlerch@redhat.com>