### PR TITLE
Tell Docker to ignore the build and dist directories

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,6 +2,8 @@
 **/__pycache__
 *.egg-info
 .git
+build
+dist
 devel/ci/integration/dumps/*
 docs/_build
 docs/developer/docblocks


### PR DESCRIPTION
I've had an error in local integration tests where an old file was deployed in the container because it was still in the python `build` dir.