### PR TITLE
Do not double enquote the update title

### DIFF
--- a/bodhi/server/models.py
+++ b/bodhi/server/models.py
@@ -2672,8 +2672,8 @@ class Update(Base):
 
             "package1, package, 2 and XXX more"
 
-        If the "amp" parameter is specified it will replace the and with and
-        &amp; html entity
+        If the "amp" parameter is specified it will replace the "and" with an
+        "&" entity.
 
         If the "nvr" parameter is specified it will include name, version and
         release information in package labels.
@@ -2688,7 +2688,7 @@ class Update(Base):
             title = ", ".join([build_label(build) for build in self.builds[:2]])
 
             if amp:
-                title += ", &amp; "
+                title += ", & "
             else:
                 title += ", and "
             title += str(len(self.builds) - 2)

--- a/devel/ci/integration/ipsilon/Dockerfile
+++ b/devel/ci/integration/ipsilon/Dockerfile
@@ -1,7 +1,7 @@
 FROM fedora
 RUN curl -o /etc/yum.repos.d/infra-tags.repo https://infrastructure.fedoraproject.org/cgit/ansible.git/plain/files/common/fedora-infra-tags.repo
 RUN dnf install -y ipsilon ipsilon-openid ipsilon-openidc ipsilon-authfas patch
-COPY devel/ci/integration/ipsilon/api.py /usr/lib/python2.7/site-packages/ipsilon/providers/openid/extensions/api.py
+COPY devel/ci/integration/ipsilon/api.py /usr/lib/python3.7/site-packages/ipsilon/providers/openid/extensions/api.py
 RUN ipsilon-server-install --root-instance --secure no --testauth yes --openid yes --fas yes --hostname id.dev.fedoraproject.org --openid-extensions "insecureAPI,Teams,CLAs,Simple Registration"
 RUN sscg --cert-file /etc/pki/tls/certs/localhost.crt --cert-key-file /etc/pki/tls/private/localhost.key
 COPY devel/ci/integration/ipsilon/start.sh /usr/local/bin/start.sh


### PR DESCRIPTION
Basically, if we specify amp=True on update.beautify_title(), it will
replace the & sign with its html quoted version: &amp;
But since we're encoding the output of this function into html again,
the & in &amp; get encoded again resulting in a "&amp;amp;" string which
is not valid html and is breaking the test suite.

Thanks to Nils for getting the idea of what is going on!

Signed-off-by: Pierre-Yves Chibon <pingou@pingoured.fr>