### PR TITLE
Disable the option to request push to testing or stable for rawhide.

### DIFF
--- a/bodhi/server/templates/update.html
+++ b/bodhi/server/templates/update.html
@@ -26,7 +26,7 @@ ${parent.css()}
 
 <%
 actions = {}
-if can_edit:
+if can_edit and update.release.composed_by_bodhi:
   if not update.locked:
     if not update.pushed:
       if update.request is None:


### PR DESCRIPTION
The push to testing and stable in a release that is not composed
by bodhi(rawhide) will happen automatically so let's not
give the option to the user to request a push.

Signed-off-by: Clement Verna <cverna@tutanota.com>