### PR TITLE
fix mismatched tags in greenwave dialog in update.html

### DIFF
--- a/bodhi/server/templates/update.html
+++ b/bodhi/server/templates/update.html
@@ -647,7 +647,6 @@ if can_edit and update.release.composed_by_bodhi:
       <div class="modal-header">
         <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
         <h3 class="modal-title" id="waiveModalLabel">Waive All Test Results</h3>
-        </button>
       </div>
       <div class="modal-body">
           <div class="row">
@@ -668,7 +667,8 @@ if can_edit and update.release.composed_by_bodhi:
         <button type="submit" class="btn btn-primary">Waive</button>
       </div>
     </div>
-    </form>
+  </div>
+  </form>
 </div>
 % endif
 


### PR DESCRIPTION
fixes a couple of mismatched tags in update.html that
was causing some rendering issues when the greenwave dialog
was included on a page.

Fixes: #3676

Signed-off-by: Ryan Lerch <rlerch@redhat.com>