### PR TITLE
work around slow /latest_candidates calls

### DIFF
--- a/bodhi/server/static/js/update_form.js
+++ b/bodhi/server/static/js/update_form.js
@@ -200,7 +200,7 @@ $(document).ready(function() {
                     $builds_search_selectize.disable()
                 }
                 $.ajax({
-                    url: '/latest_candidates?hide_existing=true&prefix=' + encodeURIComponent(query),
+                    url: '/latest_candidates?hide_existing=false&prefix=' + encodeURIComponent(query),
                     type: 'GET',
                     error: function() {
                         messenger.post({


### PR DESCRIPTION
Commit 9d6dffe15b96ab52d010aa49253ff676365f0676 introduces hide_existing
to the /latest_candidates API endpoint but setting it true slows down
initial calls in the form (with empty or short prefixes) unduly. This is
because it queries the database for each build returned by koji which
can be on the order of several thousands.

Set hide_existing=false for the time being, until we have a better
performing way to filter out builds which are related to updates
already.

Signed-off-by: Nils Philippsen <nils@redhat.com>