### PR TITLE
Speed up hide_existing=true when listing candidates

### DIFF
--- a/bodhi/server/static/js/update_form.js
+++ b/bodhi/server/static/js/update_form.js
@@ -200,7 +200,7 @@ $(document).ready(function() {
                     $builds_search_selectize.disable()
                 }
                 $.ajax({
-                    url: '/latest_candidates?hide_existing=false&prefix=' + encodeURIComponent(query),
+                    url: '/latest_candidates?hide_existing=true&prefix=' + encodeURIComponent(query),
                     type: 'GET',
                     error: function() {
                         messenger.post({

--- a/bodhi/server/views/generic.py
+++ b/bodhi/server/views/generic.py
@@ -325,8 +325,14 @@ def latest_candidates(request):
                         'id': build['id'],
                         'package_name': build['package_name'],
                         'owner_name': build['owner_name'],
-                        'release_name': tag_release[build['tag_name']]
                     }
+
+                    # The build's tag might not be present in tag_release
+                    # because its associated release is archived and therefore
+                    # filtered out in the query above.
+                    if build['tag_name'] in tag_release:
+                        item['release_name'] = tag_release[build['tag_name']]
+
                     # Prune duplicates
                     # https://github.com/fedora-infra/bodhi/issues/450
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,7 +15,7 @@ width = 80
 show-source = True
 max-line-length = 100
 exclude = .git,.tox,dist,*egg,build,tools
-ignore = E712,W503
+ignore = E711,E712,W503
 # Configure flake8-import-order
 application-import-names = bodhi
 import-order-style = pep8


### PR DESCRIPTION
Previously, the database was queried for each build returned from koji, which could result in thousands of individual queries.

Instead, query the database once for known builds associated with an update and filter out returned builds found in this set. This set isn't filtered for active releases because a build might be associated with an update for an archived release but still inherited into one of the tags we query Koji for. It performs well enough at the moment but the set can easily be cached if not.

Fixes: #3687

------

This PR also reverts the respective workaround. To test the performance, configure your testing instance to query koji.stg instead of using the mocked instance, e.g. by using `vagrant up --use-staging`  or having something like this in your `development.ini` (substitute your FAS user in `krb_principal`, also you might need to install `krb5-workstation` and acquire a matching ticket in the Vagrant box):

````
[app:main]
buildsystem = koji
koji_hub = https://koji.stg.fedoraproject.org/kojihub
koji_web_url = https://koji.stg.fedoraproject.org/koji/
krb_principal = nphilipp@STG.FEDORAPROJECT.ORG
acl_system = pagure
pagure_url = https://src.stg.fedoraproject.org/
...
````