### PR TITLE
Fix the display_name truncation on update page

### DIFF
--- a/bodhi/server/templates/new_update.html
+++ b/bodhi/server/templates/new_update.html
@@ -50,7 +50,7 @@ ${parent.css()}
             <h6 class="font-weight-bold">Name</h6>
             <input class="typeahead form-control noui" name="display_name" type="text" placeholder="(optional) update name. leave blank and bodhi will use the package names."
 % if update:
-value=${update.display_name | h}
+value="${update.display_name | h}"
 % endif
 >
           </div>


### PR DESCRIPTION
The value of the textbox in new_update.html template was not being set correctly,
resulting in truncated display_name on the html page.

Fixes #3675

Signed-off-by: Adam Saleh <asaleh@redhat.com>