### PR TITLE
Remove unused badge_ids setting from config

### DIFF
--- a/bodhi/server/config.py
+++ b/bodhi/server/config.py
@@ -251,9 +251,6 @@ class BodhiConfig(dict):
             # List of users to not create automatic updates from
             'value': ['releng'],
             'validator': _generate_list_validator()},
-        'badge_ids': {
-            'value': [],
-            'validator': _generate_list_validator('|')},
         'base_address': {
             'value': 'https://admin.fedoraproject.org/updates/',
             'validator': str},

--- a/devel/ci/integration/bodhi/production.ini
+++ b/devel/ci/integration/bodhi/production.ini
@@ -59,8 +59,6 @@ privacy_link = https://fedoraproject.org/wiki/Legal:PrivacyPolicy
 
 # The URL for a datagrepper to use in various templates.
 datagrepper_url = https://apps.fedoraproject.org/datagrepper
-# badge_ids = binary-star|both-bull-and-self-transcended-tester-viii|catching-the-bull-tester-iv|corporate-drone|corporate-overlord|corporate-shill|discovery-of-the-footprints-tester-ii|in-search-of-the-bull-tester-i|is-this-thing-on-updates-testing-i|is-this-thing-on-updates-testing-ii|is-this-thing-on-updates-testing-iii|is-this-thing-on-updates-testing-iv|it-still-works!|like-a-rock-updates-stable-i|like-a-rock-updates-stable-ii|like-a-rock-updates-stable-iii|like-a-rock-updates-stable-iv|mic-check!-updates-testing-v|missed-the-train|override,-you-say|perceiving-the-bull-tester-iii|reaching-the-source-tester-ix|return-to-society-tester-x|riding-the-bull-home-tester-vi|stop-that-update!|take-this-and-call-me-in-the-morning|taming-the-bull-tester-v|tectonic!-updates-stable-v|the-bull-transcended-tester-vii|what-goes-around-comes-around-karma-i|what-goes-around-comes-around-karma-ii|what-goes-around-comes-around-karma-iii|what-goes-around-comes-around-karma-iv|white-hat|you-can-pry-it-from-my-cold,-dead-hands
-
 
 ##
 ## Testing

--- a/devel/development.ini.example
+++ b/devel/development.ini.example
@@ -1,7 +1,6 @@
 # See production.ini for documentation on the settings that can be used in this file.
 [app:main]
 use = egg:bodhi-server
-badge_ids = binary-star|both-bull-and-self-transcended-tester-viii|catching-the-bull-tester-iv|corporate-drone|corporate-overlord|corporate-shill|discovery-of-the-footprints-tester-ii|in-search-of-the-bull-tester-i|is-this-thing-on-updates-testing-i|is-this-thing-on-updates-testing-ii|is-this-thing-on-updates-testing-iii|is-this-thing-on-updates-testing-iv|it-still-works!|like-a-rock-updates-stable-i|like-a-rock-updates-stable-ii|like-a-rock-updates-stable-iii|like-a-rock-updates-stable-iv|mic-check!-updates-testing-v|missed-the-train|override,-you-say|perceiving-the-bull-tester-iii|reaching-the-source-tester-ix|return-to-society-tester-x|riding-the-bull-home-tester-vi|stop-that-update!|take-this-and-call-me-in-the-morning|taming-the-bull-tester-v|tectonic!-updates-stable-v|the-bull-transcended-tester-vii|what-goes-around-comes-around-karma-i|what-goes-around-comes-around-karma-ii|what-goes-around-comes-around-karma-iii|what-goes-around-comes-around-karma-iv|white-hat|you-can-pry-it-from-my-cold,-dead-hands
 base_address = http://localhost:6543/
 fedora_announce_list = package-announce@lists.fedoraproject.org
 fedora_test_announce_list = test@lists.fedoraproject.org

--- a/production.ini
+++ b/production.ini
@@ -54,8 +54,6 @@ use = egg:bodhi-server
 
 
 # The URL for a datagrepper to use in various templates.
-# badge_ids = binary-star|both-bull-and-self-transcended-tester-viii|catching-the-bull-tester-iv|corporate-drone|corporate-overlord|corporate-shill|discovery-of-the-footprints-tester-ii|in-search-of-the-bull-tester-i|is-this-thing-on-updates-testing-i|is-this-thing-on-updates-testing-ii|is-this-thing-on-updates-testing-iii|is-this-thing-on-updates-testing-iv|it-still-works!|like-a-rock-updates-stable-i|like-a-rock-updates-stable-ii|like-a-rock-updates-stable-iii|like-a-rock-updates-stable-iv|mic-check!-updates-testing-v|missed-the-train|override,-you-say|perceiving-the-bull-tester-iii|reaching-the-source-tester-ix|return-to-society-tester-x|riding-the-bull-home-tester-vi|stop-that-update!|take-this-and-call-me-in-the-morning|taming-the-bull-tester-v|tectonic!-updates-stable-v|the-bull-transcended-tester-vii|what-goes-around-comes-around-karma-i|what-goes-around-comes-around-karma-ii|what-goes-around-comes-around-karma-iii|what-goes-around-comes-around-karma-iv|white-hat|you-can-pry-it-from-my-cold,-dead-hands
-
 
 ##
 ## Testing


### PR DESCRIPTION
This commit removes config setting used in the commented code, which in turn was removed in PR #3067.

Signed-off-by: Sebastian Wojciechowski <s.wojciechowski89@gmail.com>