### PR TITLE
Fix 2 issues with New / Edit Update form

### DIFF
--- a/bodhi/server/templates/new_update.html
+++ b/bodhi/server/templates/new_update.html
@@ -41,20 +41,65 @@ ${parent.css()}
 
   <div id="new-update-form" class="pt-3" style="display:none;">
     <div class="row justify-content-center">
-      <div class="col-10">
+
+        <div class="col-10">
+            <div class="card" id="builds-card">
+                <div class="card-header">
+                  <div class="row">
+                      <div class="col">
+                          <h5 class="font-weight-bold my-1 ml-2">Builds</h5>
+                      </div>
+                      <%doc>
+                      if new update form, sidetags is populated with the user's sidetags.
+                      if edit update form, sidetags is always []
+                      </%doc>
+                      % if sidetags != []:
+                      <div class="col text-right pr-0">
+                        <div class="dropdown">
+                            <button class="btn btn-outline-primary btn-sm dropdown-toggle" type="button" id="dropdownMenuButtonSidetags" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                             <span class="fa fa-tag pr-1"></span> <span class="buttonlabel">Use Side Tag</span>
+                            </button>
+                            <div class="dropdown-menu dropdown-menu-right w-100" aria-labelledby="dropdownMenuButtonSidetags">
+                              % for tag in sidetags:
+                              <a class="dropdown-item sidetag-item" href="javascript:void(0)" data-sidetagid="${tag['id']}" data-sidetagname="${tag['name']}"><span class="fa fa-tag pr-1"></span> <strong>${tag['name']}</strong> <div class="float-right text-muted">${len(tag['builds'])} build${'s' if len(tag['builds']) > 1 else ''}</div></a>
+                              % endfor
+                            </div>
+                          </div>
+                      </div>
+                      % endif
+                      % if update and update.from_tag:
+                      <div class="col text-right pr-0">
+                      <span class="text-muted"><span class="fa fa-tag pr-1"></span> ${update.from_tag} <button class="btn btn-outline-primary btn-sm ml-2" id="sidetag-update"><span class="fa fa-refresh"></span></button></span>
+                      </div>
+                      % endif
+                    </div>
+                    
+                </div>
+                <div class="card-body p-0">
+                  % if update and update.from_tag:
+                    <div class='list-group list-group-flush' id='sidetag-buildlist'>
+                      % for build in update.builds:
+                        <div class='list-group-item'>${build.nvr}</div>                  
+                      % endfor
+                    </div>
+                  % endif:
+                  <select name="builds" id="builds-search" ${'class=d-none' if update and update.from_tag else ''} multiple='multiple' placeholder="search and add builds">
+                      % if update:
+                      % for build in update.builds:
+                      <option selected value="${build.nvr}" data-data='{"nvr": "${build.nvr}", "release_name":"${build.release.long_name}", "id":"${build.get_build_id()}", "package_name":"${build.get_n_v_r()[0]}", "owner_name":"${build.get_owner_name()}"}'>${build.nvr}</option>
+                      % endfor
+                    % endif
+                  </select>
+                </div>
+              </div>
+          </div>
+
+      <div class="col-10 mt-4">
         <div class="card">
             <div class="card-header">
                 <h5 class="font-weight-bold mb-0">Metadata</h5>
             </div>
           <div class="card-body">
-            <h6 class="font-weight-bold">Name</h6>
-            <input class="typeahead form-control noui" name="display_name" type="text" placeholder="(optional) update name. leave blank and bodhi will use the package names."
-% if update:
-value="${update.display_name | h}"
-% endif
->
-          </div>
-          <div class="card-body pt-0">
             <h6 class="font-weight-bold">
               <div class="row">
                 <div class="col">
@@ -147,58 +192,6 @@ ${update.notes}
         
       </div>
       <div class="col-10 mt-4">
-        <div class="card" id="builds-card">
-            <div class="card-header">
-              <div class="row">
-                  <div class="col">
-                      <h5 class="font-weight-bold my-1 ml-2">Builds</h5>
-                  </div>
-                  <%doc>
-                  if new update form, sidetags is populated with the user's sidetags.
-                  if edit update form, sidetags is always []
-                  </%doc>
-                  % if sidetags != []:
-                  <div class="col text-right pr-0">
-                    <div class="dropdown">
-                        <button class="btn btn-outline-primary btn-sm dropdown-toggle" type="button" id="dropdownMenuButtonSidetags" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-                         <span class="fa fa-tag pr-1"></span> <span class="buttonlabel">Use Side Tag</span>
-                        </button>
-                        <div class="dropdown-menu dropdown-menu-right w-100" aria-labelledby="dropdownMenuButtonSidetags">
-                          % for tag in sidetags:
-                          <a class="dropdown-item sidetag-item" href="javascript:void(0)" data-sidetagid="${tag['id']}" data-sidetagname="${tag['name']}"><span class="fa fa-tag pr-1"></span> <strong>${tag['name']}</strong> <div class="float-right text-muted">${len(tag['builds'])} build${'s' if len(tag['builds']) > 1 else ''}</div></a>
-                          % endfor
-                        </div>
-                      </div>
-                  </div>
-                  % endif
-                  % if update and update.from_tag:
-                  <div class="col text-right pr-0">
-                  <span class="text-muted"><span class="fa fa-tag pr-1"></span> ${update.from_tag} <button class="btn btn-outline-primary btn-sm ml-2" id="sidetag-update"><span class="fa fa-refresh"></span></button></span>
-                  </div>
-                  % endif
-                </div>
-                
-            </div>
-            <div class="card-body p-0">
-              % if update and update.from_tag:
-                <div class='list-group list-group-flush' id='sidetag-buildlist'>
-                  % for build in update.builds:
-                    <div class='list-group-item'>${build.nvr}</div>                  
-                  % endfor
-                </div>
-              % endif:
-              <select name="builds" id="builds-search" ${'class=d-none' if update and update.from_tag else ''} multiple='multiple' placeholder="search and add builds">
-                  % if update:
-                  % for build in update.builds:
-                  <option selected value="${build.nvr}" data-data='{"nvr": "${build.nvr}", "release_name":"${build.release.long_name}", "id":"${build.get_build_id()}", "package_name":"${build.get_n_v_r()[0]}", "owner_name":"${build.get_owner_name()}"}'>${build.nvr}</option>
-                  % endfor
-                % endif
-              </select>
-            </div>
-          </div>
-      </div>
-
-      <div class="col-10 mt-4">
 
       <div class="card" id="bugs-card">
           <div class="card-header">
@@ -252,6 +245,14 @@ ${update.notes}
               <h5 class="font-weight-bold mb-0">Final details</h5>
           </div>
           <div class="card-body">
+            <h6 class="font-weight-bold">Name</h6>
+            <input class="typeahead form-control noui" name="display_name" type="text" placeholder="(optional) update name. leave blank and bodhi will use the package names."
+% if update:
+value="${update.display_name | h}"
+% endif
+>
+          </div>
+          <div class="card-body pt-0">
               <div class="row">
                   <div class="col-12">
                       <h6 class="font-weight-bold" title="If specified, the update will be blocked from stable until all of the listed taskotron tests are passing.">Required Taskotron checks</h6>

--- a/bodhi/server/templates/new_update.html
+++ b/bodhi/server/templates/new_update.html
@@ -13,7 +13,11 @@ ${parent.css()}
         <div class="col">
             <h3 class="font-weight-bold m-0"><a href="${request.route_url('updates')}">Updates</a>
                 <span class="text-muted"> / </span> 
+                % if not update:
                 Create New Update
+                % else:
+                Editing update ${update.alias}
+                % endif
             </h3>
         </div>
       </div>


### PR DESCRIPTION
Fixes two issues with the new new/edit update form:

1. re-arrange new/edit update form: Previously the new/edit update form had the optional update title and the metadata box at the top of the page. This commit re-arranges the new update form, moving the optional update title to the final details, and moving the builds card above the metadata card. Fixes: #3640
2. Change title of new_update.html when editing: When editing an update, the heading at the top of the page still stated create new update. Now it reads "Editing update <update alias>" Fixes: #3704