### PR TITLE
util/generate_changelog: Build#get_latest can return None

### DIFF
--- a/bodhi/server/util.py
+++ b/bodhi/server/util.py
@@ -121,14 +121,14 @@ def generate_changelog(build: 'models.Build') -> typing.Optional[str]:
         return None
 
     # Grab the RPM header of the previous update, and generate a ChangeLog
-    oldh = get_rpm_header(lastpkg)
-    oldtime = oldh['changelogtime']
-    text = oldh['changelogtext']
+    oldtime = 0
+    if lastpkg is not None:
+        oldh = get_rpm_header(lastpkg)
+        oldtime = oldh['changelogtime']
+        text = oldh['changelogtext']
 
-    if not text:
-        oldtime = 0
-    elif isinstance(oldtime, list):
-        oldtime = oldtime[0]
+        if text and isinstance(oldtime, list):
+            oldtime = oldtime[0]
 
     return build.get_changelog(oldtime)
 

--- a/bodhi/server/util.py
+++ b/bodhi/server/util.py
@@ -121,17 +121,19 @@ def generate_changelog(build: 'models.Build') -> typing.Optional[str]:
         return None
 
     # Grab the RPM header of the previous update, and generate a ChangeLog
-    if lastpkg is not None:
+
+    def _get_oldtime(lastpkg):
+        if lastpkg is None:
+            return 0
         oldh = get_rpm_header(lastpkg)
+        if not oldh['changelogtext']:
+            return 0
         oldtime = oldh['changelogtime']
-        text = oldh['changelogtext']
-
-        if not text:
-            oldtime = 0
-        elif isinstance(oldtime, list):
+        if isinstance(oldtime, list):
             oldtime = oldtime[0]
+        return oldtime
 
-    return build.get_changelog(oldtime)
+    return build.get_changelog(_get_oldtime(lastpkg))
 
 
 def build_evr(build):

--- a/bodhi/server/util.py
+++ b/bodhi/server/util.py
@@ -121,13 +121,14 @@ def generate_changelog(build: 'models.Build') -> typing.Optional[str]:
         return None
 
     # Grab the RPM header of the previous update, and generate a ChangeLog
-    oldtime = 0
     if lastpkg is not None:
         oldh = get_rpm_header(lastpkg)
         oldtime = oldh['changelogtime']
         text = oldh['changelogtext']
 
-        if text and isinstance(oldtime, list):
+        if not text:
+            oldtime = 0
+        elif isinstance(oldtime, list):
             oldtime = oldtime[0]
 
     return build.get_changelog(oldtime)

--- a/bodhi/tests/server/test_util.py
+++ b/bodhi/tests/server/test_util.py
@@ -1502,3 +1502,57 @@ class TestPyfileToModule(base.BasePyTestCase):
         except IOError as e:
             self.fail("pyfile_to_module raised an exception in silent mode: {}".format(e))
         assert not result
+
+
+class TestGenerateChangelog:
+
+    @mock.patch("bodhi.server.util.get_rpm_header")
+    def test_nominal(self, get_rpm_header):
+        """
+        Check for nominal behavior
+        """
+        get_rpm_header.return_value = {
+            "changelogtime": [42, 41, 40],
+            "changelogtext": "dummy",
+        }
+        build = mock.Mock()
+        expected = object()
+        build.get_changelog.return_value = expected
+        result = util.generate_changelog(build)
+        build.get_changelog.assert_called_with(42)
+        assert result == expected
+
+    @mock.patch("bodhi.server.util.get_rpm_header")
+    def test_time_no_list(self, get_rpm_header):
+        """
+        Check for behavior when the changelog time is not a list
+        """
+        get_rpm_header.return_value = {
+            "changelogtime": 42,
+            "changelogtext": "dummy",
+        }
+        build = mock.Mock()
+        util.generate_changelog(build)
+        build.get_changelog.assert_called_with(42)
+
+    @mock.patch("bodhi.server.util.get_rpm_header")
+    def test_no_text(self, get_rpm_header):
+        """
+        Check for behavior when there is no changelog text
+        """
+        get_rpm_header.return_value = {
+            "changelogtime": 42,
+            "changelogtext": "",
+        }
+        build = mock.Mock()
+        util.generate_changelog(build)
+        build.get_changelog.assert_called_with(0)
+
+    def test_no_latest(self):
+        """
+        Check for crash when there are no latest builds.
+        """
+        build = mock.Mock()
+        build.get_latest.return_value = None
+        util.generate_changelog(build)
+        build.get_changelog.assert_called_with(0)


### PR DESCRIPTION
Handle this case and default the last build time to 0 to prevent a crash.

I'd like to point out that this is why gradual type systems do not work.