### PR TITLE
Fix override edit in UI.

### DIFF
--- a/bodhi/server/templates/override.html
+++ b/bodhi/server/templates/override.html
@@ -67,6 +67,7 @@ ${parent.css()}
               %endif
             %else:
               <code>${override.build.nvr}</code>
+              <input id="nvr" name="nvr" type="hidden" value="${override.build.nvr}">
               <input id="edited" name="edited" type="hidden" value="${override.build.nvr}">
             %endif
           </div>
@@ -132,9 +133,7 @@ ${parent.css()}
                 Notes
             </h5>
           <div class="form-group">
-            <textarea class="form-control" id="notes" name="notes" rows="6" placeholder="Buildroot override notes go here.  They're really *really* useful, so feel free to write as you please." required="required">
-  ${override.notes if override is not UNDEFINED else ''}
-            </textarea>
+            <textarea class="form-control" id="notes" name="notes" rows="6" placeholder="Buildroot override notes go here.  They're really *really* useful, so feel free to write as you please." required="required">${override.notes if override is not UNDEFINED else ''}</textarea>
           </div>
         </div>
 

--- a/news/3710.bug
+++ b/news/3710.bug
@@ -1,0 +1,1 @@
+Fix BuildrootOverrides editing/expiring from the UI


### PR DESCRIPTION
This is just a quick fix for users being unable to expire/edit overrides after the upgrade to Bodhi 5.0.
Probably we can avoid to post both "nvr" and "edited", but this requires some more work to adjust the backend...

Fixes #3710 
Also fixes notes textarea not empty when creating a new override.

Signed-off-by: Mattia Verga <mattia.verga@tiscali.it>