### PR TITLE
Fix builds being signed without being part of an update

### DIFF
--- a/bodhi/server/consumers/signed.py
+++ b/bodhi/server/consumers/signed.py
@@ -89,7 +89,7 @@ class SignedHandler(object):
                 log.info('Build is not assigned to release, skipping')
                 return
 
-            if build.update.from_tag:
+            if build.update and build.update.from_tag:
                 koji_testing_tag = build.release.get_testing_side_tag(build.update.from_tag)
                 if tag != koji_testing_tag:
                     log.info("Tag is not testing side tag, skipping")
@@ -112,7 +112,9 @@ class SignedHandler(object):
             log.info("Build %s has been marked as signed" % build_nvr)
 
             # If every build in update is signed change status to testing
-            if not build.update.release.composed_by_bodhi and build.update.signed:
+            if build.update \
+                    and not build.update.release.composed_by_bodhi \
+                    and build.update.signed:
                 log.info("Every build in update is signed, set status to testing")
 
                 build.update.status = UpdateStatus.testing

--- a/bodhi/tests/server/consumers/test_signed.py
+++ b/bodhi/tests/server/consumers/test_signed.py
@@ -78,6 +78,17 @@ class TestSignedHandlerConsume(base.BasePyTestCase):
         assert build.signed is True
 
     @mock.patch('bodhi.server.consumers.signed.Build')
+    def test_consume_build_with_no_update(self, mock_build_model):
+        """Assert that messages marking the build as signed updates the database"""
+        build = mock_build_model.get.return_value
+        build.signed = False
+        build.update = None
+        build.release.pending_testing_tag = self.sample_message.body["tag"]
+
+        self.handler(self.sample_message)
+        assert build.signed is True
+
+    @mock.patch('bodhi.server.consumers.signed.Build')
     def test_consume_not_pending_testing_tag(self, mock_build_model):
         """
         Assert that messages whose tag don't match the pending testing tag don't update the DB

--- a/news/3720.bug
+++ b/news/3720.bug
@@ -1,0 +1,1 @@
+Fix the traceback when builds are being signed without being included in an update


### PR DESCRIPTION
@nirik reported to us that bodhi sends an error message when it
encounters a build that is signed but is not part of an update.
This commit should help preventing the traceback.

Signed-off-by: Pierre-Yves Chibon <pingou@pingoured.fr>