### PR TITLE
Adjust the hard-coded artifact type

### DIFF
--- a/bodhi/server/models.py
+++ b/bodhi/server/models.py
@@ -3881,7 +3881,7 @@ class Update(Base):
             })
 
         artifact = {
-            "type": "rpm-build-group",
+            "type": "koji-build-group",
             "id": f"{self.alias}-{self.version_hash}",
             "repository": self.abs_url(),
             "builds": builds,

--- a/bodhi/tests/messages/schemas/test_update.py
+++ b/bodhi/tests/messages/schemas/test_update.py
@@ -192,7 +192,7 @@ class UpdateMessageTests(unittest.TestCase):
                     "email": "baseos-ci@somewhere.com"
                 },
                 "artifact": {
-                    "type": "rpm-build-group",
+                    "type": "koji-build-group",
                     "id": "FEDORA-2019-d64d0caab3",
                     "repository": "https://bodhi.fp.o/updates/FEDORA-2019-d64d0caab3",
                     "builds":

--- a/bodhi/tests/server/test_models.py
+++ b/bodhi/tests/server/test_models.py
@@ -4290,7 +4290,7 @@ class TestUpdate(ModelTest):
             self.db.commit()
         assert msg.body["artifact"]["builds"][0]["component"] == "TurboGears"
         assert msg.body["artifact"]["id"].startswith("FEDORA-")
-        assert msg.body["artifact"]["type"] == "rpm-build-group"
+        assert msg.body["artifact"]["type"] == "koji-build-group"
         assert msg.packages == ['TurboGears']
 
     def test_create_with_status_testing(self):
@@ -4306,7 +4306,7 @@ class TestUpdate(ModelTest):
             self.db.commit()
         assert msg.body["artifact"]["builds"][0]["component"] == "TurboGears"
         assert msg.body["artifact"]["id"].startswith("FEDORA-")
-        assert msg.body["artifact"]["type"] == "rpm-build-group"
+        assert msg.body["artifact"]["type"] == "koji-build-group"
         assert msg.packages == ['TurboGears']
 
 


### PR DESCRIPTION
Based on the discussion at:
https://pagure.io/fedora-ci/messages/pull-request/87
the artifact group should be koji-build-group and not rpm-build-group.

Signed-off-by: Pierre-Yves Chibon <pingou@pingoured.fr>