### PR TITLE
Linkify update aliases in comments

### DIFF
--- a/bodhi/server/renderers.py
+++ b/bodhi/server/renderers.py
@@ -128,7 +128,7 @@ def rss(info):
                 for p in builds(*args, **kwargs):
                     text += f'* {p.nvr}\n'
                 text += f'## Update description:\n{notes(*args, **kwargs)}'
-                return markup(None, text)
+                return markup(None, text, bodhi=False)
             return describe
 
         getters = {

--- a/bodhi/server/util.py
+++ b/bodhi/server/util.py
@@ -505,13 +505,14 @@ def hostname(context=None):
     return socket.gethostname()
 
 
-def markup(context, text):
+def markup(context, text, bodhi=True):
     """
     Return HTML from a markdown string.
 
     Args:
         context (mako.runtime.Context): Unused.
         text (str): Markdown text to be converted to HTML.
+        bodhi (bool): Enable or disable Bodhi markup extensions.
     Returns:
         str: HTML representation of the markdown text.
     """
@@ -546,8 +547,10 @@ def markup(context, text):
         "a",
     ]
 
-    markdown_text = markdown.markdown(text, extensions=['markdown.extensions.fenced_code',
-                                                        ffmarkdown.BodhiExtension()])
+    extensions = ['markdown.extensions.fenced_code', ]
+    if bodhi == True:
+        extensions.append(ffmarkdown.BodhiExtension())
+    markdown_text = markdown.markdown(text, extensions=extensions)
 
     # previously, we linkified text in ffmarkdown.py, but this was causing issues like #1721
     # so now we use the bleach linkifier to do this for us.

--- a/bodhi/tests/server/test_util.py
+++ b/bodhi/tests/server/test_util.py
@@ -1091,6 +1091,21 @@ class TestUtils(base.BasePyTestCase):
         clean.assert_called_once_with(expected_text, tags=expected_tags,
                                       attributes=expected_attributes)
 
+    def test_markup_without_bodhi_extensions(self):
+        """Ensure Bodhi extensions are not used with bodhi=False"""
+        text = (
+            'rhbz#12345\n'
+            '@mattia\n'
+            'FEDORA-EPEL-2019-1a2b3c4d5e'
+        )
+        html = util.markup(None, text, bodhi=False)
+        assert html == \
+            (
+                '<p>rhbz#12345\n'
+                '@mattia\n'
+                'FEDORA-EPEL-2019-1a2b3c4d5e</p>'
+            )
+
     def test_rpm_header(self):
         h = util.get_rpm_header('libseccomp')
         assert h['name'] == 'libseccomp'

--- a/bodhi/tests/server/views/test_generic.py
+++ b/bodhi/tests/server/views/test_generic.py
@@ -259,6 +259,48 @@ class TestGenericViews(base.BaseTestCase):
             "</div>"
         )
 
+    def test_markdown_with_update_alias(self):
+        """Update alias should be linkified."""
+        res = self.app.get('/markdown', {
+            'text': 'See FEDORA-2019-1a2b3c4d5e.',
+        }, status=200)
+        self.assertEqual(
+            res.json_body['html'],
+            '<div class="markdown">'
+            '<p>See '
+            '<a href="http://localhost/updates/FEDORA-2019-1a2b3c4d5e">'
+            'FEDORA-2019-1a2b3c4d5e'
+            '</a>.</p></div>'
+        )
+
+    def test_markdown_with_update_link(self):
+        """Update link should be converted to alias."""
+        res = self.app.get('/markdown', {
+            'text': 'See http://localhost:6543/updates/FEDORA-2019-1a2b3c4d5e.',
+        }, status=200)
+        self.assertEqual(
+            res.json_body['html'],
+            '<div class="markdown">'
+            '<p>See '
+            '<a href="http://localhost/updates/FEDORA-2019-1a2b3c4d5e">'
+            'FEDORA-2019-1a2b3c4d5e'
+            '</a>.</p></div>'
+        )
+
+    def test_markdown_with_fake_update_link(self):
+        """Update link of another domain isn't converted to alias."""
+        res = self.app.get('/markdown', {
+            'text': 'See http://bodhi.fake.org/updates/FEDORA-2019-1a2b3c4d5e.',
+        }, status=200)
+        self.assertEqual(
+            res.json_body['html'],
+            '<div class="markdown">'
+            '<p>See '
+            '<a href="http://bodhi.fake.org/updates/FEDORA-2019-1a2b3c4d5e">'
+            'http://bodhi.fake.org/updates/FEDORA-2019-1a2b3c4d5e'
+            '</a>.</p></div>'
+        )
+
     def test_markdown_with_fenced_code_block(self):
         res = self.app.get('/markdown', {
             'text': '```\nsudo dnf install bodhi\n```',

--- a/news/776.feature
+++ b/news/776.feature
@@ -1,0 +1,1 @@
+Linkify update aliases in comments


### PR DESCRIPTION
This PR converts a simple update alias into a link to the update itself and beautify a link to an update by shortening it to the update alias.

example 1: `FEDORA-2019-1a2b3c4d5e` is converted into `<a href="{base_address}updates/FEDORA-2019-1a2b3c4d5e">FEDORA-2019-1a2b3c4d5e</a>`

example 2: `{base_address}updates/FEDORA-2019-1a2b3c4d5e` is converted into `<a href="{base_address}updates/FEDORA-2019-1a2b3c4d5e">FEDORA-2019-1a2b3c4d5e</a>`

example 3: `https://fake.bodhi.site/updates/FEDORA-2019-1a2b3c4d5e` is NOT converted (and it follows standard markup rules)

Fixes #776

Signed-off-by: Mattia Verga <mattia.verga@tiscali.it>