### PR TITLE
Correct bodhi/tests/server/test_push.py

### DIFF
--- a/bodhi/tests/server/test_push.py
+++ b/bodhi/tests/server/test_push.py
@@ -177,7 +177,10 @@ class TestFilterReleases(base.BaseTestCase):
 
         with self.assertRaises(click.BadParameter) as ex:
             push._filter_releases(self.db, query, 'RELEASE WITH NO NAME')
-            self.assertEqual(str(ex.exception), 'Unknown release: RELEASE WITH NO NAME')
+        self.assertEqual(
+            str(ex.exception),
+            'Unknown release, or release not allowed to be composed: RELEASE WITH NO NAME'
+        )
 
     def test_archived_release(self):
         """


### PR DESCRIPTION
This commit moves "assert" statement outside of the "with pytest.raises". Otherwise, check will not be performed.

Signed-off-by: Sebastian Wojciechowski <s.wojciechowski89@gmail.com>