### PR TITLE
Correct bodhi/tests/server/test_models.py

### DIFF
--- a/bodhi/tests/server/test_models.py
+++ b/bodhi/tests/server/test_models.py
@@ -241,9 +241,9 @@ class TestBugDefaultMessage(BasePyTestCase):
 
         with pytest.raises(ValueError) as exc:
             bug.default_message(update)
-            assert str(exc.exception) == (
-                f'Trying to post a default comment to a bug, but '
-                f'{update.alias} is not in Stable or Testing status.')
+        assert str(exc.value) == (
+            f'Trying to post a default comment to a bug, but '
+            f'{update.alias} is not in Stable or Testing status.')
 
     @mock.patch.dict(config, {'stable_bug_msg': 'cool fedora stuff {update_alias}',
                               'testing_bug_msg': 'not here'})
@@ -388,7 +388,7 @@ class TestDeclEnum:
         """Test the from_string() method with a value that doesn't exist."""
         with pytest.raises(ValueError) as exc:
             model.UpdateStatus.from_string('wrong')
-            assert str(exc.exception) == "Invalid value for 'UpdateStatus': 'wrong'"
+        assert str(exc.value) == "Invalid value for 'UpdateStatus': 'wrong'"
 
 
 class TestDeclEnumType(BasePyTestCase):
@@ -1020,9 +1020,9 @@ class TestModulePackage(ModelTest):
 
         with pytest.raises(ValueError) as exc_context:
             self.package.builds.append(build2)
-            assert str(exc_context.exception) == (
-                ("A RPM Build cannot be associated with a Module Package. A Package's "
-                 "builds must be the same type as the package."))
+        assert str(exc_context.value) == (
+            ("A RPM Build cannot be associated with a Module Package. A Package's "
+             "builds must be the same type as the package."))
 
     def test_adding_list_of_module_and_rpmbuild(self):
         """Assert that validation fails when adding a ModuleBuild and RpmBuild via a list."""
@@ -1031,9 +1031,9 @@ class TestModulePackage(ModelTest):
 
         with pytest.raises(ValueError) as exc_context:
             self.package.builds = [build1, build2]
-            assert str(exc_context.exception) == (
-                ("A RPM Build cannot be associated with a Module Package. A Package's "
-                 "builds must be the same type as the package."))
+        assert str(exc_context.value) == (
+            ("A RPM Build cannot be associated with a Module Package. A Package's "
+             "builds must be the same type as the package."))
 
     def test_backref_no_builds(self):
         """Assert that a ModuleBuild can be appended via a backref."""
@@ -1051,9 +1051,9 @@ class TestModulePackage(ModelTest):
 
         with pytest.raises(ValueError) as exc_context:
             build2.package = self.package
-            assert str(exc_context.exception) == (
-                ("A RPM Build cannot be associated with a Module Package. A Package's "
-                 "builds must be the same type as the package."))
+        assert str(exc_context.value) == (
+            ("A RPM Build cannot be associated with a Module Package. A Package's "
+             "builds must be the same type as the package."))
 
     def test_backref_second_modulebuild(self):
         """Assert that two ModuleBuilds can be appended via backrefs."""
@@ -1324,8 +1324,8 @@ class TestRpmPackage(ModelTest):
         with pytest.raises(BodhiException) as exc_context:
             pkg = model.RpmPackage(name='gnome-shell')
             pkg.fetch_test_cases(self.db)
-            assert len(pkg.test_cases) == 0
-            assert str(exc_context.exception) == 'Failed retrieving testcases from Wiki'
+        assert len(pkg.test_cases) == 0
+        assert str(exc_context.value) == 'Failed retrieving testcases from Wiki'
 
     def test_adding_modulebuild(self):
         """Assert that validation fails when adding a ModuleBuild."""
@@ -1335,9 +1335,9 @@ class TestRpmPackage(ModelTest):
 
         with pytest.raises(ValueError) as exc_context:
             self.package.builds.append(build2)
-            assert str(exc_context.exception) == (
-                ("A Module Build cannot be associated with a RPM Package. A Package's "
-                 "builds must be the same type as the package."))
+        assert str(exc_context.value) == (
+            ("A Module Build cannot be associated with a RPM Package. A Package's "
+             "builds must be the same type as the package."))
 
     def test_backref_no_builds(self):
         """Assert that a RpmBuild can be appended via a backref."""
@@ -1355,9 +1355,9 @@ class TestRpmPackage(ModelTest):
 
         with pytest.raises(ValueError) as exc_context:
             build2.package = self.package
-            assert str(exc_context.exception) == (
-                ("A Module Build cannot be associated with a RPM Package. A Package's "
-                 "builds must be the same type as the package."))
+        assert str(exc_context.value) == (
+            ("A Module Build cannot be associated with a RPM Package. A Package's "
+             "builds must be the same type as the package."))
 
     def test_backref_second_modulebuild(self):
         """Assert that two RpmBuilds can be appended via backrefs."""
@@ -1680,7 +1680,7 @@ class TestUpdateInit(BasePyTestCase):
         """If the release is not passed when creating an Update, a ValueError should be raised."""
         with pytest.raises(ValueError) as exc:
             model.Update()
-            assert str(exc.exception) == 'You must specify a Release when creating an Update.'
+        assert str(exc.value) == 'You must specify a Release when creating an Update.'
 
 
 @mock.patch("bodhi.server.models.handle_update", mock.Mock())
@@ -2170,7 +2170,7 @@ class TestUpdateValidateBuilds(BasePyTestCase):
         build1.update = self.update
         with pytest.raises(ValueError) as cm:
             build2.update = self.update
-            assert str(cm.exception) == 'An update must contain builds of the same type.'
+        assert str(cm.value) == 'An update must contain builds of the same type.'
 
 
 class TestUpdateMeetsTestingRequirements(BasePyTestCase):
@@ -2738,7 +2738,7 @@ class TestUpdate(ModelTest):
 
         with pytest.raises(RuntimeError) as exc:
             self.obj.requested_tag
-            assert str(exc.exception) == f'Unable to determine requested tag for {self.obj.alias}.'
+        assert str(exc.value) == f'Unable to determine requested tag for {self.obj.alias}.'
 
     def test_requested_tag_request_obsolete(self):
         """requested_tag() should return the candidate_tag if the request is obsolete."""
@@ -2947,7 +2947,7 @@ class TestUpdate(ModelTest):
 
         with pytest.raises(BodhiException) as exc:
             self.obj.unpush(self.db)
-            assert str(exc.exception) == "Can't unpush a stable update"
+        assert str(exc.value) == "Can't unpush a stable update"
         debug.assert_called_once_with('Unpushing %s', self.obj.alias)
         assert self.obj.untag.call_count == 0
 
@@ -3028,8 +3028,6 @@ class TestUpdate(ModelTest):
     def test_dupe(self):
         with pytest.raises(IntegrityError):
             session = Session()
-            session.add(self.get_update())
-            session.commit()
             session.add(self.get_update())
             session.commit()
 
@@ -3175,7 +3173,7 @@ class TestUpdate(ModelTest):
 
         with pytest.raises(ValueError) as exc:
             self.obj.last_modified
-            assert 'Update has no timestamps set:' in str(exc.exception)
+        assert 'Update has no timestamps set:' in str(exc.value)
 
     def test_stable_karma(self):
         update = self.obj
@@ -3238,7 +3236,7 @@ class TestUpdate(ModelTest):
 
         with pytest.raises(BodhiException) as exc:
             self.obj.revoke()
-            assert str(exc.exception) == 'Can only revoke an update with an existing request'
+        assert str(exc.value) == 'Can only revoke an update with an existing request'
 
     def test_unstable_karma(self):
         update = self.obj
@@ -3401,7 +3399,7 @@ class TestUpdate(ModelTest):
         assert self.obj.status == UpdateStatus.pending
         with pytest.raises(BodhiException) as exc:
             self.obj.set_request(self.db, UpdateRequest.stable, req.user.name)
-            assert str(exc.exception) == config.get('not_yet_tested_msg')
+        assert str(exc.value) == config.get('not_yet_tested_msg')
         assert self.obj.request == UpdateRequest.testing
         assert self.obj.status == UpdateStatus.pending
 
@@ -3489,7 +3487,7 @@ class TestUpdate(ModelTest):
         with pytest.raises(BodhiException) as exc:
             with mock_sends():
                 self.obj.set_request(self.db, UpdateRequest.stable, req.user.name)
-            assert str(exc.exception) == config['not_yet_tested_epel_msg']
+        assert str(exc.value) == config['not_yet_tested_epel_msg']
 
         assert self.obj.request is None
 
@@ -3534,19 +3532,19 @@ class TestUpdate(ModelTest):
         with pytest.raises(BodhiException) as exc:
             self.obj.set_request(self.db, UpdateRequest.stable, req.user.name)
 
-            expected_msg = (
-                'This critical path update has not yet been approved for pushing to the '
-                'stable repository.  It must first reach a karma of %s, consisting of %s '
-                'positive karma from proventesters, along with %d additional karma from '
-                'the community. Or, it must spend %s days in testing without any negative '
-                'feedback')
-            expected_msg = expected_msg % (
-                config.get('critpath.min_karma'),
-                config.get('critpath.num_admin_approvals'),
-                (config.get('critpath.min_karma') - config.get('critpath.num_admin_approvals')),
-                config.get('critpath.stable_after_days_without_negative_karma'))
-            expected_msg += ' Additionally, it must pass automated tests.'
-            assert str(exc.exception) == expected_msg
+        expected_msg = (
+            'This critical path update has not yet been approved for pushing to the '
+            'stable repository.  It must first reach a karma of %s, consisting of %s '
+            'positive karma from proventesters, along with %d additional karma from '
+            'the community. Or, it must spend %s days in testing without any negative '
+            'feedback')
+        expected_msg = expected_msg % (
+            config.get('critpath.min_karma'),
+            config.get('critpath.num_admin_approvals'),
+            (config.get('critpath.min_karma') - config.get('critpath.num_admin_approvals')),
+            config.get('critpath.stable_after_days_without_negative_karma'))
+        expected_msg += ' Additionally, it must pass automated tests.'
+        assert str(exc.value) == expected_msg
 
     def test_set_request_string_action(self):
         """Ensure that the action can be passed as a str."""
@@ -3722,13 +3720,13 @@ class TestUpdate(ModelTest):
         """A comment with no author should raise a ValueError."""
         with pytest.raises(ValueError) as exc:
             self.obj.comment(self.db, 'Broke.', -1)
-            assert str(exc.exception) == 'You must provide a comment author'
+        assert str(exc.value) == 'You must provide a comment author'
 
     def test_comment_empty(self):
         """A comment with no text or feedback should raise a ValueError."""
         with pytest.raises(ValueError) as exc:
             self.obj.comment(self.db, '', author='bowlofeggs')
-            assert str(exc.exception) == 'You must provide either some text or feedback'
+        assert str(exc.value) == 'You must provide either some text or feedback'
 
     def test_get_url(self):
         assert self.obj.get_url() == f'updates/{self.obj.alias}'
@@ -3738,7 +3736,7 @@ class TestUpdate(ModelTest):
         assert bug.url == 'https://bugzilla.redhat.com/show_bug.cgi?id=1'
         with pytest.raises(ValueError) as exc:
             bug.testing(self.obj)
-            assert 'is not in Stable or Testing status' in str(exc.exception)
+        assert 'is not in Stable or Testing status' in str(exc.value)
         self.obj.status = UpdateStatus.testing
         bug.testing(self.obj)
         bug.add_comment(self.obj)
@@ -4055,7 +4053,7 @@ class TestUpdate(ModelTest):
         # We should not be allowed to add our RPM Update to the Module release.
         with pytest.raises(ValueError) as exc:
             self.obj.release = release
-            assert str(exc.exception) == 'A release must contain updates of the same type.'
+        assert str(exc.value) == 'A release must contain updates of the same type.'
 
     def test_validate_release_none(self):
         """Test validate_release() with the release set to None."""
@@ -4117,15 +4115,14 @@ class TestUpdate(ModelTest):
         update = self.obj
         with pytest.raises(BodhiException) as exc:
             update.waive_test_results('foo')
-            assert str(exc.exception) == ("Test gating is not enabled")
+        assert str(exc.value) == "Test gating is not enabled"
 
     @mock.patch.dict('bodhi.server.config.config', {'test_gating.required': True})
     def test_cannot_waive_test_results_of_an_update_which_passes_gating(self):
         update = self.obj
         with pytest.raises(BodhiException) as exc:
             update.waive_test_results('foo')
-            assert str(exc.exception) == (
-                "Can't waive test results on an update that passes test gating")
+        assert str(exc.value) == "Can't waive test results on an update that passes test gating"
 
     @mock.patch.dict('bodhi.server.config.config', {'test_gating.required': True})
     def test_cannot_waive_test_results_of_an_update_which_is_locked(self):
@@ -4133,7 +4130,7 @@ class TestUpdate(ModelTest):
         update.locked = True
         with pytest.raises(LockedUpdateException) as exc:
             update.waive_test_results('foo')
-            assert str(exc.exception) == ("Can't waive test results on a locked update")
+        assert str(exc.value) == "Can't waive test results on a locked update"
 
     @mock.patch('bodhi.server.util.greenwave_api_post')
     @mock.patch('bodhi.server.util.http_session.post')


### PR DESCRIPTION
This commit moves "assert" statement outside of the "with pytest.raises". Otherwise, check will not be performed.

Signed-off-by: Sebastian Wojciechowski <s.wojciechowski89@gmail.com>