### PR TITLE
Add back the ability to add abitairy text as a build

### DIFF
--- a/bodhi/server/static/css/site.css
+++ b/bodhi/server/static/css/site.css
@@ -384,7 +384,7 @@ padding-bottom: 2em;
 #builds-card .selectize-control.multi .selectize-input > div,
 #bugs-card .selectize-control.multi .selectize-input > div
 {
-    background-color: white; 428bca
+    background-color: white;
 }
 
 #builds-card .selectize-control.multi .selectize-input > div.active,
@@ -399,9 +399,6 @@ padding-bottom: 2em;
     padding-top:4px;
 }
 
-#builds-card  .selectize-dropdown .create{
-    display: none;
-}
 .masthead{
     border-bottom: 1px solid #ccc;
     box-shadow: 0 0 10px 2px #ddd;

--- a/bodhi/server/static/js/update_form.js
+++ b/bodhi/server/static/js/update_form.js
@@ -131,19 +131,7 @@ $(document).ready(function() {
         var $builds_search_selectize = $('#builds-search').selectize({
             valueField: 'nvr',
             labelField: 'nvr',
-            create: function(input, callback){
-                if (input in $builds_search_selectize.options){
-                    callback($builds_search_selectize.options[input])
-                } else {
-                    messenger.post({
-                        message: input+' is not tagged in koji as a candidate build',
-                        type: 'error',
-                    });
-                    callback();
-                }
-                console.log();
-                callback()
-            },
+            create: true,
             searchField: ['nvr', 'tag_name', 'owner_name'],
             preload: true,
             plugins: ['remove_button','restore_on_backspace'],
@@ -178,9 +166,6 @@ $(document).ready(function() {
                 $('#builds-search-selectized').attr("placeholder", $builds_search_selectize.settings.placeholder);
             },
             onInitialize: function(){
-                // make sure the placeholder shows when items already exist when page loads
-                $('#builds-search-selectized').attr("placeholder", "loading candidate builds...");
-
                 // preload bugs from builds that exist when the page loads (i.e. when editing an existing update)
                     for (var b in this.options) {
                         if (this.options.hasOwnProperty(b)) {
@@ -195,12 +180,8 @@ $(document).ready(function() {
                 $('#builds-search-selectized').attr("placeholder", "");
             },
             load: function(query, callback) {
-                if (query == ""){
-                    console.log("query -"+query+"-");
-                    $builds_search_selectize.disable()
-                }
                 $.ajax({
-                    url: '/latest_candidates?hide_existing=true&prefix=' + encodeURIComponent(query),
+                    url: '/latest_candidate?hide_existing=true&prefix=' + encodeURIComponent(query),
                     type: 'GET',
                     error: function() {
                         messenger.post({
@@ -211,7 +192,6 @@ $(document).ready(function() {
                     },
                     success: function(res) {
                         $('#builds-search-selectized').attr("placeholder", "search and add builds");
-                        $builds_search_selectize.enable()
                         callback(res);
                     }
                 });


### PR DESCRIPTION
the call to get the list of candidate builds from koji
seems to be timing out a lot, so adding back the ability
to just add an abitairy build to the builds list.

Fixes: #3765 
Fixes: #3707
Signed-off-by: Ryan Lerch <rlerch@redhat.com>