### PR TITLE
Enable handling bugs by default for the Security Response product

### DIFF
--- a/bodhi/server/config.py
+++ b/bodhi/server/config.py
@@ -276,7 +276,7 @@ class BodhiConfig(dict):
             'value': 'dev',
             'validator': str},
         'bz_products': {
-            'value': ['Fedora', 'Fedora EPEL', 'Fedora Modules'],
+            'value': ['Fedora', 'Fedora EPEL', 'Fedora Modules', 'Security Response'],
             'validator': _generate_list_validator(',')},
         'bz_server': {
             'value': 'https://bugzilla.redhat.com/xmlrpc.cgi',

--- a/news/3789.bug
+++ b/news/3789.bug
@@ -1,0 +1,1 @@
+Enabled bugs handling for the Bugzilla `Security Response` product


### PR DESCRIPTION
Bugs for the `Security Response` Bugzilla product have never been handled by Bodhi, but they should.

Fixes #3789 

Signed-off-by: Mattia Verga <mattia.verga@tiscali.it>