### PR TITLE
Fix JS error when removing bug from the list

### DIFF
--- a/bodhi/server/static/js/update_form.js
+++ b/bodhi/server/static/js/update_form.js
@@ -82,7 +82,11 @@ $(document).ready(function() {
                                 type: 'error',
                             });
                         }
-                        callback({'id': data.bugs[0].id, 'summary': data.bugs[0].summary})
+                        callback({
+                            'id': data.bugs[0].id, 'summary': data.bugs[0].summary,
+                            'component': data.bugs[0].component, 'product': data.bugs[0].product,
+                            'version': data.bugs[0].version
+                        });
                     }
                     $("#bugs-card .selectize-control").removeClass("loading")
                 }

--- a/news/PR3796.bug
+++ b/news/PR3796.bug
@@ -1,0 +1,1 @@
+Fix JS error when removing a bug from the list in the update form


### PR DESCRIPTION
In the  New Update form, when a user create a bug by entering the bug # and then removes it by the remove button, JS crashes because it misses `component`, `product` and `version` properties:
`TypeError: item.component is undefined`

This PR will make the callback memorize those properties. Another solution would be to just make selectize forget about the removed bug by setting `persist: false` in its options... you have the choice.

Could be somehow related to #3790 

Signed-off-by: Mattia Verga <mattia.verga@tiscali.it>