### PR TITLE
fix typo in latest candidates URL

### DIFF
--- a/bodhi/server/static/js/update_form.js
+++ b/bodhi/server/static/js/update_form.js
@@ -181,7 +181,7 @@ $(document).ready(function() {
             },
             load: function(query, callback) {
                 $.ajax({
-                    url: '/latest_candidate?hide_existing=true&prefix=' + encodeURIComponent(query),
+                    url: '/latest_candidates?hide_existing=true&prefix=' + encodeURIComponent(query),
                     type: 'GET',
                     error: function() {
                         messenger.post({


### PR DESCRIPTION
a previous commit introduced a typo in the URL for
the latest candidates URL used by the update form.
this commit fixes this issue

Signed-off-by: Ryan Lerch <rlerch@redhat.com>