### PR TITLE
[5.1-Backports] Correctly handle bug titles with double quote in new update form

### DIFF
--- a/bodhi/server/templates/new_update.html
+++ b/bodhi/server/templates/new_update.html
@@ -1,4 +1,7 @@
 <%inherit file="master.html"/>
+<%
+  from bodhi.server.util import json_escape
+%>
 
 <%block name="css">
 ${parent.css()}
@@ -205,7 +208,7 @@ ${update.notes}
             <select id="bugs-search" name="bugs" multiple="multiple" placeholder="search and add bugs">
                 % if update:
                 % for bug in update.bugs:
-                <option selected value="${bug.bug_id}" data-data='{"id": "${bug.bug_id}", "summary":"${bug.title}"}'>${bug.title}</option>
+                <option selected value="${bug.bug_id}" data-data='{"id": "${bug.bug_id}", "summary":"${bug.title | json_escape}"}'>${bug.title}</option>
                 % endfor
               % endif
             </select>

--- a/bodhi/server/util.py
+++ b/bodhi/server/util.py
@@ -1303,3 +1303,14 @@ def pyfile_to_module(
         e.strerror = 'Unable to load file (%s)' % e.strerror
         raise
     return d
+
+
+def json_escape(text: str) -> str:
+    """Escape double quotes for JSON.parse compatibility.
+
+    Args:
+        text: The text to sanitize.
+    Returns:
+        Escaped text.
+    """
+    return text.replace('"', '\\"')

--- a/bodhi/tests/server/test_util.py
+++ b/bodhi/tests/server/test_util.py
@@ -1572,3 +1572,11 @@ class TestGenerateChangelog:
         build.get_latest.return_value = None
         util.generate_changelog(build)
         build.get_changelog.assert_called_with(0)
+
+
+class TestJsonEscape:
+    """Tests for the json_escape() function."""
+    def test_doublequotes_escaped(self):
+        """Test that double quotes are escaped correctly for JSON.parse()."""
+        title = 'This is a "terrible" bug title!'
+        assert util.json_escape(title) == 'This is a \\"terrible\\" bug title!'

--- a/news/3714.bug
+++ b/news/3714.bug
@@ -1,0 +1,1 @@
+Fix bug title escaping to prevent a JS crash while editing updates


### PR DESCRIPTION
Double quotes in bug titles need to be escaped with `\\` to be compatible with JSON.parse().
Fix #3714 #3814 

Signed-off-by: Mattia Verga <mattia.verga@tiscali.it>