### PR TITLE
Handle side tag updates in stable releases.

### DIFF
--- a/bodhi/client/__init__.py
+++ b/bodhi/client/__init__.py
@@ -543,6 +543,13 @@ def edit(user: str, password: str, url: str, debug: bool, openid_api: str, **kwa
                     " --addbuilds or --removebuilds.", err=True
                 )
                 sys.exit(1)
+            if former_update.get('release', {}).get('composed_by_bodhi'):
+                click.echo(
+                    "ERROR: The release of the update is composed by Bodhi, i.e. follows the normal"
+                    " update workflow. Please build packages normally, using build root overrides"
+                    " as required, and edit the update accordingly with these new builds.", err=True
+                )
+                sys.exit(1)
             kwargs['from_tag'] = former_update['from_tag']
             del kwargs['builds']
         else:

--- a/bodhi/server/services/updates.py
+++ b/bodhi/server/services/updates.py
@@ -467,8 +467,12 @@ def new_update(request):
     empty, the list of builds will be filled with the latest builds in this
     Koji tag. This is done by validate_from_tag() because the list of builds
     needs to be available in validate_acls().
-    Ensure that related tags ``from_tag``-pending-signing and ``from_tag``-testing
-    exists and if not create them in Koji.
+
+    If the release is composed by Bodhi (i.e. a branched or stable release
+    after the Bodhi activation point), ensure that related tags
+    ``from_tag``-pending-signing and ``from_tag``-testing exists and if not
+    create them in Koji. If the state of the release is not `pending`, add its
+    pending-signing tag and remove it if it's a side tag.
 
     Args:
         request (pyramid.request): The current request.
@@ -569,20 +573,32 @@ def new_update(request):
             if from_tag:
                 koji = buildsys.get_session()
                 for update in updates:
-                    # Validate that <koji_tag>-pending-signing and <koji-tag>-testing exists,
-                    # if not create them
-                    side_tag_signing_pending = update.release.get_pending_signing_side_tag(
-                        from_tag)
-                    side_tag_testing_pending = update.release.get_testing_side_tag(from_tag)
-                    if not koji.getTag(side_tag_signing_pending):
-                        koji.createTag(side_tag_signing_pending, parent=from_tag)
-                    if not koji.getTag(side_tag_testing_pending):
-                        koji.createTag(side_tag_testing_pending, parent=from_tag)
-                        koji.editTag2(side_tag_testing_pending, perm="autosign")
+                    release = update.release
+                    if not release.composed_by_bodhi:
+                        # Before the Bodhi activation point of a release, keep builds tagged
+                        # with the side-tag and its associate tags. Validate that
+                        # <koji_tag>-pending-signing and <koji-tag>-testing exists, if not create
+                        # them.
+                        side_tag_signing_pending = update.release.get_pending_signing_side_tag(
+                            from_tag)
+                        side_tag_testing_pending = update.release.get_testing_side_tag(from_tag)
+                        if not koji.getTag(side_tag_signing_pending):
+                            koji.createTag(side_tag_signing_pending, parent=from_tag)
+                        if not koji.getTag(side_tag_testing_pending):
+                            koji.createTag(side_tag_testing_pending, parent=from_tag)
+                            koji.editTag2(side_tag_testing_pending, perm="autosign")
 
-                    to_tag = side_tag_signing_pending
-                    # Move every new build to <from_tag>-signing-pending tag
-                    update.add_tag(to_tag)
+                        to_tag = side_tag_signing_pending
+                        # Move every new build to <from_tag>-signing-pending tag
+                        update.add_tag(to_tag)
+                    else:
+                        # After the Bodhi activation point of a release, add the pending-signing tag
+                        # of the release to funnel the builds back into a normal workflow for a
+                        # stable release.
+                        update.add_tag(release.pending_signing_tag)
+
+                        # From here on out, we don't need the side-tag anymore.
+                        koji.removeSideTag(from_tag)
 
     except LockedUpdateException as e:
         log.warning(str(e))

--- a/bodhi/server/templates/new_update.html
+++ b/bodhi/server/templates/new_update.html
@@ -71,7 +71,7 @@ ${parent.css()}
                           </div>
                       </div>
                       % endif
-                      % if update and update.from_tag:
+                      % if update and update.from_tag and not update.release.composed_by_bodhi:
                       <div class="col text-right pr-0">
                       <span class="text-muted"><span class="fa fa-tag pr-1"></span> ${update.from_tag} <button class="btn btn-outline-primary btn-sm ml-2" id="sidetag-update"><span class="fa fa-refresh"></span></button></span>
                       </div>
@@ -379,7 +379,7 @@ value="${update.display_name | h}"
 <%block name="javascript">
 ${parent.javascript()}
 <script src="${request.static_url('bodhi:server/static/vendor/selectize/selectize-0.12.3.min.js')}"></script>
-% if update and update.from_tag:
+% if update and update.from_tag and not update.release.composed_by_bodhi:
   <script>var existing_sidetag_update = true;</script>
 % else:
   <script>var existing_sidetag_update = false;</script>

--- a/bodhi/server/templates/update.html
+++ b/bodhi/server/templates/update.html
@@ -416,7 +416,7 @@ if can_edit and update.release.composed_by_bodhi:
                   <div class="h5 d-flex align-items-center font-weight-bold border-bottom">
                       <div class="py-2 text-uppercase font-size-09">Builds</div>
                        <span class="badge badge-secondary badge-pill ml-1">${len(update.builds)}</span>
-                      % if request.user and update.from_tag:
+                      % if request.user and update.from_tag and not update.release.composed_by_bodhi:
                       <span class="badge badge-light badge-pill ml-auto border" title="Builds from the Side Tag: ${update.from_tag}" data-toggle="tooltip"><i class="fa fa-tag pr-1"></i> ${update.from_tag}</span>
                       % endif
                   </div>

--- a/bodhi/tests/server/base.py
+++ b/bodhi/tests/server/base.py
@@ -184,6 +184,9 @@ class BaseTestCaseMixin:
                 _app = TestApp(main({}, testing='guest', **self.app_settings))
         self.app = _app
 
+        # ensure a clean state of the dev build system
+        buildsys.DevBuildsys.clear()
+
     def get_csrf_token(self, app=None):
         """
         Return a CSRF token that can be used by tests as they test the REST API.

--- a/bodhi/tests/server/services/test_updates.py
+++ b/bodhi/tests/server/services/test_updates.py
@@ -476,7 +476,7 @@ class TestNewUpdate(BasePyTestCase):
         assert self.db.query(ModulePackage).count() == 2
 
     @mock.patch(**mock_valid_requirements)
-    def test_multiple_updates_single_module_steam(self, *args):
+    def test_multiple_updates_single_module_stream(self, *args):
         # Ensure there are no module packages in the DB to begin with.
         assert not self.db.query(ModulePackage).count()
         self.create_release('27M')

--- a/bodhi/tests/server/services/test_updates.py
+++ b/bodhi/tests/server/services/test_updates.py
@@ -27,6 +27,7 @@ import time
 
 from fedora_messaging import api, testing as fml_testing
 import koji
+import pytest
 import requests
 from webtest import TestApp
 
@@ -81,6 +82,12 @@ mock_absent_taskotron_results = {
     'target': 'bodhi.server.util.taskotron_results',
     'return_value': [],
 }
+
+
+def unused_mock_patch(_mockcls=mock.MagicMock, **kwargs):
+    target = kwargs.pop('target')
+    mockobj = _mockcls(**kwargs)
+    return mock.patch(target, new=mockobj)
 
 
 @mock.patch('bodhi.server.models.handle_update', mock.Mock())
@@ -286,17 +293,19 @@ class TestNewUpdate(BasePyTestCase):
         assert up['errors'][0]['description'] == "Koji error getting build: bodhi-2.0.0-2.fc17"
 
     @mock.patch.dict('bodhi.server.validators.config', {'acl_system': 'dummy'})
-    @mock.patch(**mock_uuid4_version1)
-    @mock.patch(**mock_valid_requirements)
-    def test_new_rpm_update_from_tag(self, *args):
+    @unused_mock_patch(**mock_uuid4_version1)
+    @unused_mock_patch(**mock_valid_requirements)
+    @pytest.mark.parametrize('rawhide_workflow', (True, False))
+    def test_new_rpm_update_from_tag(self, rawhide_workflow):
         """Test creating an update using builds from a Koji tag."""
         # We don't want the new update to obsolete the existing one.
         self.db.delete(Update.query.one())
 
-        # We need release that is not composed by bodhi
-        release = Release.query.one()
-        release.composed_by_bodhi = False
-        self.db.commit()
+        if rawhide_workflow:
+            # We need a release that isn't composed by bodhi
+            release = Release.query.one()
+            release.composed_by_bodhi = False
+            self.db.commit()
 
         update = self.get_update(builds=None, from_tag='f17-build-side-7777')
         with mock.patch('bodhi.server.buildsys.DevBuildsys.getTag', self.mock_getTag):
@@ -325,33 +334,47 @@ class TestNewUpdate(BasePyTestCase):
         assert up['requirements'] == 'rpmlint'
         assert up['from_tag'] == 'f17-build-side-7777'
 
-        # check that the sidetag gets displayed on the update page
         resp = self.app.get(f"/updates/{up['alias']}", headers={'Accept': 'text/html'})
-        assert 'title="Builds from the Side Tag: f17-build-side-7777' in resp
 
         koji_session = buildsys.get_session()
-        expected_pending_signing = ('f17-build-side-7777-signing-pending',
-                                    {'parent': 'f17-build-side-7777',
-                                     'locked': False,
-                                     'maven_support': False,
-                                     'name': 'f17-build-side-7777-signing-pending',
-                                     'perm': 'admin',
-                                     'arches': None,
-                                     'maven_include_all': False,
-                                     'perm_id': 1})
-        expected_testing = ('f17-build-side-7777-testing-pending',
-                            {'parent': 'f17-build-side-7777',
-                             'locked': False,
-                             'maven_support': False,
-                             'name': 'f17-build-side-7777-testing-pending',
-                             'perm': 'admin',
-                             'arches': None,
-                             'maven_include_all': False,
-                             'perm_id': 1})
-        assert expected_pending_signing in koji_session.__tags__
-        assert expected_testing in koji_session.__tags__
-        assert ('f17-build-side-7777-signing-pending',
-                'gnome-backgrounds-3.0-1.fc17') in koji_session.__added__
+        if rawhide_workflow:
+            # check that the sidetag gets displayed on the update page
+            assert 'title="Builds from the Side Tag: f17-build-side-7777' in resp
+
+            expected_pending_signing = ('f17-build-side-7777-signing-pending',
+                                        {'parent': 'f17-build-side-7777',
+                                         'locked': False,
+                                         'maven_support': False,
+                                         'name': 'f17-build-side-7777-signing-pending',
+                                         'perm': 'admin',
+                                         'arches': None,
+                                         'maven_include_all': False,
+                                         'perm_id': 1})
+            expected_testing = ('f17-build-side-7777-testing-pending',
+                                {'parent': 'f17-build-side-7777',
+                                 'locked': False,
+                                 'maven_support': False,
+                                 'name': 'f17-build-side-7777-testing-pending',
+                                 'perm': 'admin',
+                                 'arches': None,
+                                 'maven_include_all': False,
+                                 'perm_id': 1})
+            assert expected_pending_signing in koji_session.__tags__
+            assert expected_testing in koji_session.__tags__
+            assert ('f17-build-side-7777-signing-pending',
+                    'gnome-backgrounds-3.0-1.fc17') in koji_session.__added__
+        else:
+            # stable release workflow
+
+            # check that the sidetag doesn't get displayed on the update page,
+            # by the time the update is created, it shouldn't exist anymore
+            assert 'title="Builds from the Side Tag:' not in resp
+
+            update_added_tag = ('f17-updates-signing-pending', 'gnome-backgrounds-3.0-1.fc17')
+            removed_tag = {'id': 7777, 'name': 'f17-build-side-7777'}
+            assert update_added_tag in koji_session.__added__
+            assert removed_tag not in koji_session.__side_tags__
+            assert removed_tag in koji_session.__removed_side_tags__
 
         koji_session.clear()
 
@@ -2995,6 +3018,11 @@ class TestUpdatesService(BasePyTestCase):
         """Test editing an update using (updated) builds from a Koji tag."""
         # We don't want the new update to obsolete the existing one.
         self.db.delete(Update.query.one())
+
+        # We need a release that isn't composed by bodhi
+        release = Release.query.one()
+        release.composed_by_bodhi = False
+        self.db.commit()
 
         # We don't want an existing buildroot override to clutter the messages.
         self.db.delete(BuildrootOverride.query.one())

--- a/bodhi/tests/server/tasks/test_composer.py
+++ b/bodhi/tests/server/tasks/test_composer.py
@@ -173,7 +173,6 @@ class TestComposer(base.BasePyTestCase):
         os.makedirs(os.path.join(self._new_compose_stage_dir, 'compose'))
 
         self.koji = buildsys.get_session()
-        self.koji.clear()  # clear out our dev introspection
 
         self.tempdir = tempfile.mkdtemp('bodhi')
         self.db_factory = base.TransactionalSessionMaker(self.Session)

--- a/bodhi/tests/server/test_models.py
+++ b/bodhi/tests/server/test_models.py
@@ -2902,7 +2902,6 @@ class TestUpdate(ModelTest):
         b = self.obj.builds[0]
         release = self.obj.release
         koji = buildsys.get_session()
-        koji.clear()
         koji.__tagged__[b.nvr] = [release.testing_tag,
                                   release.pending_signing_tag,
                                   release.pending_testing_tag,
@@ -2922,7 +2921,6 @@ class TestUpdate(ModelTest):
         release = self.obj.release
         build = self.obj.builds[0]
         koji = buildsys.get_session()
-        koji.clear()
         koji.__tagged__[build.nvr] = [
             release.testing_tag, release.pending_signing_tag, release.pending_testing_tag,
             release.pending_stable_tag,

--- a/bodhi/tests/server/views/test_generic.py
+++ b/bodhi/tests/server/views/test_generic.py
@@ -484,22 +484,24 @@ class TestGenericViews(base.BaseTestCase):
         # test without any parameters
         res = self.app.get('/get_sidetags')
         body = res.json_body
-        self.assertEqual(len(body), 1)
-        self.assertEqual(body[0]['id'], 7777)
-        self.assertEqual(body[0]['name'], 'f17-build-side-7777')
-        self.assertEqual(len(body[0]['builds']), 1)
-        self.assertEqual(body[0]['builds'][0]['name'], 'gnome-backgrounds')
+        self.assertEqual(len(body), 2)
+        for i, tid in enumerate((1234, 7777)):
+            self.assertEqual(body[i]['id'], tid)
+            self.assertEqual(body[i]['name'], f'f17-build-side-{tid}')
+            self.assertEqual(len(body[i]['builds']), 1)
+            self.assertEqual(body[i]['builds'][0]['name'], 'gnome-backgrounds')
 
         # test with a user parameter.
         # the actual user filtering is done on the koji side, so results
         # are the same
         res = self.app.get('/get_sidetags', {'user': 'dudemcpants'})
         body = res.json_body
-        self.assertEqual(len(body), 1)
-        self.assertEqual(body[0]['id'], 7777)
-        self.assertEqual(body[0]['name'], 'f17-build-side-7777')
-        self.assertEqual(len(body[0]['builds']), 1)
-        self.assertEqual(body[0]['builds'][0]['name'], 'gnome-backgrounds')
+        self.assertEqual(len(body), 2)
+        for i, tid in enumerate((1234, 7777)):
+            self.assertEqual(body[i]['id'], tid)
+            self.assertEqual(body[i]['name'], f'f17-build-side-{tid}')
+            self.assertEqual(len(body[i]['builds']), 1)
+            self.assertEqual(body[i]['builds'][0]['name'], 'gnome-backgrounds')
 
         # test that the contains_builds flag works
         with mock.patch('bodhi.server.buildsys.DevBuildsys.multiCall', create=True) as multicall:


### PR DESCRIPTION
In releases after the Bodhi activation point, updates will be funneled into the normal workflow and the side tag deleted.

@ryanlerch: For these updates, the side-tag info & UI will not be shown and because the PR is also based on #3810 (another PyTest migration), which is why I want to raise both to your attention.

fixes: #3800