### PR TITLE
In Cornice 4.0, schema arguments must be instances

### DIFF
--- a/bodhi/server/services/builds.py
+++ b/bodhi/server/services/builds.py
@@ -60,7 +60,7 @@ def get_build(request):
     return build
 
 
-@builds.get(schema=bodhi.server.schemas.ListBuildSchema, renderer='json',
+@builds.get(schema=bodhi.server.schemas.ListBuildSchema(), renderer='json',
             error_handler=bodhi.server.services.errors.json_handler,
             validators=(colander_querystring_validator, validate_releases, validate_updates,
                         validate_packages))

--- a/bodhi/server/services/comments.py
+++ b/bodhi/server/services/comments.py
@@ -88,21 +88,21 @@ validators = (
 
 
 @comments_rss.get(
-    schema=bodhi.server.schemas.ListCommentSchema, renderer='rss',
+    schema=bodhi.server.schemas.ListCommentSchema(), renderer='rss',
     error_handler=bodhi.server.services.errors.html_handler, validators=validators)
 @comments.get(
-    schema=bodhi.server.schemas.ListCommentSchema, renderer='rss',
+    schema=bodhi.server.schemas.ListCommentSchema(), renderer='rss',
     accept=('application/atom+xml',),
     error_handler=bodhi.server.services.errors.html_handler, validators=validators)
 @comments.get(
-    schema=bodhi.server.schemas.ListCommentSchema, accept=('application/json', 'text/json'),
+    schema=bodhi.server.schemas.ListCommentSchema(), accept=('application/json', 'text/json'),
     renderer='json', error_handler=bodhi.server.services.errors.json_handler, validators=validators)
 @comments.get(
-    schema=bodhi.server.schemas.ListCommentSchema, accept=('application/javascript'),
+    schema=bodhi.server.schemas.ListCommentSchema(), accept=('application/javascript'),
     renderer='jsonp', error_handler=bodhi.server.services.errors.jsonp_handler,
     validators=validators)
 @comments.get(
-    schema=bodhi.server.schemas.ListCommentSchema, accept=('text/html'), renderer='comments.html',
+    schema=bodhi.server.schemas.ListCommentSchema(), accept=('text/html'), renderer='comments.html',
     error_handler=bodhi.server.services.errors.html_handler, validators=validators)
 def query_comments(request):
     """
@@ -186,7 +186,7 @@ def query_comments(request):
     )
 
 
-@comments.post(schema=bodhi.server.schemas.SaveCommentSchema,
+@comments.post(schema=bodhi.server.schemas.SaveCommentSchema(),
                renderer='json',
                error_handler=bodhi.server.services.errors.json_handler,
                validators=(

--- a/bodhi/server/services/overrides.py
+++ b/bodhi/server/services/overrides.py
@@ -97,22 +97,22 @@ validators = (
 )
 
 
-@overrides_rss.get(schema=bodhi.server.schemas.ListOverrideSchema, renderer='rss',
+@overrides_rss.get(schema=bodhi.server.schemas.ListOverrideSchema(), renderer='rss',
                    error_handler=bodhi.server.services.errors.html_handler,
                    validators=validators)
-@overrides.get(schema=bodhi.server.schemas.ListOverrideSchema, renderer='rss',
+@overrides.get(schema=bodhi.server.schemas.ListOverrideSchema(), renderer='rss',
                accept=('application/atom+xml',),
                error_handler=bodhi.server.services.errors.html_handler,
                validators=validators)
-@overrides.get(schema=bodhi.server.schemas.ListOverrideSchema,
+@overrides.get(schema=bodhi.server.schemas.ListOverrideSchema(),
                accept=("application/json", "text/json"), renderer="json",
                error_handler=bodhi.server.services.errors.json_handler,
                validators=validators)
-@overrides.get(schema=bodhi.server.schemas.ListOverrideSchema,
+@overrides.get(schema=bodhi.server.schemas.ListOverrideSchema(),
                accept=("application/javascript"), renderer="jsonp",
                error_handler=bodhi.server.services.errors.jsonp_handler,
                validators=validators)
-@overrides.get(schema=bodhi.server.schemas.ListOverrideSchema,
+@overrides.get(schema=bodhi.server.schemas.ListOverrideSchema(),
                accept=('text/html'), renderer='overrides.html',
                error_handler=bodhi.server.services.errors.html_handler,
                validators=validators)
@@ -207,7 +207,7 @@ def query_overrides(request):
     )
 
 
-@overrides.post(schema=bodhi.server.schemas.SaveOverrideSchema,
+@overrides.post(schema=bodhi.server.schemas.SaveOverrideSchema(),
                 permission='edit',
                 accept=("application/json", "text/json"), renderer='json',
                 error_handler=bodhi.server.services.errors.json_handler,
@@ -216,7 +216,7 @@ def query_overrides(request):
                     validate_override_builds,
                     validate_expiration_date,
                 ))
-@overrides.post(schema=bodhi.server.schemas.SaveOverrideSchema,
+@overrides.post(schema=bodhi.server.schemas.SaveOverrideSchema(),
                 permission='edit',
                 accept=("application/javascript"), renderer="jsonp",
                 error_handler=bodhi.server.services.errors.jsonp_handler,

--- a/bodhi/server/services/packages.py
+++ b/bodhi/server/services/packages.py
@@ -35,7 +35,7 @@ packages = Service(name='packages', path='/packages/',
 
 
 @packages.get(
-    schema=bodhi.server.schemas.ListPackageSchema, renderer='json',
+    schema=bodhi.server.schemas.ListPackageSchema(), renderer='json',
     error_handler=bodhi.server.services.errors.json_handler,
     validators=(colander_querystring_validator,))
 def query_packages(request):

--- a/bodhi/server/services/releases.py
+++ b/bodhi/server/services/releases.py
@@ -198,7 +198,7 @@ releases_get_validators = (colander_querystring_validator, validate_release, val
                            validate_packages)
 
 
-@releases.get(accept="text/html", schema=bodhi.server.schemas.ListReleaseSchema,
+@releases.get(accept="text/html", schema=bodhi.server.schemas.ListReleaseSchema(),
               renderer='releases.html',
               error_handler=bodhi.server.services.errors.html_handler,
               validators=releases_get_validators)
@@ -271,7 +271,7 @@ def query_releases_html(request):
 
 
 @releases.get(accept=('application/json', 'text/json'),
-              schema=bodhi.server.schemas.ListReleaseSchema, renderer='json',
+              schema=bodhi.server.schemas.ListReleaseSchema(), renderer='json',
               error_handler=bodhi.server.services.errors.json_handler,
               validators=releases_get_validators)
 def query_releases_json(request):
@@ -340,7 +340,7 @@ def query_releases_json(request):
     )
 
 
-@releases.post(schema=bodhi.server.schemas.SaveReleaseSchema,
+@releases.post(schema=bodhi.server.schemas.SaveReleaseSchema(),
                permission='admin', renderer='json',
                error_handler=bodhi.server.services.errors.json_handler,
                validators=(colander_body_validator, validate_tags, validate_enums)

--- a/bodhi/server/services/updates.py
+++ b/bodhi/server/services/updates.py
@@ -171,7 +171,7 @@ def get_update_for_editing(request):
     )
 
 
-@update_request.post(schema=bodhi.server.schemas.UpdateRequestSchema,
+@update_request.post(schema=bodhi.server.schemas.UpdateRequestSchema(),
                      validators=(
                          colander_body_validator,
                          validate_enums,
@@ -237,22 +237,22 @@ validators = (
 )
 
 
-@updates_rss.get(schema=bodhi.server.schemas.ListUpdateSchema, renderer='rss',
+@updates_rss.get(schema=bodhi.server.schemas.ListUpdateSchema(), renderer='rss',
                  error_handler=bodhi.server.services.errors.html_handler,
                  validators=validators)
-@updates.get(schema=bodhi.server.schemas.ListUpdateSchema, renderer='rss',
+@updates.get(schema=bodhi.server.schemas.ListUpdateSchema(), renderer='rss',
              accept=('application/atom+xml',),
              error_handler=bodhi.server.services.errors.html_handler,
              validators=validators)
-@updates.get(schema=bodhi.server.schemas.ListUpdateSchema,
+@updates.get(schema=bodhi.server.schemas.ListUpdateSchema(),
              accept=('application/json', 'text/json'), renderer='json',
              error_handler=bodhi.server.services.errors.json_handler,
              validators=validators)
-@updates.get(schema=bodhi.server.schemas.ListUpdateSchema,
+@updates.get(schema=bodhi.server.schemas.ListUpdateSchema(),
              accept=('application/javascript'), renderer='jsonp',
              error_handler=bodhi.server.services.errors.jsonp_handler,
              validators=validators)
-@updates.get(schema=bodhi.server.schemas.ListUpdateSchema,
+@updates.get(schema=bodhi.server.schemas.ListUpdateSchema(),
              accept=('text/html'), renderer='updates.html',
              error_handler=bodhi.server.services.errors.html_handler,
              validators=validators)
@@ -438,7 +438,7 @@ def query_updates(request):
     return return_values
 
 
-@updates.post(schema=bodhi.server.schemas.SaveUpdateSchema,
+@updates.post(schema=bodhi.server.schemas.SaveUpdateSchema(),
               permission='create', renderer='json',
               error_handler=bodhi.server.services.errors.json_handler,
               validators=(
@@ -619,7 +619,7 @@ def new_update(request):
     return result
 
 
-@update_waive_test_results.post(schema=bodhi.server.schemas.WaiveTestResultsSchema,
+@update_waive_test_results.post(schema=bodhi.server.schemas.WaiveTestResultsSchema(),
                                 validators=(colander_body_validator,
                                             validate_update_id,
                                             validate_acls),
@@ -653,7 +653,7 @@ def waive_test_results(request):
     return dict(update=update)
 
 
-@update_get_test_results.get(schema=bodhi.server.schemas.GetTestResultsSchema,
+@update_get_test_results.get(schema=bodhi.server.schemas.GetTestResultsSchema(),
                              validators=(validate_update_id),
                              renderer='json',
                              error_handler=bodhi.server.services.errors.json_handler)
@@ -691,7 +691,7 @@ def get_test_results(request):
     return dict(decision=decision)
 
 
-@update_trigger_tests.post(schema=bodhi.server.schemas.TriggerTestsSchema,
+@update_trigger_tests.post(schema=bodhi.server.schemas.TriggerTestsSchema(),
                            validators=(colander_body_validator,
                                        validate_update_id,
                                        validate_acls),

--- a/bodhi/server/services/user.py
+++ b/bodhi/server/services/user.py
@@ -96,19 +96,19 @@ validators = (
 )
 
 
-@users.get(schema=bodhi.server.schemas.ListUserSchema,
+@users.get(schema=bodhi.server.schemas.ListUserSchema(),
            accept=("application/json", "text/json"), renderer="json",
            error_handler=bodhi.server.services.errors.json_handler,
            validators=validators)
-@users.get(schema=bodhi.server.schemas.ListUserSchema,
+@users.get(schema=bodhi.server.schemas.ListUserSchema(),
            accept=("application/javascript"), renderer="jsonp",
            error_handler=bodhi.server.services.errors.jsonp_handler,
            validators=validators)
-@users.get(schema=bodhi.server.schemas.ListUserSchema, renderer="rss",
+@users.get(schema=bodhi.server.schemas.ListUserSchema(), renderer="rss",
            accept=('application/atom+xml',),
            error_handler=bodhi.server.services.errors.html_handler,
            validators=validators)
-@users_rss.get(schema=bodhi.server.schemas.ListUserSchema, renderer="rss",
+@users_rss.get(schema=bodhi.server.schemas.ListUserSchema(), renderer="rss",
                error_handler=bodhi.server.services.errors.html_handler,
                validators=validators)
 def query_users(request):


### PR DESCRIPTION
See https://github.com/Cornices/cornice/releases/tag/4.0.0, the check for being a `MappingSchema` instance only works on instances and not on classes.