### PR TITLE
Fix user field in updates search box

### DIFF
--- a/bodhi/server/templates/updates.html
+++ b/bodhi/server/templates/updates.html
@@ -199,7 +199,7 @@ ${parent.css()}
                   <label for="updateuser" class="col-auto align-self-center pl-1 pr-0 m-0">User:</label>
                   </div>
                   <div class="col-8 pl-1">
-                      <input type="text" id="updateuser" name="user" class="form-control" ${"value="+parameters['user'][0] if 'user' in parameters else ""}/>
+                      <input type="text" id="updateuser" name="user" class="form-control" value="${parameters['user'][0] if 'user' in parameters else '' | h}"/>
                   </div>
                   <div class="col-1 pl-0 pr-1 pt-1">
                     <i class="fa fa-times fa-fw text-muted clear-button" data-clear="updateuser"></i>


### PR DESCRIPTION
The `value` attribute of the `<input>` associated with the updates page's user search filter was not surrounded by double quotes. Since it was immediately followed by the tag's closing slash (e.g. `value=user/>`), the closing slash was interpreted by browsers as being part of the value.

Signed-off-by: Eli Young <elyscape@gmail.com>