### PR TITLE
Try to avoid timeout error when requesting latest_candidates with hide_existing=true

### DIFF
--- a/bodhi/server/static/js/update_form.js
+++ b/bodhi/server/static/js/update_form.js
@@ -188,6 +188,7 @@ $(document).ready(function() {
                 // make sure the placeholder disappears when focused
                 $('#builds-search-selectized').attr("placeholder", "");
             },
+            loadThrottle: 800,
             load: function(query, callback) {
                 $.ajax({
                     url: '/latest_candidates?hide_existing=true&prefix=' + encodeURIComponent(query),

--- a/bodhi/server/views/generic.py
+++ b/bodhi/server/views/generic.py
@@ -299,6 +299,9 @@ def latest_candidates(request):
 
         if hide_existing:
             # We want to filter out builds associated with an update.
+            # Since the candidate_tag is removed when an update is pushed to
+            # stable, we only need a list of builds that are associated to
+            # updates still in pending state.
 
             # Don't filter by releases here, because the associated update
             # might be archived but the build might be inherited into an active
@@ -306,7 +309,9 @@ def latest_candidates(request):
             # this set should be easy enough.
             associated_build_nvrs = set(
                 row[0] for row in
-                db.query(models.Build.nvr).filter(models.Build.update_id != None)
+                db.query(models.Build.nvr).
+                join(models.Update).
+                filter(models.Update.status == models.UpdateStatus.pending)
             )
 
         kwargs = dict(package=pkg, prefix=prefix, latest=True)

--- a/news/3841.bug
+++ b/news/3841.bug
@@ -1,0 +1,1 @@
+Try to avoid timeout error when requesting latest_candidates with `hide_existing=true`


### PR DESCRIPTION
Refine the query used to build up the list of builds we want to exclude from the results: if I'm correct, the `candidate_tag` is removed from a build when the update is pushed to testing, so those builds are already filtered from the koji response.

Results from Vagrant test, from the actual query:
```
>>> associated_build_nvrs = set(row[0] for row in db.query(m.Build.nvr).filter(m.Build.update_id != None))
>>> len(associated_build_nvrs)
217947
```
and the refined query:
```
>>> associated_build_nvrs = set(row[0] for row in db.query(m.Build.nvr).join(m.Update).filter(m.Update.status == m.UpdateStatus.pending))
>>> len(associated_build_nvrs)
210
```
This should hopefully close #3841 

In a side commit, I've added a delay to the javascript used to query koji, so that we don't fire a query for every letter we type in the search field.