### PR TITLE
Allow task id to be null in the bodhi.update.status.testing message s…

### DIFF
--- a/bodhi/messages/schemas/update.py
+++ b/bodhi/messages/schemas/update.py
@@ -662,7 +662,7 @@ class UpdateReadyForTestingV1(BodhiMessage):
                     },
                     'task_id': {
                         'description': 'Task ID of the koji build.',
-                        'type': 'integer',
+                        'type': ['null', 'integer'],
                     },
                     'component': {
                         'description': 'Name of the component tested.',

--- a/bodhi/tests/messages/schemas/test_update.py
+++ b/bodhi/tests/messages/schemas/test_update.py
@@ -206,7 +206,7 @@ class TestUpdateMessage:
                         }, {
                             "type": "koji-build",
                             "id": 14546278,
-                            "task_id": 14546277,
+                            "task_id": None,
                             "issuer": "plautrba",
                             "component": "libsepol",
                             "nvr": "libsepol-2.8-3.fc29.x86_64",

--- a/news/3852.bug
+++ b/news/3852.bug
@@ -1,0 +1,1 @@
+Allow task id to be null in the bodhi.update.status.testing message schema.


### PR DESCRIPTION
…chema.

In the case of modular build there is no Koji task so
we need to allow the task_id to be null.

Signed-off-by: Clement Verna <cverna@tutanota.com>