### PR TITLE
Fix potential race condition with the celery update handler.

### DIFF
--- a/bodhi/server/models.py
+++ b/bodhi/server/models.py
@@ -1830,7 +1830,7 @@ class Update(Base):
         backref=backref('updates', passive_deletes=True))
 
     # Many-to-many relationships
-    bugs = relationship('Bug', secondary=update_bug_table, backref='updates')
+    bugs = relationship('Bug', secondary=update_bug_table, backref='updates', order_by='Bug.bug_id')
 
     user_id = Column(Integer, ForeignKey('users.id'))
 

--- a/bodhi/server/models.py
+++ b/bodhi/server/models.py
@@ -2271,14 +2271,14 @@ class Update(Base):
                                f"release value of {up.mandatory_days_in_testing} days"
             })
 
+        log.debug("Adding new update to the db.")
+        db.add(up)
+        log.debug("Triggering db commit for new update.")
+        db.commit()
+
         if not data.get("from_tag"):
             log.debug("Setting request for new update.")
             up.set_request(db, req, request.user.name)
-
-        log.debug("Adding new update to the db.")
-        db.add(up)
-        log.debug("Triggering db flush for new update.")
-        db.flush()
 
         if config.get('test_gating.required'):
             log.debug(
@@ -2431,14 +2431,18 @@ class Update(Base):
 
         up.date_modified = datetime.utcnow()
 
+        # Commit the changes in the db before calling a celery task.
+        db.commit()
+
+        notifications.publish(update_schemas.UpdateEditV1.from_dict(
+            message={'update': up, 'agent': request.user.name, 'new_bugs': new_bugs}))
+
         handle_update.delay(
             api_version=1, action='edit',
             update=up.__json__(request=request),
             agent=request.user.name,
             new_bugs=new_bugs
         )
-        notifications.publish(update_schemas.UpdateEditV1.from_dict(
-            message={'update': up, 'agent': request.user.name, 'new_bugs': new_bugs}))
 
         return up, caveats
 
@@ -2871,12 +2875,9 @@ class Update(Base):
             )
         self.comment(db, comment_text, author=u'bodhi')
 
-        if action == UpdateRequest.testing:
-            handle_update.delay(
-                api_version=1, action="testing",
-                update=self.__json__(),
-                agent=username
-            )
+        # Commit the changes in the db before calling a celery task.
+        db.commit()
+
         action_message_map = {
             UpdateRequest.revoke: update_schemas.UpdateRequestRevokeV1,
             UpdateRequest.stable: update_schemas.UpdateRequestStableV1,
@@ -2885,6 +2886,12 @@ class Update(Base):
             UpdateRequest.obsolete: update_schemas.UpdateRequestObsoleteV1}
         notifications.publish(action_message_map[action].from_dict(
             dict(update=self, agent=username)))
+
+        if action == UpdateRequest.testing:
+            handle_update.delay(
+                api_version=1, action="testing",
+                update=self.__json__(),
+                agent=username)
 
     def waive_test_results(self, username, comment=None, tests=None):
         """

--- a/bodhi/tests/server/services/test_updates.py
+++ b/bodhi/tests/server/services/test_updates.py
@@ -1491,7 +1491,8 @@ class TestUpdatesService(BasePyTestCase):
         update = Build.query.filter_by(nvr=nvr).one().update
         assert update.karma == 2
         assert update.request is None
-        update.comment(self.db, "foo", 1, 'biz')
+        with fml_testing.mock_sends(api.Message, api.Message):
+            update.comment(self.db, "foo", 1, 'biz')
         update = Build.query.filter_by(nvr=nvr).one().update
         assert update.karma == 3
         assert update.request == UpdateRequest.stable
@@ -3305,7 +3306,8 @@ class TestUpdatesService(BasePyTestCase):
         up.comment(self.db, 'WFM', author='dustymabe', karma=1)
         up = self.db.query(Build).filter_by(nvr=nvr).one().update
 
-        up.comment(self.db, 'LGTM', author='bowlofeggs', karma=1)
+        with fml_testing.mock_sends(api.Message):
+            up.comment(self.db, 'LGTM', author='bowlofeggs', karma=1)
         up = self.db.query(Build).filter_by(nvr=nvr).one().update
 
         assert up.karma == 2
@@ -3336,7 +3338,8 @@ class TestUpdatesService(BasePyTestCase):
         up.comment(self.db, 'WFM', author='dustymabe', karma=1)
         up = self.db.query(Build).filter_by(nvr=nvr).one().update
 
-        up.comment(self.db, 'LGTM', author='bowlofeggs', karma=1)
+        with fml_testing.mock_sends(api.Message):
+            up.comment(self.db, 'LGTM', author='bowlofeggs', karma=1)
         up = self.db.query(Build).filter_by(nvr=nvr).one().update
 
         assert up.karma == 2
@@ -4662,7 +4665,8 @@ class TestUpdatesService(BasePyTestCase):
         up.comment(self.db, 'LGTM', author='ralph', karma=1)
         up = self.db.query(Update).filter_by(alias=resp.json['alias']).one()
 
-        up.comment(self.db, 'LGTM', author='bowlofeggs', karma=1)
+        with fml_testing.mock_sends(api.Message):
+            up.comment(self.db, 'LGTM', author='bowlofeggs', karma=1)
         up = self.db.query(Update).filter_by(alias=resp.json['alias']).one()
         assert up.karma == 2
 
@@ -4859,7 +4863,8 @@ class TestUpdatesService(BasePyTestCase):
         up.comment(self.db, 'LGTM Now', author='ralph', karma=1)
         up = self.db.query(Update).filter_by(alias=resp.json['alias']).one()
 
-        up.comment(self.db, 'WFM', author='puiterwijk', karma=1)
+        with fml_testing.mock_sends(api.Message):
+            up.comment(self.db, 'WFM', author='puiterwijk', karma=1)
         up = self.db.query(Update).filter_by(alias=resp.json['alias']).one()
 
         # No negative karma: Update gets automatically marked as stable
@@ -5364,7 +5369,8 @@ class TestUpdatesService(BasePyTestCase):
                         stable_karma=3, unstable_karma=-3)
         update.comment(self.db, "foo1", 1, 'foo1')
         update.comment(self.db, "foo2", 1, 'foo2')
-        update.comment(self.db, "foo3", 1, 'foo3')
+        with fml_testing.mock_sends(api.Message, api.Message):
+            update.comment(self.db, "foo3", 1, 'foo3')
         self.db.add(update)
         # Let's clear any messages that might get sent
         self.db.info['messages'] = []

--- a/bodhi/tests/server/test_models.py
+++ b/bodhi/tests/server/test_models.py
@@ -27,6 +27,7 @@ import uuid
 from urllib.error import URLError
 
 from fedora_messaging.testing import mock_sends
+from fedora_messaging.api import Message
 from pyramid.testing import DummyRequest
 import pytest
 from sqlalchemy.exc import IntegrityError
@@ -2201,7 +2202,8 @@ class TestUpdateMeetsTestingRequirements(BasePyTestCase):
         update.status = UpdateStatus.testing
         update.stable_karma = 1
         # Now let's add some karma to get it to the required threshold
-        update.comment(self.db, 'testing', author='hunter2', karma=1)
+        with mock_sends(Message):
+            update.comment(self.db, 'testing', author='hunter2', karma=1)
 
         # meets_testing_requirement() should return True since the karma threshold has been reached
         assert update.meets_testing_requirements
@@ -2238,12 +2240,13 @@ class TestUpdateMeetsTestingRequirements(BasePyTestCase):
         update.critpath = True
         update.stable_karma = 1
         with mock.patch('bodhi.server.models.handle_update'):
-            update.comment(self.db, 'testing', author='enemy', karma=-1)
-            update.comment(self.db, 'testing', author='bro', karma=1)
-            # Despite meeting the stable_karma, the function should still not mark this as meeting
-            # testing requirements because critpath packages have a higher requirement for minimum
-            # karma. So let's get it a second one.
-            update.comment(self.db, 'testing', author='ham', karma=1)
+            with mock_sends(Message, Message, Message, Message):
+                update.comment(self.db, 'testing', author='enemy', karma=-1)
+                update.comment(self.db, 'testing', author='bro', karma=1)
+                # Despite meeting the stable_karma, the function should still not
+                # mark this as meeting testing requirements because critpath packages
+                # have a higher requirement for minimum karma. So let's get it a second one.
+                update.comment(self.db, 'testing', author='ham', karma=1)
 
         assert update.meets_testing_requirements
 

--- a/news/3858.bug
+++ b/news/3858.bug
@@ -1,0 +1,1 @@
+Fix potential race condition with the celery worker accessing an update before the web request was commited.


### PR DESCRIPTION
The update handler is called before the update object was flush
to the database. Since the worker is using a different connection
than the web request that would make the worker not find the
corresponding update.

Fixes #3858.

Signed-off-by: Clement Verna <cverna@tutanota.com>