### PR TITLE
Use existing db session when creating a package.

### DIFF
--- a/bodhi/server/consumers/automatic_updates.py
+++ b/bodhi/server/consumers/automatic_updates.py
@@ -122,7 +122,7 @@ class AutomaticUpdateHandler:
 
                 # Package.get_or_create() infers content type already
                 log.debug("Getting/creating related package object.")
-                pkg = Package.get_or_create(rbuildinfo)
+                pkg = Package.get_or_create(dbsession, rbuildinfo)
 
                 log.debug("Creating build object, adding it to the DB.")
                 build = bcls(nvr=bnvr, package=pkg, release=rel)

--- a/bodhi/server/models.py
+++ b/bodhi/server/models.py
@@ -1242,7 +1242,7 @@ class Package(Base):
         return name
 
     @staticmethod
-    def get_or_create(build):
+    def get_or_create(session, build):
         """
         Identify and return the Package instance associated with the build.
 
@@ -1250,6 +1250,7 @@ class Package(Base):
         Or, given a container, return a ContainerBuild instance.
 
         Args:
+            session (sqlalchemy.orm.session.Session): A database session.
             build (dict): Information about the build from the build system (koji).
         Returns:
             Package: A type-specific instance of Package for the specific build requested.
@@ -1259,8 +1260,8 @@ class Package(Base):
         package = base.query.filter_by(name=name).one_or_none()
         if not package:
             package = base(name=name)
-            Session().add(package)
-            Session().flush()
+            session.add(package)
+            session.flush()
         return package
 
 
@@ -2324,7 +2325,7 @@ class Update(Base):
                                                 "locked update")
 
                 new_builds.append(build)
-                Package.get_or_create(buildinfo[build])
+                Package.get_or_create(db, buildinfo[build])
                 b = db.query(Build).filter_by(nvr=build).first()
 
                 up.builds.append(b)

--- a/bodhi/server/services/updates.py
+++ b/bodhi/server/services/updates.py
@@ -500,7 +500,7 @@ def new_update(request):
         for nvr in build_nvrs:
             name, version, release = request.buildinfo[nvr]['nvr']
 
-            package = Package.get_or_create(request.buildinfo[nvr])
+            package = Package.get_or_create(request.db, request.buildinfo[nvr])
 
             # Also figure out the build type and create the build if absent.
             build_class = ContentType.infer_content_class(

--- a/bodhi/server/validators.py
+++ b/bodhi/server/validators.py
@@ -450,7 +450,7 @@ def validate_acls(request, **kwargs):
                 return
 
             # Get the Package and Release objects
-            package = Package.get_or_create(buildinfo)
+            package = Package.get_or_create(request.db, buildinfo)
             release = cache_release(request, build)
             if release is None:
                 return
@@ -560,7 +560,7 @@ def validate_build_uniqueness(request, **kwargs):
             return
         seen_build.add(build)
 
-        pkg = Package.get_or_create(request.buildinfo[build])
+        pkg = Package.get_or_create(request.db, request.buildinfo[build])
         if (pkg, rel) in seen_packages:
             request.errors.add(
                 'body', 'builds', f'Multiple {pkg.name} builds specified in {rel.name}')
@@ -1163,7 +1163,8 @@ def _validate_override_build(request, nvr, db):
             return
 
         build_info = request.koji.getBuild(nvr)
-        package = Package.get_or_create({'nvr': (build_info['name'],
+        package = Package.get_or_create(db,
+                                        {'nvr': (build_info['name'],
                                                  build_info['version'],
                                                  build_info['release']),
                                          'info': build_info})

--- a/news/PR3860.dev
+++ b/news/PR3860.dev
@@ -1,0 +1,1 @@
+Use existing db session when creating a package: `Package.get_or_create()` now requires a session object in input


### PR DESCRIPTION
Do not create a new Session() object, but pass an existing db session to `get_or_create()` so that we are sure the session is then closed properly.

Signed-off-by: Mattia Verga <mattia.verga@tiscali.it>