### PR TITLE
Upgrade Vagrant box to f30

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -37,9 +37,9 @@ end
 VAGRANTFILE_API_VERSION = "2"
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
- config.vm.box_url = "https://download.fedoraproject.org/pub/fedora/linux/releases/29/Cloud/x86_64/images/Fedora-Cloud-Base-Vagrant-29-1.2.x86_64.vagrant-libvirt.box"
- config.vm.box = "f29-cloud-libvirt"
- config.vm.box_download_checksum = "30a58db024a5203fea0fee8fffcbc1998b3e6de787dbc504dc5c511b97c84777"
+ config.vm.box_url = "https://download.fedoraproject.org/pub/fedora/linux/releases/30/Cloud/x86_64/images/Fedora-Cloud-Base-Vagrant-30-1.2.x86_64.vagrant-libvirt.box"
+ config.vm.box = "f30-cloud-libvirt"
+ config.vm.box_download_checksum = "2ae5aad7621ce7735c905bf6b882d391949f8bfa3534b8631c9b2161126ca2f0"
  config.vm.box_download_checksum_type = "sha256"
 
  # Forward traffic on the host to the development server on the guest.

--- a/devel/ansible/roles/bodhi/tasks/main.yml
+++ b/devel/ansible/roles/bodhi/tasks/main.yml
@@ -56,6 +56,7 @@
       - python3-rpdb
       - python3-simplemediawiki
       - python3-sqlalchemy
+      - python3-sqlalchemy_schemadisplay
       - python3-webtest
       - redhat-rpm-config
       - screen
@@ -90,12 +91,6 @@
   shell: runuser -l postgres -c 'createdb bodhi2' && touch /home/vagrant/.db-created
   args:
       creates: /home/vagrant/.db-created
-
-# This is only packaged for Python 3 for Fedora >= 30, so we'll pip install it for now.
-- name: pip install sqlalchemy_schemadisplay
-  pip:
-    executable: pip-3
-    name: sqlalchemy_schemadisplay
 
 # This isn't packaged in Fedora yet, but it's only a development tool (we should still add it)
 - name: pip install debugtoolbar

--- a/devel/ansible/roles/bodhi/tasks/rabbitmq.yml
+++ b/devel/ansible/roles/bodhi/tasks/rabbitmq.yml
@@ -6,6 +6,12 @@
   with_items:
       - rabbitmq-server
 
+- name: Start rabbitmq
+  service:
+    name: rabbitmq-server
+    state: started
+    enabled: yes
+
 - name: Create RabbitMQ systemd override directory
   file:
     path: /etc/systemd/system/rabbitmq-server.service.d/
@@ -24,9 +30,6 @@
   notify:
     - reload rabbitmq
 
-- name: start rabbitmq
-  service: name=rabbitmq-server state=started enabled=yes
-
 - name: Ensure default vhost exists
   rabbitmq_vhost:
     name: /
@@ -37,9 +40,8 @@
     user: guest
     password: guest
     tags: administrator
-    permissions:
-      - vhost: /
-        configure_priv: .*
-        read_priv: .*
-        write_priv: .*
+    vhost: /
+    configure_priv: .*
+    read_priv: .*
+    write_priv: .*
     state: present


### PR DESCRIPTION
I'd rather wanted to upgrade it to f31, but it seems docker [doesn't run on that](https://github.com/docker/for-linux/issues/792) by default, so I've upgrade to f30.

Signed-off-by: Mattia Verga <mattia.verga@tiscali.it>