### PR TITLE
responses 0.10.8 breaks the unit tests.

### DIFF
--- a/devel/ci/Dockerfile-pip
+++ b/devel/ci/Dockerfile-pip
@@ -1,4 +1,4 @@
-FROM registry.fedoraproject.org/fedora:29
+FROM registry.fedoraproject.org/fedora:30
 LABEL maintainer="Randy Barlow <bowlofeggs@fedoraproject.org>"
 
 # This works around https://bugzilla.redhat.com/show_bug.cgi?id=1705265
@@ -31,7 +31,7 @@ RUN pip-3 install \
     diff-cover \
     flake8 \
     flake8-import-order \
-    responses \
+    "responses<0.10.8" \
     "pydocstyle<4.0" \
     pytest \
     pytest-cov \


### PR DESCRIPTION
The 0.10.8 version of responses adds the text/plain content-type to
the response headers. This is breaking skopeo_lite which does not
expect this content type in the response.

Upstream issue https://github.com/getsentry/responses/issues/290

Signed-off-by: Clement Verna <cverna@tutanota.com>