### PR TITLE
Prevent whitespaces string to be set as display name of an update

### DIFF
--- a/bodhi/server/models.py
+++ b/bodhi/server/models.py
@@ -2224,6 +2224,11 @@ class Update(Base):
         data['critpath'] = cls.contains_critpath_component(
             data['builds'], data['release'].name)
 
+        # Be sure to not add an empty string as alternative title
+        # and strip whitespaces from it
+        if 'display_name' in data:
+            data['display_name'] = data['display_name'].strip()
+
         # Create the Bug entities, but don't talk to rhbz yet.  We do that
         # offline in the UpdatesHandler task worker now.
         bugs = []
@@ -2304,6 +2309,11 @@ class Update(Base):
 
         caveats = []
         edited_builds = [build.nvr for build in up.builds]
+
+        # Be sure to not add an empty string as alternative title
+        # and strip whitespaces from it
+        if 'display_name' in data:
+            data['display_name'] = data['display_name'].strip()
 
         # stable_days can be set by the user. We want to make sure that the value
         # will not be lower than the mandatory_days_in_testing.

--- a/bodhi/tests/server/test_models.py
+++ b/bodhi/tests/server/test_models.py
@@ -1739,6 +1739,21 @@ class TestUpdateEdit(BasePyTestCase):
         with pytest.raises(model.LockedUpdateException):
             model.Update.edit(request, data)
 
+    def test_empty_display_name(self):
+        """An only whitespaces string should not be set as display name."""
+        update = model.Update.query.first()
+        data = {
+            'edited': update.alias, 'builds': [update.builds[0].nvr],
+            'bugs': [], 'display_name': '  '}
+        request = mock.MagicMock()
+        request.db = self.db
+        request.user.name = 'tester'
+
+        model.Update.edit(request, data)
+
+        update = model.Update.query.first()
+        assert update.display_name == ''
+
 
 @mock.patch("bodhi.server.models.handle_update", mock.Mock())
 class TestUpdateVersionHash(BasePyTestCase):

--- a/news/3877.bug
+++ b/news/3877.bug
@@ -1,0 +1,1 @@
+Prevent whitespaces string to be set as display name of an update


### PR DESCRIPTION
Strip whitespaces from Update.display_name. This avoids whitespaces to be set as alternative title.

Fixes #3877 

Signed-off-by: Mattia Verga <mattia.verga@tiscali.it>