### PR TITLE
Fix release timeline graph data.

### DIFF
--- a/bodhi/server/services/releases.py
+++ b/bodhi/server/services/releases.py
@@ -80,7 +80,7 @@ def get_release_html(request):
         Update.date_submitted.desc())
 
     updates_count = request.db.query(Update.date_submitted, Update.type).filter(
-        Update.release == release).order_by(Update.date_submitted.desc())
+        Update.release == release).order_by(Update.date_submitted.asc())
 
     date_commits = {}
     dates = set()


### PR DESCRIPTION
The data displayed in the timeline graph of a release is actually wrong, because values and labels lists are reversed. This will fix it.

Signed-off-by: Mattia Verga <mattia.verga@tiscali.it>