### PR TITLE
Add quick release filters for listing updates

### DIFF
--- a/bodhi/server/templates/master.html
+++ b/bodhi/server/templates/master.html
@@ -80,7 +80,7 @@
                         % else:
                         <li class="nav-item font-weight-bold">
                         % endif
-                          <a class="nav-link" href="${request.route_url('updates')}">
+                          <a class="nav-link" href="${request.route_url('updates')}?releases=__current__&releases=__pending__">
                             Updates
                           </a>
                         </li>

--- a/bodhi/server/templates/updates.html
+++ b/bodhi/server/templates/updates.html
@@ -71,6 +71,9 @@ ${parent.css()}
                                 "user",
                                 "updateid",
                                 "alias"]
+              macroCatReleases = [('__current__', 'all current'),
+                                  ('__pending__', 'all pending'),
+                                  ('__archived__', 'all archived')]
               searchterm=''
               parameters = request.params.dict_of_lists()
               if 'search' in parameters:
@@ -136,6 +139,14 @@ ${parent.css()}
                   <div class="col-8 pl-1">
                       <select id="updatereleases" name="releases" multiple="multiple">
                           <option value="">&nbsp;</option>
+                          <optgroup label="quick filters">
+                          % for macrocat in macroCatReleases:
+                            <option value="${macrocat[0]}"
+                            % if 'releases' in parameters and macrocat[0] in parameters['releases']:
+                            selected="selected"
+                            % endif
+                            >${macrocat[1]}</option>
+                          %endfor
                           % for rstatus in ['current', 'pending', "archived"]:
                             <optgroup label="${rstatus}">
                             % for value in releases[rstatus]:

--- a/bodhi/server/validators.py
+++ b/bodhi/server/validators.py
@@ -738,6 +738,21 @@ def validate_releases(request, **kwargs):
     bad_releases = []
     validated_releases = []
 
+    if '__current__' in releases:
+        releases.remove('__current__')
+        active_releases = db.query(Release).filter(Release.state == ReleaseState.current).all()
+        validated_releases.extend(active_releases)
+
+    if '__pending__' in releases:
+        releases.remove('__pending__')
+        active_releases = db.query(Release).filter(Release.state == ReleaseState.pending).all()
+        validated_releases.extend(active_releases)
+
+    if '__archived__' in releases:
+        releases.remove('__archived__')
+        active_releases = db.query(Release).filter(Release.state == ReleaseState.archived).all()
+        validated_releases.extend(active_releases)
+
     for r in releases:
         release = db.query(Release).filter(or_(Release.name == r, Release.name == r.upper(),
                                                Release.version == r)).first()

--- a/bodhi/tests/server/base.py
+++ b/bodhi/tests/server/base.py
@@ -251,10 +251,10 @@ class BaseTestCaseMixin:
         """
         Create and return an Update with the given iterable of build_nvrs.
 
-        Each build_nvr should be a tuple of strings describing the name, version, and release for
-        the build. For example, build_nvrs might look like this:
+        Each build_nvr should be a string describing the name, version, and release for the build
+        separated by dashes. For example, build_nvrs might look like this:
 
-        (('bodhi', '2.3.3', '1.fc24'), ('python-fedora-atomic-composer', '2016.3', '1.fc24'))
+        ('bodhi-2.3.3-1.fc24', 'python-fedora-atomic-composer-2016.3-1.fc24')
 
         You can optionally pass a release_name to select a different release than the default F17,
         but the release must already exist in the database.

--- a/docs/user/man_pages/bodhi.rst
+++ b/docs/user/man_pages/bodhi.rst
@@ -126,7 +126,9 @@ The ``overrides`` command allows users to manage build overrides.
     ``--releases <releases>``
 
         Query for overrides related to a list of releases, given as a comma-separated list.
-        <releases> is the release shortname, for example: F26 or F26,F25
+        <releases> is the release shortname, for example: F26 or F26,F25, or a macro filter
+        (`__current__`, `__pending__`, `__archived__`) to include all releases in a
+        certain status.
 
     ``--builds <builds>``
 
@@ -425,6 +427,8 @@ The ``updates`` command allows users to interact with bodhi updates.
     ``--releases <releases>``
 
         Query for updates related to a list of releases, given as a comma-separated list.
+        It is possible to use the macro filters `__current__`, `__pending__` and `__archived__`
+        to include all releases in a certain status.
 
     ``--locked``
 

--- a/news/PR3892.feature
+++ b/news/PR3892.feature
@@ -1,0 +1,1 @@
+Added `__current__`, `__pending__` and `__archived__` macro filters to quickly filter Updates by Release status


### PR DESCRIPTION
This PR adds three quick filters to the update list search form. The `all current`, `all pending` and `all archived` are just wrappers to select all releases in a specific state. They can be combined by themselves or with specific release names as usual.

The third commit in this PR also changes the default link to the Updates page to only list updates from `current` and `pending` releases to lower the query results. On my local test machine the update page generation speed has decreased from 1.9s to 1.2s.

Signed-off-by: Mattia Verga mattia.verga@tiscali.it