### PR TITLE
Take precautions to avoid DB transaction leaks

### DIFF
--- a/bodhi/server/tasks/approve_testing.py
+++ b/bodhi/server/tasks/approve_testing.py
@@ -23,6 +23,7 @@ from sqlalchemy import func
 
 from bodhi.messages.schemas import update as update_schemas
 from bodhi.server import Session, notifications, buildsys
+from bodhi.server.util import transactional_session_maker
 from ..models import Update, UpdateStatus, UpdateRequest
 from ..config import config
 
@@ -37,16 +38,16 @@ def main():
     Queries for updates in the testing state that have a NULL request, and run approve_update on
     them.
     """
-    db = Session()
-    try:
-        testing = db.query(Update).filter_by(status=UpdateStatus.testing, request=None)
-        for update in testing:
-            approve_update(update, db)
-            db.commit()
-    except Exception:
-        log.exception("There was an error approving testing updates.")
-        db.rollback()
-        Session.remove()
+    db_factory = transactional_session_maker()
+    with db_factory() as db:
+        try:
+            testing = db.query(Update).filter_by(status=UpdateStatus.testing, request=None)
+            for update in testing:
+                approve_update(update, db)
+                db.commit()
+        except Exception:
+            log.exception("There was an error approving testing updates.")
+            raise
 
 
 def approve_update(update: Update, db: Session):

--- a/bodhi/server/tasks/updates.py
+++ b/bodhi/server/tasks/updates.py
@@ -82,7 +82,18 @@ class UpdatesHandler:
             data: Information about a new or edited update.
         """
         action = data["action"]
-        alias = data['update'].get('alias')
+        if api_version == 1:
+            alias = data["update"].get("alias")
+        elif api_version == 2:
+            try:
+                alias = data['update_alias']
+            except KeyError:
+                log.error(f"Wrong message format for the handle_update task: {data}")
+                return
+        else:
+            log.error(f"The Updates Handler doesn't know how to handle api_version {api_version}. "
+                      f"Message was: {data}")
+            return
 
         log.info("Updates Handler handling  %s, %s" % (alias, action))
 


### PR DESCRIPTION
Use transactional_session_maker in the celery tasks to ensure that DB sessions are removed when the task is done.
Only pass scalar as celery task arguments to prevent celery from having to emit SQL