### PR TITLE
Fix bodhi-client unit tests failing

### DIFF
--- a/bodhi/tests/client/test___init__.py
+++ b/bodhi/tests/client/test___init__.py
@@ -879,7 +879,7 @@ real_open = open
 def fake_open_no_session_cache(*args, **kwargs):
     """Fake open so that it looks like we have no session cache."""
     if args[0] == fedora.client.openidbaseclient.b_SESSION_FILE:
-        return mock.mock_open(read_data='{}')(*args, **kwargs)
+        return mock.mock_open(read_data=b'{}')(*args, **kwargs)
     return real_open(*args, **kwargs)
 
 

--- a/devel/ci/Dockerfile-pip
+++ b/devel/ci/Dockerfile-pip
@@ -1,8 +1,5 @@
-FROM registry.fedoraproject.org/fedora:29
+FROM registry.fedoraproject.org/fedora:31
 LABEL maintainer="Randy Barlow <bowlofeggs@fedoraproject.org>"
-
-# This works around https://bugzilla.redhat.com/show_bug.cgi?id=1705265
-RUN dnf install -y dnf-plugin-ovl
 
 RUN dnf install -y \
     createrepo_c \
@@ -23,6 +20,9 @@ RUN dnf install -y \
     python3-libcomps
 
 COPY requirements.txt /bodhi/requirements.txt
+
+# Workaround base image bug #1737013.
+COPY devel/ci/integration/bodhi/zone.tab /usr/share/zoneinfo/zone.tab
 
 RUN pip-3 install -r /bodhi/requirements.txt
 RUN pip-3 install \

--- a/devel/ci/integration/bodhi/Dockerfile-pip
+++ b/devel/ci/integration/bodhi/Dockerfile-pip
@@ -30,7 +30,7 @@ RUN groupadd -r bodhi && \
     useradd  -r -s /sbin/nologin -d /home/bodhi/ -m -c 'Bodhi Server' -g bodhi bodhi
 
 # Install it
-RUN python3 setup.py build && pip3 install .
+RUN python3 setup.py build && pip3 install --no-use-pep517 .
 
 # Configuration
 RUN mkdir -p /etc/bodhi


### PR DESCRIPTION
For some reason the two client tests that requires a mocked user input for entering their username have started to failing.
I'm trying to find where the issue is. The pip-unit still uses a F29 image, so let's upgrade it to F31.
Another difference with other dockerfiles is that pip-unit installs pytest from pypi and gets 5.3.5, while in all other dockerfiles pytest comes from fedora repositories and is < 5. But I have upgraded pytest to 5.3.5 locally and I can't reproduce the failure, so I don't think that's the real problem.

Signed-off-by: Mattia Verga <mattia.verga@tiscali.it>