### PR TITLE
Make sure we are sending the messages before triggering a celery task.

### DIFF
--- a/bodhi/server/models.py
+++ b/bodhi/server/models.py
@@ -2444,11 +2444,11 @@ class Update(Base):
         # Store the update alias so Celery doesn't have to emit SQL
         update_alias = up.alias
 
-        # Commit the changes in the db before calling a celery task.
-        db.commit()
-
         notifications.publish(update_schemas.UpdateEditV1.from_dict(
             message={'update': up, 'agent': request.user.name, 'new_bugs': new_bugs}))
+
+        # Commit the changes in the db before calling a celery task.
+        db.commit()
 
         handle_update.delay(
             api_version=2, action='edit',
@@ -2891,9 +2891,6 @@ class Update(Base):
         # Store the update alias so Celery doesn't have to emit SQL
         alias = self.alias
 
-        # Commit the changes in the db before calling a celery task.
-        db.commit()
-
         action_message_map = {
             UpdateRequest.revoke: update_schemas.UpdateRequestRevokeV1,
             UpdateRequest.stable: update_schemas.UpdateRequestStableV1,
@@ -2902,6 +2899,9 @@ class Update(Base):
             UpdateRequest.obsolete: update_schemas.UpdateRequestObsoleteV1}
         notifications.publish(action_message_map[action].from_dict(
             dict(update=self, agent=username)))
+
+        # Commit the changes in the db before calling a celery task.
+        db.commit()
 
         if action == UpdateRequest.testing:
             handle_update.delay(

--- a/bodhi/tests/server/services/test_updates.py
+++ b/bodhi/tests/server/services/test_updates.py
@@ -1507,7 +1507,7 @@ class TestUpdatesService(BasePyTestCase):
         update = Build.query.filter_by(nvr=nvr).one().update
         assert update.karma == 2
         assert update.request is None
-        with fml_testing.mock_sends(api.Message, api.Message):
+        with fml_testing.mock_sends(api.Message, api.Message, api.Message):
             update.comment(self.db, "foo", 1, 'biz')
         update = Build.query.filter_by(nvr=nvr).one().update
         assert update.karma == 3
@@ -3351,7 +3351,7 @@ class TestUpdatesService(BasePyTestCase):
         up.comment(self.db, 'WFM', author='dustymabe', karma=1)
         up = self.db.query(Build).filter_by(nvr=nvr).one().update
 
-        with fml_testing.mock_sends(api.Message):
+        with fml_testing.mock_sends(api.Message, api.Message):
             up.comment(self.db, 'LGTM', author='bowlofeggs', karma=1)
         up = self.db.query(Build).filter_by(nvr=nvr).one().update
 
@@ -3383,7 +3383,7 @@ class TestUpdatesService(BasePyTestCase):
         up.comment(self.db, 'WFM', author='dustymabe', karma=1)
         up = self.db.query(Build).filter_by(nvr=nvr).one().update
 
-        with fml_testing.mock_sends(api.Message):
+        with fml_testing.mock_sends(api.Message, api.Message):
             up.comment(self.db, 'LGTM', author='bowlofeggs', karma=1)
         up = self.db.query(Build).filter_by(nvr=nvr).one().update
 
@@ -4710,7 +4710,7 @@ class TestUpdatesService(BasePyTestCase):
         up.comment(self.db, 'LGTM', author='ralph', karma=1)
         up = self.db.query(Update).filter_by(alias=resp.json['alias']).one()
 
-        with fml_testing.mock_sends(api.Message):
+        with fml_testing.mock_sends(api.Message, api.Message):
             up.comment(self.db, 'LGTM', author='bowlofeggs', karma=1)
         up = self.db.query(Update).filter_by(alias=resp.json['alias']).one()
         assert up.karma == 2
@@ -4908,7 +4908,7 @@ class TestUpdatesService(BasePyTestCase):
         up.comment(self.db, 'LGTM Now', author='ralph', karma=1)
         up = self.db.query(Update).filter_by(alias=resp.json['alias']).one()
 
-        with fml_testing.mock_sends(api.Message):
+        with fml_testing.mock_sends(api.Message, api.Message):
             up.comment(self.db, 'WFM', author='puiterwijk', karma=1)
         up = self.db.query(Update).filter_by(alias=resp.json['alias']).one()
 
@@ -5414,7 +5414,7 @@ class TestUpdatesService(BasePyTestCase):
                         stable_karma=3, unstable_karma=-3)
         update.comment(self.db, "foo1", 1, 'foo1')
         update.comment(self.db, "foo2", 1, 'foo2')
-        with fml_testing.mock_sends(api.Message, api.Message):
+        with fml_testing.mock_sends(api.Message, api.Message, api.Message):
             update.comment(self.db, "foo3", 1, 'foo3')
         self.db.add(update)
         # Let's clear any messages that might get sent

--- a/bodhi/tests/server/tasks/test_approve_testing.py
+++ b/bodhi/tests/server/tasks/test_approve_testing.py
@@ -822,8 +822,8 @@ class TestMain(BaseTaskTestCase):
         # Clear pending messages
         self.db.info['messages'] = []
 
-        update.comment(self.db, u'Works great', author=u'luke', karma=1)
         with fml_testing.mock_sends(api.Message, api.Message, api.Message):
+            update.comment(self.db, u'Works great', author=u'luke', karma=1)
             self.db.commit()
 
         approve_testing_main()

--- a/bodhi/tests/server/test_models.py
+++ b/bodhi/tests/server/test_models.py
@@ -1720,7 +1720,8 @@ class TestUpdateEdit(BasePyTestCase):
         update.release.pending_signing_tag = ''
         self.db.flush()
 
-        model.Update.edit(request, data)
+        with mock_sends(Message):
+            model.Update.edit(request, data)
 
         warning.assert_called_once_with('F17 has no pending_signing_tag')
         update = model.Update.query.first()
@@ -1749,8 +1750,8 @@ class TestUpdateEdit(BasePyTestCase):
         request = mock.MagicMock()
         request.db = self.db
         request.user.name = 'tester'
-
-        model.Update.edit(request, data)
+        with mock_sends(Message):
+            model.Update.edit(request, data)
 
         update = model.Update.query.first()
         assert update.display_name == ''
@@ -1790,7 +1791,8 @@ class TestUpdateVersionHash(BasePyTestCase):
         request.db = self.db
         request.user.name = 'tester'
         self.db.flush()
-        model.Update.edit(request, data)
+        with mock_sends(Message):
+            model.Update.edit(request, data)
 
         # now, with two builds, check the hash has changed
         updated_expected_hash = "d89b54971b965505179438481d761f8b5ee64e8c"
@@ -2217,7 +2219,7 @@ class TestUpdateMeetsTestingRequirements(BasePyTestCase):
         update.status = UpdateStatus.testing
         update.stable_karma = 1
         # Now let's add some karma to get it to the required threshold
-        with mock_sends(Message):
+        with mock_sends(Message, Message):
             update.comment(self.db, 'testing', author='hunter2', karma=1)
 
         # meets_testing_requirement() should return True since the karma threshold has been reached
@@ -2255,7 +2257,7 @@ class TestUpdateMeetsTestingRequirements(BasePyTestCase):
         update.critpath = True
         update.stable_karma = 1
         with mock.patch('bodhi.server.models.handle_update'):
-            with mock_sends(Message, Message, Message, Message):
+            with mock_sends(Message, Message, Message, Message, Message):
                 update.comment(self.db, 'testing', author='enemy', karma=-1)
                 update.comment(self.db, 'testing', author='bro', karma=1)
                 # Despite meeting the stable_karma, the function should still not
@@ -3366,7 +3368,8 @@ class TestUpdate(ModelTest):
         req.koji = buildsys.get_session()
         assert self.obj.status == UpdateStatus.pending
         self.obj.stable_karma = 1
-        self.obj.comment(self.db, 'works', karma=1, author='bowlofeggs')
+        with mock_sends(Message):
+            self.obj.comment(self.db, 'works', karma=1, author='bowlofeggs')
 
         self.obj.set_request(self.db, UpdateRequest.stable, req.user.name)
 
@@ -3583,7 +3586,8 @@ class TestUpdate(ModelTest):
         req.koji = buildsys.get_session()
         assert self.obj.status == UpdateStatus.pending
         self.obj.stable_karma = 1
-        self.obj.comment(self.db, 'works', karma=1, author='bowlofeggs')
+        with mock_sends(Message):
+            self.obj.comment(self.db, 'works', karma=1, author='bowlofeggs')
 
         self.obj.set_request(self.db, 'stable', req.user.name)
 

--- a/news/3904.bug
+++ b/news/3904.bug
@@ -1,0 +1,1 @@
+Make sure we send the fedora-messaging messages before trigerring a celery task.


### PR DESCRIPTION
We need to make sure to commit the database session before
triggering a celery task, but since the fedora-messaging messages
are sent on the database session commit let's commit this one after
the messages were added to the queue.

Fixes #3904

Signed-off-by: Clement Verna <cverna@tutanota.com>