### PR TITLE
server: Close the db session when the approve_testing tasks succeed

### DIFF
--- a/bodhi/server/tasks/approve_testing.py
+++ b/bodhi/server/tasks/approve_testing.py
@@ -47,6 +47,8 @@ def main():
                 db.commit()
     except Exception:
         log.exception("There was an error approving testing updates.")
+    finally:
+        db_factory._end_session()
 
 
 def approve_update(update: Update, db: Session):


### PR DESCRIPTION
Add a finally close to the try statement to close the connection in
all the other cases.

Fixes: #3849

Signed-off-by: Richard Gregory <richardgrecoson@gmail.com>