### PR TITLE
Make sure to escape the description of the error in the error template.

### DIFF
--- a/bodhi/server/templates/errors.html
+++ b/bodhi/server/templates/errors.html
@@ -6,7 +6,7 @@
       <div class="panel error-page-panel">
         <h1>${status} <small>${summary}</small></h1>
         % for error in errors:
-        <p class="lead">${error['description']}</p>
+        <p class="lead">${error['description'] | h}</p>
         % endfor
       </div>
     </div>

--- a/bodhi/tests/server/services/test_updates.py
+++ b/bodhi/tests/server/services/test_updates.py
@@ -1121,7 +1121,8 @@ class TestEditUpdateForm(BasePyTestCase):
             '/updates/FEDORA-{}-a3bbe1a8f2/edit'.format(datetime.utcnow().year), status=400,
             headers={'accept': 'text/html'})
         assert (
-            'anonymous is not a member of "packager", which is a mandatory packager group') in resp
+            'anonymous is not a member of &#34;packager&#34;, which is a mandatory packager group'
+        ) in resp
 
     def test_edit_not_loggedin(self):
         """


### PR DESCRIPTION
We need to escape the error description since it can display
input from the user.

Signed-off-by: Clement Verna <cverna@tutanota.com>