### PR TITLE
Associate bugs in changelog to rawhide updates.

### DIFF
--- a/bodhi/server/config.py
+++ b/bodhi/server/config.py
@@ -278,6 +278,10 @@ class BodhiConfig(dict):
         'bz_products': {
             'value': ['Fedora', 'Fedora EPEL', 'Fedora Modules'],
             'validator': _generate_list_validator(',')},
+        'bz_regex': {
+            'value': (r'(?:fix(?:es)?|close(?:s)?)\s'
+                      r'(?:fedora|epel|rh(?:bz)?)#(\d{5,})'),
+            'validator': str},
         'bz_server': {
             'value': 'https://bugzilla.redhat.com/xmlrpc.cgi',
             'validator': str},

--- a/bodhi/server/consumers/automatic_updates.py
+++ b/bodhi/server/consumers/automatic_updates.py
@@ -23,13 +23,14 @@ tagged with certain tags.
 """
 
 import logging
+import re
 
 import fedora_messaging
 
 from bodhi.server import buildsys
 from bodhi.server.config import config
-from bodhi.server.models import Build, ContentType, Package, Release
-from bodhi.server.models import Update, UpdateStatus, UpdateType, User
+from bodhi.server.models import (
+    Bug, Build, ContentType, Package, Release, Update, UpdateStatus, UpdateType, User)
 from bodhi.server.util import transactional_session_maker
 
 log = logging.getLogger('bodhi')
@@ -140,7 +141,9 @@ class AutomaticUpdateHandler:
 
             log.debug(f"Creating new update for {bnvr}.")
             changelog = build.get_changelog(lastupdate=True)
+            closing_bugs = []
             if changelog:
+                log.debug("Adding changelog to update notes.")
                 notes = f"""Automatic update for {bnvr}.
 
 ##### **Changelog**
@@ -148,11 +151,23 @@ class AutomaticUpdateHandler:
 ```
 {changelog}
 ```"""
+
+                for b in re.finditer(config.get('bz_regex'), changelog, re.IGNORECASE):
+                    idx = int(b.group(1))
+                    log.debug(f'Adding bug #{idx} to the update.')
+                    bug = Bug.get(idx)
+                    if bug is None:
+                        bug = Bug(bug_id=idx)
+                        dbsession.add(bug)
+                        dbsession.flush()
+                    if bug not in closing_bugs:
+                        closing_bugs.append(bug)
             else:
                 notes = f"Automatic update for {bnvr}."
             update = Update(
                 release=rel,
                 builds=[build],
+                bugs=closing_bugs,
                 notes=notes,
                 type=UpdateType.unspecified,
                 stable_karma=3,

--- a/bodhi/tests/server/consumers/test_automatic_updates.py
+++ b/bodhi/tests/server/consumers/test_automatic_updates.py
@@ -123,6 +123,32 @@ class TestAutomaticUpdateHandler(base.BasePyTestCase):
         else:  # no changelog
             assert update.notes == "Automatic update for colord-1.3.4-1.fc26."
 
+    @mock.patch('bodhi.server.models.RpmBuild.get_changelog')
+    def test_bug_added(self, mock_generate_changelog):
+        """Assert that a bug is added to the update if proper string is in changelog."""
+        changelog = ('* Sat Aug  3 2013 Fedora Releng <rel-eng@lists.fedoraproject.org> - 2\n'
+                     '- Added a free money feature.\n- Fix rhbz#112233.')
+
+        mock_generate_changelog.return_value = changelog
+
+        # process the message
+        self.handler(self.sample_message)
+
+        # check if the update exists...
+        update = self.db.query(Update).filter(
+            Update.builds.any(Build.nvr == self.sample_nvr)
+        ).first()
+
+        assert update.notes == f"""Automatic update for colord-1.3.4-1.fc26.
+
+##### **Changelog**
+
+```
+{changelog}
+```"""
+        assert len(update.bugs) > 0
+        assert update.bugs[0].bug_id == 112233
+
     def test_consume_with_orphan_build(self, caplog):
         """
         Assert existing builds without an update can be handled.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -34,6 +34,7 @@ User Guide
    user/testing
    user/update_states
    user/buildroot_overrides
+   user/automatic_updates
    user/man_pages/index
 
 .. toctree::

--- a/docs/user/automatic_updates.rst
+++ b/docs/user/automatic_updates.rst
@@ -1,0 +1,43 @@
+=================
+Automatic Updates
+=================
+
+Updates for releases which haven't yet reached the activation point (e.g. Rawhide) are automatically
+created when Koji tags a build in the release candidate tag.
+
+The Update then is processed through the common flow: if gating tests pass, the Update is pushed to
+`Testing` and, immediatly after, to `Stable`. Usually it takes seconds or few minutes for the Update
+to reach the `Stable` state.
+
+Associate bugs to automatic updates
+===================================
+
+Bugs can be associated to automatic updates by using appropriate keyword in the RPM changelog
+of a build. The regex used to aquire the bug ids can be set in Bodhi config file. For a default
+Bodhi installation this is automatically set to::
+
+    fix(es)|close(s) (fedora|epel|rh|rhbz)#BUG_ID
+
+The regex is performed case insensitive. So, if you want bug number 123456 to be attached to an
+automatic update and closed upon update reaching stable, you can add a line to the RPM changelog
+like this::
+
+    %changelog
+    * Sat Apr 04 2020 Mattia Verga  <mattia@fedoraproject.org> - 0.78-1
+    - Update to 0.78
+    - Fixes rhbz#123456
+
+Just be sure to use the appropriate format for every bug you want to add. For example, this will
+**NOT** work::
+
+   %changelog
+    * Sat Apr 04 2020 Mattia Verga  <mattia@fedoraproject.org> - 0.78-1
+    - Update to 0.78
+    - Fix rhbz#123456, rhbz#987654
+
+Use this instead::
+
+   %changelog
+    * Sat Apr 04 2020 Mattia Verga  <mattia@fedoraproject.org> - 0.78-1
+    - Update to 0.78
+    - Fix rhbz#123456, fix rhbz#987654

--- a/news/3925.feature
+++ b/news/3925.feature
@@ -1,0 +1,1 @@
+Associate bugs mentioned in rpm changelog to automatically created Rawhide updates; the bugs mentioned with the format `fix(es)|close(s) (fedora|epel|rh|rhbz)#BUG_ID` will be associated to the update and automatically closed

--- a/production.ini
+++ b/production.ini
@@ -381,6 +381,10 @@ use = egg:bodhi-server
 # A template to use for links to Bugzilla tickets. %%s will be filled in with the bug number.
 # buglink = https://bugzilla.redhat.com/show_bug.cgi?id=%%s
 
+# A regex used to recognize bug numbers in build changelog to be associated to automatic updates.
+# Since this is not treated as raw string, remember to use double backslash.
+# bz_regex = (?:fix(?:es)?|close(?:s)?)\\s(?:fedora|epel|rh(?:bz)?)#(\\d{5,})
+
 
 ##
 ## Critical Path Packages


### PR DESCRIPTION
This will make possible to associate bugs to automatic rawhide updates by reading the notes from the changelog.

To add a bug use the following format: `fix(es)|close(s) (fedora|epel|rh|rhbz)#BUG_ID` (case insensitive).
For example: `- This will fix rhbz#123456`
or `- Closes EPEL#987654`

Fixes #3925 

Signed-off-by: Mattia Verga <mattia.verga@tiscali.it>