### PR TITLE
webui & client: revise display for update's settings

### DIFF
--- a/bodhi/client/bindings.py
+++ b/bodhi/client/bindings.py
@@ -839,7 +839,8 @@ class BodhiClient(OpenIdBaseClient):
             line_formatter.format('Karma', update['karma']),
             line_formatter.format(
                 'Autokarma',
-                f"{update['autokarma']}  [{update['unstable_karma']}, {update['stable_karma']}]")
+                f"{update['autokarma']}  [{update['unstable_karma']}, {update['stable_karma']}]"),
+            line_formatter.format('Autotime', update['autotime'])
         ]
 
         try:

--- a/bodhi/server/templates/update.html
+++ b/bodhi/server/templates/update.html
@@ -442,7 +442,6 @@ if can_edit and update.release.composed_by_bodhi:
                       <div class="py-2 text-uppercase font-size-09">Settings</div>
                   </div>
 
-
               % if update.unstable_karma:
               <div class="pb-1">
                   <div class="row">
@@ -456,32 +455,44 @@ if can_edit and update.release.composed_by_bodhi:
               </div>
               % endif
 
-              % if update.autokarma is True and update.stable_karma:
               <div class="pb-1">
                   <div class="row">
                     <div class="col font-weight-bold text-muted">Stable by Karma</div>
                     <div class="col-xs-auto font-weight-bold">
+                      % if update.autokarma is True and update.stable_karma:
                           <span class="text-muted font-weight-bold" data-toggle='tooltip' title='The update will be automatically pushed to stable when karma reaches ${update.stable_karma}'>
                             <i class="fa fa-thumbs-up pr-1"></i>${update.stable_karma}
                           </span>
-                    </div>
-                  </div>
-              </div>
-              % endif
-
-              % if update.autotime is True and update.stable_days:
-              <div class="pb-1">
-                  <div class="row">
-                    <div class="col font-weight-bold text-muted">Stable by Time</div>
-                    <div class="col-xs-auto font-weight-bold">
-                          <span class="text-muted font-weight-bold" data-toggle='tooltip' title='The update will be automatically pushed to stable after being in testing for ${update.stable_days} days'>
-                            ${update.stable_days} days
+                      % else:
+                          <span class="text-muted font-weight-bold" data-toggle='tooltip'
+                            title='The update will not be automatically pushed to stable by karma'>
+                            disabled
                           </span>
+                      % endif
                     </div>
                   </div>
               </div>
-              % endif
+              
+              <div class="pb-1">
+                <div class="row">
+                  <div class="col font-weight-bold text-muted">Stable by Time</div>
+                  <div class="col-xs-auto font-weight-bold">
+                    % if update.autotime is True and update.stable_days:
+                        <span class="text-muted font-weight-bold" data-toggle='tooltip'
+                        title='The update will be automatically pushed to stable after being in testing for ${update.stable_days} days'>
+                          ${update.stable_days} days
+                        </span>
+                    % else:
+                        <span class="text-muted font-weight-bold" data-toggle='tooltip'
+                          title='The update will not be automatically pushed to stable by a time frame'>
+                          disabled
+                        </span>
+                    % endif
+                  </div>
+                </div>
               </div>
+              </div>
+
               <div class="mt-3">
                   <div class="h5 d-flex align-items-center font-weight-bold border-bottom">
                       <div class="py-2 text-uppercase font-size-09">Dates</div>

--- a/bodhi/tests/client/__init__.py
+++ b/bodhi/tests/client/__init__.py
@@ -28,7 +28,7 @@ EXAMPLE_COMMENT_MUNCH = Munch({
             'date_testing': '2017-02-13 22:56:06', 'pushed': True,
             'require_testcases': False, 'date_stable': None, 'critpath': False,
             'date_approved': None, 'stable_karma': 3, 'date_pushed': '2017-02-13 22:56:06',
-            'requirements': '', 'severity': 'low', 'autokarma': True,
+            'requirements': '', 'severity': 'low', 'autokarma': True, 'autotime': True,
             'title': 'nodejs-grunt-wrap-0.3.0-2.fc25', 'suggest': 'unspecified',
             'require_bugs': False, 'date_locked': None, 'type': 'newpackage',
             'close_bugs': True, 'status': 'testing', 'meets_testing_requirements': True,
@@ -187,6 +187,7 @@ EXAMPLE_QUERY_MUNCH = Munch({
     'updates': [{
         'alias': 'FEDORA-2017-c95b33872d',
         'autokarma': True,
+        'autotime': True,
         'content_type': 'rpm',
         'bugs': [{
             'bug_id': 1420605,
@@ -309,6 +310,7 @@ Content Type: rpm
     Severity: low
        Karma: 0
    Autokarma: True  [-3, 3]
+    Autotime: True
         Bugs: 1420605 - Review Request: nodejs-grunt-wrap - A Grunt plugin for
             : wrapping project text files
        Notes: New package.
@@ -337,6 +339,7 @@ EXAMPLE_QUERY_MUNCH_MULTI = Munch({
     'updates': [{
         'alias': 'FEDORA-2017-c95b33872d',
         'autokarma': True,
+        'autotime': True,
         'content_type': 'rpm',
         'bugs': [{
             'bug_id': 1420605,
@@ -404,6 +407,7 @@ EXAMPLE_QUERY_MUNCH_MULTI = Munch({
         {
         'alias': 'FEDORA-2017-c95b33872d',
         'autokarma': True,
+        'autotime': True,
         'content_type': 'rpm',
         'bugs': [{
             'bug_id': 1420605,
@@ -709,7 +713,7 @@ EXAMPLE_UPDATE_MUNCH = Munch({
     'date_testing': '2016-10-06 00:55:15', 'pushed': True,
     'require_testcases': True, 'date_locked': None, 'critpath': False, 'date_approved': None,
     'stable_karma': 3, 'date_pushed': '2016-10-21 13:23:01', 'requirements': '',
-    'severity': 'unspecified', 'autokarma': True, 'title': 'bodhi-2.2.4-1.el7',
+    'severity': 'unspecified', 'autokarma': True, 'autotime': True, 'title': 'bodhi-2.2.4-1.el7',
     'suggest': 'unspecified', 'require_bugs': True,
     'comments': [
         Munch({
@@ -764,8 +768,8 @@ SINGLE_UPDATE_MUNCH = Munch({
         'require_testcases': True, 'date_locked': None,
         'critpath': False, 'date_approved': None,
         'stable_karma': 3, 'date_pushed': '2016-10-21 13:23:01', 'requirements': '',
-        'severity': 'unspecified', 'autokarma': True, 'title': 'bodhi-2.2.4-1.el7',
-        'suggest': 'unspecified', 'require_bugs': True,
+        'severity': 'unspecified', 'autokarma': True, 'autotime': True,
+        'title': 'bodhi-2.2.4-1.el7', 'suggest': 'unspecified', 'require_bugs': True,
         'comments': [
             Munch({
                 'bug_feedback': [], 'user_id': 91, 'timestamp': '2016-10-05 18:10:22',
@@ -843,6 +847,7 @@ Content Type: rpm
     Severity: unspecified
        Karma: 0
    Autokarma: True  [-3, 3]
+    Autotime: True
        Notes: Update to 2.2.4. Release notes available at https://github.com
             : /fedora-infra/bodhi/releases/tag/2.2.4
    Submitter: bowlofeggs

--- a/bodhi/tests/client/test_bindings.py
+++ b/bodhi/tests/client/test_bindings.py
@@ -1124,7 +1124,7 @@ class TestBodhiClient_update_str:
         assert compare_output(
             text,
             client_test_data.EXPECTED_UPDATE_OUTPUT.replace(
-                '[-3, 3]', '[-3, 3]\n        Bugs: 1234 - it broke\n            : 1235 - halp'))
+                'Autotime: True', 'Autotime: True\n   Bugs: 1234 - it broke\n    : 1235 - halp'))
 
     @mock.patch('bodhi.client.bindings.datetime.datetime')
     def test_minimal(self, mock_datetime):
@@ -1243,11 +1243,12 @@ class TestBodhiClient_update_str:
         client.base_url = 'http://example.com/tests/'
 
         text = client.update_str(client_test_data.EXAMPLE_UPDATE_MUNCH)
+        print("This is", text)
 
         assert compare_output(
             text,
             client_test_data.EXPECTED_UPDATE_OUTPUT.replace(
-                '[-3, 3]', '[-3, 3]\n     Request: stable'))
+                'Autotime: True', 'Autotime: True\n     Request: stable'))
 
     def test_severity(self):
         """Test that severity is rendered."""
@@ -1283,6 +1284,33 @@ class TestBodhiClient_update_str:
 
         expected_output = client_test_data.EXPECTED_UPDATE_OUTPUT.replace(
             'Autokarma: True  [-3, 3]', 'Autokarma: False  [-3, 3]')
+        assert compare_output(text, expected_output)
+
+    def test_autotime_set(self):
+        """
+        Ensure correct operation when autotime is True.
+        """
+        client = bindings.BodhiClient(username='some_user', password='s3kr3t')
+        client.base_url = 'http://example.com/tests/'
+
+        text = client.update_str(client_test_data.EXAMPLE_UPDATE_MUNCH)
+
+        assert compare_output(text, client_test_data.EXPECTED_UPDATE_OUTPUT)
+
+    def test_autotime_unset(self):
+        """
+        Ensure correct operation when autotime is False.
+        """
+        client = bindings.BodhiClient(username='some_user', password='s3kr3t')
+        client.base_url = 'http://example.com/tests/'
+        update = copy.deepcopy(client_test_data.EXAMPLE_UPDATE_MUNCH)
+        # Set the update's autotime and to False.
+        update.autotime = False
+
+        text = client.update_str(update)
+
+        expected_output = client_test_data.EXPECTED_UPDATE_OUTPUT.replace(
+            'Autotime: True', 'Autotime: False')
         assert compare_output(text, expected_output)
 
     def test_update_as_string(self):

--- a/bodhi/tests/server/services/test_updates.py
+++ b/bodhi/tests/server/services/test_updates.py
@@ -3569,7 +3569,7 @@ class TestUpdatesService(BasePyTestCase):
         resp = self.app.get(f"/updates/{resp.json['alias']}", headers={'Accept': 'text/html'})
         assert 'text/html' in resp.headers['Content-Type']
         assert nvr in resp
-        assert 'Stable by Karma' in resp
+        assert 'The update will be automatically pushed to stable when karma reaches' in resp
 
     @mock.patch(**mock_valid_requirements)
     def test_disabled_button_for_autopush(self, *args):
@@ -3583,7 +3583,7 @@ class TestUpdatesService(BasePyTestCase):
         resp = self.app.get(f"/updates/{resp.json['alias']}", headers={'Accept': 'text/html'})
         assert 'text/html' in resp.headers['Content-Type']
         assert nvr in resp
-        assert 'Stable by Karma' not in resp
+        assert 'The update will not be automatically pushed to stable by karma' in resp
 
     @mock.patch(**mock_taskotron_results)
     @mock.patch(**mock_valid_requirements)

--- a/devel/ci/integration/tests/test_bodhi.py
+++ b/devel/ci/integration/tests/test_bodhi.py
@@ -386,11 +386,13 @@ def test_get_update_view(bodhi_container, db_container):
         if update_info['request']:
             assert update_info['request'] in http_response.text
         if update_info['autokarma']:
-            assert "Stable by Karma" in http_response.text
+            assert "The update will be automatically pushed to stable when karma reaches"\
+                in http_response.text
             assert (f"The update will be automatically pushed to stable"
                     f" when karma reaches {update_info['stable_karma']}") in http_response.text
         else:
-            assert "Stable by Karma" not in http_response.text
+            assert "The update will not be automatically pushed to stable by karma"\
+                in http_response.text
         if update_info['locked']:
             assert "Locked" in http_response.text
         if update_info['suggest'] == "reboot":


### PR DESCRIPTION
Showed a 'stable by karma: disabled' and a 'stable by time: disabled' in
the UI when appropriate. Also added a 'Autotime: False' to the CLI output.

Fixes: #3957

Signed-off-by: Richard O. Gregory <richardgrecoson@gmail.com>