### PR TITLE
Get the update object in the celery worker from the database.

### DIFF
--- a/bodhi/server/tasks/__init__.py
+++ b/bodhi/server/tasks/__init__.py
@@ -126,7 +126,7 @@ def expire_overrides_task(**kwargs):
 
 
 @app.task(name="handle_side_and_related_tags")
-def handle_side_and_related_tags_task(updates: typing.List["Update"], from_tag: str):
+def handle_side_and_related_tags_task(updates: typing.List[dict], from_tag: str):
     """Handle side-tags and related tags for updates in Koji."""
     from .handle_side_and_related_tags import main
     log.info("Received an order for handling update tags")
@@ -135,7 +135,7 @@ def handle_side_and_related_tags_task(updates: typing.List["Update"], from_tag: 
 
 
 @app.task(name="tag_update_builds")
-def tag_update_builds_task(update: "Update", builds: typing.List[str]):
+def tag_update_builds_task(update: dict, builds: typing.List[str]):
     """Handle tagging builds for an update in Koji."""
     from .tag_update_builds import main
     log.info("Received an order to tag builds for an update")

--- a/bodhi/server/tasks/handle_side_and_related_tags.py
+++ b/bodhi/server/tasks/handle_side_and_related_tags.py
@@ -20,14 +20,13 @@
 import logging
 import typing
 
-from bodhi.server import buildsys
+from bodhi.server import buildsys, util
 from bodhi.server.models import Update
-
 
 log = logging.getLogger(__name__)
 
 
-def main(updates: typing.List[Update], from_tag: str):
+def main(updates: typing.List[dict], from_tag: str):
     """Handle side-tags and related tags for updates in Koji.
 
     Args:
@@ -35,31 +34,34 @@ def main(updates: typing.List[Update], from_tag: str):
         from_tag: the tag into which the builds were built
     """
     koji = buildsys.get_session()
-    for update in updates:
-        release = update.release
-        if not release.composed_by_bodhi:
-            # Before the Bodhi activation point of a release, keep builds tagged
-            # with the side-tag and its associate tags. Validate that
-            # <koji_tag>-pending-signing and <koji-tag>-testing exists, if not create
-            # them.
-            side_tag_signing_pending = update.release.get_pending_signing_side_tag(
-                from_tag
-            )
-            side_tag_testing_pending = update.release.get_testing_side_tag(from_tag)
-            if not koji.getTag(side_tag_signing_pending):
-                koji.createTag(side_tag_signing_pending, parent=from_tag)
-            if not koji.getTag(side_tag_testing_pending):
-                koji.createTag(side_tag_testing_pending, parent=from_tag)
-                koji.editTag2(side_tag_testing_pending, perm="autosign")
+    db_factory = util.transactional_session_maker()
+    with db_factory() as session:
+        for update_alias in updates:
+            update = session.query(Update).filter_by(alias=update_alias["alias"]).first()
+            release = update.release
+            if not release.composed_by_bodhi:
+                # Before the Bodhi activation point of a release, keep builds tagged
+                # with the side-tag and its associate tags. Validate that
+                # <koji_tag>-pending-signing and <koji-tag>-testing exists, if not create
+                # them.
+                side_tag_signing_pending = update.release.get_pending_signing_side_tag(
+                    from_tag
+                )
+                side_tag_testing_pending = update.release.get_testing_side_tag(from_tag)
+                if not koji.getTag(side_tag_signing_pending):
+                    koji.createTag(side_tag_signing_pending, parent=from_tag)
+                if not koji.getTag(side_tag_testing_pending):
+                    koji.createTag(side_tag_testing_pending, parent=from_tag)
+                    koji.editTag2(side_tag_testing_pending, perm="autosign")
 
-            to_tag = side_tag_signing_pending
-            # Move every new build to <from_tag>-signing-pending tag
-            update.add_tag(to_tag)
-        else:
-            # After the Bodhi activation point of a release, add the pending-signing tag
-            # of the release to funnel the builds back into a normal workflow for a
-            # stable release.
-            update.add_tag(release.pending_signing_tag)
+                to_tag = side_tag_signing_pending
+                # Move every new build to <from_tag>-signing-pending tag
+                update.add_tag(to_tag)
+            else:
+                # After the Bodhi activation point of a release, add the pending-signing tag
+                # of the release to funnel the builds back into a normal workflow for a
+                # stable release.
+                update.add_tag(release.pending_signing_tag)
 
-            # From here on out, we don't need the side-tag anymore.
-            koji.removeSideTag(from_tag)
+                # From here on out, we don't need the side-tag anymore.
+                koji.removeSideTag(from_tag)

--- a/bodhi/server/tasks/tag_update_builds.py
+++ b/bodhi/server/tasks/tag_update_builds.py
@@ -20,14 +20,14 @@
 import logging
 import typing
 
-from bodhi.server import buildsys
+from bodhi.server import buildsys, util
 from bodhi.server.models import Update
 
 
 log = logging.getLogger(__name__)
 
 
-def main(update: Update, builds: typing.List[str]):
+def main(update: dict, builds: typing.List[str]):
     """Handle tagging builds for an update in Koji.
 
     Args:
@@ -36,16 +36,19 @@ def main(update: Update, builds: typing.List[str]):
     """
     koji = buildsys.get_session()
     koji.multicall = True
-    for build in builds:
-        if update.from_tag:
-            # this is a sidetag based update. use the sidetag pending signing tag
-            side_tag_pending_signing = update.release.get_pending_signing_side_tag(update.from_tag)
-            koji.tagBuild(side_tag_pending_signing, build)
-        elif update.release.pending_signing_tag:
-            # Add the release's pending_signing_tag to all new builds
-            koji.tagBuild(update.release.pending_signing_tag, build)
-        else:
-            # EL6 doesn't have these, and that's okay...
-            # We still warn in case the config gets messed up.
-            log.warning(f'{update.release.name} has no pending_signing_tag')
-    koji.multiCall()
+    db_factory = util.transactional_session_maker()
+    with db_factory() as session:
+        update = session.query(Update).filter_by(alias=update["alias"]).first()
+        for build in builds:
+            if update.from_tag:
+                # this is a sidetag based update. use the sidetag pending signing tag
+                side_tag_pending_signing = update.release.get_pending_signing_side_tag(update.from_tag)
+                koji.tagBuild(side_tag_pending_signing, build)
+            elif update.release.pending_signing_tag:
+                # Add the release's pending_signing_tag to all new builds
+                koji.tagBuild(update.release.pending_signing_tag, build)
+            else:
+                # EL6 doesn't have these, and that's okay...
+                # We still warn in case the config gets messed up.
+                log.warning(f'{update.release.name} has no pending_signing_tag')
+        koji.multiCall()

--- a/bodhi/tests/server/tasks/test_handle_side_and_related_tags.py
+++ b/bodhi/tests/server/tasks/test_handle_side_and_related_tags.py
@@ -29,6 +29,7 @@ class TestMain(BaseTaskTestCase):
 
     def test_side_tag_composed_by_bodhi(self):
         updates = self.db.query(models.Update).all()
+        updates = [u.__json__() for u in updates]
         handle_srtags_main(updates, "f17-build-side-1234")
         koji = buildsys.get_session()
 
@@ -39,7 +40,7 @@ class TestMain(BaseTaskTestCase):
         update = self.db.query(models.Update).first()
         update.release.composed_by_bodhi = False
         self.db.commit()
-        handle_srtags_main([update], "f32-build-side-1234")
+        handle_srtags_main([update.__json__()], "f32-build-side-1234")
         koji = buildsys.get_session()
 
         assert ('f32-build-side-1234-signing-pending', 'bodhi-2.0-1.fc17') in koji.__added__

--- a/bodhi/tests/server/tasks/test_tag_update_builds.py
+++ b/bodhi/tests/server/tasks/test_tag_update_builds.py
@@ -31,7 +31,7 @@ class TestMain(BaseTaskTestCase):
     def test_tag_pending_signing_builds(self):
         update = self.db.query(models.Update).first()
         pending_signing_tag = update.release.pending_signing_tag
-        tag_update_builds_main(update, update.builds)
+        tag_update_builds_main(update.__json__(), update.builds)
         koji = buildsys.get_session()
         assert (pending_signing_tag, update.builds[0]) in koji.__added__
 
@@ -41,7 +41,7 @@ class TestMain(BaseTaskTestCase):
         side_tag_pending_signing = "f17-build-side-1234-signing-pending"
         self.db.commit()
 
-        tag_update_builds_main(update, update.builds)
+        tag_update_builds_main(update.__json__(), update.builds)
 
         koji = buildsys.get_session()
         assert (side_tag_pending_signing, update.builds[0]) in koji.__added__
@@ -52,6 +52,6 @@ class TestMain(BaseTaskTestCase):
         update = self.db.query(models.Update).first()
         update.release.pending_signing_tag = ""
         self.db.commit()
-        tag_update_builds_main(update, update.builds)
+        tag_update_builds_main(update.__json__(), update.builds)
 
         assert f'{update.release.name} has no pending_signing_tag' in caplog.messages

--- a/news/3966.bug
+++ b/news/3966.bug
@@ -1,0 +1,1 @@
+Get the update object in the celery worker from the database.


### PR DESCRIPTION
This commit makes sure that we get the update object from
the database in the celery tasks.

Fixes #3966

Signed-off-by: Clement Verna <cverna@tutanota.com>