### PR TITLE
Only pass scalar argument to celery (part 2).

### DIFF
--- a/bodhi/server/services/updates.py
+++ b/bodhi/server/services/updates.py
@@ -577,7 +577,8 @@ def new_update(request):
                 result = dict(updates=updates)
 
             if from_tag:
-                handle_side_and_related_tags_task.delay(updates, from_tag)
+                aliases = [u.alias for u in updates]
+                handle_side_and_related_tags_task.delay(aliases, from_tag)
 
     except LockedUpdateException as e:
         log.warning(str(e))

--- a/bodhi/server/tasks/__init__.py
+++ b/bodhi/server/tasks/__init__.py
@@ -123,18 +123,18 @@ def expire_overrides_task(**kwargs):
 
 
 @app.task(name="handle_side_and_related_tags")
-def handle_side_and_related_tags_task(updates: typing.List[dict], from_tag: str):
+def handle_side_and_related_tags_task(aliases: typing.List[str], from_tag: str):
     """Handle side-tags and related tags for updates in Koji."""
     from .handle_side_and_related_tags import main
     log.info("Received an order for handling update tags")
     _do_init()
-    main(updates, from_tag)
+    main(aliases, from_tag)
 
 
 @app.task(name="tag_update_builds")
-def tag_update_builds_task(update: dict, builds: typing.List[str]):
+def tag_update_builds_task(alias: str, builds: typing.List[str]):
     """Handle tagging builds for an update in Koji."""
     from .tag_update_builds import main
     log.info("Received an order to tag builds for an update")
     _do_init()
-    main(update, builds)
+    main(alias, builds)

--- a/bodhi/server/tasks/handle_side_and_related_tags.py
+++ b/bodhi/server/tasks/handle_side_and_related_tags.py
@@ -20,49 +20,67 @@
 import logging
 import typing
 
+import koji  # noqa: 401
+
 from bodhi.server import buildsys, util
 from bodhi.server.models import Update
 
 log = logging.getLogger(__name__)
 
 
-def main(updates: typing.List[dict], from_tag: str):
+def main(aliases: typing.List[str], from_tag: str):
     """Handle side-tags and related tags for updates in Koji.
 
     Args:
-        updates: one or more Update objects
+        aliases: one or more Update alias
         from_tag: the tag into which the builds were built
     """
-    koji = buildsys.get_session()
     db_factory = util.transactional_session_maker()
-    with db_factory() as session:
-        for update_alias in updates:
-            update = session.query(Update).filter_by(alias=update_alias["alias"]).first()
-            if update is not None:
-                release = update.release
-                if not release.composed_by_bodhi:
-                    # Before the Bodhi activation point of a release, keep builds tagged
-                    # with the side-tag and its associate tags. Validate that
-                    # <koji_tag>-pending-signing and <koji-tag>-testing exists, if not create
-                    # them.
-                    side_tag_signing_pending = update.release.get_pending_signing_side_tag(
-                        from_tag
-                    )
-                    side_tag_testing_pending = update.release.get_testing_side_tag(from_tag)
-                    if not koji.getTag(side_tag_signing_pending):
-                        koji.createTag(side_tag_signing_pending, parent=from_tag)
-                    if not koji.getTag(side_tag_testing_pending):
-                        koji.createTag(side_tag_testing_pending, parent=from_tag)
-                        koji.editTag2(side_tag_testing_pending, perm="autosign")
+    koji = buildsys.get_session()
+    try:
+        with db_factory() as db:
+            for alias in aliases:
+                update = db.query(Update).filter_by(alias=alias).first()
+                if update is not None:
+                    handle_tagging(update, from_tag, koji)
+    except Exception:
+        log.exception("There was an error handling side-tags updates")
+    finally:
+        db_factory._end_session()
 
-                    to_tag = side_tag_signing_pending
-                    # Move every new build to <from_tag>-signing-pending tag
-                    update.add_tag(to_tag)
-                else:
-                    # After the Bodhi activation point of a release, add the pending-signing tag
-                    # of the release to funnel the builds back into a normal workflow for a
-                    # stable release.
-                    update.add_tag(release.pending_signing_tag)
 
-                    # From here on out, we don't need the side-tag anymore.
-                    koji.removeSideTag(from_tag)
+def handle_tagging(update: Update, from_tag: str,
+                   koji: typing.Union[koji.ClientSession, buildsys.DevBuildsys]):
+    """Handle the tagging of the updates in koji.
+
+    Args:
+        update: an Update objects
+        from_tag: the tag into which the builds were built
+        koji: koji client.
+    """
+    if not update.release.composed_by_bodhi:
+        # Before the Bodhi activation point of a release, keep builds tagged
+        # with the side-tag and its associate tags. Validate that
+        # <koji_tag>-pending-signing and <koji-tag>-testing exists, if not create
+        # them.
+        side_tag_signing_pending = update.release.get_pending_signing_side_tag(
+            from_tag
+        )
+        side_tag_testing_pending = update.release.get_testing_side_tag(from_tag)
+        if not koji.getTag(side_tag_signing_pending):
+            koji.createTag(side_tag_signing_pending, parent=from_tag)
+        if not koji.getTag(side_tag_testing_pending):
+            koji.createTag(side_tag_testing_pending, parent=from_tag)
+            koji.editTag2(side_tag_testing_pending, perm="autosign")
+
+        to_tag = side_tag_signing_pending
+        # Move every new build to <from_tag>-signing-pending tag
+        update.add_tag(to_tag)
+    else:
+        # After the Bodhi activation point of a release, add the pending-signing tag
+        # of the release to funnel the builds back into a normal workflow for a
+        # stable release.
+        update.add_tag(update.release.pending_signing_tag)
+
+        # From here on out, we don't need the side-tag anymore.
+        koji.removeSideTag(from_tag)

--- a/bodhi/tests/server/tasks/test_tag_update_builds.py
+++ b/bodhi/tests/server/tasks/test_tag_update_builds.py
@@ -1,5 +1,5 @@
 import logging
-from unittest.mock import patch
+from unittest.mock import patch, MagicMock
 
 from bodhi.server import buildsys, models
 from bodhi.server.tasks import tag_update_builds_task
@@ -16,7 +16,7 @@ class TestTask(BasePyTestCase):
     @patch("bodhi.server.tasks.config")
     @patch("bodhi.server.tasks.tag_update_builds.main")
     def test_task(self, main_function, config_mock, init_db_mock, buildsys):
-        tag_update_builds_task(update=None, builds=[])
+        tag_update_builds_task(alias=None, builds=[])
         config_mock.load_config.assert_called_with()
         init_db_mock.assert_called_with(config_mock)
         buildsys.setup_buildsystem.assert_called_with(config_mock)
@@ -31,7 +31,7 @@ class TestMain(BaseTaskTestCase):
     def test_tag_pending_signing_builds(self):
         update = self.db.query(models.Update).first()
         pending_signing_tag = update.release.pending_signing_tag
-        tag_update_builds_main(update.__json__(), update.builds)
+        tag_update_builds_main(update.alias, update.builds)
         koji = buildsys.get_session()
         assert (pending_signing_tag, update.builds[0]) in koji.__added__
 
@@ -41,7 +41,7 @@ class TestMain(BaseTaskTestCase):
         side_tag_pending_signing = "f17-build-side-1234-signing-pending"
         self.db.commit()
 
-        tag_update_builds_main(update.__json__(), update.builds)
+        tag_update_builds_main(update.alias, update.builds)
 
         koji = buildsys.get_session()
         assert (side_tag_pending_signing, update.builds[0]) in koji.__added__
@@ -52,6 +52,17 @@ class TestMain(BaseTaskTestCase):
         update = self.db.query(models.Update).first()
         update.release.pending_signing_tag = ""
         self.db.commit()
-        tag_update_builds_main(update.__json__(), update.builds)
+        tag_update_builds_main(update.alias, update.builds)
 
         assert f'{update.release.name} has no pending_signing_tag' in caplog.messages
+
+    def test_tag_raise_execption(self, caplog):
+        mock_release = MagicMock()
+        mock_release.get_pending_signing_side_tag.return_value = None
+        update = self.db.query(models.Update).first()
+        update.from_tag = "f17-build-side-1234"
+        self.db.commit()
+        with patch("bodhi.server.models.Update.release", mock_release):
+            tag_update_builds_main(update.alias, update.builds)
+
+        assert "There was an error handling tagging builds in koji" in caplog.messages

--- a/news/3966.bug
+++ b/news/3966.bug
@@ -1,1 +1,0 @@
-Get the update object in the celery worker from the database.

--- a/news/8b30a825.bug
+++ b/news/8b30a825.bug
@@ -1,0 +1,1 @@
+Only pass scalar argument to celery (part 2). Avoid the celery enqueuer emitting SQL queries to resolve attributes, and therefore opening new transactions.


### PR DESCRIPTION
This avoids the celery enqueuer emitting SQL queries to resolve
attributes, and therefore opening new transactions.

Signed-off-by: Clement Verna <cverna@tutanota.com>