### PR TITLE
Ignore builds associated with unpushed Updates when validating

### DIFF
--- a/bodhi/server/validators.py
+++ b/bodhi/server/validators.py
@@ -295,9 +295,10 @@ def validate_builds(request, **kwargs):
     for nvr in builds:
         build = request.db.query(Build).filter_by(nvr=nvr).first()
         if build and build.update is not None:
-            request.errors.add('body', 'builds',
-                               "Update for {} already exists".format(nvr))
-            return
+            if build.update.status != UpdateStatus.unpushed:
+                request.errors.add('body', 'builds',
+                                   "Update for {} already exists".format(nvr))
+                return
 
 
 @postschema_validator

--- a/bodhi/tests/server/services/test_updates.py
+++ b/bodhi/tests/server/services/test_updates.py
@@ -172,6 +172,17 @@ class TestNewUpdate(BasePyTestCase):
         assert 'Update for bodhi-2.0-1.fc17 already exists' in res
 
     @mock.patch(**mock_valid_requirements)
+    def test_unpushed_update(self, *args):
+
+        unpushed_update = self.create_update(['whoopsie-1.0.0-1.fc17'])
+        unpushed_update.status = UpdateStatus.unpushed
+        self.db.commit()
+
+        res = self.app.post_json('/updates/', self.get_update('whoopsie-1.0.0-1.fc17'))
+
+        assert res.json['alias'] != unpushed_update.alias
+
+    @mock.patch(**mock_valid_requirements)
     def test_invalid_requirements(self, *args):
         update = self.get_update()
         update['requirements'] = 'rpmlint silly-dilly'

--- a/bodhi/tests/server/services/test_updates.py
+++ b/bodhi/tests/server/services/test_updates.py
@@ -173,12 +173,13 @@ class TestNewUpdate(BasePyTestCase):
 
     @mock.patch(**mock_valid_requirements)
     def test_unpushed_update(self, *args):
-
+        """Allow posting a duplicate build if the old update is unpushed."""
         unpushed_update = self.create_update(['whoopsie-1.0.0-1.fc17'])
         unpushed_update.status = UpdateStatus.unpushed
         self.db.commit()
 
-        res = self.app.post_json('/updates/', self.get_update('whoopsie-1.0.0-1.fc17'))
+        with fml_testing.mock_sends(update_schemas.UpdateRequestTestingV1):
+            res = self.app.post_json('/updates/', self.get_update('whoopsie-1.0.0-1.fc17'))
 
         assert res.json['alias'] != unpushed_update.alias
 

--- a/news/1809.bug
+++ b/news/1809.bug
@@ -1,0 +1,1 @@
+Ignore builds in Unpushed updates when checking for duplicate builds


### PR DESCRIPTION
Currently, if you create an Update with a build, then unpush it, you
cannot create a new Update with that same build. This commit ignores
builds assigned to Unpushed commits when validating duplicate builds.

Resolves #3715, #1809