### PR TITLE
Do not bound the database session to the TransactionalSessionMaker cl…

### DIFF
--- a/bodhi/server/util.py
+++ b/bodhi/server/util.py
@@ -874,16 +874,16 @@ class TransactionalSessionMaker(object):
         Exceptions or rolls back the transaction. In either case, it also will close and remove the
         Session.
         """
-        self.session = Session()
+        session = Session()
         try:
-            yield self.session
-            self.session.commit()
+            yield session
+            session.commit()
         except Exception as e:
             # It is possible for session.rollback() to raise Exceptions, so we will wrap it in an
             # Exception handler as well so we can log the rollback failure and still raise the
             # original Exception.
             try:
-                self.session.rollback()
+                session.rollback()
             except Exception:
                 log.exception('An Exception was raised while rolling back a transaction.')
             raise e
@@ -897,7 +897,6 @@ class TransactionalSessionMaker(object):
         This has been split off the main __call__ method to make it easier to
         mock it out in unit tests.
         """
-        self.session.close()
         Session.remove()
 
 

--- a/bodhi/tests/server/test_util.py
+++ b/bodhi/tests/server/test_util.py
@@ -1443,7 +1443,6 @@ class TestTransactionalSessionMaker(base.BasePyTestCase):
             'An Exception was raised while rolling back a transaction.')
         assert Session.return_value.commit.call_count == 0
         Session.return_value.rollback.assert_called_once_with()
-        Session.return_value.close.assert_called_once_with()
         Session.remove.assert_called_once_with()
 
     @mock.patch('bodhi.server.util.log.exception')
@@ -1466,7 +1465,6 @@ class TestTransactionalSessionMaker(base.BasePyTestCase):
         assert log_exception.call_count == 0
         assert Session.return_value.commit.call_count == 0
         Session.return_value.rollback.assert_called_once_with()
-        Session.return_value.close.assert_called_once_with()
         Session.remove.assert_called_once_with()
 
     @mock.patch('bodhi.server.util.log.exception')
@@ -1486,7 +1484,6 @@ class TestTransactionalSessionMaker(base.BasePyTestCase):
         assert log_exception.call_count == 0
         assert Session.return_value.rollback.call_count == 0
         Session.return_value.commit.assert_called_once_with()
-        Session.return_value.close.assert_called_once_with()
         Session.remove.assert_called_once_with()
 
 

--- a/news/3979.bug
+++ b/news/3979.bug
@@ -1,0 +1,3 @@
+Do not bound the database session created using TransactionalSessionMaker class to the object created.
+Since threads are sharing the memory binding to the session object, it makes it possible for threads to
+override a previous session leading to unexpected behaviours.


### PR DESCRIPTION
…ass.

Since Threads are sharing the memory binding the session object to the class
make it possible for threads to override a previous session leading to unexpected
behaviours.

Fixes #3979

Signed-off-by: Clement Verna <cverna@tutanota.com>