### PR TITLE
Avoid using a database session in the tag_update_builds_task.

### DIFF
--- a/bodhi/server/models.py
+++ b/bodhi/server/models.py
@@ -2426,7 +2426,14 @@ class Update(Base):
                 })
 
             # Add the pending_signing_tag to all new builds
-            tag_update_builds_task.delay(update=up, builds=new_builds)
+            tag = None
+            if up.from_tag:
+                tag = up.release.get_pending_signing_side_tag(up.from_tag)
+            elif up.release.pending_signing_tag:
+                tag = up.release.pending_signing_tag
+
+            if tag is not None:
+                tag_update_builds_task.delay(tag=tag, builds=new_builds)
 
         # And, updates with new or removed builds always get their karma reset.
         # https://github.com/fedora-infra/bodhi/issues/511

--- a/bodhi/server/tasks/__init__.py
+++ b/bodhi/server/tasks/__init__.py
@@ -132,9 +132,9 @@ def handle_side_and_related_tags_task(aliases: typing.List[str], from_tag: str):
 
 
 @app.task(name="tag_update_builds")
-def tag_update_builds_task(alias: str, builds: typing.List[str]):
+def tag_update_builds_task(tag: str, builds: typing.List[str]):
     """Handle tagging builds for an update in Koji."""
     from .tag_update_builds import main
     log.info("Received an order to tag builds for an update")
     _do_init()
-    main(alias, builds)
+    main(tag, builds)

--- a/bodhi/server/tasks/tag_update_builds.py
+++ b/bodhi/server/tasks/tag_update_builds.py
@@ -20,56 +20,25 @@
 import logging
 import typing
 
-import koji  # noqa: 401
-
-from bodhi.server import buildsys, util
-from bodhi.server.models import Update
+from bodhi.server import buildsys
 
 
 log = logging.getLogger(__name__)
 
 
-def main(alias: str, builds: typing.List[str]):
+def main(tag: str, builds: typing.List[str]):
     """Handle tagging builds for an update in Koji.
 
     Args:
-        alias: an Update alias
+        tag: a koji tag to apply on the builds.
         builds: list of new build added to the update.
     """
-    koji = buildsys.get_session()
-    koji.multicall = True
-    db_factory = util.transactional_session_maker()
     try:
-        with db_factory() as session:
-            update = session.query(Update).filter_by(alias=alias).first()
-        if update is not None:
-            tag_builds(update, builds, koji)
+        kc = buildsys.get_session()
+        kc.multicall = True
+        for build in builds:
+            kc.tagBuild(tag, build)
+            log.info(f"Tagging build {build} in {tag}")
+        kc.multiCall()
     except Exception:
-        log.exception("There was an error handling tagging builds in koji")
-    finally:
-        db_factory._end_session()
-
-
-def tag_builds(update: Update, builds: typing.List[str],
-               koji: typing.Union[koji.ClientSession, buildsys.DevBuildsys]):
-    """Tag the update builds in koji.
-
-    Args:
-        update: an Update object
-        builds: list of new build added to the update.
-        koji: Koji client.
-    """
-    for build in builds:
-        if update.from_tag:
-            # this is a sidetag based update. use the sidetag pending signing tag
-            side_tag_pending_signing = update.release.get_pending_signing_side_tag(
-                update.from_tag)
-            koji.tagBuild(side_tag_pending_signing, build)
-        elif update.release.pending_signing_tag:
-            # Add the release's pending_signing_tag to all new builds
-            koji.tagBuild(update.release.pending_signing_tag, build)
-        else:
-            # EL6 doesn't have these, and that's okay...
-            # We still warn in case the config gets messed up.
-            log.warning(f'{update.release.name} has no pending_signing_tag')
-    koji.multiCall()
+        log.exception(f"There was an error handling tagging builds in koji.")

--- a/bodhi/tests/server/tasks/test_tag_update_builds.py
+++ b/bodhi/tests/server/tasks/test_tag_update_builds.py
@@ -1,4 +1,3 @@
-import logging
 from unittest.mock import patch, MagicMock
 
 from bodhi.server import buildsys, models
@@ -16,7 +15,7 @@ class TestTask(BasePyTestCase):
     @patch("bodhi.server.tasks.config")
     @patch("bodhi.server.tasks.tag_update_builds.main")
     def test_task(self, main_function, config_mock, init_db_mock, buildsys):
-        tag_update_builds_task(alias=None, builds=[])
+        tag_update_builds_task(tag=None, builds=[])
         config_mock.load_config.assert_called_with()
         init_db_mock.assert_called_with(config_mock)
         buildsys.setup_buildsystem.assert_called_with(config_mock)
@@ -31,7 +30,7 @@ class TestMain(BaseTaskTestCase):
     def test_tag_pending_signing_builds(self):
         update = self.db.query(models.Update).first()
         pending_signing_tag = update.release.pending_signing_tag
-        tag_update_builds_main(update.alias, update.builds)
+        tag_update_builds_main(pending_signing_tag, update.builds)
         koji = buildsys.get_session()
         assert (pending_signing_tag, update.builds[0]) in koji.__added__
 
@@ -41,20 +40,10 @@ class TestMain(BaseTaskTestCase):
         side_tag_pending_signing = "f17-build-side-1234-signing-pending"
         self.db.commit()
 
-        tag_update_builds_main(update.alias, update.builds)
+        tag_update_builds_main(side_tag_pending_signing, update.builds)
 
         koji = buildsys.get_session()
         assert (side_tag_pending_signing, update.builds[0]) in koji.__added__
-
-    def test_tag_release_no_pending_signing_tag(self, caplog):
-        caplog.set_level(logging.WARNING)
-
-        update = self.db.query(models.Update).first()
-        update.release.pending_signing_tag = ""
-        self.db.commit()
-        tag_update_builds_main(update.alias, update.builds)
-
-        assert f'{update.release.name} has no pending_signing_tag' in caplog.messages
 
     def test_tag_raise_execption(self, caplog):
         mock_release = MagicMock()
@@ -62,7 +51,7 @@ class TestMain(BaseTaskTestCase):
         update = self.db.query(models.Update).first()
         update.from_tag = "f17-build-side-1234"
         self.db.commit()
-        with patch("bodhi.server.models.Update.release", mock_release):
-            tag_update_builds_main(update.alias, update.builds)
+        with patch("bodhi.server.buildsys._buildsystem", return_value=None):
+            tag_update_builds_main("f17-signing-pending", update.builds)
 
-        assert "There was an error handling tagging builds in koji" in caplog.messages
+        assert "There was an error handling tagging builds in koji." in caplog.messages

--- a/news/3981.dev
+++ b/news/3981.dev
@@ -1,0 +1,1 @@
+Avoid using a database session in the tag_update_builds_task.


### PR DESCRIPTION
In the tag_update_builds_task we do not need a
database session we just need to pass the list of
builds and the koji tag to be used.

Signed-off-by: Clement Verna <cverna@tutanota.com>