### PR TITLE
Avoid using a database session in the handle side tag task.

### DIFF
--- a/bodhi/server/tasks/__init__.py
+++ b/bodhi/server/tasks/__init__.py
@@ -123,12 +123,16 @@ def expire_overrides_task(**kwargs):
 
 
 @app.task(name="handle_side_and_related_tags")
-def handle_side_and_related_tags_task(aliases: typing.List[str], from_tag: str):
+def handle_side_and_related_tags_task(
+        builds: typing.List[str],
+        pending_signing_tag: str,
+        from_tag: str,
+        pending_testing_tag: typing.Optional[str] = None):
     """Handle side-tags and related tags for updates in Koji."""
     from .handle_side_and_related_tags import main
     log.info("Received an order for handling update tags")
     _do_init()
-    main(aliases, from_tag)
+    main(builds, pending_signing_tag, from_tag, pending_testing_tag)
 
 
 @app.task(name="tag_update_builds")

--- a/bodhi/tests/server/services/test_updates.py
+++ b/bodhi/tests/server/services/test_updates.py
@@ -344,20 +344,24 @@ class TestNewUpdate(BasePyTestCase):
 
         resp = self.app.get(f"/updates/{up['alias']}", headers={'Accept': 'text/html'})
 
+        handle_side_and_related_tags_task.delay.assert_called_once()
+        called_args = handle_side_and_related_tags_task.delay.call_args[1]
+        # don't check the first argument, it's the update object
+        assert called_args['builds'] == ['gnome-backgrounds-3.0-1.fc17']
+        assert called_args['from_tag'] == 'f17-build-side-7777'
+
         if rawhide_workflow:
             # check that the sidetag gets displayed on the update page
             assert 'title="Builds from the Side Tag: f17-build-side-7777' in resp
+            assert called_args['pending_signing_tag'] == 'f17-build-side-7777-signing-pending'
+            assert called_args['pending_testing_tag'] == 'f17-build-side-7777-testing-pending'
         else:
             # stable release workflow
 
             # check that the sidetag doesn't get displayed on the update page,
             # by the time the update is created, it shouldn't exist anymore
             assert 'title="Builds from the Side Tag:' not in resp
-
-        handle_side_and_related_tags_task.delay.assert_called_once()
-        called_args = handle_side_and_related_tags_task.delay.call_args[0]
-        # don't check the first argument, it's the update object
-        assert called_args[1] == 'f17-build-side-7777'
+            assert called_args['pending_signing_tag'] == 'f17-updates-signing-pending'
 
         # now try to create another update with the same side tag
         update = self.get_update(builds=None, from_tag='f17-build-side-7777')

--- a/bodhi/tests/server/tasks/test_handle_side_and_related_tags.py
+++ b/bodhi/tests/server/tasks/test_handle_side_and_related_tags.py
@@ -15,11 +15,11 @@ class TestTask(BasePyTestCase):
     @patch("bodhi.server.tasks.config")
     @patch("bodhi.server.tasks.handle_side_and_related_tags.main")
     def test_task(self, main_function, config_mock, init_db_mock, buildsys):
-        handle_side_and_related_tags_task(aliases=[], from_tag="")
+        handle_side_and_related_tags_task(builds=[], pending_signing_tag="", from_tag="")
         config_mock.load_config.assert_called_with()
         init_db_mock.assert_called_with(config_mock)
         buildsys.setup_buildsystem.assert_called_with(config_mock)
-        main_function.assert_called_with([], "")
+        main_function.assert_called_with([], "", "", None)
 
 
 class TestMain(BaseTaskTestCase):
@@ -28,26 +28,30 @@ class TestMain(BaseTaskTestCase):
     """
 
     def test_side_tag_composed_by_bodhi(self):
-        updates = self.db.query(models.Update).all()
-        updates = [u.alias for u in updates]
-        handle_srtags_main(updates, "f17-build-side-1234")
-        koji = buildsys.get_session()
+        u = self.db.query(models.Update).first()
+        from_tag = "f17-build-side-1234"
+        builds = [b.nvr for b in u.builds]
+        handle_srtags_main(builds, u.release.pending_signing_tag, from_tag, None)
 
+        koji = buildsys.get_session()
         assert ('f17-updates-signing-pending', 'bodhi-2.0-1.fc17') in koji.__added__
         assert {'id': 1234, 'name': 'f17-build-side-1234'} in koji.__removed_side_tags__
 
     def test_side_tag_not_composed_by_bodhi(self):
-        update = self.db.query(models.Update).first()
-        update.release.composed_by_bodhi = False
-        self.db.commit()
-        handle_srtags_main([update.alias], "f32-build-side-1234")
-        koji = buildsys.get_session()
+        u = self.db.query(models.Update).first()
+        from_tag = "f32-build-side-1234"
+        side_tag_signing_pending = u.release.get_pending_signing_side_tag(from_tag)
+        side_tag_testing_pending = u.release.get_testing_side_tag(from_tag)
+        builds = [b.nvr for b in u.builds]
+        handle_srtags_main(builds, side_tag_signing_pending, from_tag, side_tag_testing_pending)
 
+        koji = buildsys.get_session()
         assert ('f32-build-side-1234-signing-pending', 'bodhi-2.0-1.fc17') in koji.__added__
         assert "f32-build-side-1234-signing-pending" in koji.__tags__[0][0]
         assert "f32-build-side-1234-testing-pending" in koji.__tags__[1][0]
 
     def test_side_tag_raise_exception(self, caplog):
         update = self.db.query(models.Update).first()
-        handle_srtags_main([update.alias], None)
+        builds = [b.nvr for b in update.builds]
+        handle_srtags_main(builds, update.release.pending_signing_tag, None, None)
         assert "There was an error handling side-tags updates" in caplog.messages

--- a/news/3983.dev
+++ b/news/3983.dev
@@ -1,0 +1,1 @@
+Avoid using a database session in the handle side tag task.


### PR DESCRIPTION
In handle_side_and_related_tags_task we don't modify any object in the
database. Therefore we don't need to have a database session in the task.
We can just pass the value needed as argument.

Signed-off-by: Clement Verna <cverna@tutanota.com>