### PR TITLE
Split handle_update task into two celery tasks for bugs and testcases

### DIFF
--- a/bodhi/server/exceptions.py
+++ b/bodhi/server/exceptions.py
@@ -28,3 +28,7 @@ class RepodataException(Exception):
 
 class LockedUpdateException(Exception):
     """Raised when something attempts to operate on a locked update."""
+
+
+class ExternalCallException(Exception):
+    """Raised when a call to an external service fails."""

--- a/bodhi/server/models.py
+++ b/bodhi/server/models.py
@@ -30,7 +30,7 @@ import uuid
 from urllib.error import URLError
 
 from simplemediawiki import MediaWiki
-from sqlalchemy import (and_, Boolean, Column, DateTime, event, ForeignKey,
+from sqlalchemy import (and_, Boolean, Column, DateTime, event, func, ForeignKey,
                         Integer, or_, Table, Unicode, UnicodeText, UniqueConstraint)
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import class_mapper, relationship, backref, validates
@@ -45,8 +45,8 @@ from bodhi.messages.schemas import (buildroot_override as override_schemas,
                                     errata as errata_schemas, update as update_schemas)
 from bodhi.server import bugs, buildsys, log, mail, notifications, Session, util
 from bodhi.server.config import config
-from bodhi.server.exceptions import BodhiException, LockedUpdateException
-from bodhi.server.tasks import handle_update, tag_update_builds_task
+from bodhi.server.exceptions import BodhiException, ExternalCallException, LockedUpdateException
+from bodhi.server.tasks import fetch_test_cases_task, tag_update_builds_task, work_on_bugs_task
 from bodhi.server.util import (
     avatar as get_avatar, build_evr, get_critpath_components,
     get_rpm_header, header, tokenize, pagure_api_get)
@@ -1130,7 +1130,7 @@ class Package(Base):
         Args:
             db (sqlalchemy.orm.session.Session): A database session.
         Raises:
-            BodhiException: When retrieving testcases from Wiki failed.
+            ExternalCallException: When retrieving testcases from Wiki failed.
         """
         if not config.get('query_wiki_test_cases'):
             return
@@ -1148,7 +1148,7 @@ class Package(Base):
             try:
                 response = wiki.call(query)
             except URLError:
-                raise BodhiException('Failed retrieving testcases from Wiki')
+                raise ExternalCallException('Failed retrieving testcases from Wiki')
             members = [entry['title'] for entry in
                        response.get('query', {}).get('categorymembers', {})
                        if 'title' in entry]
@@ -2451,22 +2451,36 @@ class Update(Base):
 
         up.date_modified = datetime.utcnow()
 
-        # Store the update alias so Celery doesn't have to emit SQL
-        update_alias = up.alias
-
         notifications.publish(update_schemas.UpdateEditV1.from_dict(
             message={'update': up, 'agent': request.user.name, 'new_bugs': new_bugs}))
 
-        # Commit the changes in the db before calling a celery task.
+        # If editing a Pending update, all of whose builds are signed, for a release
+        # which isn't composed by Bodhi (i.e. Rawhide), move it directly to Testing.
+        if not up.release.composed_by_bodhi and up.status == UpdateStatus.pending \
+                and up.signed:
+            log.info("Every build in the update is signed, set status to testing")
+            up.status = UpdateStatus.testing
+            up.date_testing = func.current_timestamp()
+            up.request = None
+            log.info(f"Update status of {up.alias} has been set to testing")
+
+        if config['test_gating.required']:
+            log.info(f"Updating test gating status of {up.alias}")
+            up.update_test_gating_status()
+
+        # Commit the changes in the db before calling celery tasks.
         db.commit()
 
-        handle_update.delay(
-            api_version=2, action='edit',
-            update_alias=update_alias,
-            agent=request.user.name,
-            new_bugs=new_bugs
-        )
+        log.info("Deferring working on bugs and fetching test cases to celery")
+        alias = up.alias
+        if not bool(config.get('bodhi_email')):
+            log.warning("Not configured to handle bugs")
+        else:
+            work_on_bugs_task.delay(alias, new_bugs)
 
+        fetch_test_cases_task.delay(alias)
+
+        log.info(f"Done editing {up.alias}")
         return up, caveats
 
     @property
@@ -2916,10 +2930,19 @@ class Update(Base):
         db.commit()
 
         if action == UpdateRequest.testing:
-            handle_update.delay(
-                api_version=2, action="testing",
-                update_alias=alias,
-                agent=username)
+            if config['test_gating.required']:
+                log.info(f"Updating test gating status of {self.alias}")
+                self.update_test_gating_status()
+                db.commit()
+
+            log.info("Deferring working on bugs and fetching test cases to celery")
+            if not bool(config.get('bodhi_email')):
+                log.warning("Not configured to handle bugs")
+            else:
+                bugs = [bug.bug_id for bug in self.bugs]
+                work_on_bugs_task.delay(alias, bugs)
+
+            fetch_test_cases_task.delay(alias)
 
     def waive_test_results(self, username, comment=None, tests=None):
         """

--- a/bodhi/server/tasks/fetch_test_cases.py
+++ b/bodhi/server/tasks/fetch_test_cases.py
@@ -1,0 +1,50 @@
+# Copyright © 2019-2020 Red Hat, Inc.
+#
+# This file is part of Bodhi.
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+"""Query the wiki for test cases for each package on the given update."""
+
+import logging
+
+from bodhi.server.exceptions import BodhiException, ExternalCallException
+from bodhi.server.util import transactional_session_maker
+
+
+log = logging.getLogger(__name__)
+
+
+def main(alias: str):
+    """
+    Query the wiki for test cases for each package on the given update.
+
+    Args:
+        alias: The update's builds are iterated upon to find test cases for
+            their associated Packages.
+    """
+    from bodhi.server.models import Update
+
+    db_factory = transactional_session_maker()
+    with db_factory() as session:
+        update = Update.get(alias)
+        if not update:
+            raise BodhiException(f"Couldn't find alias {alias} in DB")
+
+        for build in update.builds:
+            try:
+                build.package.fetch_test_cases(session)
+            except ExternalCallException:
+                log.warning('Error occurred during fetching testcases', exc_info=True)
+                raise ExternalCallException

--- a/bodhi/server/tasks/updates.py
+++ b/bodhi/server/tasks/updates.py
@@ -40,7 +40,7 @@ from sqlalchemy import func
 
 from bodhi.server import util, bugs as bug_module
 from bodhi.server.config import config
-from bodhi.server.exceptions import BodhiException
+from bodhi.server.exceptions import BodhiException, ExternalCallException
 from bodhi.server.models import Bug, Update, UpdateType, UpdateStatus
 
 
@@ -161,7 +161,7 @@ class UpdatesHandler:
         for build in update.builds:
             try:
                 build.package.fetch_test_cases(session)
-            except BodhiException:
+            except ExternalCallException:
                 log.warning('Error occurred during fetching testcases', exc_info=True)
 
     def work_on_bugs(self, session, update, bugs):

--- a/bodhi/server/tasks/work_on_bugs.py
+++ b/bodhi/server/tasks/work_on_bugs.py
@@ -1,0 +1,86 @@
+# Copyright © 2019-2020 Red Hat, Inc.
+#
+# This file is part of Bodhi.
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+"""Iterate the list of bugs, retrieving information from Bugzilla and modifying them."""
+
+import logging
+import typing
+
+from bodhi.server import util, bugs as bug_module
+from bodhi.server.config import config
+from bodhi.server.exceptions import BodhiException, ExternalCallException
+
+
+log = logging.getLogger(__name__)
+
+
+def main(alias: str, bugs: typing.List[int]):
+    """
+    Iterate the list of bugs, retrieving information from Bugzilla and modifying them.
+
+    Iterate the given list of bugs associated with the given update. For each bug, retrieve
+    details from Bugzilla, comment on the bug to let watchers know about the update, and mark
+    the bug as MODIFIED. If the bug is a security issue, mark the update as a security update.
+
+    Args:
+        update: The update that the bugs are associated with.
+        bugs: A list of bodhi.server.models.Bug instances that we wish to act on.
+    """
+    from bodhi.server.models import Bug, Update, UpdateType
+
+    log.info(f'Got {len(bugs)} bugs to sync for {alias}')
+
+    db_factory = util.transactional_session_maker()
+    with db_factory() as session:
+        update = Update.get(alias)
+        if not update:
+            raise BodhiException(f"Couldn't find alias {alias} in DB")
+
+        for bug_id in bugs:
+            bug = Bug.get(bug_id)
+            # Sanity check
+            if bug is None or bug not in update.bugs:
+                update_bugs_ids = [b.bug_id for b in update.bugs]
+                update.update_bugs(update_bugs_ids + [bug_id], session)
+                # Now, after update.update_bugs, bug with bug_id should exists in DB
+                bug = Bug.get(bug_id)
+
+            log.info(f'Getting RHBZ bug {bug.bug_id}')
+            try:
+                rhbz_bug = bug_module.bugtracker.getbug(bug.bug_id)
+
+                log.info(f'Updating our details for {bug.bug_id}')
+                bug.update_details(rhbz_bug)
+                log.info(f'  Got title {bug.title} for {bug.bug_id}')
+
+                # If you set the type of your update to 'enhancement' but you
+                # attach a security bug, we automatically change the type of your
+                # update to 'security'. We need to do this first, so we don't
+                # accidentally comment on stuff that we shouldn't.
+                if not update.type == UpdateType.security and bug.security:
+                    log.info("Setting our UpdateType to security.")
+                    update.type = UpdateType.security
+
+                log.info(f'Commenting on {bug.bug_id}')
+                comment = config['initial_bug_msg'] % (
+                    update.alias, update.release.long_name, update.abs_url())
+
+                log.info(f'Modifying {bug.bug_id}')
+                bug.modified(update, comment)
+            except Exception:
+                log.warning('Error occurred during updating single bug', exc_info=True)
+                raise ExternalCallException

--- a/bodhi/tests/server/consumers/test_automatic_updates.py
+++ b/bodhi/tests/server/consumers/test_automatic_updates.py
@@ -293,9 +293,6 @@ class TestAutomaticUpdateHandler(base.BasePyTestCase):
             self.db.add(user)
         self.db.flush()
 
-        with mock.patch('bodhi.server.models.handle_update'):
-            self.handler(self.sample_message)
-
         assert(f"Creating bodhi user for '{expected_username}'."
                not in caplog.messages)
 

--- a/bodhi/tests/server/services/test_updates.py
+++ b/bodhi/tests/server/services/test_updates.py
@@ -90,7 +90,8 @@ def unused_mock_patch(_mockcls=mock.MagicMock, **kwargs):
     return mock.patch(target, new=mockobj)
 
 
-@mock.patch('bodhi.server.models.handle_update', mock.Mock())
+@mock.patch('bodhi.server.models.work_on_bugs_task', mock.Mock())
+@mock.patch('bodhi.server.models.fetch_test_cases_task', mock.Mock())
 class TestNewUpdate(BasePyTestCase):
     """
     This class contains tests for the new_update() function.
@@ -948,7 +949,6 @@ class TestNewUpdate(BasePyTestCase):
         )
 
 
-@mock.patch('bodhi.server.models.handle_update', mock.Mock())
 class TestSetRequest(BasePyTestCase):
     """
     This class contains tests for the set_request() function.
@@ -1099,7 +1099,8 @@ class TestSetRequest(BasePyTestCase):
         log_exception.assert_called_once_with("Unhandled exception in set_request")
 
 
-@mock.patch('bodhi.server.models.handle_update', mock.Mock())
+@mock.patch('bodhi.server.models.work_on_bugs_task', mock.Mock())
+@mock.patch('bodhi.server.models.fetch_test_cases_task', mock.Mock())
 class TestEditUpdateForm(BasePyTestCase):
 
     def test_edit_with_permission(self):
@@ -1207,7 +1208,8 @@ class TestEditUpdateForm(BasePyTestCase):
         assert str(resp).count("&lt;script&gt;thisIsBad()&lt;/script&gt;") == 2
 
 
-@mock.patch('bodhi.server.models.handle_update', mock.Mock())
+@mock.patch('bodhi.server.models.work_on_bugs_task', mock.Mock())
+@mock.patch('bodhi.server.models.fetch_test_cases_task', mock.Mock())
 class TestUpdatesService(BasePyTestCase):
     @pytest.fixture
     def create_quick_filters_data(self):
@@ -4951,11 +4953,13 @@ class TestUpdatesService(BasePyTestCase):
         assert '<span class="fa fa-fw fa-pencil-square-o"></span> Edit' not in resp
 
     @mock.patch.dict('bodhi.server.models.config', {'test_gating.required': True})
-    def test_push_to_stable_button_not_present_when_test_gating_status_failed(self):
+    @mock.patch('bodhi.server.models.Update.update_test_gating_status')
+    def test_push_to_stable_button_not_present_when_test_gating_status_failed(self, update_tg):
         """The push to stable button should not appear if the test_gating_status is failed."""
         nvr = 'bodhi-2.0.0-2.fc17'
         args = self.get_update(nvr)
         args['requirements'] = ''
+        update_tg.return_value = TestGatingStatus.failed
 
         with fml_testing.mock_sends(update_schemas.UpdateRequestTestingV1):
             resp = self.app.post_json('/updates/', args, headers={'Accept': 'application/json'})
@@ -4978,11 +4982,13 @@ class TestUpdatesService(BasePyTestCase):
         assert 'Edit' in resp
 
     @mock.patch.dict('bodhi.server.models.config', {'test_gating.required': True})
-    def test_push_to_stable_button_present_when_test_gating_status_passed(self):
+    @mock.patch('bodhi.server.models.Update.update_test_gating_status')
+    def test_push_to_stable_button_present_when_test_gating_status_passed(self, update_tg):
         """The push to stable button should appear if the test_gating_status is passed."""
         nvr = 'bodhi-2.0.0-2.fc17'
         args = self.get_update(nvr)
         args['requirements'] = ''
+        update_tg.return_value = TestGatingStatus.passed
 
         with fml_testing.mock_sends(update_schemas.UpdateRequestTestingV1):
             resp = self.app.post_json('/updates/', args, headers={'Accept': 'application/json'})
@@ -5559,7 +5565,6 @@ class TestUpdatesService(BasePyTestCase):
         assert update.meets_testing_requirements is True
 
 
-@mock.patch('bodhi.server.models.handle_update', mock.Mock())
 class TestWaiveTestResults(BasePyTestCase):
     """
     This class contains tests for the waive_test_results() function.
@@ -6099,7 +6104,6 @@ class TestWaiveTestResults(BasePyTestCase):
         assert up.test_gating_status == TestGatingStatus.waiting
 
 
-@mock.patch('bodhi.server.models.handle_update', mock.Mock())
 class TestGetTestResults(BasePyTestCase):
     """
     This class contains tests for the get_test_results() function.

--- a/bodhi/tests/server/tasks/test_composer.py
+++ b/bodhi/tests/server/tasks/test_composer.py
@@ -1980,6 +1980,7 @@ testmodule:master:20172:2
     @mock.patch('bodhi.server.tasks.composer.PungiComposerThread._wait_for_sync')
     @mock.patch('bodhi.server.tasks.composer.time.sleep')
     @mock.patch('bodhi.server.util.cmd')
+    @mock.patch('bodhi.server.models.Update.update_test_gating_status', mock.Mock())
     def test_retry_done_compose(self, mock_cmd, sleep,
                                 mock_wait_for_sync, mock_generate_updateinfo,
                                 mock_wait_for_repo_signature, mock_stage_repo,

--- a/bodhi/tests/server/tasks/test_fetch_test_cases.py
+++ b/bodhi/tests/server/tasks/test_fetch_test_cases.py
@@ -1,0 +1,92 @@
+# Copyright © 2016-2020 Red Hat, Inc. and others.
+#
+# This file is part of Bodhi.
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+"""
+This module contains tests for the bodhi.server.fetch_test_cases module.
+"""
+
+from unittest.mock import patch
+from urllib.error import URLError
+
+import pytest
+
+from bodhi.server import config, models
+from bodhi.server.exceptions import BodhiException, ExternalCallException
+from bodhi.server.tasks import fetch_test_cases_task
+from bodhi.server.tasks.fetch_test_cases import main as fetch_test_cases_main
+from bodhi.tests.server.base import BasePyTestCase
+from .base import BaseTaskTestCase
+
+
+class TestTask(BasePyTestCase):
+    """Test the task in bodhi.server.tasks."""
+
+    @patch("bodhi.server.tasks.buildsys")
+    @patch("bodhi.server.tasks.initialize_db")
+    @patch("bodhi.server.tasks.config")
+    @patch("bodhi.server.tasks.fetch_test_cases.main")
+    def test_task(self, main_function, config_mock, init_db_mock, buildsys):
+        fetch_test_cases_task('foo')
+        config_mock.load_config.assert_called_with()
+        init_db_mock.assert_called_with(config_mock)
+        buildsys.setup_buildsystem.assert_called_with(config_mock)
+        main_function.assert_called_with('foo')
+
+
+class TestFetchTestCases(BaseTaskTestCase):
+    """This test class contains tests for the main() function."""
+
+    @patch.dict(config.config, {'query_wiki_test_cases': True})
+    @patch('bodhi.server.models.Package.fetch_test_cases')
+    def test_update_nonexistent(self, fetch):
+        """
+        Assert BodhiException is raised if the update doesn't exist.
+        """
+        with pytest.raises(BodhiException) as exc:
+            fetch_test_cases_main('foo')
+
+        assert str(exc.value) == "Couldn't find alias foo in DB"
+        fetch.assert_not_called()
+
+    @patch.dict(config.config, {'query_wiki_test_cases': True})
+    @patch('bodhi.server.models.MediaWiki')
+    @patch('bodhi.server.tasks.fetch_test_cases.log.warning')
+    def test_fetch_test_cases_exception(self, warning, MediaWiki):
+        """
+        Assert that fetch_test_cases logs a warning when an exception is raised.
+        """
+        MediaWiki.return_value.call.side_effect = URLError("oh no!")
+
+        update = self.db.query(models.Update).filter(
+            models.Build.nvr == 'bodhi-2.0-1.fc17').one()
+
+        with pytest.raises(ExternalCallException):
+            fetch_test_cases_main(update.alias)
+
+        warning.assert_called_once_with('Error occurred during fetching testcases', exc_info=True)
+
+    @patch.dict(config.config, {'query_wiki_test_cases': True})
+    @patch('bodhi.server.models.Package.fetch_test_cases')
+    def test_fetch_test_cases_run(self, fetch):
+        """
+        Assert that package.fetch_test_cases is called.
+        """
+        update = self.db.query(models.Update).filter(
+            models.Build.nvr == 'bodhi-2.0-1.fc17').one()
+        fetch_test_cases_main(update.alias)
+
+        fetch.assert_called_once()

--- a/bodhi/tests/server/tasks/test_work_on_bugs.py
+++ b/bodhi/tests/server/tasks/test_work_on_bugs.py
@@ -1,0 +1,123 @@
+# Copyright © 2016-2020 Red Hat, Inc. and others.
+#
+# This file is part of Bodhi.
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+"""
+This module contains tests for the bodhi.server.work_on_bugs module.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+from bodhi.server import config, models
+from bodhi.server.exceptions import BodhiException, ExternalCallException
+from bodhi.server.tasks import work_on_bugs_task
+from bodhi.server.tasks.work_on_bugs import main as work_on_bugs_main
+from bodhi.tests.server.base import BasePyTestCase
+from .base import BaseTaskTestCase
+
+
+class TestTask(BasePyTestCase):
+    """Test the task in bodhi.server.tasks."""
+
+    @patch("bodhi.server.tasks.buildsys")
+    @patch("bodhi.server.tasks.initialize_db")
+    @patch("bodhi.server.tasks.config")
+    @patch("bodhi.server.tasks.work_on_bugs.main")
+    def test_task(self, main_function, config_mock, init_db_mock, buildsys):
+        work_on_bugs_task('foo', [12345, 67890])
+        config_mock.load_config.assert_called_with()
+        init_db_mock.assert_called_with(config_mock)
+        buildsys.setup_buildsystem.assert_called_with(config_mock)
+        main_function.assert_called_with('foo', [12345, 67890])
+
+
+class TestWorkOnBugs(BaseTaskTestCase):
+    """This test class contains tests for the main() function."""
+
+    @patch.dict(config.config, {'query_wiki_test_cases': True})
+    def test_update_nonexistent(self):
+        """
+        Assert BodhiException is raised if the update doesn't exist.
+        """
+        with pytest.raises(BodhiException) as exc:
+            work_on_bugs_main('foo', [])
+
+        assert str(exc.value) == "Couldn't find alias foo in DB"
+
+    def test_security_bug_sets_update_to_security(self):
+        """Assert that associating a security bug with an Update changes the Update to security."""
+        update = models.Build.query.filter_by(nvr='bodhi-2.0-1.fc17').one().update
+        # The update should start out in a non-security state so we know that work_on_bugs() changed
+        # it.
+        assert update.type == models.UpdateType.bugfix
+        bug = models.Bug.query.first()
+        # Set this bug to security, so that the update gets switched to security.
+        bug.security = True
+        self.db.flush()
+        bugs = models.Bug.query.all()
+        bug_ids = [bug.bug_id for bug in bugs]
+
+        work_on_bugs_main(update.alias, bug_ids)
+
+        assert update.type == models.UpdateType.security
+
+    @patch('bodhi.server.tasks.work_on_bugs.log.warning')
+    def test_work_on_bugs_exception(self, warning):
+        """
+        Assert that work_on_bugs logs a warning when an exception is raised.
+        """
+        update = models.Build.query.filter_by(nvr='bodhi-2.0-1.fc17').one().update
+        bugs = models.Bug.query.all()
+        bug_ids = [bug.bug_id for bug in bugs]
+
+        with patch('bodhi.server.tasks.work_on_bugs.bug_module.bugtracker.getbug',
+                   side_effect=RuntimeError("oh no!")):
+            with pytest.raises(ExternalCallException):
+                work_on_bugs_main(update.alias, bug_ids)
+
+        warning.assert_called_once_with('Error occurred during updating single bug', exc_info=True)
+
+    @patch('bodhi.server.models.Bug.modified')
+    def test_bug_not_in_database(self, modified):
+        """Test that a bug is automatically created if not present in database."""
+        update = models.Build.query.filter_by(nvr='bodhi-2.0-1.fc17').one().update
+
+        bug = models.Bug.query.filter_by(bug_id=123456).first()
+        assert bug is None
+
+        work_on_bugs_main(update.alias, [123456, ])
+
+        bug = models.Bug.query.filter_by(bug_id=123456).one()
+        update = models.Build.query.filter_by(nvr='bodhi-2.0-1.fc17').one().update
+        assert bug in update.bugs
+        assert modified.assert_called_once
+
+    @patch('bodhi.server.models.Bug.modified')
+    def test_bug_not_associated_to_update(self, modified):
+        """Test that a bug is added to the update if not already associated."""
+        bug = models.Bug(bug_id=123456)
+        self.db.add(bug)
+        self.db.commit()
+        update = models.Build.query.filter_by(nvr='bodhi-2.0-1.fc17').one().update
+
+        work_on_bugs_main(update.alias, [123456, ])
+
+        bug = models.Bug.query.filter_by(bug_id=123456).one()
+        update = models.Build.query.filter_by(nvr='bodhi-2.0-1.fc17').one().update
+        assert bug in update.bugs
+        assert modified.assert_called_once

--- a/bodhi/tests/server/test_models.py
+++ b/bodhi/tests/server/test_models.py
@@ -37,7 +37,7 @@ import requests.exceptions
 from bodhi.messages.schemas import errata as errata_schemas, update as update_schemas
 from bodhi.server import models as model, buildsys, mail, util, Session
 from bodhi.server.config import config
-from bodhi.server.exceptions import BodhiException, LockedUpdateException
+from bodhi.server.exceptions import BodhiException, ExternalCallException, LockedUpdateException
 from bodhi.server.models import (
     BugKarma, ReleaseState, UpdateRequest, UpdateSeverity, UpdateStatus,
     UpdateSuggestion, UpdateType, TestGatingStatus, PackageManager)
@@ -1322,7 +1322,7 @@ class TestRpmPackage(ModelTest):
         """Test querying the wiki for test cases when connection to Wiki failed"""
         MediaWiki.return_value.call.side_effect = URLError("oh no!")
 
-        with pytest.raises(BodhiException) as exc_context:
+        with pytest.raises(ExternalCallException) as exc_context:
             pkg = model.RpmPackage(name='gnome-shell')
             pkg.fetch_test_cases(self.db)
         assert len(pkg.test_cases) == 0
@@ -1684,7 +1684,8 @@ class TestUpdateInit(BasePyTestCase):
         assert str(exc.value) == 'You must specify a Release when creating an Update.'
 
 
-@mock.patch("bodhi.server.models.handle_update", mock.Mock())
+@mock.patch('bodhi.server.models.work_on_bugs_task', mock.Mock())
+@mock.patch('bodhi.server.models.fetch_test_cases_task', mock.Mock())
 class TestUpdateEdit(BasePyTestCase):
     """Tests for the Update.edit() method."""
 
@@ -1714,6 +1715,21 @@ class TestUpdateEdit(BasePyTestCase):
         with pytest.raises(model.LockedUpdateException):
             model.Update.edit(request, data)
 
+    @mock.patch.dict('bodhi.server.config.config', {'bodhi_email': None})
+    @mock.patch('bodhi.server.models.log.warning')
+    def test_add_bugs_bodhi_not_configured(self, warning):
+        """Adding a bug should log a warning if Bodhi isn't configured to handle bugs."""
+        update = model.Update.query.first()
+        data = {
+            'edited': update.alias, 'builds': [update.builds[0].nvr], 'bugs': [12345, ], }
+        request = mock.MagicMock()
+        request.db = self.db
+        request.user.name = 'tester'
+        with mock_sends(Message):
+            model.Update.edit(request, data)
+
+        warning.assert_called_with('Not configured to handle bugs')
+
     def test_empty_display_name(self):
         """An only whitespaces string should not be set as display name."""
         update = model.Update.query.first()
@@ -1729,9 +1745,178 @@ class TestUpdateEdit(BasePyTestCase):
         update = model.Update.query.first()
         assert update.display_name == ''
 
+    @mock.patch.dict('bodhi.server.config.config', {'test_gating.required': False})
+    def test_gating_required_false(self):
+        """Assert that test_gating_status is not updated if test_gating is not enabled."""
+        update = model.Update.query.first()
+        update.test_gating_status = None
+        data = {
+            'edited': update.alias, 'builds': [update.builds[0].nvr],
+            'bugs': [], 'display_name': '  '}
+        request = mock.MagicMock()
+        request.db = self.db
+        request.user.name = 'tester'
+        with mock_sends(update_schemas.UpdateEditV1):
+            with mock.patch('bodhi.server.models.util.greenwave_api_post') as mock_greenwave:
+                greenwave_response = {
+                    'policies_satisfied': False,
+                    'summary': 'what have you done‽',
+                    'applicable_policies': ['taskotron_release_critical_tasks'],
+                    'unsatisfied_requirements': [
+                        {'testcase': 'dist.rpmdeplint',
+                         'item': {'item': 'bodhi-2.0-1.fc17', 'type': 'koji_build'},
+                         'type': 'test-result-missing', 'scenario': None},
+                        {'testcase': 'dist.rpmdeplint',
+                         'item': {'item': update.alias, 'type': 'bodhi_update'},
+                         'type': 'test-result-missing', 'scenario': None}]}
+                mock_greenwave.return_value = greenwave_response
+                model.Update.edit(request, data)
+
+        update = model.Update.query.first()
+        assert update.test_gating_status is None
+
+    @mock.patch.dict('bodhi.server.config.config', {'test_gating.required': True})
+    def test_gating_required_true(self):
+        """Assert that test_gating_status is updated if test_gating is enabled."""
+        update = model.Update.query.first()
+        update.test_gating_status = None
+        data = {
+            'edited': update.alias, 'builds': [update.builds[0].nvr],
+            'bugs': [], 'display_name': '  '}
+        request = mock.MagicMock()
+        request.db = self.db
+        request.user.name = 'tester'
+        with mock_sends(update_schemas.UpdateEditV1):
+            with mock.patch('bodhi.server.models.util.greenwave_api_post') as mock_greenwave:
+                greenwave_response = {
+                    'policies_satisfied': False,
+                    'summary': 'what have you done‽',
+                    'applicable_policies': ['taskotron_release_critical_tasks'],
+                    'unsatisfied_requirements': [
+                        {'testcase': 'dist.rpmdeplint',
+                         'item': {'item': 'bodhi-2.0-1.fc17', 'type': 'koji_build'},
+                         'type': 'test-result-missing', 'scenario': None},
+                        {'testcase': 'dist.rpmdeplint',
+                         'item': {'item': update.alias, 'type': 'bodhi_update'},
+                         'type': 'test-result-missing', 'scenario': None}]}
+                mock_greenwave.return_value = greenwave_response
+                model.Update.edit(request, data)
+
+        update = model.Update.query.first()
+        assert update.test_gating_status == model.TestGatingStatus.failed
+
+    @mock.patch.dict('bodhi.server.config.config', {'test_gating.required': True})
+    def test_rawhide_update_edit_move_to_testing(self):
+        """
+        Assert that a pending rawhide update that was edited gets moved to testing
+        if all the builds in the update are signed.
+        """
+        update = model.Build.query.filter_by(nvr='bodhi-2.0-1.fc17').one().update
+        update.status = model.UpdateStatus.pending
+        update.release.composed_by_bodhi = False
+        update.builds[0].signed = True
+        data = {
+            'edited': update.alias, 'builds': [update.builds[0].nvr],
+            'bugs': [], 'display_name': '  '}
+        request = mock.MagicMock()
+        request.db = self.db
+        request.user.name = 'tester'
+
+        with mock_sends(update_schemas.UpdateEditV1, update_schemas.UpdateReadyForTestingV1):
+            with mock.patch('bodhi.server.models.util.greenwave_api_post') as mock_greenwave:
+                greenwave_response = {
+                    'policies_satisfied': False,
+                    'summary': 'what have you done‽',
+                    'applicable_policies': ['taskotron_release_critical_tasks'],
+                    'unsatisfied_requirements': [
+                        {'testcase': 'dist.rpmdeplint',
+                         'item': {'item': 'bodhi-2.0-1.fc17', 'type': 'koji_build'},
+                         'type': 'test-result-missing', 'scenario': None},
+                        {'testcase': 'dist.rpmdeplint',
+                         'item': {'item': update.alias, 'type': 'bodhi_update'},
+                         'type': 'test-result-missing', 'scenario': None}]}
+                mock_greenwave.return_value = greenwave_response
+                model.Update.edit(request, data)
+
+        assert update.status == model.UpdateStatus.testing
+        assert update.test_gating_status == model.TestGatingStatus.failed
+
+    @mock.patch.dict('bodhi.server.config.config', {'test_gating.required': True})
+    def test_rawhide_update_edit_stays_pending(self):
+        """
+        Assert that a pending rawhide update that was edited does not get moved to testing
+        if not all the builds in the update are signed.
+        """
+        update = model.Build.query.filter_by(nvr='bodhi-2.0-1.fc17').one().update
+        update.status = model.UpdateStatus.pending
+        update.release.composed_by_bodhi = False
+        update.builds[0].signed = False
+        data = {
+            'edited': update.alias, 'builds': [update.builds[0].nvr],
+            'bugs': [], 'display_name': '  '}
+        request = mock.MagicMock()
+        request.db = self.db
+        request.user.name = 'tester'
+
+        with mock_sends(update_schemas.UpdateEditV1):
+            with mock.patch('bodhi.server.models.util.greenwave_api_post') as mock_greenwave:
+                greenwave_response = {
+                    'policies_satisfied': False,
+                    'summary': 'what have you done‽',
+                    'applicable_policies': ['taskotron_release_critical_tasks'],
+                    'unsatisfied_requirements': [
+                        {'testcase': 'dist.rpmdeplint',
+                         'item': {'item': 'bodhi-2.0-1.fc17', 'type': 'koji_build'},
+                         'type': 'test-result-missing', 'scenario': None},
+                        {'testcase': 'dist.rpmdeplint',
+                         'item': {'item': update.alias, 'type': 'bodhi_update'},
+                         'type': 'test-result-missing', 'scenario': None}]}
+                mock_greenwave.return_value = greenwave_response
+                model.Update.edit(request, data)
+
+        assert update.status == model.UpdateStatus.pending
+        assert update.test_gating_status == model.TestGatingStatus.failed
+
+    @mock.patch.dict('bodhi.server.config.config', {'test_gating.required': True})
+    def test_not_rawhide_update_signed_stays_pending(self):
+        """
+        Assert that a non rawhide pending update that was edited does not get moved to testing
+        if all the builds in the update are signed.
+        """
+        update = model.Build.query.filter_by(nvr='bodhi-2.0-1.fc17').one().update
+        update.status = model.UpdateStatus.pending
+        update.release.composed_by_bodhi = True
+        update.builds[0].signed = True
+        data = {
+            'edited': update.alias, 'builds': [update.builds[0].nvr],
+            'bugs': [], 'display_name': '  '}
+        request = mock.MagicMock()
+        request.db = self.db
+        request.user.name = 'tester'
+
+        with mock_sends(update_schemas.UpdateEditV1):
+            with mock.patch('bodhi.server.models.util.greenwave_api_post') as mock_greenwave:
+                greenwave_response = {
+                    'policies_satisfied': False,
+                    'summary': 'what have you done‽',
+                    'applicable_policies': ['taskotron_release_critical_tasks'],
+                    'unsatisfied_requirements': [
+                        {'testcase': 'dist.rpmdeplint',
+                         'item': {'item': 'bodhi-2.0-1.fc17', 'type': 'koji_build'},
+                         'type': 'test-result-missing', 'scenario': None},
+                        {'testcase': 'dist.rpmdeplint',
+                         'item': {'item': update.alias, 'type': 'bodhi_update'},
+                         'type': 'test-result-missing', 'scenario': None}]}
+                mock_greenwave.return_value = greenwave_response
+                model.Update.edit(request, data)
+
+        assert update.status == model.UpdateStatus.pending
+        assert update.test_gating_status == model.TestGatingStatus.failed
+
 
 @mock.patch("bodhi.server.models.tag_update_builds_task", mock.Mock())
-@mock.patch("bodhi.server.models.handle_update", mock.Mock())
+@mock.patch('bodhi.server.models.work_on_bugs_task', mock.Mock())
+@mock.patch('bodhi.server.models.fetch_test_cases_task', mock.Mock())
 class TestUpdateVersionHash(BasePyTestCase):
     """Tests for the Update.version_hash property."""
 
@@ -2180,6 +2365,8 @@ class TestUpdateValidateBuilds(BasePyTestCase):
         assert str(cm.value) == 'An update must contain builds of the same type.'
 
 
+@mock.patch('bodhi.server.models.work_on_bugs_task', mock.Mock())
+@mock.patch('bodhi.server.models.fetch_test_cases_task', mock.Mock())
 class TestUpdateMeetsTestingRequirements(BasePyTestCase):
     """Test the Update.meets_testing_requirements() method."""
 
@@ -2230,14 +2417,13 @@ class TestUpdateMeetsTestingRequirements(BasePyTestCase):
         update = model.Update.query.first()
         update.critpath = True
         update.stable_karma = 1
-        with mock.patch('bodhi.server.models.handle_update'):
-            with mock_sends(Message, Message, Message, Message, Message):
-                update.comment(self.db, 'testing', author='enemy', karma=-1)
-                update.comment(self.db, 'testing', author='bro', karma=1)
-                # Despite meeting the stable_karma, the function should still not
-                # mark this as meeting testing requirements because critpath packages
-                # have a higher requirement for minimum karma. So let's get it a second one.
-                update.comment(self.db, 'testing', author='ham', karma=1)
+        with mock_sends(Message, Message, Message, Message, Message):
+            update.comment(self.db, 'testing', author='enemy', karma=-1)
+            update.comment(self.db, 'testing', author='bro', karma=1)
+            # Despite meeting the stable_karma, the function should still not
+            # mark this as meeting testing requirements because critpath packages
+            # have a higher requirement for minimum karma. So let's get it a second one.
+            update.comment(self.db, 'testing', author='ham', karma=1)
 
         assert update.meets_testing_requirements
 
@@ -2411,7 +2597,8 @@ class TestUpdateMeetsTestingRequirements(BasePyTestCase):
         assert not update.meets_testing_requirements
 
 
-@mock.patch("bodhi.server.models.handle_update", mock.Mock())
+@mock.patch('bodhi.server.models.work_on_bugs_task', mock.Mock())
+@mock.patch('bodhi.server.models.fetch_test_cases_task', mock.Mock())
 class TestUpdate(ModelTest):
     """Unit test case for the ``Update`` model."""
     klass = model.Update
@@ -3351,6 +3538,80 @@ class TestUpdate(ModelTest):
 
         assert link == ("<a target='_blank' href='https://bugzilla.redhat.com/show_bug.cgi?id=1'"
                         " class='notblue'>BZ#1</a> foo\xe9bar")
+
+    @mock.patch.dict('bodhi.server.config.config', {'test_gating.required': False})
+    def test_set_request_pending_testing_gating_false(self):
+        """Ensure that test gating is not updated when it is disabled in config."""
+        req = DummyRequest(user=DummyUser())
+        req.errors = cornice.Errors()
+        req.koji = buildsys.get_session()
+        self.obj.request = None
+        self.obj.test_gating_status = None
+        assert self.obj.status == UpdateStatus.pending
+
+        with mock.patch('bodhi.server.models.util.greenwave_api_post') as mock_greenwave:
+            greenwave_response = {
+                'policies_satisfied': False,
+                'summary': 'what have you done‽',
+                'applicable_policies': ['taskotron_release_critical_tasks'],
+                'unsatisfied_requirements': [
+                    {'testcase': 'dist.rpmdeplint',
+                     'item': {'item': 'bodhi-2.0-1.fc17', 'type': 'koji_build'},
+                     'type': 'test-result-missing', 'scenario': None},
+                    {'testcase': 'dist.rpmdeplint',
+                     'item': {'item': self.obj.alias, 'type': 'bodhi_update'},
+                     'type': 'test-result-missing', 'scenario': None}]}
+            mock_greenwave.return_value = greenwave_response
+            with mock_sends(Message):
+                self.obj.set_request(self.db, UpdateRequest.testing, req.user.name)
+
+        assert self.obj.request == UpdateRequest.testing
+        assert self.obj.test_gating_status is None
+
+    @mock.patch.dict('bodhi.server.config.config', {'test_gating.required': True})
+    def test_set_request_pending_testing_gating_true(self):
+        """Ensure that test gating is  updated when it is enabled in config."""
+        req = DummyRequest(user=DummyUser())
+        req.errors = cornice.Errors()
+        req.koji = buildsys.get_session()
+        self.obj.request = None
+        self.obj.test_gating_status = None
+        assert self.obj.status == UpdateStatus.pending
+
+        with mock.patch('bodhi.server.models.util.greenwave_api_post') as mock_greenwave:
+            greenwave_response = {
+                'policies_satisfied': False,
+                'summary': 'what have you done‽',
+                'applicable_policies': ['taskotron_release_critical_tasks'],
+                'unsatisfied_requirements': [
+                    {'testcase': 'dist.rpmdeplint',
+                     'item': {'item': 'bodhi-2.0-1.fc17', 'type': 'koji_build'},
+                     'type': 'test-result-missing', 'scenario': None},
+                    {'testcase': 'dist.rpmdeplint',
+                     'item': {'item': self.obj.alias, 'type': 'bodhi_update'},
+                     'type': 'test-result-missing', 'scenario': None}]}
+            mock_greenwave.return_value = greenwave_response
+            with mock_sends(Message):
+                self.obj.set_request(self.db, UpdateRequest.testing, req.user.name)
+
+        assert self.obj.request == UpdateRequest.testing
+        assert self.obj.test_gating_status == TestGatingStatus.failed
+
+    @mock.patch.dict('bodhi.server.config.config', {'bodhi_email': None})
+    @mock.patch('bodhi.server.models.log.warning')
+    def test_add_bugs_bodhi_not_configured(self, warning):
+        """Adding a bug should log a warning if Bodhi isn't configured to handle bugs."""
+        req = DummyRequest(user=DummyUser())
+        req.errors = cornice.Errors()
+        req.koji = buildsys.get_session()
+        self.obj.request = None
+        self.obj.test_gating_status = None
+        assert self.obj.status == UpdateStatus.pending
+
+        with mock_sends(Message):
+            self.obj.set_request(self.db, UpdateRequest.testing, req.user.name)
+
+        warning.assert_called_with('Not configured to handle bugs')
 
     def test_set_request_pending_stable(self):
         """Ensure that we can submit an update to stable if it is pending and has enough karma."""

--- a/news/PR3989.dependency
+++ b/news/PR3989.dependency
@@ -1,0 +1,1 @@
+Splitted handle_update task into two celery tasks for bugs and testcases. These two new tasks will make use of Celery's `autoretry_for` and `retry_backoff` features to circumvent external services connection problems. `retry_backoff` needs Celery >= 4.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ alembic
 arrow
 backoff
 bleach
-celery
+celery>=4.2
 click
 colander
 cornice>=3.1.0


### PR DESCRIPTION
This will split the `updates_handler` celery task in two separate tasks for bugs and testcases, so that we can safely retry to fetch testcase details or work on bugs in case of temporary connection problems.

The other logic behind handling the update is moved in the two methods under Update model that used `updates_handler` - `edit()` and `set_request()` - without too much code duplication (only the test gating check was in common by the two).
We may want to move the greenwave query to a separate celery task also, maybe?

Signed-off-by: Mattia Verga <mattia.verga@tiscali.it>