### PR TITLE
Editing builds in an update should not remove override tags

### DIFF
--- a/news/3988.bug
+++ b/news/3988.bug
@@ -1,0 +1,1 @@
+Editing builds in an update should not remove override tags


### PR DESCRIPTION
Editing builds in an update triggers the `unpush()` method which causes all existing tags being deleted from the builds. We don't want the `-override` tag to be removed, so adding an optional parameter to the call will prevent that.

Note that the obsoleting an update will still delete the `-override` tag also.

fix #699, fix #798, fix #867, fix #1947, fix #3978, fix #3988 

Signed-off-by: Mattia Verga <mattia.verga@tiscali.it>