### PR TITLE
side tag update composed by bodhi needs the candidate tag.

### DIFF
--- a/bodhi/server/services/updates.py
+++ b/bodhi/server/services/updates.py
@@ -593,10 +593,13 @@ def new_update(request):
                         # After the Bodhi activation point of a release, add the pending-signing tag
                         # of the release to funnel the builds back into a normal workflow for a
                         # stable release.
+                        pending_signing_tag = u.release.pending_signing_tag
+                        candidate_tag = u.release.candidate_tag
                         handle_side_and_related_tags_task.delay(
                             builds=builds,
-                            pending_signing_tag=u.release.pending_signing_tag,
-                            from_tag=from_tag)
+                            pending_signing_tag=pending_signing_tag,
+                            from_tag=from_tag,
+                            candidate_tag=candidate_tag)
 
     except LockedUpdateException as e:
         log.warning(str(e))

--- a/bodhi/server/tasks/__init__.py
+++ b/bodhi/server/tasks/__init__.py
@@ -127,12 +127,13 @@ def handle_side_and_related_tags_task(
         builds: typing.List[str],
         pending_signing_tag: str,
         from_tag: str,
-        pending_testing_tag: typing.Optional[str] = None):
+        pending_testing_tag: typing.Optional[str] = None,
+        candidate_tag: typing.Optional[str] = None):
     """Handle side-tags and related tags for updates in Koji."""
     from .handle_side_and_related_tags import main
     log.info("Received an order for handling update tags")
     _do_init()
-    main(builds, pending_signing_tag, from_tag, pending_testing_tag)
+    main(builds, pending_signing_tag, from_tag, pending_testing_tag, candidate_tag)
 
 
 @app.task(name="tag_update_builds")

--- a/bodhi/server/tasks/handle_side_and_related_tags.py
+++ b/bodhi/server/tasks/handle_side_and_related_tags.py
@@ -29,7 +29,8 @@ log = logging.getLogger(__name__)
 def main(builds: typing.List[str],
          pending_signing_tag: str,
          from_tag: str,
-         pending_testing_tag: typing.Optional[str]):
+         pending_testing_tag: typing.Optional[str],
+         candidate_tag: typing.Optional[str]):
     """Handle side-tags and related tags for updates in Koji.
 
     Args:
@@ -37,11 +38,12 @@ def main(builds: typing.List[str],
         pending_signing_tag: the pending signing tag to apply on the builds.
         from_tag: the tag into which the builds were built.
         pending_testing_tag: the pending_testing_tag to create if not None.
+        candidate_tag: the candidate tag needed for update that are composed by bodhi.
     """
     try:
         koji = buildsys.get_session()
-        koji.multicall = True
 
+        tags = [pending_signing_tag]
         if pending_testing_tag is not None:
             # Validate that <koji_tag>-pending-signing and <koji-tag>-testing-signing exists
             # if not create them.
@@ -52,16 +54,18 @@ def main(builds: typing.List[str],
                 log.info(f"Create {pending_testing_tag} in koji")
                 koji.createTag(pending_testing_tag, parent=from_tag)
                 koji.editTag2(pending_testing_tag, perm="autosign")
-        else:
+        elif candidate_tag is not None:
             # If we don't provide a pending_testing_tag, then we have merged the
-            # side tag into the release pending_signing tag.
+            # side tag into the release pending_signing and candidate tag.
             # We can remove the side tag.
+            tags.append(candidate_tag)
             koji.removeSideTag(from_tag)
 
+        koji.multicall = True
         for b in builds:
-            log.info(f"Tagging build {b} in {pending_signing_tag}")
-            koji.tagBuild(pending_signing_tag, b)
-
+            for t in tags:
+                log.info(f"Tagging build {b} in {t}")
+                koji.tagBuild(t, b)
         koji.multiCall()
 
     except Exception:

--- a/bodhi/tests/server/tasks/test_handle_side_and_related_tags.py
+++ b/bodhi/tests/server/tasks/test_handle_side_and_related_tags.py
@@ -19,7 +19,7 @@ class TestTask(BasePyTestCase):
         config_mock.load_config.assert_called_with()
         init_db_mock.assert_called_with(config_mock)
         buildsys.setup_buildsystem.assert_called_with(config_mock)
-        main_function.assert_called_with([], "", "", None)
+        main_function.assert_called_with([], "", "", None, None)
 
 
 class TestMain(BaseTaskTestCase):
@@ -31,10 +31,12 @@ class TestMain(BaseTaskTestCase):
         u = self.db.query(models.Update).first()
         from_tag = "f17-build-side-1234"
         builds = [b.nvr for b in u.builds]
-        handle_srtags_main(builds, u.release.pending_signing_tag, from_tag, None)
+        handle_srtags_main(builds, u.release.pending_signing_tag, from_tag,
+                           None, u.release.candidate_tag)
 
         koji = buildsys.get_session()
         assert ('f17-updates-signing-pending', 'bodhi-2.0-1.fc17') in koji.__added__
+        assert ('f17-updates-candidate', 'bodhi-2.0-1.fc17') in koji.__added__
         assert {'id': 1234, 'name': 'f17-build-side-1234'} in koji.__removed_side_tags__
 
     def test_side_tag_not_composed_by_bodhi(self):
@@ -43,7 +45,8 @@ class TestMain(BaseTaskTestCase):
         side_tag_signing_pending = u.release.get_pending_signing_side_tag(from_tag)
         side_tag_testing_pending = u.release.get_testing_side_tag(from_tag)
         builds = [b.nvr for b in u.builds]
-        handle_srtags_main(builds, side_tag_signing_pending, from_tag, side_tag_testing_pending)
+        handle_srtags_main(builds, side_tag_signing_pending, from_tag,
+                           side_tag_testing_pending, None)
 
         koji = buildsys.get_session()
         assert ('f32-build-side-1234-signing-pending', 'bodhi-2.0-1.fc17') in koji.__added__
@@ -53,5 +56,6 @@ class TestMain(BaseTaskTestCase):
     def test_side_tag_raise_exception(self, caplog):
         update = self.db.query(models.Update).first()
         builds = [b.nvr for b in update.builds]
-        handle_srtags_main(builds, update.release.pending_signing_tag, None, None)
+        handle_srtags_main(builds, update.release.pending_signing_tag, None, None,
+                           update.release.candidate_tag)
         assert "There was an error handling side-tags updates" in caplog.messages


### PR DESCRIPTION
During the compose builds that don't have the candidate tag
are ejected from the compose. So we need to apply the candidate tag
on the builds coming from the side tag.

Signed-off-by: Clement Verna <cverna@tutanota.com>