### PR TITLE
Add url_name to User class to provide safe URLs

### DIFF
--- a/bodhi/server/migrations/versions/4cf90f327ed6_add_a_url_name_to_user.py
+++ b/bodhi/server/migrations/versions/4cf90f327ed6_add_a_url_name_to_user.py
@@ -1,0 +1,49 @@
+# Copyright (c) 2020 Mattia Verga
+#
+# This file is part of Bodhi.
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+"""
+Add a url_name to User.
+
+Revision ID: 4cf90f327ed6
+Revises: ff834fa4f23e
+Create Date: 2020-04-13 12:00:04.155563
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '4cf90f327ed6'
+down_revision = 'ff834fa4f23e'
+
+
+def upgrade():
+    """Add a url_name column to User class."""
+    op.add_column('users',
+                  sa.Column('url_name',
+                            sa.Unicode(length=64),
+                            nullable=True)
+                  )
+    op.execute("UPDATE users SET url_name = REPLACE(REPLACE(name,'/','_'),'.','_')")
+    op.alter_column('users', 'url_name', nullable=False)
+    op.create_unique_constraint('users_url_name_fkey', 'users', ['url_name'])
+
+
+def downgrade():
+    """Drop url_name column to User class."""
+    op.drop_constraint('users_url_name_fkey', 'users', type_='unique')
+    op.drop_column('users', 'url_name')

--- a/bodhi/server/services/user.py
+++ b/bodhi/server/services/user.py
@@ -65,6 +65,7 @@ def get_user(request):
     """
     id = request.matchdict.get('name')
     user = User.get(id)
+    user_urlname = user.url_name
 
     if not user:
         request.errors.add('body', 'name', 'No such user')
@@ -76,14 +77,14 @@ def get_user(request):
     # Throw some extra information in there
     rurl = request.route_url  # Just shorthand
     urls = {
-        'comments_by': rurl('comments') + '?user=%s' % id,
-        'comments_on': rurl('comments') + '?update_owner=%s' % id,
-        'recent_updates': rurl('updates') + '?user=%s' % id,
-        'recent_overrides': rurl('overrides') + '?user=%s' % id,
-        'comments_by_rss': rurl('comments_rss') + '?user=%s' % id,
-        'comments_on_rss': rurl('comments_rss') + '?update_owner=%s' % id,
-        'recent_updates_rss': rurl('updates_rss') + '?user=%s' % id,
-        'recent_overrides_rss': rurl('overrides_rss') + '?user=%s' % id,
+        'comments_by': rurl('comments') + '?user=%s' % user_urlname,
+        'comments_on': rurl('comments') + '?update_owner=%s' % user_urlname,
+        'recent_updates': rurl('updates') + '?user=%s' % user_urlname,
+        'recent_overrides': rurl('overrides') + '?user=%s' % user_urlname,
+        'comments_by_rss': rurl('comments_rss') + '?user=%s' % user_urlname,
+        'comments_on_rss': rurl('comments_rss') + '?update_owner=%s' % user_urlname,
+        'recent_updates_rss': rurl('updates_rss') + '?user=%s' % user_urlname,
+        'recent_overrides_rss': rurl('overrides_rss') + '?user=%s' % user_urlname,
     }
 
     return dict(user=user, urls=urls)

--- a/bodhi/server/templates/fragments.html
+++ b/bodhi/server/templates/fragments.html
@@ -96,7 +96,7 @@ ${statusmap[status]}\
         <div class="row no-gutters">
           <div class="col font-size-09">
           % if comment.user:
-          <a href="${request.route_url('user', name=comment.user.name)}" class="font-weight-bold notblue">
+          <a href="${request.route_url('user', name=comment.user.url_name)}" class="font-weight-bold notblue">
             <img src="${util.avatar(comment.user.name, size=16)}" alt="User Icon"/>
             ${comment.user.name}
           </a>
@@ -187,7 +187,7 @@ ${statusmap[status]}\
                       <div class="line-height-1">
                         <small> created
                         %if display_user:
-    by <a href="${request.route_url('user', name=update['user']['name'])}">
+    by <a href="${request.route_url('user', name=update['user']['url_name'])}">
       ${update['user']['name']}
     </a>
                         %endif
@@ -230,7 +230,7 @@ ${statusmap[status]}\
             <small>created 
               %if display_user:
               by
-                <a href="${request.route_url('user', name=override['submitter']['name'])}">
+                <a href="${request.route_url('user', name=override['submitter']['url_name'])}">
                   ${override['submitter']['name']}
                 </a>
               %endif

--- a/bodhi/server/templates/update.html
+++ b/bodhi/server/templates/update.html
@@ -66,7 +66,7 @@ if can_edit and update.release.composed_by_bodhi:
                       </a>
                     </div>
                     <div class="h5 mt-1">
-                        ${update.alias} created by <a href="${request.route_url('user', name=update['user']['name'])}"> ${update['user']['name']}</a>
+                        ${update.alias} created by <a href="${request.route_url('user', name=update['user']['url_name'])}"> ${update['user']['name']}</a>
                         <span title="${update['date_submitted']} UTC"> ${self.util.age(update['date_submitted'])} </span>
                         for <a href="${request.route_url('release', name=update['release']['name'])}">${update['release']['long_name']}
                         </a>

--- a/bodhi/server/validators.py
+++ b/bodhi/server/validators.py
@@ -845,7 +845,7 @@ def ensure_user_exists(param, request):
     validated_users = []
 
     for u in users:
-        user = db.query(User).filter_by(name=u).first()
+        user = db.query(User).filter(or_(User.name == u, User.url_name == u)).first()
 
         if not user:
             bad_users.append(u)

--- a/bodhi/tests/server/test_models.py
+++ b/bodhi/tests/server/test_models.py
@@ -4344,6 +4344,32 @@ class TestUser(ModelTest):
         group = model.Group(name='proventesters')
         return dict(groups=[group])
 
+    def test_url_name(self):
+        """Test that url_name is safe when creating a new User with odd characters."""
+        user = model.User(name='packagerbot/os-master01.phx2.fedoraproject.org',
+                          email='bodhi@fp.o')
+        self.db.add(user)
+        self.db.flush()
+
+        user = model.User.get('packagerbot/os-master01.phx2.fedoraproject.org')
+        assert user.url_name == 'packagerbot_os-master01_phx2_fedoraproject_org'
+
+    def test_url_name_not_unique(self):
+        """Test that url_name is suffixed when the first part is not unique."""
+        user1 = model.User(name='packagerbot/os-master01.phx2.fedoraproject.org',
+                           email='bodhi@fp.o')
+        self.db.add(user1)
+        self.db.flush()
+        user2 = model.User(name='packagerbot.os-master01.phx2.fedoraproject.org',
+                           email='bodhi@fp.o')
+        self.db.add(user2)
+        self.db.flush()
+
+        user1 = model.User.get('packagerbot/os-master01.phx2.fedoraproject.org')
+        assert user1.url_name == 'packagerbot_os-master01_phx2_fedoraproject_org'
+        user2 = model.User.get('packagerbot.os-master01.phx2.fedoraproject.org')
+        assert user2.url_name == 'packagerbot_os-master01_phx2_fedoraproject_org_01'
+
 
 class TestGroup(ModelTest):
     klass = model.Group

--- a/news/3993.bug
+++ b/news/3993.bug
@@ -1,0 +1,1 @@
+Add `url_name` to User to provide safe username for URLs. This will be `username` with all characters other than [a-zA-Z\d_-] replaced by `_` (underscore) and possibly a numbered suffix to avoid collisions

--- a/news/summary.migration
+++ b/news/summary.migration
@@ -1,0 +1,1 @@
+Add `url_name` to `users` table


### PR DESCRIPTION
Since some usernames contain illegal characters to be used in URLs, we will use this sanitized internal username. The original username is preserved and it's still displayed to the frontend user.

I've also removed the previous workaround to get CI tests working, since this change should prevent those errors.

Fixes #3993 

Signed-off-by: Mattia Verga <mattia.verga@tiscali.it>