### PR TITLE
Use 'exact' search for koji

### DIFF
--- a/bodhi/server/templates/update.html
+++ b/bodhi/server/templates/update.html
@@ -427,7 +427,7 @@ if can_edit and update.release.composed_by_bodhi:
               % for build in update.builds:
               <%
               koji_web_url = request.registry.settings.get('koji_web_url').strip('/') + '/'
-              build_url = urljoin(koji_web_url, 'search?terms='+build.nvr+'&type=build&match=glob')
+              build_url = urljoin(koji_web_url, 'search?terms='+build.nvr+'&type=build&match=exact')
               %>
               <div class="pb-1">
                   <div class="row">
@@ -589,7 +589,7 @@ if can_edit and update.release.composed_by_bodhi:
           <td>
             <%
               koji_web_url = request.registry.settings.get('koji_web_url').strip('/') + '/'
-              build_url = urljoin(koji_web_url, 'search?terms='+build.nvr+'&type=build&match=glob')
+              build_url = urljoin(koji_web_url, 'search?terms='+build.nvr+'&type=build&match=exact')
             %>
             <a href="${build_url}" target="_blank">
                 ${build.nvr}</a>

--- a/bodhi/tests/server/services/test_updates.py
+++ b/bodhi/tests/server/services/test_updates.py
@@ -386,7 +386,7 @@ class TestNewUpdate(BasePyTestCase):
         resp = self.app.get(f"/updates/{resp.json['alias']}", headers={'Accept': 'text/html'})
 
         assert re.search(r'https://koji.fedoraproject.org/koji/search\?terms=.*\&amp;'
-                         r'type=build\&amp;match=glob', str(resp))
+                         r'type=build\&amp;match=exact', str(resp))
 
     @mock.patch(**mock_valid_requirements)
     def test_koji_config_url_without_trailing_slash(self, *args):
@@ -401,7 +401,7 @@ class TestNewUpdate(BasePyTestCase):
         resp = self.app.get(f"/updates/{resp.json['alias']}", headers={'Accept': 'text/html'})
 
         assert re.search(r'https://koji.fedoraproject.org/koji/search\?terms=.*\&amp;'
-                         r'type=build\&amp;match=glob', str(resp))
+                         r'type=build\&amp;match=exact', str(resp))
 
     @mock.patch(**mock_valid_requirements)
     def test_koji_config_mock_url_without_trailing_slash(self, *args):
@@ -416,7 +416,7 @@ class TestNewUpdate(BasePyTestCase):
 
         resp = self.app.get(f"/updates/{resp.json['alias']}", headers={'Accept': 'text/html'})
 
-        assert re.search(r'https://host.org/search\?terms=.*\&amp;type=build\&amp;match=glob',
+        assert re.search(r'https://host.org/search\?terms=.*\&amp;type=build\&amp;match=exact',
                          str(resp))
 
     @mock.patch.dict('bodhi.server.validators.config', {'acl_system': 'dummy'})


### PR DESCRIPTION
NVR is passed to koji search page. There is no reason to expect, that
this NVR is a glob. Koji would be happier if it can use "exact" search
instead of "glob".