### PR TITLE
Remove url column from Bug model

### DIFF
--- a/bodhi/server/models.py
+++ b/bodhi/server/models.py
@@ -4377,8 +4377,6 @@ class Bug(Base):
         bug_id (int): The bug's id.
         title (str): The description of the bug.
         security (bool): True if the bug is marked as a security issue.
-        url (str): The URL for the bug. Inaccessible due to being overridden by the url
-            property (https://github.com/fedora-infra/bodhi/issues/1995).
         parent (bool): True if this is a parent tracker bug for release-specific bugs.
     """
 
@@ -4394,9 +4392,6 @@ class Bug(Base):
 
     # If we're dealing with a security bug
     security = Column(Boolean, default=False)
-
-    # Bug URL.  If None, then assume it's in Red Hat Bugzilla
-    url = Column('url', UnicodeText)
 
     # If this bug is a parent tracker bug for release-specific bugs
     parent = Column(Boolean, default=False)


### PR DESCRIPTION
It seems that the Bug model still reference `url` as a column in the database, but that has already been removed:
```
>>> query = "SELECT * FROM bugs WHERE TRUE LIMIT 1"
>>> with conn:
...     with conn.cursor() as curs:
...             curs.execute(query)
...             row = curs.fetchone()
... 
>>> row
(52767, 1670508, 'Review Request: ckb-next - driver for Corsair RGB keyboards and mice', False, False)
```
(fields are id, bug_id, title, security, parent)

So I think we can safely remove that reference from the model without any database migration (trying to drop the `url` column results in an error, I've double checked).

Fixes #1995
an possibly fixes #4008 

Signed-off-by: Mattia Verga <mattia.verga@tiscali.it>