### PR TITLE
Improve Json API response times

### DIFF
--- a/bodhi/server/migrations/versions/8904f10d03ab_make_comments_user_id_not_nullable.py
+++ b/bodhi/server/migrations/versions/8904f10d03ab_make_comments_user_id_not_nullable.py
@@ -1,0 +1,45 @@
+# Copyright (c) 2020 Mattia Verga
+#
+# This file is part of Bodhi.
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+"""
+Make comments.user_id not nullable.
+
+Revision ID: 8904f10d03ab
+Revises: ff834fa4f23e
+Create Date: 2020-05-09 13:39:38.513106
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '8904f10d03ab'
+down_revision = 'ff834fa4f23e'
+
+
+def upgrade():
+    """Make comments.user_id not nullable so as to use inner joins."""
+    op.alter_column('comments', 'user_id',
+                    existing_type=sa.INTEGER(),
+                    nullable=False)
+
+
+def downgrade():
+    """Revert back comments.user_id to be nullable."""
+    op.alter_column('comments', 'user_id',
+                    existing_type=sa.INTEGER(),
+                    nullable=True)

--- a/bodhi/tests/server/services/test_comments.py
+++ b/bodhi/tests/server/services/test_comments.py
@@ -103,7 +103,7 @@ class TestCommentsService(base.BasePyTestCase):
         assert'errors' not in res.json_body
         assert'comment' in res.json_body
         assert res.json_body['comment']['text'] == 'Test'
-        assert res.json_body['comment']['user_id'] == 1
+        assert res.json_body['comment']['user']['id'] == 1
         assert res.json_body['comment']['karma_critpath'] == -1
 
     def test_commenting_with_bug_feedback(self):
@@ -117,7 +117,7 @@ class TestCommentsService(base.BasePyTestCase):
         assert'errors' not in res.json_body
         assert 'comment' in res.json_body
         assert res.json_body['comment']['text'] == 'Test'
-        assert res.json_body['comment']['user_id'] == 1
+        assert res.json_body['comment']['user']['id'] == 1
         assert'bug_feedback' in res.json_body['comment']
         feedback = res.json_body['comment']['bug_feedback']
         assert len(feedback) == 1
@@ -133,7 +133,7 @@ class TestCommentsService(base.BasePyTestCase):
         assert 'errors' not in res.json_body
         assert 'comment' in res.json_body
         assert res.json_body['comment']['text'] == 'Test'
-        assert res.json_body['comment']['user_id'] == 1
+        assert res.json_body['comment']['user']['id'] == 1
         assert'testcase_feedback' in res.json_body['comment']
         feedback = res.json_body['comment']['testcase_feedback']
         assert len(feedback) == 1
@@ -145,7 +145,7 @@ class TestCommentsService(base.BasePyTestCase):
         assert 'errors' not in res.json_body
         assert 'comment' in res.json_body
         assert res.json_body['comment']['text'] == 'Test'
-        assert res.json_body['comment']['user_id'] == 1
+        assert res.json_body['comment']['user']['id'] == 1
 
     def test_commenting_twice_with_neutral_karma(self):
         with fml_testing.mock_sends(update_schemas.UpdateCommentV1):
@@ -154,7 +154,7 @@ class TestCommentsService(base.BasePyTestCase):
         assert 'errors' not in res.json_body
         assert 'comment' in res.json_body
         assert res.json_body['comment']['text'] == 'Test'
-        assert res.json_body['comment']['user_id'] == 1
+        assert res.json_body['comment']['user']['id'] == 1
 
         with fml_testing.mock_sends(update_schemas.UpdateCommentV1):
             res = self.app.post_json('/comments/', self.make_comment())
@@ -162,7 +162,7 @@ class TestCommentsService(base.BasePyTestCase):
         assert 'errors' not in res.json_body
         assert 'comment' in res.json_body
         assert res.json_body['comment']['text'] == 'Test'
-        assert res.json_body['comment']['user_id'] == 1
+        assert res.json_body['comment']['user']['id'] == 1
 
     def test_commenting_twice_with_double_positive_karma(self):
         with fml_testing.mock_sends(update_schemas.UpdateCommentV1):
@@ -171,7 +171,7 @@ class TestCommentsService(base.BasePyTestCase):
         assert 'errors' not in res.json_body
         assert 'comment' in res.json_body
         assert res.json_body['comment']['text'] == 'Test'
-        assert res.json_body['comment']['user_id'] == 1
+        assert res.json_body['comment']['user']['id'] == 1
         assert res.json_body['comment']['karma'] == 1
         assert res.json_body['comment']['update']['karma'] == 1
 
@@ -181,7 +181,7 @@ class TestCommentsService(base.BasePyTestCase):
         assert 'errors' not in res.json_body
         assert 'comment' in res.json_body
         assert res.json_body['comment']['text'] == 'Test'
-        assert res.json_body['comment']['user_id'] == 1
+        assert res.json_body['comment']['user']['id'] == 1
         # Mainly, ensure that the karma didn't increase *again*
         assert res.json_body['comment']['update']['karma'] == 1
 
@@ -192,7 +192,7 @@ class TestCommentsService(base.BasePyTestCase):
         assert 'errors' not in res.json_body
         assert 'comment' in res.json_body
         assert res.json_body['comment']['text'] == 'Test'
-        assert res.json_body['comment']['user_id'] == 1
+        assert res.json_body['comment']['user']['id'] == 1
         assert res.json_body['comment']['update']['karma'] == 1
 
         with fml_testing.mock_sends(update_schemas.UpdateCommentV1):
@@ -201,7 +201,7 @@ class TestCommentsService(base.BasePyTestCase):
         assert 'errors' not in res.json_body
         assert 'comment' in res.json_body
         assert res.json_body['comment']['text'] == 'Test'
-        assert res.json_body['comment']['user_id'] == 1
+        assert res.json_body['comment']['user']['id'] == 1
 
         # Mainly, ensure that original karma is overwritten..
         assert res.json_body['comment']['update']['karma'] == -1
@@ -214,7 +214,7 @@ class TestCommentsService(base.BasePyTestCase):
         assert 'errors' not in res.json_body
         assert 'comment' in res.json_body
         assert res.json_body['comment']['text'] == 'Test'
-        assert res.json_body['comment']['user_id'] == 1
+        assert res.json_body['comment']['user']['id'] == 1
         assert res.json_body['comment']['update']['karma'] == -1
 
     def test_empty_comment(self):
@@ -242,8 +242,8 @@ class TestCommentsService(base.BasePyTestCase):
 
     def test_get_single_comment(self):
         res = self.app.get('/comments/1')
-        assert res.json_body['comment']['update_id'] == 1
-        assert res.json_body['comment']['user_id'] == 1
+        assert res.json_body['comment']['update']['id'] == 1
+        assert res.json_body['comment']['user']['id'] == 1
         assert res.json_body['comment']['id'] == 1
 
     def test_get_single_comment_page(self):
@@ -257,7 +257,7 @@ class TestCommentsService(base.BasePyTestCase):
                            headers=dict(accept='application/javascript'))
         assert 'application/javascript' in res.headers['Content-Type']
         assert 'callback' in res
-        assert 'libravatar.org' in res
+        assert 'karma' in res
 
     def test_404(self):
         self.app.get('/comments/a', status=400)

--- a/bodhi/tests/server/services/test_overrides.py
+++ b/bodhi/tests/server/services/test_overrides.py
@@ -306,7 +306,7 @@ class TestOverridesService(base.BasePyTestCase):
             res = self.app.post('/overrides/', data)
 
         o = res.json_body
-        assert o['build_id'] == build.id
+        assert o['build']['id'] == build.id
         assert o['notes'] == 'blah blah blah'
         assert o['expiration_date'] == expiration_date.strftime("%Y-%m-%d %H:%M:%S")
         assert o['expired_date'] is None
@@ -357,7 +357,7 @@ class TestOverridesService(base.BasePyTestCase):
             res = self.app.post('/overrides/', data)
 
         o = res.json_body
-        assert o['build_id'] == build.id
+        assert o['build']['id'] == build.id
         assert o['notes'] == 'blah blah blah'
         assert o['expiration_date'] == expiration_date.strftime("%Y-%m-%d %H:%M:%S")
         assert o['expired_date'] is None
@@ -405,11 +405,11 @@ new blah blah""".format(datetime.utcnow().strftime("%b %d, %Y"))
         assert result['caveats'][0]['description'] == 'Your override submission was split into 2.'
 
         o1, o2 = result['overrides']
-        assert o1['build_id'] == build1.id
+        assert o1['build']['id'] == build1.id
         assert o1['notes'] == 'blah blah blah'
         assert o1['expiration_date'] == expiration_date.strftime("%Y-%m-%d %H:%M:%S")
         assert o1['expired_date'] is None
-        assert o2['build_id'] == build2.id
+        assert o2['build']['id'] == build2.id
         assert o2['notes'] == 'blah blah blah'
         assert o2['expiration_date'] == expiration_date.strftime("%Y-%m-%d %H:%M:%S")
         assert o2['expired_date'] is None
@@ -451,7 +451,7 @@ new blah blah""".format(datetime.utcnow().strftime("%b %d, %Y"))
             res = self.app.post('/overrides/', data)
 
         o = res.json_body
-        assert o['build_id'] == build.id
+        assert o['build']['id'] == build.id
         assert o['notes'] == 'blah blah blah'
         assert o['expiration_date'] == expiration_date.strftime("%Y-%m-%d %H:%M:%S")
         assert o['expired_date'] is None
@@ -469,7 +469,7 @@ new blah blah""".format(datetime.utcnow().strftime("%b %d, %Y"))
                            headers={'Accept': 'application/json'})
         o = res.json_body['override']
         expiration_date = o['expiration_date']
-        old_build_id = o['build_id']
+        old_build_id = o['build']['id']
 
         build = RpmBuild(nvr='bodhi-2.0-2.fc17', release=release,
                          package=RpmPackage.query.filter_by(name='bodhi').one())
@@ -486,7 +486,7 @@ new blah blah""".format(datetime.utcnow().strftime("%b %d, %Y"))
             res = self.app.post('/overrides/', o)
 
         override = res.json_body
-        assert override['build_id'] == old_build_id
+        assert override['build']['id'] == old_build_id
         assert override['notes'] == 'blah blah blah'
         assert override['expiration_date'] == expiration_date
         assert override['expired_date'] is None
@@ -567,7 +567,7 @@ new blah blah""".format(datetime.utcnow().strftime("%b %d, %Y"))
         res = self.app.get('/overrides/%s' % old_nvr,
                            headers={'Accept': 'application/json'})
         o = res.json_body['override']
-        build_id = o['build_id']
+        build_id = o['build']['id']
         expiration_date = o['expiration_date']
 
         o.update({'nvr': old_nvr, 'notes': 'blah blah blah blah',
@@ -575,7 +575,7 @@ new blah blah""".format(datetime.utcnow().strftime("%b %d, %Y"))
         res = self.app.post('/overrides/', o)
 
         override = res.json_body
-        assert override['build_id'] == build_id
+        assert override['build']['id'] == build_id
         assert override['notes'] == 'blah blah blah blah'
         assert override['expiration_date'] == expiration_date
         assert override['expired_date'] is None

--- a/bodhi/tests/server/services/test_updates.py
+++ b/bodhi/tests/server/services/test_updates.py
@@ -2849,8 +2849,8 @@ class TestUpdatesService(BasePyTestCase):
         res = self.app.get('/updates/', {"status": ["pending", "testing"]})
         body = res.json_body
         assert len(body['updates']) == 2
-        assert body['updates'][0]['title'] == 'python-nose-1.3.7-11.fc17'
-        assert body['updates'][1]['title'] == 'bodhi-2.0-1.fc17'
+        assert body['updates'][0]['title'] == 'bodhi-2.0-1.fc17'
+        assert body['updates'][1]['title'] == 'python-nose-1.3.7-11.fc17'
 
     def test_list_updates_by_suggest(self):
         res = self.app.get('/updates/', {"suggest": "unspecified"})

--- a/bodhi/tests/server/tasks/test_composer.py
+++ b/bodhi/tests/server/tasks/test_composer.py
@@ -526,7 +526,7 @@ That was the actual one''' % compose_dir
             compose_schemas.ComposeComposingV1.from_dict({
                 'repo': 'f17-updates-testing',
                 'ctype': 'rpm',
-                'updates': ['bodhi-2.0-2.fc17', 'bodhi-2.0-1.fc17'],
+                'updates': ['bodhi-2.0-1.fc17', 'bodhi-2.0-2.fc17'],
                 'agent': 'bowlofeggs'}),
             update_schemas.UpdateReadyForTestingV1,
             update_schemas.UpdateReadyForTestingV1,

--- a/bodhi/tests/server/test___init__.py
+++ b/bodhi/tests/server/test___init__.py
@@ -124,7 +124,7 @@ class TestGetUser(base.BasePyTestCase):
 
         user = server.get_user(Request())
 
-        assert user['groups'] == [{'name': 'packager'}]
+        assert user['groups'] == [{'id': 2, 'name': 'packager'}]
         assert user['name'] == 'guest'
         assert isinstance(user, munch.Munch)
 

--- a/bodhi/tests/server/test_push.py
+++ b/bodhi/tests/server/test_push.py
@@ -202,9 +202,9 @@ TEST_ABORT_PUSH_EXPECTED_OUTPUT = """
 
 ===== <Compose: F17 testing> =====
 
+bodhi-2.0-1.fc17
 python-nose-1.3.7-11.fc17
 python-paste-deploy-1.5.2-8.fc17
-bodhi-2.0-1.fc17
 
 
 Push these 3 updates? [y/N]: n
@@ -215,8 +215,8 @@ TEST_BUILDS_FLAG_EXPECTED_OUTPUT = """
 
 ===== <Compose: F17 testing> =====
 
-ejabberd-16.09-4.fc17
 python-nose-1.3.7-11.fc17
+ejabberd-16.09-4.fc17
 
 
 Push these 2 updates? [y/N]: y
@@ -230,9 +230,9 @@ TEST_YES_FLAG_EXPECTED_OUTPUT = """
 
 ===== <Compose: F17 testing> =====
 
+bodhi-2.0-1.fc17
 python-nose-1.3.7-11.fc17
 python-paste-deploy-1.5.2-8.fc17
-bodhi-2.0-1.fc17
 
 
 Pushing 3 updates.
@@ -295,8 +295,8 @@ TEST_REQUEST_FLAG_EXPECTED_OUTPUT = """
 
 ===== <Compose: F17 testing> =====
 
-python-paste-deploy-1.5.2-8.fc17
 bodhi-2.0-1.fc17
+python-paste-deploy-1.5.2-8.fc17
 
 
 Push these 2 updates? [y/N]: y

--- a/devel/ci/bodhi-ci
+++ b/devel/ci/bodhi-ci
@@ -1083,7 +1083,7 @@ class IntegrationJob(Job):
         """
         super(IntegrationJob, self).__init__(*args, **kwargs)
 
-        self._command = [sys.executable, '-m', 'pytest', '-v', '--no-cov',
+        self._command = [sys.executable, '-m', 'pytest', '-vv', '--no-cov',
                          'devel/ci/integration/tests/']
         bodhi_container_image = '{}-integration-bodhi/{}'.format(CONTAINER_NAME, self.release)
         self._popen_kwargs["env"] = os.environ.copy()

--- a/devel/ci/integration/tests/test_bodhi.py
+++ b/devel/ci/integration/tests/test_bodhi.py
@@ -475,7 +475,7 @@ def test_get_users_json(bodhi_container, db_container):
     )
     query_groups = (
         "SELECT "
-        "  groups.name as group_name "
+        "  groups.id as group_id, groups.name as group_name "
         "FROM user_group_table "
         "JOIN groups ON user_group_table.group_id = groups.id "
         "WHERE user_group_table.user_id = %s"
@@ -500,7 +500,7 @@ def test_get_users_json(bodhi_container, db_container):
                 rows = curs.fetchall()
                 user_groups = []
                 for row in rows:
-                    user_groups.append({"name": row[0]})
+                    user_groups.append({"id": row[0], "name": row[1]})
                 user["groups"] = user_groups
             curs.execute(query_total_users)
             total = curs.fetchone()[0]
@@ -544,7 +544,7 @@ def test_get_user_json(bodhi_container, db_container):
     )
     query_groups = (
         "SELECT "
-        "  groups.name as group_name "
+        "  groups.id as group_id, groups.name as group_name "
         "FROM user_group_table "
         "JOIN groups ON user_group_table.group_id = groups.id "
         "WHERE user_group_table.user_id = %s"
@@ -562,7 +562,7 @@ def test_get_user_json(bodhi_container, db_container):
             rows = curs.fetchall()
             user_groups = []
             for row in rows:
-                user_groups.append({"name": row[0]})
+                user_groups.append({"id": row[0], "name": row[1]})
     conn.close()
 
     if user_name.startswith('packagerbot/'):
@@ -911,7 +911,9 @@ def test_get_build_json(bodhi_container, db_container):
         "  release_id, "
         "  signed, "
         "  type, "
-        "  epoch "
+        "  epoch, "
+        "  package_id, "
+        "  update_id "
         "FROM builds "
         "WHERE update_id = %s LIMIT 1"
     )
@@ -922,7 +924,7 @@ def test_get_build_json(bodhi_container, db_container):
             curs.execute(query_updates)
             update_id = curs.fetchone()[0]
             curs.execute(query_builds, (update_id, ))
-            nvr, release_id, signed, build_type, epoch = curs.fetchone()
+            nvr, release_id, signed, build_type, epoch, package_id, update_id = curs.fetchone()
     conn.close()
 
     # GET on build
@@ -931,6 +933,7 @@ def test_get_build_json(bodhi_container, db_container):
 
     build = {
         "nvr": nvr, "release_id": release_id, "signed": signed, "type": build_type,
+        "package_id": package_id, "update_id": update_id,
     }
     if build_type == 'rpm':
         build["epoch"] = epoch
@@ -961,7 +964,9 @@ def test_get_builds_json(bodhi_container, db_container):
         "  release_id, "
         "  signed, "
         "  type, "
-        "  epoch "
+        "  epoch, "
+        "  package_id, "
+        "  update_id "
         "FROM builds "
         "WHERE update_id = %s"
         "ORDER BY nvr ASC"
@@ -1026,25 +1031,9 @@ def test_get_compose_json(bodhi_container, db_container):
     # Fetch release for compose from the DB
     query_releases = (
         "SELECT "
+        "  id, "
         "  name, "
-        "  long_name, "
-        "  version, "
-        "  id_prefix, "
-        "  branch, "
-        "  dist_tag, "
-        "  stable_tag, "
-        "  testing_tag, "
-        "  candidate_tag, "
-        "  pending_signing_tag, "
-        "  pending_testing_tag, "
-        "  pending_stable_tag, "
-        "  override_tag, "
-        "  mail_template, "
-        "  state, "
-        "  composed_by_bodhi, "
-        "  create_automatic_updates, "
-        "  package_manager, "
-        "  testing_repository "
+        "  long_name "
         "FROM releases "
         "WHERE id = %s "
     )

--- a/news/301.bic
+++ b/news/301.bic
@@ -1,0 +1,1 @@
+Improved Bodhi performance in quering object lists and serializing objects. This changes the JSON schema of some objects, especially when returning inherited objects

--- a/news/summary.migration
+++ b/news/summary.migration
@@ -1,0 +1,1 @@
+The user_id column in comments table has been set to be not nullable


### PR DESCRIPTION
The changes here aim to improve Bodhi's JSON API response times.
At database/sqlalchemy level, I've changed some problematic relationships load modes. Some were set to be `lazy='joined'`, but that caused to load very large amounts of data from the db.
In some cases I've set the relationship to use inner joins (where the referenced object id was not nullable).

The PR include a database change to set user_id in comments table to be not nullable (I've checked the db and all comments are correctly linked to a user).
There could be some other places where this seems possible: for example all comments should be linked to an update... but there are some in the db for which this isn't true (don't know why).

At object serialization level, I've added a `__relation_fields__` property to BodhiBase object along with relevant object. The scope is to select what attributes should be serialized when the object is loaded as relation inside another object.

# Performance tests
I've made some dummy tests to measure performance improvements of this change.
## Query times
The code used to conduct this test is (from bodhi-shell):
```
def query_time(query):
    t0=time.time()
    query.all()
    print(time.time() - t0)

models = (m.Build, m.Comment, m.BuildrootOverride, m.Package, m.Release, m.Update, m.User)
for model in models:
    query = s.query(model)
    query = query.limit(1000)
    query_time(query)
```
The results are:
| Class | Before changes | After changes | Improvement |
|---|---|---|---|
| Build | 1,51109004020691 | 0,182040214538574 | -87,95% |
| Comment | 0,390185356140137 | 0,038461446762085 | -90,14% |
| BuildrootOverride | 1,15033030509949 | 0,199055910110474 | -82,70% |
| Package | 0,037990093231201 | 0,036218881607056 | -4,66% |
| Release | 0,005536556243896 | 0,005467653274536 | -1,24% |
| Update | 1,27048087120056 | 0,099624633789063 | -92,16% |
| User | 8,3333420753479 | 0,02573299407959 | -99,69% |

## JSON lists
| URL | Before changes | After changes | Improvement |
|---|---|---|---|
| http://localhost:6543/builds/?rows_per_page=1000 | 13s | 4,6s | -64,62% |
| http://localhost:6543/comments/?rows_per_page=1000 | 55s | 31s | -43,64% |
| http://localhost:6543/overrides/?rows_per_page=1000 | 6,1s | 0,6s | -90,16% |
| http://localhost:6543/packages/?rows_per_page=1000 | 186ms | 170ms | -8,60% |
| http://localhost:6543/releases/?rows_per_page=1000 | 75ms | 103ms | +37,33% |
| http://localhost:6543/updates/?rows_per_page=1000 | 136s | 26s | -80,88% |
| http://localhost:6543/users/?rows_per_page=1000 | 11s | 2,5s | -77,27% |

Because the JSON schema is changed, some tools that depends on this can break. So, I've tagged the PR as backwards incompatible.

Some longstanding issues that should be fixed by this:
fix #271
fix #301 
fix #1899
fix #3204 


Signed-off-by: Mattia Verga <mattia.verga@tiscali.it>