### PR TITLE
Don't use dummy_threading in tests, the module is gone in Python 3.9

### DIFF
--- a/bodhi/tests/server/tasks/test_composer.py
+++ b/bodhi/tests/server/tasks/test_composer.py
@@ -19,7 +19,6 @@ from unittest import mock
 from urllib.error import HTTPError, URLError
 import urllib.parse as urlparse
 import datetime
-import dummy_threading
 import errno
 import json
 import os
@@ -153,15 +152,13 @@ class TestComposer(base.BasePyTestCase):
         super(TestComposer, self).setup_method(method)
         self._new_compose_stage_dir = tempfile.mkdtemp()
 
-        # Since the ComposerThread is a subclass of Thread and since it is already constructed
-        # before we have a chance to alter it, we need to change its superclass to be
-        # dummy_threading.Thread so that the test suite doesn't launch real Threads. Threads cannot
+        # We don't want the test suite to launch real Threads. Threads cannot
         # use the same database sessions, and that means that changes that threads make will not
         # appear in other thread's sessions, which cause a lot of problems in these tests.
-        # Mock was not able to make this change since the __bases__ attribute cannot be removed, but
-        # we don't really need this to be cleaned up since we don't want any tests launching theads
-        # anyway.
-        ComposerThread.__bases__ = (dummy_threading.Thread,)
+        # We don't really need this to be cleaned up since we don't want any tests launching threads
+        # anyway, so we don't bother with mock.
+        ComposerThread.start = lambda self: self.run()
+        ComposerThread.join = lambda self, timeout=None: None
         test_config = base.original_config.copy()
         test_config['compose_stage_dir'] = self._new_compose_stage_dir
         test_config['compose_dir'] = os.path.join(self._new_compose_stage_dir, 'compose')


### PR DESCRIPTION
The suggested usage of `dummy_threading` is:

    try:
        import threading
    except ImportError:
        import dummy_threading as threading

To support installations without the threading module:
  https://docs.python.org/3.6/library/dummy_threading.html

Installations without the threading module are no longer possible since Python 3.7:
  https://docs.python.org/3.7/library/dummy_threading.html

And hence this module was removed from Python 3.9.
  https://bugs.python.org/issue37312

In the tests the dummy_thread module was used in a non-traditional way to
prevent the ComposerThread class from spawning new threads.
Instead, we reset the ComposerThread.start() and ComposerThread.join() methods.

Fixes https://github.com/fedora-infra/bodhi/issues/4007
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1814243