### PR TITLE
use koji gssapi_login instead of krb_login.

### DIFF
--- a/bodhi/server/buildsys.py
+++ b/bodhi/server/buildsys.py
@@ -647,14 +647,14 @@ def koji_login(config: 'BodhiConfig', authenticate: bool) -> koji.ClientSession:
     }
 
     koji_client = koji.ClientSession(_koji_hub, koji_options)
-    if authenticate and not koji_client.krb_login(**get_krb_conf(config)):
-        log.error('Koji krb_login failed')
+    if authenticate and not koji_client.gssapi_login(**get_krb_conf(config)):
+        log.error('Koji gssapi_login failed')
     return koji_client
 
 
 def get_krb_conf(config: 'BodhiConfig') -> typing.Mapping[str, str]:
     """
-    Return arguments for krb_login.
+    Return arguments for gssapi_login.
 
     Args:
         config: Bodhi's configuration dictionary.

--- a/bodhi/tests/server/test_push.py
+++ b/bodhi/tests/server/test_push.py
@@ -1178,8 +1178,8 @@ class TetUpdateSigStatus(base.BasePyTestCase):
     @mock.patch.dict('bodhi.server.push.config',
                      {'buildsystem': 'koji', 'koji_hub': 'https://example.com/koji'})
     @mock.patch('bodhi.server.buildsys._buildsystem', None)
-    @mock.patch('bodhi.server.buildsys.koji.ClientSession.krb_login')
-    def test_sets_up_buildsys_without_auth(self, krb_login):
+    @mock.patch('bodhi.server.buildsys.koji.ClientSession.gssapi_login')
+    def test_sets_up_buildsys_without_auth(self, gssapi_login):
         """
         bodhi-push should not set up authentication for the build system.
 
@@ -1189,4 +1189,4 @@ class TetUpdateSigStatus(base.BasePyTestCase):
 
         push.update_sig_status(u)
 
-        assert krb_login.call_count == 0
+        assert gssapi_login.call_count == 0

--- a/news/4029.bug
+++ b/news/4029.bug
@@ -1,0 +1,1 @@
+Replace koji krb_login with gssapi_login.


### PR DESCRIPTION
krb_login is going to be removed in koji 1.22 so this commit
switch to the recommended replacement.

Fixes #4029

Signed-off-by: Clement Verna <cverna@tutanota.com>