### PR TITLE
Fix for search results not selectable.

### DIFF
--- a/bodhi/server/static/js/search.js
+++ b/bodhi/server/static/js/search.js
@@ -87,12 +87,15 @@ $(document).ready(function() {
 
     $(".bodhi-searchbar-input").focus(function() {
         if ($(this).val() != '') {
-            $("#bodhi-searchbar .typeahead__list").attr("style", "display: inline !important");
+            $("#bodhi-searchbar .typeahead__list").attr("style", "display: block !important");
         }
     });
 
-    $(".bodhi-searchbar-input").blur(function() {
-        $("#bodhi-searchbar .typeahead__list").attr("style", "display: none !important");
+    $(document).click(function(event) { 
+        var target = $(event.target);
+        if(!target.closest('#bodhi-searchbar').length && $('#bodhi-searchbar .typeahead__list').is(":visible")) {
+            $('#bodhi-searchbar .typeahead__list').hide();
+        }        
     });
 });
 // @license-end


### PR DESCRIPTION
Clicking on results of the new search bar in Bodhi stg doesn't work as expected (sometimes it works, sometimes not).
This JS hack should make it work reliably.

Signed-off-by: Mattia Verga <mattia.verga@tiscali.it>