### PR TITLE
Making sure that builds of side tags update are marked as signed.

### DIFF
--- a/bodhi/server/consumers/signed.py
+++ b/bodhi/server/consumers/signed.py
@@ -89,7 +89,9 @@ class SignedHandler(object):
                 log.info('Build is not assigned to release, skipping')
                 return
 
-            if build.update and build.update.from_tag:
+            if build.update \
+               and build.update.from_tag \
+               and not build.update.release.composed_by_bodhi:
                 koji_testing_tag = build.release.get_testing_side_tag(build.update.from_tag)
                 if tag != koji_testing_tag:
                     log.info("Tag is not testing side tag, skipping")

--- a/news/4032.bug
+++ b/news/4032.bug
@@ -1,0 +1,1 @@
+Making sure that builds of side tag update for normal releases are marked as signed.


### PR DESCRIPTION
Fixes #4032.

Signed-off-by: Clement Verna <cverna@tutanota.com>