### PR TITLE
Adjust debug logs output.

### DIFF
--- a/bodhi/server/buildsys.py
+++ b/bodhi/server/buildsys.py
@@ -427,7 +427,6 @@ class DevBuildsys:
             for tag_ in DevBuildsys.__tagged__[build]:
                 if tag_ == tag:
                     builds.append(self.getBuild(build))
-        log.debug(builds)
         return builds
 
     def getLatestBuilds(self, *args, **kw) -> typing.List[typing.Any]:

--- a/bodhi/server/models.py
+++ b/bodhi/server/models.py
@@ -2298,13 +2298,13 @@ class Update(Base):
                                f"release value of {up.mandatory_days_in_testing} days"
             })
 
-        log.debug("Adding new update to the db.")
+        log.debug(f"Adding new update to the db {up.alias}.")
         db.add(up)
-        log.debug("Triggering db commit for new update.")
+        log.debug(f"Triggering db commit for new update {up.alias}.")
         db.commit()
 
         if not data.get("from_tag"):
-            log.debug("Setting request for new update.")
+            log.debug(f"Setting request for new update {up.alias}.")
             up.set_request(db, req, request.user.name)
 
         if config.get('test_gating.required'):
@@ -2312,7 +2312,7 @@ class Update(Base):
                 'Test gating required is enforced, marking the update as waiting on test gating')
             up.test_gating_status = TestGatingStatus.waiting
 
-        log.debug("Done with Update.new(...)")
+        log.debug(f"Done with Update.new(...) {up.alias}")
         return up, caveats
 
     @classmethod

--- a/bodhi/server/util.py
+++ b/bodhi/server/util.py
@@ -746,7 +746,6 @@ def sorted_updates(updates):
     # Otherwise, we would be depending on the way Python orders dict keys
     for package in sorted(builds.keys()):
         if len(builds[package]) > 1:
-            log.debug(builds[package])
             for build in sorted_builds(builds[package])[::-1]:
                 if build.update not in sync:
                     sync.append(build.update)
@@ -795,7 +794,7 @@ def cmd(cmd, cwd=None, raise_on_error=False):
         if raise_on_error:
             raise RuntimeError(msg)
     elif out or err:
-        log.debug(output)
+        log.debug(f"subprocess output: {output}")
     return out, err, p.returncode
 
 

--- a/bodhi/server/views/generic.py
+++ b/bodhi/server/views/generic.py
@@ -336,8 +336,6 @@ def latest_candidates(request):
                 log.error(taglist)
             else:
                 for build in taglist[0]:
-                    log.debug(build)
-
                     if hide_existing and build['nvr'] in associated_build_nvrs:
                         continue
 
@@ -370,8 +368,6 @@ def latest_candidates(request):
         result = work(testing, hide_existing, pkg=pkg)
     else:
         result = work(testing, hide_existing, prefix=prefix)
-
-    log.debug(result)
     return result
 
 

--- a/bodhi/tests/server/test_util.py
+++ b/bodhi/tests/server/test_util.py
@@ -1313,7 +1313,7 @@ class TestCMDFunctions:
             shell=False)
         mock_error.assert_not_called()
         assert mock_debug.mock_calls == \
-            [mock.call('Running /bin/echo'), mock.call('output\nNone')]
+            [mock.call('Running /bin/echo'), mock.call('subprocess output: output\nNone')]
 
     @mock.patch('bodhi.server.log.debug')
     @mock.patch('bodhi.server.log.error')
@@ -1334,7 +1334,7 @@ class TestCMDFunctions:
             ['/bin/echo'], cwd='"home/imgs/catpix"', stdout=subprocess.PIPE, stderr=subprocess.PIPE,
             shell=False)
         mock_error.assert_not_called()
-        mock_debug.assert_called_with('output\nerror')
+        mock_debug.assert_called_with('subprocess output: output\nerror')
 
     @mock.patch('bodhi.server.buildsys.get_session')
     def test__get_build_repository(self, session):


### PR DESCRIPTION
When turning the debug log level in production we
have a lot of noise. This commit adjusts some of the
debug output to be more informative and removes
some output that is not really useful.

Signed-off-by: Clement Verna <cverna@tutanota.com>