### PR TITLE
Make comments.user_id not nullable and tweak some joins

### DIFF
--- a/bodhi/server/migrations/versions/f50dc199039c_make_comments_user_id_not_nullable.py
+++ b/bodhi/server/migrations/versions/f50dc199039c_make_comments_user_id_not_nullable.py
@@ -1,0 +1,45 @@
+# Copyright (c) 2020 Mattia Verga
+#
+# This file is part of Bodhi.
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+"""
+Make comments.user_id not nullable.
+
+Revision ID: f50dc199039c
+Revises: 325954bac9f7
+Create Date: 2020-05-30 07:37:23.035661
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'f50dc199039c'
+down_revision = '325954bac9f7'
+
+
+def upgrade():
+    """Make comments.user_id not nullable so as to use inner joins."""
+    op.alter_column('comments', 'user_id',
+                    existing_type=sa.INTEGER(),
+                    nullable=False)
+
+
+def downgrade():
+    """Revert back comments.user_id to be nullable."""
+    op.alter_column('comments', 'user_id',
+                    existing_type=sa.INTEGER(),
+                    nullable=True)

--- a/bodhi/server/models.py
+++ b/bodhi/server/models.py
@@ -832,6 +832,10 @@ class Release(Base):
     package_manager = Column(PackageManager.db_type(), default=PackageManager.unspecified)
     testing_repository = Column(UnicodeText, nullable=True)
 
+    # One-to-many relationships
+    # builds backref from Build
+    # composes backref from Compos
+
     @property
     def critpath_min_karma(self) -> int:
         """
@@ -1034,6 +1038,9 @@ class TestCase(Base):
 
     name = Column(UnicodeText, nullable=False, unique=True)
 
+    # One-to-many relationships
+    # feedback backref from TestCaseKarma
+
     # Many-to-many relationships
     # builds backref
 
@@ -1076,7 +1083,8 @@ class Package(Base):
     requirements = Column(UnicodeText)
     type = Column(ContentType.db_type(), nullable=False)
 
-    builds = relationship('Build', backref=backref('package', lazy='joined'))
+    # One-to-many relationships
+    builds = relationship('Build', backref=backref('package', lazy='joined', innerjoin=True))
 
     __mapper_args__ = {
         'polymorphic_on': type,
@@ -1320,12 +1328,15 @@ class Build(Base):
     __get_by__ = ('nvr',)
 
     nvr = Column(Unicode(100), unique=True, nullable=False)
-    package_id = Column(Integer, ForeignKey('packages.id'), nullable=False)
-    release_id = Column(Integer, ForeignKey('releases.id'))
     signed = Column(Boolean, default=False, nullable=False)
-    update_id = Column(Integer, ForeignKey('updates.id'), index=True)
 
+    # Many-to-one relationships
+    package_id = Column(Integer, ForeignKey('packages.id'), nullable=False)
+    # package backref from Package
+    release_id = Column(Integer, ForeignKey('releases.id'))
     release = relationship('Release', backref='builds', lazy=False)
+    update_id = Column(Integer, ForeignKey('updates.id'), index=True)
+    # update backref from Update
 
     # Many-to-many relationships
     testcases = relationship('TestCase', secondary=build_testcase_table,
@@ -1862,15 +1873,13 @@ class Update(Base):
     # eg: FEDORA-EPEL-2009-12345
     alias = Column(Unicode(64), unique=True, nullable=False)
 
-    # One-to-one relationships
+    # Many-to-one relationships
     release_id = Column(Integer, ForeignKey('releases.id'), nullable=False)
-    release = relationship('Release', lazy='joined')
+    release = relationship('Release', lazy='joined', innerjoin=True)
 
-    # One-to-many relationships
-    comments = relationship('Comment', backref=backref('update', lazy='joined'), lazy='joined',
-                            order_by='Comment.timestamp')
-    builds = relationship('Build', backref=backref('update', lazy='joined'), lazy='joined',
-                          order_by='Build.nvr')
+    user_id = Column(Integer, ForeignKey('users.id'))
+    # user backref from User
+
     # If the update is locked and a Compose exists for the same release and request, this will be
     # set to that Compose.
     compose = relationship(
@@ -1880,10 +1889,12 @@ class Update(Base):
         foreign_keys=(release_id, request),
         backref=backref('updates', passive_deletes=True))
 
+    # One-to-many relationships
+    comments = relationship('Comment', backref='update', order_by='Comment.timestamp')
+    builds = relationship('Build', backref='update', order_by='Build.nvr')
+
     # Many-to-many relationships
     bugs = relationship('Bug', secondary=update_bug_table, backref='updates', order_by='Bug.bug_id')
-
-    user_id = Column(Integer, ForeignKey('users.id'))
 
     # Greenwave
     test_gating_status = Column(TestGatingStatus.db_type(), default=None, nullable=True)
@@ -3319,16 +3330,15 @@ class Update(Base):
                 notice = 'You may not give karma to your own updates.'
                 caveats.append({'name': 'karma', 'description': notice})
 
-        comment = Comment(text=text, karma=karma, karma_critpath=karma_critpath)
-        session.add(comment)
-
         try:
             user = session.query(User).filter_by(name=author).one()
         except NoResultFound:
             user = User(name=author)
             session.add(user)
 
-        user.comments.append(comment)
+        comment = Comment(text=text, karma=karma, karma_critpath=karma_critpath, user=user)
+        session.add(comment)
+
         self.comments.append(comment)
         session.flush()
 
@@ -4295,6 +4305,7 @@ class BugKarma(Base):
 
     karma = Column(Integer, default=0)
 
+    # Many-to-one relationships
     comment_id = Column(Integer, ForeignKey('comments.id'))
     comment = relationship("Comment", backref='bug_feedback')
 
@@ -4317,6 +4328,7 @@ class TestCaseKarma(Base):
 
     karma = Column(Integer, default=0)
 
+    # Many-to-one relationships
     comment_id = Column(Integer, ForeignKey('comments.id'))
     comment = relationship("Comment", backref='testcase_feedback')
 
@@ -4348,8 +4360,15 @@ class Comment(Base):
     text = Column(UnicodeText, nullable=False)
     timestamp = Column(DateTime, default=datetime.utcnow)
 
+    # One-to-many relationships
+    # bug_feedback backref from BugKarma
+    # testcase_feedback backref from TestCaseKarma
+
+    # Many-to-one relationships
     update_id = Column(Integer, ForeignKey('updates.id'), index=True)
-    user_id = Column(Integer, ForeignKey('users.id'))
+    # update backref from Update
+    user_id = Column(Integer, ForeignKey('users.id'), nullable=False)
+    # user backref from User
 
     def url(self) -> str:
         """
@@ -4457,6 +4476,10 @@ class Bug(Base):
 
     # If this bug is a parent tracker bug for release-specific bugs
     parent = Column(Boolean, default=False)
+
+    # Many-to-many relationships
+    # updates backref from Update
+    # feedback backref from BugKarma
 
     @property
     def url(self) -> str:
@@ -4613,6 +4636,7 @@ class User(Base):
     # One-to-many relationships
     comments = relationship(Comment, backref=backref('user'), lazy='dynamic')
     updates = relationship(Update, backref=backref('user'), lazy='dynamic')
+    # buildroot_overrides backref from BuildrootOverride
 
     # Many-to-many relationships
     groups = relationship("Group", secondary=user_group_table, backref='users')
@@ -4662,7 +4686,8 @@ class Group(Base):
 
     name = Column(Unicode(64), unique=True, nullable=False)
 
-    # users backref
+    # Many-to-many relationships
+    # users backref from User
 
 
 class BuildrootOverride(Base):
@@ -4689,20 +4714,20 @@ class BuildrootOverride(Base):
     __include_extras__ = ('nvr',)
     __get_by__ = ('build_id',)
 
-    build_id = Column(Integer, ForeignKey('builds.id'), nullable=False)
-    submitter_id = Column(Integer, ForeignKey('users.id'), nullable=False)
     notes = Column(Unicode, nullable=False)
 
     submission_date = Column(DateTime, default=datetime.utcnow, nullable=False)
     expiration_date = Column(DateTime, nullable=False)
     expired_date = Column(DateTime)
 
-    build = relationship('Build', lazy='joined',
-                         backref=backref('override', lazy='joined',
-                                         uselist=False))
-    submitter = relationship('User', lazy='joined',
-                             backref=backref('buildroot_overrides',
-                                             lazy='joined'))
+    # Many-to-one relationships
+    build_id = Column(Integer, ForeignKey('builds.id'), nullable=False)
+    build = relationship('Build', lazy='joined', innerjoin=True,
+                         backref=backref('override', uselist=False))
+
+    submitter_id = Column(Integer, ForeignKey('users.id'), nullable=False)
+    submitter = relationship('User', lazy='joined', innerjoin=True,
+                             backref='buildroot_overrides')
 
     @property
     def nvr(self) -> str:

--- a/bodhi/tests/server/services/test_updates.py
+++ b/bodhi/tests/server/services/test_updates.py
@@ -2849,8 +2849,8 @@ class TestUpdatesService(BasePyTestCase):
         res = self.app.get('/updates/', {"status": ["pending", "testing"]})
         body = res.json_body
         assert len(body['updates']) == 2
-        assert body['updates'][0]['title'] == 'python-nose-1.3.7-11.fc17'
-        assert body['updates'][1]['title'] == 'bodhi-2.0-1.fc17'
+        assert body['updates'][0]['title'] == 'bodhi-2.0-1.fc17'
+        assert body['updates'][1]['title'] == 'python-nose-1.3.7-11.fc17'
 
     def test_list_updates_by_suggest(self):
         res = self.app.get('/updates/', {"suggest": "unspecified"})

--- a/bodhi/tests/server/tasks/test_composer.py
+++ b/bodhi/tests/server/tasks/test_composer.py
@@ -526,7 +526,7 @@ That was the actual one''' % compose_dir
             compose_schemas.ComposeComposingV1.from_dict({
                 'repo': 'f17-updates-testing',
                 'ctype': 'rpm',
-                'updates': ['bodhi-2.0-2.fc17', 'bodhi-2.0-1.fc17'],
+                'updates': ['bodhi-2.0-1.fc17', 'bodhi-2.0-2.fc17'],
                 'agent': 'bowlofeggs'}),
             update_schemas.UpdateReadyForTestingV1,
             update_schemas.UpdateReadyForTestingV1,

--- a/bodhi/tests/server/test_models.py
+++ b/bodhi/tests/server/test_models.py
@@ -188,7 +188,7 @@ class TestBodhiBase(BasePyTestCase):
 
     def test_grid_columns(self):
         """Assert correct return value from the grid_columns() method."""
-        assert model.Build.grid_columns() == ['nvr', 'release_id', 'signed', 'type', 'epoch']
+        assert model.Build.grid_columns() == ['nvr', 'signed', 'release_id', 'type', 'epoch']
 
     def test_find_child_for_rpm(self):
         subclass = model.Package.find_polymorphic_child(model.ContentType.rpm)

--- a/bodhi/tests/server/test_push.py
+++ b/bodhi/tests/server/test_push.py
@@ -202,9 +202,9 @@ TEST_ABORT_PUSH_EXPECTED_OUTPUT = """
 
 ===== <Compose: F17 testing> =====
 
+bodhi-2.0-1.fc17
 python-nose-1.3.7-11.fc17
 python-paste-deploy-1.5.2-8.fc17
-bodhi-2.0-1.fc17
 
 
 Push these 3 updates? [y/N]: n
@@ -215,8 +215,8 @@ TEST_BUILDS_FLAG_EXPECTED_OUTPUT = """
 
 ===== <Compose: F17 testing> =====
 
-ejabberd-16.09-4.fc17
 python-nose-1.3.7-11.fc17
+ejabberd-16.09-4.fc17
 
 
 Push these 2 updates? [y/N]: y
@@ -230,9 +230,9 @@ TEST_YES_FLAG_EXPECTED_OUTPUT = """
 
 ===== <Compose: F17 testing> =====
 
+bodhi-2.0-1.fc17
 python-nose-1.3.7-11.fc17
 python-paste-deploy-1.5.2-8.fc17
-bodhi-2.0-1.fc17
 
 
 Pushing 3 updates.
@@ -295,8 +295,8 @@ TEST_REQUEST_FLAG_EXPECTED_OUTPUT = """
 
 ===== <Compose: F17 testing> =====
 
-python-paste-deploy-1.5.2-8.fc17
 bodhi-2.0-1.fc17
+python-paste-deploy-1.5.2-8.fc17
 
 
 Push these 2 updates? [y/N]: y

--- a/devel/ci/bodhi-ci
+++ b/devel/ci/bodhi-ci
@@ -1083,7 +1083,7 @@ class IntegrationJob(Job):
         """
         super(IntegrationJob, self).__init__(*args, **kwargs)
 
-        self._command = [sys.executable, '-m', 'pytest', '-v', '--no-cov',
+        self._command = [sys.executable, '-m', 'pytest', '-vv', '--no-cov',
                          'devel/ci/integration/tests/']
         bodhi_container_image = '{}-integration-bodhi/{}'.format(CONTAINER_NAME, self.release)
         self._popen_kwargs["env"] = os.environ.copy()

--- a/news/PR4046.dev
+++ b/news/PR4046.dev
@@ -1,0 +1,1 @@
+The user_id field in the comments table has been made not nullable. Some database joins have been tweaked to get better performance

--- a/news/summary.migration
+++ b/news/summary.migration
@@ -1,1 +1,3 @@
-Migrate relationship between TestCase and Package to TestCase and Build. The migration script will take care of migrate existing data to the new relation
+Migrate relationship between TestCase and Package to TestCase and Build. The migration script will take care of migrate existing data to the new relation.
+The user_id column in comments table has been set to be not nullable.
+


### PR DESCRIPTION
This splits off joins changes from #4017 
Setting the `user_id` field for comments to be not nullable makes possible to use faster inner joins. Also, I've disable the `lazy='joined'` relationship property in the Update model against builds and comments: this will avoid to unconditionally load all the builds and all the comments associated to the update when we retrieve it from the database.
In my opinion, this should give better performance. Locally I can see some speed improvements when loading some pages, like builds or users lists, but unfortunately the updates page list is not getting substantial improvement.

Signed-off-by: Mattia Verga <mattia.verga@tiscali.it>