### PR TITLE
Correct infra-tags.repo url

### DIFF
--- a/devel/ci/integration/bodhi/Dockerfile-f30
+++ b/devel/ci/integration/bodhi/Dockerfile-f30
@@ -6,7 +6,7 @@ LABEL \
   license="MIT"
 
 # For integration testing we're using the infrastructure repo
-RUN curl -o /etc/yum.repos.d/infra-tags.repo https://infrastructure.fedoraproject.org/cgit/ansible.git/plain/files/common/fedora-infra-tags.repo
+RUN curl -o /etc/yum.repos.d/infra-tags.repo https://pagure.io/fedora-infra/ansible/raw/master/f/files/common/fedora-infra-tags.repo
 # work around https://bugzilla.redhat.com/show_bug.cgi?id=1699396
 RUN rpm --import "$(awk -F= '{if ($0 ~ "gpgkey *=") {print $2;}}' < /etc/yum.repos.d/infra-tags.repo)"
 

--- a/devel/ci/integration/bodhi/Dockerfile-f31
+++ b/devel/ci/integration/bodhi/Dockerfile-f31
@@ -6,12 +6,7 @@ LABEL \
   license="MIT"
 
 # For integration testing we're using the infrastructure repo
-RUN curl -o /etc/yum.repos.d/infra-tags.repo https://infrastructure.fedoraproject.org/cgit/ansible.git/plain/files/common/fedora-infra-tags.repo
-# work around https://bugzilla.redhat.com/show_bug.cgi?id=1699396
-# and deal with https://fedoraproject.org/wiki/Changes/Set_skip_if_unavailable_default_to_false
-RUN rpm --import "$(awk -F= '{if ($0 ~ "gpgkey *=") {print $2;}}' \
-        < /etc/yum.repos.d/infra-tags.repo)" && \
-    echo skip_if_unavailable=True >> /etc/yum.repos.d/infra-tags.repo
+RUN curl -o /etc/yum.repos.d/infra-tags.repo https://pagure.io/fedora-infra/ansible/raw/master/f/files/common/fedora-infra-tags.repo
 
 # Install Bodhi deps (that were not needed by the unittests container)
 RUN dnf install -y \

--- a/devel/ci/integration/bodhi/Dockerfile-f32
+++ b/devel/ci/integration/bodhi/Dockerfile-f32
@@ -6,12 +6,7 @@ LABEL \
   license="MIT"
 
 # For integration testing we're using the infrastructure repo
-RUN curl -o /etc/yum.repos.d/infra-tags.repo https://infrastructure.fedoraproject.org/cgit/ansible.git/plain/files/common/fedora-infra-tags.repo
-# work around https://bugzilla.redhat.com/show_bug.cgi?id=1699396
-# and deal with https://fedoraproject.org/wiki/Changes/Set_skip_if_unavailable_default_to_false
-RUN rpm --import "$(awk -F= '{if ($0 ~ "gpgkey *=") {print $2;}}' \
-        < /etc/yum.repos.d/infra-tags.repo)" && \
-    echo skip_if_unavailable=True >> /etc/yum.repos.d/infra-tags.repo
+RUN curl -o /etc/yum.repos.d/infra-tags.repo https://pagure.io/fedora-infra/ansible/raw/master/f/files/common/fedora-infra-tags.repo
 
 # Install Bodhi deps (that were not needed by the unittests container)
 RUN dnf install -y \

--- a/devel/ci/integration/bodhi/Dockerfile-pip
+++ b/devel/ci/integration/bodhi/Dockerfile-pip
@@ -6,9 +6,7 @@ LABEL \
   license="MIT"
 
 # For integration testing we're using the infrastructure repo
-RUN curl -o /etc/yum.repos.d/infra-tags.repo https://infrastructure.fedoraproject.org/cgit/ansible.git/plain/files/common/fedora-infra-tags.repo
-# work around https://bugzilla.redhat.com/show_bug.cgi?id=1699396
-RUN rpm --import "$(awk -F= '{if ($0 ~ "gpgkey *=") {print $2;}}' < /etc/yum.repos.d/infra-tags.repo)"
+RUN curl -o /etc/yum.repos.d/infra-tags.repo https://pagure.io/fedora-infra/ansible/raw/master/f/files/common/fedora-infra-tags.repo
 
 # Install Bodhi deps (that were not needed by the unittests container)
 RUN dnf install -y \

--- a/devel/ci/integration/bodhi/Dockerfile-rawhide
+++ b/devel/ci/integration/bodhi/Dockerfile-rawhide
@@ -6,12 +6,7 @@ LABEL \
   license="MIT"
 
 # For integration testing we're using the infrastructure repo
-RUN curl -o /etc/yum.repos.d/infra-tags.repo https://infrastructure.fedoraproject.org/cgit/ansible.git/plain/files/common/fedora-infra-tags.repo
-# work around https://bugzilla.redhat.com/show_bug.cgi?id=1699396
-# and deal with https://fedoraproject.org/wiki/Changes/Set_skip_if_unavailable_default_to_false
-RUN rpm --import "$(awk -F= '{if ($0 ~ "gpgkey *=") {print $2;}}' \
-        < /etc/yum.repos.d/infra-tags.repo)" && \
-    echo skip_if_unavailable=True >> /etc/yum.repos.d/infra-tags.repo
+RUN curl -o /etc/yum.repos.d/infra-tags.repo https://pagure.io/fedora-infra/ansible/raw/master/f/files/common/fedora-infra-tags.repo
 
 # Install Bodhi deps (that were not needed by the unittests container)
 RUN dnf install -y \

--- a/devel/ci/integration/ipsilon/Dockerfile
+++ b/devel/ci/integration/ipsilon/Dockerfile
@@ -1,5 +1,5 @@
 FROM fedora
-RUN curl -o /etc/yum.repos.d/infra-tags.repo https://infrastructure.fedoraproject.org/cgit/ansible.git/plain/files/common/fedora-infra-tags.repo
+RUN curl -o /etc/yum.repos.d/infra-tags.repo https://pagure.io/fedora-infra/ansible/raw/master/f/files/common/fedora-infra-tags.repo
 RUN dnf install -y ipsilon ipsilon-openid ipsilon-openidc ipsilon-authfas patch
 COPY devel/ci/integration/ipsilon/api.py /usr/lib/python3.7/site-packages/ipsilon/providers/openid/extensions/api.py
 RUN ipsilon-server-install --root-instance --secure no --testauth yes --openid yes --fas yes --hostname id.dev.fedoraproject.org --openid-extensions "insecureAPI,Teams,CLAs,Simple Registration"


### PR DESCRIPTION
Use the new pagure ansible repo for downloading the infra-tag.repo file to fix ci failures.
Also remove a workaround no more needed with F>=31

Signed-off-by: Mattia Verga <mattia.verga@tiscali.it>