### PR TITLE
Add a periodic task to check sign status of Builds in pending Updates

### DIFF
--- a/bodhi/server/config.py
+++ b/bodhi/server/config.py
@@ -294,6 +294,9 @@ class BodhiConfig(dict):
         'celery_config': {
             'value': '/etc/bodhi/celeryconfig.py',
             'validator': str},
+        'check_signed_builds_delay': {
+            'value': 2,
+            'validator': int},
         'clean_old_composes': {
             'value': True,
             'validator': _validate_bool},

--- a/bodhi/server/tasks/__init__.py
+++ b/bodhi/server/tasks/__init__.py
@@ -105,6 +105,15 @@ def check_policies_task(**kwargs):
     main()
 
 
+@app.task(name="check_signed_builds")
+def check_signed_builds_task(**kwargs):
+    """Trigger the check signed builds job. This is a periodic task."""
+    from .check_signed_builds import main
+    log.info("Received a check signed builds order")
+    _do_init()
+    main()
+
+
 @app.task(name="clean_old_composes")
 def clean_old_composes_task(num_to_keep: int, **kwargs):
     """Trigger the clean old composes job. This is a periodic task."""

--- a/bodhi/tests/server/tasks/test_check_signed_builds.py
+++ b/bodhi/tests/server/tasks/test_check_signed_builds.py
@@ -1,0 +1,172 @@
+# Copyright © 2020 Mattia Verga.
+#
+# This file is part of Bodhi.
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+"""
+This module contains tests for the bodhi.server.tasks.check_signed_builds module.
+"""
+
+from datetime import datetime
+from unittest.mock import patch
+
+from bodhi.server import models
+from bodhi.server.tasks import check_signed_builds_task
+from bodhi.server.tasks.check_signed_builds import main as check_signed_builds_main
+from bodhi.tests.server.base import BasePyTestCase
+from .base import BaseTaskTestCase
+
+
+class TestTask(BasePyTestCase):
+    """Test the task in bodhi.server.tasks."""
+
+    @patch("bodhi.server.tasks.buildsys")
+    @patch("bodhi.server.tasks.initialize_db")
+    @patch("bodhi.server.tasks.config")
+    @patch("bodhi.server.tasks.check_signed_builds.main")
+    def test_task(self, main_function, config_mock, init_db_mock, buildsys):
+        check_signed_builds_task()
+        config_mock.load_config.assert_called_with()
+        init_db_mock.assert_called_with(config_mock)
+        buildsys.setup_buildsystem.assert_called_with(config_mock)
+        main_function.assert_called()
+
+
+class TestCheckSignedBuilds(BaseTaskTestCase):
+    """This test class contains tests for the main() function."""
+
+    @patch('bodhi.server.tasks.check_signed_builds.buildsys')
+    @patch('bodhi.server.tasks.check_signed_builds.log.debug')
+    def test_check_signed_builds_exclude_archived(self, debug, buildsys):
+        """
+        The task should ignore archived releases.
+        """
+        release = models.Release.query.first()
+        release.state = models.ReleaseState.archived
+
+        self.db.commit()
+
+        check_signed_builds_main()
+
+        debug.assert_called_once_with('No stuck Updates found')
+        buildsys.get_session.assert_not_called()
+
+    @patch('bodhi.server.tasks.check_signed_builds.buildsys')
+    @patch('bodhi.server.tasks.check_signed_builds.log.debug')
+    def test_check_signed_builds_ignore_fresh_update(self, debug, buildsys):
+        """
+        The task should ignore fresh updates.
+        """
+        update = models.Update.query.first()
+        update.date_submitted = datetime.utcnow()
+        update.builds[0].signed = False
+
+        self.db.commit()
+
+        listTags = [
+            {'arches': 'i386 x86_64 ppc ppc64', 'id': 10, 'locked': True,
+             'name': 'f17-updates-candidate', 'perm': None, 'perm_id': None},
+            {'arches': 'i386 x86_64 ppc ppc64', 'id': 10, 'locked': True,
+             'name': 'f17-updates-pending', 'perm': None, 'perm_id': None}, ]
+
+        buildsys.get_session.return_value.listTags.return_value = listTags
+        check_signed_builds_main()
+
+        update = models.Update.query.first()
+        buildsys.get_session.assert_called_once()
+        assert update.builds[0].signed == False
+
+    @patch('bodhi.server.tasks.check_signed_builds.buildsys')
+    @patch('bodhi.server.tasks.check_signed_builds.log.debug')
+    def test_check_signed_builds_ignore_signed_builds(self, debug, buildsys):
+        """
+        The task should not touch builds already marked as signed in db.
+        """
+        update = models.Update.query.first()
+        assert update.builds[0].signed
+
+        self.db.commit()
+
+        check_signed_builds_main()
+
+        buildsys.get_session.assert_called_once()
+        debug.assert_called_once_with('bodhi-2.0-1.fc17 already marked as signed')
+
+    @patch('bodhi.server.tasks.check_signed_builds.buildsys')
+    @patch('bodhi.server.tasks.check_signed_builds.log.debug')
+    def test_check_signed_builds_still_not_signed(self, debug, buildsys):
+        """
+        The task should NOT mark signed builds if it is still pending-signing.
+        """
+        update = models.Update.query.first()
+        update.builds[0].signed = False
+
+        self.db.commit()
+
+        listTags = [
+            {'arches': 'i386 x86_64 ppc ppc64', 'id': 10, 'locked': True,
+             'name': 'f17-updates-candidate', 'perm': None, 'perm_id': None},
+            {'arches': 'i386 x86_64 ppc ppc64', 'id': 10, 'locked': True,
+             'name': 'f17-signing-pending', 'perm': None, 'perm_id': None}, ]
+
+        buildsys.get_session.return_value.listTags.return_value = listTags
+        check_signed_builds_main()
+
+        update = models.Update.query.first()
+        buildsys.get_session.assert_called_once()
+        assert update.builds[0].signed == False
+
+    @patch('bodhi.server.tasks.check_signed_builds.buildsys')
+    @patch('bodhi.server.tasks.check_signed_builds.log.debug')
+    def test_check_signed_builds_mark_signed(self, debug, buildsys):
+        """
+        The task should mark signed builds with correct tags.
+        """
+        update = models.Update.query.first()
+        update.builds[0].signed = False
+
+        self.db.commit()
+
+        listTags = [
+            {'arches': 'i386 x86_64 ppc ppc64', 'id': 10, 'locked': True,
+             'name': 'f17-updates-candidate', 'perm': None, 'perm_id': None},
+            {'arches': 'i386 x86_64 ppc ppc64', 'id': 10, 'locked': True,
+             'name': 'f17-updates-testing-pending', 'perm': None, 'perm_id': None}, ]
+
+        buildsys.get_session.return_value.listTags.return_value = listTags
+        check_signed_builds_main()
+
+        update = models.Update.query.first()
+        buildsys.get_session.assert_called_once()
+        debug.assert_called_once_with('Changing signed status of bodhi-2.0-1.fc17')
+        assert update.builds[0].signed == True
+
+    @patch('bodhi.server.tasks.check_signed_builds.buildsys')
+    @patch('bodhi.server.tasks.check_signed_builds.log.debug')
+    def test_check_signed_builds_obsolete_empty_update(self, debug, buildsys):
+        """
+        The task should obsolete an Update if there are no Builds attached to it.
+        """
+        update = models.Update.query.first()
+        update.builds = []
+
+        self.db.commit()
+
+        check_signed_builds_main()
+
+        update = models.Update.query.first()
+        buildsys.get_session.assert_called_once()
+        debug.assert_called_once_with(f'Obsoleting empty update {update.alias}')
+        assert update.status == models.UpdateStatus.obsolete

--- a/celeryconfig.py
+++ b/celeryconfig.py
@@ -43,6 +43,10 @@ beat_schedule = {
         "task": "check_policies",
         "schedule": 60 * 60,  # every hour
     },
+    "check-signed-builds": {
+        "task": "check_signed_builds",
+        "schedule": crontab(hour=2, minute=33),
+    },
     "clean-old-composes": {
         "task": "clean_old_composes",
         "schedule": crontab(hour=3, minute=3),

--- a/docs/developer/4064.feature
+++ b/docs/developer/4064.feature
@@ -1,0 +1,1 @@
+Add a periodic task to check sign status of Builds in pending Updates


### PR DESCRIPTION
It may happen that Bodhi misses fedora-messaging messages announcing builds
have been signed.
In these cases, the Update remains stuck in pending until a manual intervention.
This script will daily cycle through builds of Updates in pending status and update
the signed status in the db to match the tags found in Koji.

Signed-off-by: Mattia Verga <mattia.verga@tiscali.it>