### PR TITLE
Fetch bug information when an automatic update is created

### DIFF
--- a/bodhi/tests/server/consumers/test_automatic_updates.py
+++ b/bodhi/tests/server/consumers/test_automatic_updates.py
@@ -33,6 +33,7 @@ from bodhi.server.models import (
 from bodhi.tests.server import base
 
 
+@mock.patch('bodhi.server.consumers.automatic_updates.work_on_bugs_task', mock.Mock())
 class TestAutomaticUpdateHandler(base.BasePyTestCase):
     """Test the automatic update handler."""
 


### PR DESCRIPTION
We should fetch bug information also when an automatic update is created.


Signed-off-by: Mattia Verga <mattia.verga@tiscali.it>