### PR TITLE
Added metrics endpoint for scraping by Prometheus.

### DIFF
--- a/bodhi/server/__init__.py
+++ b/bodhi/server/__init__.py
@@ -26,6 +26,7 @@ from pyramid.authentication import AuthTktAuthenticationPolicy
 from pyramid.authorization import ACLAuthorizationPolicy
 from pyramid.config import Configurator
 from pyramid.renderers import JSONP
+from pyramid.tweens import EXCVIEW
 from sqlalchemy import engine_from_config, event
 from sqlalchemy.orm import scoped_session, sessionmaker
 import pkg_resources
@@ -292,6 +293,14 @@ def main(global_config, testing=None, session=None, **settings):
             secure=bodhi_config['authtkt.secure'], hashalg='sha512', timeout=timeout,
             max_age=timeout))
         config.set_authorization_policy(ACLAuthorizationPolicy())
+
+    # Collect metrics for endpoints
+    config.add_tween(
+        'bodhi.server.services.metrics_tween.histo_tween_factory', over=EXCVIEW
+    )
+
+    # Metrics Route
+    config.add_route('prometheus_metric', '/metrics')
 
     # Frontpage
     config.add_route('home', '/')

--- a/bodhi/server/services/metrics_tween.py
+++ b/bodhi/server/services/metrics_tween.py
@@ -1,0 +1,68 @@
+"""Tween to hook prometheus metric collection into pyramid."""
+
+
+from time import time
+
+from prometheus_client import Histogram, Gauge
+from pyramid.interfaces import IRoutesMapper
+
+
+def get_pattern(request):
+    """
+    Extract the pattern from request.
+
+    For example `/updates/FEDORA-2019-0c2e93b669` to `/updates/{id}`
+    """
+    path_info_pattern = ''
+    if request.matched_route is None:
+        routes_mapper = request.registry.queryUtility(IRoutesMapper)
+        if routes_mapper:
+            info = routes_mapper(request)
+            if info and info['route']:
+                path_info_pattern = info['route'].pattern
+    else:
+        path_info_pattern = request.matched_route.pattern
+    return path_info_pattern
+
+
+pyramid_request_ingress = Gauge(
+    'pyramid_request_ingress',
+    'Number of requests currrently processed',
+    labelnames=['method', 'path_info_pattern'],)
+
+
+pyramid_request = Histogram(
+    'pyramid_request',
+    'HTTP Requests',
+    labelnames=['method', 'status', 'path_info_pattern']
+)
+
+
+def histo_tween_factory(handler, registry):
+    """
+    Create a tween to monitor number of requests at a given time.
+
+    Collects metrics on individual requests.
+    """
+    def tween(request):
+        gauge_labels = {
+            'method': request.method,
+            'path_info_pattern': get_pattern(request),
+        }
+        pyramid_request_ingress.labels(**gauge_labels).inc()
+
+        start = time()
+        status = '500'
+        try:
+            response = handler(request)
+            status = str(response.status_int)
+            return response
+        finally:
+            duration = time() - start
+            pyramid_request.labels(
+                method=request.method,
+                path_info_pattern=get_pattern(request),
+                status=status,
+            ).observe(duration)
+            pyramid_request_ingress.labels(**gauge_labels).dec()
+    return tween

--- a/bodhi/server/views/generic.py
+++ b/bodhi/server/views/generic.py
@@ -19,6 +19,8 @@
 
 import datetime
 
+from prometheus_client import generate_latest, CONTENT_TYPE_LATEST, REGISTRY
+from pyramid.response import Response
 from pyramid.settings import asbool
 from pyramid.view import view_config, notfound_view_config
 from pyramid.exceptions import HTTPForbidden, HTTPBadRequest
@@ -215,6 +217,28 @@ def _get_active_overrides(request):
     query = query.order_by(models.BuildrootOverride.submission_date.desc())
 
     return query.all()
+
+
+@view_config(route_name='prometheus_metric')
+def get_metrics(request):
+    """
+    Provide the metrics to be consumed by prometheus.
+
+    See the metrics_tween.py for hook to collect metrics for page requests
+
+    Args:
+        request (pyramid.request): The current web request.
+    Returns:
+        str: text in the prometheus metrics format.
+    """
+    registry = REGISTRY
+
+    request.response.content_type = CONTENT_TYPE_LATEST
+    resp = Response(
+        content_type=CONTENT_TYPE_LATEST,
+    )
+    resp.body = generate_latest(registry)
+    return resp
 
 
 @view_config(route_name='home', renderer='home.html')

--- a/bodhi/tests/server/views/test_generic.py
+++ b/bodhi/tests/server/views/test_generic.py
@@ -462,6 +462,10 @@ class TestGenericViews(base.BasePyTestCase):
         res = self.app.get('/healthz/live')
         assert 'ok' == res.json_body
 
+    def test_metrics(self):
+        res = self.app.get('/metrics')
+        assert 'python_gc_objects_collected_total' in res.text
+
     def test_new_update_form(self):
         """Test the new update Form page"""
 

--- a/devel/ansible/roles/bodhi/tasks/main.yml
+++ b/devel/ansible/roles/bodhi/tasks/main.yml
@@ -45,6 +45,7 @@
       - python3-markdown
       - python3-munch
       - python3-openid
+      - python3-prometheus_client
       - python3-psycopg2
       - python3-pydocstyle
       - python3-pylibravatar

--- a/devel/ci/Dockerfile-f31
+++ b/devel/ci/Dockerfile-f31
@@ -18,6 +18,7 @@ RUN dnf install -y \
     python3-colander \
     python3-cornice \
     python3-cornice-sphinx \
+    python3-prometheus_client \
     python3-createrepo_c \
     python3-diff-cover \
     python3-dnf \

--- a/devel/ci/Dockerfile-f32
+++ b/devel/ci/Dockerfile-f32
@@ -32,6 +32,7 @@ RUN dnf install -y \
     python3-munch \
     python3-openid \
     python3-psycopg2 \
+    python3-prometheus_client \
     python3-pylibravatar \
     python3-pyramid \
     python3-pyramid-fas-openid \

--- a/devel/ci/Dockerfile-rawhide
+++ b/devel/ci/Dockerfile-rawhide
@@ -32,6 +32,7 @@ RUN dnf install --disablerepo rawhide-modular -y \
     python3-munch \
     python3-openid \
     python3-psycopg2 \
+    python3-prometheus_client \
     python3-pylibravatar \
     python3-pyramid \
     python3-pyramid-fas-openid \

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,6 +14,7 @@ graphene
 graphene-sqlalchemy
 jinja2
 markdown
+prometheus_client
 psycopg2
 py3dns  # Should be required by pyLibravatar https://bugs.launchpad.net/pylibravatar/+bug/1661218
 pylibravatar


### PR DESCRIPTION
Introduces prometheus-client to expose an endpoint for  metrics collection.
Uses a tween to hook into all of the incomming requests and gather basic information,
to compute metrics on number of requests grouped by endpoints and their result status. 

Signed-off-by: Adam Saleh <asaleh@redhat.com>