### PR TITLE
Querying Updates using arguments

### DIFF
--- a/bodhi/server/graphql_schemas.py
+++ b/bodhi/server/graphql_schemas.py
@@ -19,7 +19,7 @@
 from graphene import relay, Field, String
 from graphene_sqlalchemy import SQLAlchemyObjectType
 
-from bodhi.server.models import Release as ReleaseModel
+from bodhi.server.models import Release as ReleaseModel, Update as UpdateModel
 
 
 class Release(SQLAlchemyObjectType):
@@ -32,3 +32,16 @@ class Release(SQLAlchemyObjectType):
         interfaces = (relay.Node, )
     state = Field(String)
     package_manager = Field(String)
+
+
+class Update(SQLAlchemyObjectType):
+    """Type object representing an update from bodhi.server.models."""
+
+    class Meta:
+        """Allow to set different options to the class."""
+
+        model = UpdateModel
+        interfaces = (relay.Node, )
+    status = Field(String)
+    request = Field(String)
+    date_approved = Field(String)

--- a/bodhi/server/services/graphql.py
+++ b/bodhi/server/services/graphql.py
@@ -21,8 +21,7 @@ from cornice import Service
 from webob_graphql import serve_graphql_request
 
 from bodhi.server.config import config
-from bodhi.server.graphql_schemas import Release, ReleaseModel
-
+from bodhi.server.graphql_schemas import Release, ReleaseModel, Update, UpdateModel
 
 graphql = Service(name='graphql', path='/graphql', description='graphql service')
 
@@ -48,17 +47,25 @@ class Query(graphene.ObjectType):
     """Allow querying objects."""
 
     allReleases = graphene.List(Release)
-    getRelease = graphene.Field(
+    getReleases = graphene.Field(
         lambda: graphene.List(Release), name=graphene.String(),
         id_prefix=graphene.String(), composed_by_bodhi=graphene.Boolean(),
         state=graphene.String())
+
+    getUpdates = graphene.Field(
+        lambda: graphene.List(Update), stable_karma=graphene.Int(),
+        stable_days=graphene.Int(), unstable_karma=graphene.Int(),
+        status=graphene.String(), request=graphene.String(),
+        pushed=graphene.Boolean(), critpath=graphene.Boolean(),
+        date_approved=graphene.String(), alias=graphene.String(),
+        user_id=graphene.Int())
 
     def resolve_allReleases(self, info):
         """Answer Queries by fetching data from the Schema."""
         query = Release.get_query(info)  # SQLAlchemy query
         return query.all()
 
-    def resolve_getRelease(self, info, **args):
+    def resolve_getReleases(self, info, **args):
         """Answer Release queries with a given argument."""
         query = Release.get_query(info)
 
@@ -77,6 +84,52 @@ class Query(graphene.ObjectType):
         state = args.get("state")
         if state is not None:
             query = query.filter(ReleaseModel.state == state)
+
+        return query.all()
+
+    def resolve_getUpdates(self, info, **args):
+        """Answer Release queries with a given argument."""
+        query = Update.get_query(info)
+
+        stable_karma = args.get("stable_karma")
+        if stable_karma is not None:
+            query = query.filter(UpdateModel.stable_karma == stable_karma)
+
+        stable_days = args.get("stable_days")
+        if stable_days is not None:
+            query = query.filter(UpdateModel.stable_days == stable_days)
+
+        unstable_karma = args.get("unstable_karma")
+        if unstable_karma is not None:
+            query = query.filter(UpdateModel.unstable_karma == unstable_karma)
+
+        status = args.get("status")
+        if status is not None:
+            query = query.filter(UpdateModel.status == status)
+
+        request = args.get("request")
+        if request is not None:
+            query = query.filter(UpdateModel.request == request)
+
+        pushed = args.get("pushed")
+        if pushed is not None:
+            query = query.filter(UpdateModel.pushed == pushed)
+
+        critpath = args.get("critpath")
+        if critpath is not None:
+            query = query.filter(UpdateModel.critpath == critpath)
+
+        date_approved = args.get("date_approved")
+        if date_approved is not None:
+            query = query.filter(UpdateModel.date_approved == date_approved)
+
+        alias = args.get("alias")
+        if alias is not None:
+            query = query.filter(UpdateModel.alias == alias)
+
+        user_id = args.get("user_id")
+        if user_id is not None:
+            query = query.filter(UpdateModel.user_id == user_id)
 
         return query.all()
 

--- a/bodhi/tests/server/services/test_graphql.py
+++ b/bodhi/tests/server/services/test_graphql.py
@@ -15,6 +15,8 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+import datetime
+
 from graphene.test import Client
 
 from bodhi.tests.server import base
@@ -64,16 +66,16 @@ class TestGraphQLService(base.BasePyTestCase):
             }
         }
 
-    def test_getRelease(self):
-        """Testing getRelease."""
+    def test_getReleases(self):
+        """Testing getReleases query."""
         base.BaseTestCaseMixin.create_release(self, version='22')
         client = Client(schema)
         self.db.commit()
 
-        executed = client.execute("""{  getRelease(idPrefix: "FEDORA"){  name  }}""")
+        executed = client.execute("""{  getReleases(idPrefix: "FEDORA"){  name  }}""")
         assert executed == {
             "data": {
-                "getRelease": [{
+                "getReleases": [{
                     "name": "F17"
                 }, {
                     "name": "F22"
@@ -81,19 +83,19 @@ class TestGraphQLService(base.BasePyTestCase):
             }
         }
 
-        executed = client.execute("""{  getRelease(name: "F17"){  id  }}""")
+        executed = client.execute("""{  getReleases(name: "F17"){  id  }}""")
         assert executed == {
             "data": {
-                "getRelease": [{
+                "getReleases": [{
                     "id": "UmVsZWFzZTox"
                 }]
             }
         }
 
-        executed = client.execute("""{  getRelease(composedByBodhi: true){  name  }}""")
+        executed = client.execute("""{  getReleases(composedByBodhi: true){  name  }}""")
         assert executed == {
             "data": {
-                "getRelease": [{
+                "getReleases": [{
                     "name": "F17"
                 }, {
                     "name": "F22"
@@ -102,13 +104,80 @@ class TestGraphQLService(base.BasePyTestCase):
         }
 
         executed = client.execute(
-            """{  getRelease(state: "current", composedByBodhi: true){  name  }}""")
+            """{  getReleases(state: "current", composedByBodhi: true){  name  }}""")
         assert executed == {
             "data": {
-                "getRelease": [{
+                "getReleases": [{
                     "name": "F17"
                 }, {
                     "name": "F22"
+                }]
+            }
+        }
+
+    def test_getUpdates(self):
+        """Testing getUpdates query."""
+        release = base.BaseTestCaseMixin.create_release(self, version='22')
+        self.create_update(build_nvrs=['TurboGears-2.1-1.el5'],
+                           release_name=release.name)
+        up2 = self.create_update(build_nvrs=['freetype-2.10.2-1.fc32'],
+                                 release_name=release.name)
+        up2.alias = "FEDORA-2020-3223f9ec8b"
+        up2.stable_days = 1
+        up2.date_approved = datetime.datetime(2019, 10, 13, 16, 16, 22, 438484)
+        self.db.commit()
+        client = Client(schema)
+
+        executed = client.execute("""{  getUpdates(stableDays: 1,
+                                  dateApproved: "2019-10-13 16:16:22.438484")
+                                  {  alias  request  unstableKarma  }}""")
+        assert executed == {
+            "data": {
+                "getUpdates": [{
+                    "alias": "FEDORA-2020-3223f9ec8b",
+                    "request": "testing",
+                    "unstableKarma": -3
+                }]
+            }
+        }
+
+        executed = client.execute("""{  getUpdates(stableKarma: 3, status: "pending",
+                                  critpath: false, pushed: false, request:"testing"){  stableDays
+                                  userId  }}""")
+        assert executed == {
+            'data': {
+                'getUpdates': [{
+                    'stableDays': 0,
+                    'userId': 1
+                }, {
+                    'stableDays': 0,
+                    'userId': 1
+                }, {
+                    'stableDays': 1,
+                    'userId': 1
+                }]
+            }
+        }
+
+        executed = client.execute("""{  getUpdates(stableDays: 1,
+                                  unstableKarma: -3, alias: "FEDORA-2020-3223f9ec8b")
+                                  {  dateApproved  request  }}""")
+        assert executed == {
+            'data': {
+                'getUpdates': [{
+                    'dateApproved': "2019-10-13 16:16:22.438484",
+                    'request': 'testing'
+                }]
+            }
+        }
+
+        executed = client.execute("""{  getUpdates(critpath: false, stableDays: 1,
+                                  userId: 1){  request    unstableKarma  }}""")
+        assert executed == {
+            'data': {
+                'getUpdates': [{
+                    'request': 'testing',
+                    'unstableKarma': -3,
                 }]
             }
         }

--- a/devel/ci/Dockerfile-f31
+++ b/devel/ci/Dockerfile-f31
@@ -25,6 +25,7 @@ RUN dnf install -y \
     python3-dogpile-cache \
     python3-fedora \
     python3-feedgen \
+    python3-gssapi \
     python3-jinja2 \
     python3-koji \
     python3-libcomps \

--- a/devel/ci/Dockerfile-f32
+++ b/devel/ci/Dockerfile-f32
@@ -24,6 +24,7 @@ RUN dnf install -y \
     python3-dogpile-cache \
     python3-fedora \
     python3-feedgen \
+    python3-gssapi \
     python3-jinja2 \
     python3-koji \
     python3-libcomps \

--- a/devel/ci/Dockerfile-pip
+++ b/devel/ci/Dockerfile-pip
@@ -18,6 +18,7 @@ RUN dnf install -y \
     python3-simplemediawiki \
     redhat-rpm-config \
     python3-libcomps \
+    python3-gssapi \
     python3-pip
 
 COPY requirements.txt /bodhi/requirements.txt

--- a/devel/ci/Dockerfile-rawhide
+++ b/devel/ci/Dockerfile-rawhide
@@ -24,6 +24,7 @@ RUN dnf install --disablerepo rawhide-modular -y \
     python3-dogpile-cache \
     python3-fedora \
     python3-feedgen \
+    python3-gssapi \
     python3-jinja2 \
     python3-koji \
     python3-libcomps \


### PR DESCRIPTION
Returns null on the GraphiQL client as of now. Uses `stable_karma`, `unstable_karma`, `stable_days`, `status`, `request`, `pushed`, `critpath`, `date_approved`, `alias`, and `user_id` as arguments to Query.

@cverna @StephenCoady 
Signed-off-by: Karma Dolkar <karmadolkar29@gmail.com>