### PR TITLE
Fix TestCase validation upon feedback submission

### DIFF
--- a/bodhi/server/models.py
+++ b/bodhi/server/models.py
@@ -1047,21 +1047,6 @@ class TestCase(Base):
     # Many-to-many relationships
     # builds backref
 
-    @property
-    def package_name(self) -> str:
-        """
-        Return the package name of the associated builds.
-
-        Since a TestCase name is unique and is created from the name of the Package,
-        each TestCase can only be associated to Builds of the same Package.
-        We use this for quickly validate the TestCase against Package upon feedback submission.
-
-        Returns:
-            The name of the package this testcase is intended for.
-        """
-        build = Build.query.filter(Build.testcases.any(name=self.name)).first()
-        return build.package.name
-
 
 class Package(Base):
     """

--- a/bodhi/server/validators.py
+++ b/bodhi/server/validators.py
@@ -1004,7 +1004,11 @@ def validate_testcase_feedback(request, **kwargs):
             request.errors.status = HTTPNotFound.code
             return
 
-    packages = [build.package.name for build in update.builds]
+    # Get all TestCase names associated to the Update
+    allowed_testcases = [tc.name
+                         for build in update.builds
+                         for tc in build.testcases
+                         if len(build.testcases) > 0]
 
     bad_testcases = []
     validated = []
@@ -1013,7 +1017,7 @@ def validate_testcase_feedback(request, **kwargs):
         name = item.pop('testcase_name')
         testcase = TestCase.get(name)
 
-        if not testcase or testcase.package_name not in packages:
+        if not testcase or testcase.name not in allowed_testcases:
             bad_testcases.append(name)
         else:
             item['testcase'] = testcase

--- a/bodhi/tests/server/test_models.py
+++ b/bodhi/tests/server/test_models.py
@@ -1516,7 +1516,6 @@ class TestBuild(ModelTest):
         assert len(build.testcases) == 3
         assert {tc.name for tc in model.TestCase.query.all()} == (
             {'Does Bodhi eat +1s', 'Fake', 'Uploading cat pictures'})
-        assert {tc.package_name for tc in model.TestCase.query.all()} == {'gnome-shell'}
 
     @mock.patch.dict(config, {'query_wiki_test_cases': True})
     @mock.patch('bodhi.server.models.MediaWiki')

--- a/news/4088.bug
+++ b/news/4088.bug
@@ -1,0 +1,1 @@
+Fix TestCase validation upon feedback submission


### PR DESCRIPTION
The validation logic I implemented in #4043 was wrong, a TestCase can be associated to multiple packages, so we cannot check against package name.

Fixes #4088 

Signed-off-by: Mattia Verga <mattia.verga@tiscali.it>