### PR TITLE
Do not let update through when bodhi fails to talk to greenwave

### DIFF
--- a/bodhi/tests/server/test_models.py
+++ b/bodhi/tests/server/test_models.py
@@ -2191,17 +2191,6 @@ class TestUpdateSigned(BasePyTestCase):
         assert not update.signed
 
 
-class TestUpdateTestGatingPassed(BasePyTestCase):
-    """Test the Update.test_gating_passed() method."""
-
-    def test_greenwave_failed(self):
-        """The greenwave_failed TestGatingStatus should count as passed."""
-        update = model.Update.query.first()
-        update.test_gating_status = TestGatingStatus.greenwave_failed
-
-        assert update.test_gating_passed
-
-
 class TestUpdateUpdateTestGatingStatus(BasePyTestCase):
     """Test the Update.update_test_gating_status() method."""
 
@@ -2219,7 +2208,7 @@ class TestUpdateUpdateTestGatingStatus(BasePyTestCase):
 
         update.update_test_gating_status()
 
-        assert update.test_gating_status == model.TestGatingStatus.greenwave_failed
+        assert update.test_gating_status == model.TestGatingStatus.waiting
         assert sleep.mock_calls == [mock.call(1), mock.call(1), mock.call(1)]
         expected_post = mock.call(
             'https://greenwave-web-greenwave.app.os.fedoraproject.org/api/v1.0/decision',
@@ -2261,7 +2250,7 @@ class TestUpdateUpdateTestGatingStatus(BasePyTestCase):
 
         update.update_test_gating_status()
 
-        assert update.test_gating_status == model.TestGatingStatus.greenwave_failed
+        assert update.test_gating_status == model.TestGatingStatus.waiting
         # The call_url() handler doesn't catch a Timeout so there are no sleeps/retries.
         assert sleep.mock_calls == []
         expected_post = mock.call(

--- a/news/4089.bug
+++ b/news/4089.bug
@@ -1,0 +1,1 @@
+Do not let update through when bodhi fails to talk to greenwave.


### PR DESCRIPTION
This commit removes the greenwave_failed status of
the test_gating_status update attribute. Instead in case of
a failure to communicate to greenwave we set the status to
waiting and rely on the fedora-messaging greenwave consumer
to update the gating status.

The greenwave_failed status is still present in the database
table and old updates having that status are not changed.

Fixes #4089

Signed-off-by: Clement Verna <cverna@tutanota.com>