### PR TITLE
Fix 404 pages for bot users with nonstandard characters in usernames

### DIFF
--- a/bodhi/server/services/user.py
+++ b/bodhi/server/services/user.py
@@ -32,7 +32,7 @@ import bodhi.server.services.errors
 import bodhi.server.services.updates
 
 
-user = Service(name='user', path='/users/{name}',
+user = Service(name='user', path=r'/users/{name:\S+}',
                description='Bodhi users',
                # These we leave wide-open since these are only GETs
                cors_origins=bodhi.server.security.cors_origins_ro)

--- a/bodhi/tests/server/functional/test_users.py
+++ b/bodhi/tests/server/functional/test_users.py
@@ -39,6 +39,15 @@ class TestUsersService(base.BasePyTestCase):
         res = self.app.get('/users/bodhi')
         assert res.json_body['user']['name'] == 'bodhi'
 
+    def test_get_single_user_with_nonstandard_characters(self):
+        """Test that we don't receive a 404 page with bot usernames."""
+        user = User(name='bot/a.bad.name')
+        self.db.add(user)
+        self.db.flush()
+
+        res = self.app.get('/users/bot/a.bad.name')
+        assert res.json_body['user']['name'] == 'bot/a.bad.name'
+
     def test_get_hardcoded_avatar(self):
         res = self.app.get('/users/bodhi')
         assert res.json_body['user']['name'] == 'bodhi'

--- a/news/3993.bug
+++ b/news/3993.bug
@@ -1,0 +1,1 @@
+Fix 404 pages for bot users with nonstandard characters in usernames


### PR DESCRIPTION
This PR changes the default Pyramid's regex for replacement markers allowing usernames to have slashes.
https://docs.pylonsproject.org/projects/pyramid/en/latest/narr/urldispatch.html#route-pattern-syntax
I've used a rather permissive regex here (all non-whitespace characters) so anything behind `/users/` will be considered to be the username to search. I don't see any security concerns or other troubles for that, correct me if I'm wrong.

Fixes https://bodhi.fedoraproject.org/users/bpeck/jenkins-continuous-infra.apps.ci.centos.org
Fixes #3993 

Signed-off-by: Mattia Verga <mattia.verga@tiscali.it>