### PR TITLE
Do not force critpath packages to stay in testing for long pre-beta

### DIFF
--- a/bodhi/server/models.py
+++ b/bodhi/server/models.py
@@ -1993,7 +1993,7 @@ class Update(Base):
         :return: The number of mandatory days in testing.
         :rtype:  int
         """
-        if self.critpath:
+        if self.critpath and self.release.composed_by_bodhi:
             return config.get('critpath.stable_after_days_without_negative_karma')
 
         days = self.release.mandatory_days_in_testing


### PR DESCRIPTION
If a release is not composed by bodhi, we should not force packages in
critpath to stay 14 days in testing. Otherwise, between branching and
beta, when bodhi is still in "rawhide" mode, critpath packages get stuck
for 14 days.

Signed-off-by: Pierre-Yves Chibon <pingou@pingoured.fr>