### PR TITLE
Use Whitenoise to serve the documentation.

### DIFF
--- a/bodhi/server/__init__.py
+++ b/bodhi/server/__init__.py
@@ -29,6 +29,7 @@ from pyramid.renderers import JSONP
 from pyramid.tweens import EXCVIEW
 from sqlalchemy import engine_from_config, event
 from sqlalchemy.orm import scoped_session, sessionmaker
+from whitenoise import WhiteNoise
 import pkg_resources
 
 from bodhi.server import bugs, buildsys
@@ -361,4 +362,6 @@ def main(global_config, testing=None, session=None, **settings):
     Session.remove()
 
     log.info('Bodhi ready and at your service!')
-    return config.make_wsgi_app()
+    app = config.make_wsgi_app()
+    app = WhiteNoise(app, root="/usr/share/doc/bodhi-docs/html/", prefix="/docs", index_file=True)
+    return app

--- a/bodhi/tests/server/services/test_updates.py
+++ b/bodhi/tests/server/services/test_updates.py
@@ -406,7 +406,8 @@ class TestNewUpdate(BasePyTestCase):
         """
         Test html rendering of default build link
         """
-        self.app.app.registry.settings['koji_web_url'] = 'https://koji.fedoraproject.org/koji/'
+        self.app.app.application.registry.settings['koji_web_url'] = \
+            'https://koji.fedoraproject.org/koji/'
         nvr = 'bodhi-2.0.0-2.fc17'
         with fml_testing.mock_sends(update_schemas.UpdateRequestTestingV1):
             resp = self.app.post_json('/updates/', self.get_update(nvr))
@@ -421,7 +422,8 @@ class TestNewUpdate(BasePyTestCase):
         """
         Test html rendering of default build link without trailing slash
         """
-        self.app.app.registry.settings['koji_web_url'] = 'https://koji.fedoraproject.org/koji'
+        self.app.app.application.registry.settings['koji_web_url'] = \
+            'https://koji.fedoraproject.org/koji'
         nvr = 'bodhi-2.0.0-2.fc17'
         with fml_testing.mock_sends(update_schemas.UpdateRequestTestingV1):
             resp = self.app.post_json('/updates/', self.get_update(nvr))
@@ -437,7 +439,7 @@ class TestNewUpdate(BasePyTestCase):
         Test html rendering of build link using a mock config variable 'koji_web_url'
         without a trailing slash in it
         """
-        self.app.app.registry.settings['koji_web_url'] = 'https://host.org'
+        self.app.app.application.registry.settings['koji_web_url'] = 'https://host.org'
         nvr = 'bodhi-2.0.0-2.fc17'
         with fml_testing.mock_sends(update_schemas.UpdateRequestTestingV1):
             resp = self.app.post_json('/updates/', self.get_update(nvr))
@@ -1305,7 +1307,8 @@ class TestUpdatesService(BasePyTestCase):
     def test_home_html_legal(self):
         """Test the home page HTML when a legal link is configured."""
         with mock.patch.dict(
-                self.app.app.registry.settings, {'legal_link': 'http://loweringthebar.net/'}):
+                self.app.app.application.registry.settings,
+                {'legal_link': 'http://loweringthebar.net/'}):
             resp = self.app.get('/', headers={'Accept': 'text/html'})
 
         assert 'Fedora Updates System' in resp
@@ -1315,7 +1318,7 @@ class TestUpdatesService(BasePyTestCase):
 
     def test_home_html_no_legal(self):
         """Test the home page HTML when no legal link is configured."""
-        with mock.patch.dict(self.app.app.registry.settings, {'legal_link': ''}):
+        with mock.patch.dict(self.app.app.application.registry.settings, {'legal_link': ''}):
             resp = self.app.get('/', headers={'Accept': 'text/html'})
 
         assert 'Fedora Updates System' in resp
@@ -1852,7 +1855,7 @@ class TestUpdatesService(BasePyTestCase):
         """Test getting a single update via HTML when no privacy link is configured."""
         update = Build.query.filter_by(nvr='bodhi-2.0-1.fc17').one().update
 
-        with mock.patch.dict(self.app.app.registry.settings, {'privacy_link': ''}):
+        with mock.patch.dict(self.app.app.application.registry.settings, {'privacy_link': ''}):
             resp = self.app.get(f'/updates/{update.alias}',
                                 headers={'Accept': 'text/html'})
 
@@ -1868,7 +1871,8 @@ class TestUpdatesService(BasePyTestCase):
         update = Build.query.filter_by(nvr='bodhi-2.0-1.fc17').one().update
 
         with mock.patch.dict(
-                self.app.app.registry.settings, {'privacy_link': 'https://privacyiscool.com'}):
+                self.app.app.application.registry.settings,
+                {'privacy_link': 'https://privacyiscool.com'}):
             resp = self.app.get(f'/updates/{update.alias}',
                                 headers={'Accept': 'text/html'})
 
@@ -5001,7 +5005,7 @@ class TestUpdatesService(BasePyTestCase):
         update.comment(self.db, 'works', 1, 'bowlofeggs')
         # Let's clear any messages that might get sent
         self.db.info['messages'] = []
-        self.app.app.registry.settings['test_gating.required'] = True
+        self.app.app.application.registry.settings['test_gating.required'] = True
 
         resp = self.app.get(f'/updates/{update.alias}', headers={'Accept': 'text/html'})
 
@@ -5030,7 +5034,7 @@ class TestUpdatesService(BasePyTestCase):
         update.comment(self.db, 'works', 1, 'bowlofeggs')
         # Let's clear any messages that might get sent
         self.db.info['messages'] = []
-        self.app.app.registry.settings['test_gating.required'] = True
+        self.app.app.application.registry.settings['test_gating.required'] = True
 
         resp = self.app.get(f'/updates/{update.alias}', headers={'Accept': 'text/html'})
 

--- a/devel/ansible/roles/bodhi/tasks/main.yml
+++ b/devel/ansible/roles/bodhi/tasks/main.yml
@@ -59,6 +59,7 @@
       - python3-sqlalchemy
       - python3-sqlalchemy_schemadisplay
       - python3-webtest
+      - python3-whitenoise
       - redhat-rpm-config
       - screen
       - skopeo

--- a/devel/ci/Dockerfile-f31
+++ b/devel/ci/Dockerfile-f31
@@ -46,6 +46,7 @@ RUN dnf install -y \
     python3-sqlalchemy_schemadisplay \
     python3-waitress \
     python3-webtest \
+    python3-whitenoise \
     python3-yaml &&\
     pip-3 install graphene graphene-sqlalchemy WebOb-GraphQL koji
 

--- a/devel/ci/Dockerfile-f32
+++ b/devel/ci/Dockerfile-f32
@@ -46,6 +46,7 @@ RUN dnf install -y \
     python3-sqlalchemy_schemadisplay \
     python3-waitress \
     python3-webtest \
+    python3-whitenoise \
     python3-yaml &&\
     pip-3 install graphene graphene-sqlalchemy WebOb-GraphQL koji
 

--- a/devel/ci/Dockerfile-rawhide
+++ b/devel/ci/Dockerfile-rawhide
@@ -46,6 +46,7 @@ RUN dnf install --disablerepo rawhide-modular -y \
     python3-sqlalchemy_schemadisplay \
     python3-waitress \
     python3-webtest \
+    python3-whitenoise \
     python3-yaml &&\
     pip-3 install graphene graphene-sqlalchemy WebOb-GraphQL koji
 

--- a/news/4066.bug
+++ b/news/4066.bug
@@ -1,0 +1,1 @@
+Serve the documentation directly from the WSGI application using WhiteNoise.

--- a/requirements.txt
+++ b/requirements.txt
@@ -29,3 +29,4 @@ simplemediawiki
 sqlalchemy
 waitress
 WebOb-GraphQL
+whitenoise


### PR DESCRIPTION
This commit introduces a new dependency WhiteNoise so that we can use the
WSGI app to serve the documentation.

Fixes #4066

Signed-off-by: Clement Verna <cverna@tutanota.com>