### PR TITLE
Enable builds synch button in side-tag updates edit page for non-rawh…

### DIFF
--- a/bodhi/server/templates/new_update.html
+++ b/bodhi/server/templates/new_update.html
@@ -74,7 +74,7 @@ ${parent.css()}
                           </div>
                       </div>
                       % endif
-                      % if update and update.from_tag and not update.release.composed_by_bodhi:
+                      % if update and update.from_tag:
                       <div class="col text-right pr-0">
                       <span class="text-muted"><span class="fa fa-tag pr-1"></span> ${update.from_tag} <button class="btn btn-outline-primary btn-sm ml-2" id="sidetag-update"><span class="fa fa-refresh"></span></button></span>
                       </div>

--- a/bodhi/server/templates/update.html
+++ b/bodhi/server/templates/update.html
@@ -419,7 +419,7 @@ if can_edit and update.release.composed_by_bodhi:
                   <div class="h5 d-flex align-items-center font-weight-bold border-bottom">
                       <div class="py-2 text-uppercase font-size-09">Builds</div>
                        <span class="badge badge-secondary badge-pill ml-1">${len(update.builds)}</span>
-                      % if request.user and update.from_tag and not update.release.composed_by_bodhi:
+                      % if request.user and update.from_tag:
                       <span class="badge badge-light badge-pill ml-auto border" title="Builds from the Side Tag: ${update.from_tag}" data-toggle="tooltip"><i class="fa fa-tag pr-1"></i> ${update.from_tag}</span>
                       % endif
                   </div>

--- a/bodhi/tests/server/services/test_updates.py
+++ b/bodhi/tests/server/services/test_updates.py
@@ -384,11 +384,8 @@ class TestNewUpdate(BasePyTestCase):
             assert called_args['pending_signing_tag'] == 'f17-build-side-7777-signing-pending'
             assert called_args['pending_testing_tag'] == 'f17-build-side-7777-testing-pending'
         else:
-            # stable release workflow
-
-            # check that the sidetag doesn't get displayed on the update page,
-            # by the time the update is created, it shouldn't exist anymore
-            assert 'title="Builds from the Side Tag:' not in resp
+            # the sidetag should be still displayed on the update page
+            assert 'title="Builds from the Side Tag: f17-build-side-7777' in resp
             assert called_args['pending_signing_tag'] == 'f17-updates-signing-pending'
 
         # now try to create another update with the same side tag

--- a/news/4122.bug
+++ b/news/4122.bug
@@ -1,0 +1,1 @@
+Side-tag updates builds were not editable in the WebUI


### PR DESCRIPTION
…ide releases

Fixes #4122 

Signed-off-by: Mattia Verga <mattia.verga@tiscali.it>