### PR TITLE
Grant side-tag owners rights to builds tagged into it

### DIFF
--- a/bodhi/server/services/updates.py
+++ b/bodhi/server/services/updates.py
@@ -492,6 +492,7 @@ def new_update(request):
 
     # Same here, but it can be missing.
     data.pop('builds_from_tag', None)
+    data.pop('sidetag_owner', None)
 
     build_nvrs = data.get('builds', [])
     from_tag = data.get('from_tag')

--- a/bodhi/server/validators.py
+++ b/bodhi/server/validators.py
@@ -396,6 +396,8 @@ def validate_acls(request, **kwargs):
         request.errors.add('cookies', 'user', 'No ACLs for anonymous user')
         return
     user = User.get(request.user.name)
+    user_groups = [group.name for group in user.groups]
+    acl_system = config.get('acl_system')
     committers = []
     groups = []
 
@@ -408,11 +410,10 @@ def validate_acls(request, **kwargs):
     # (either the explicitly listed ones or on the ones associated with the
     # pre-existing update).. and so we'll do some conditional branching below
     # to handle those two scenarios.
-
-    # This can get confusing.
-    # TODO -- we should break these two roles out into two different clearly
-    # defined validator functions like `validate_acls_for_builds` and
-    # `validate_acls_for_update`.
+    #
+    # In case of a side-tag update, we don't validate against the builds,
+    # but we require the submitter to be who created the side-tag.
+    # The 'sidetag_owner' field is set by `validate_from_tag()`.
 
     builds = None
     if 'builds' in request.validated:
@@ -427,6 +428,43 @@ def validate_acls(request, **kwargs):
                            'unable to determine ACLs.')
         return
 
+    # Allow certain groups to push updates for any package
+    admin_groups = config['admin_packager_groups']
+    for group in admin_groups:
+        if group in user_groups:
+            log.debug(f'{user.name} is in {group} admin group')
+            return
+
+    # Make sure the user is in the mandatory packager groups. This is a
+    # safeguard in the event a user has commit access on the ACL system
+    # but isn't part of the mandatory groups.
+    mandatory_groups = config['mandatory_packager_groups']
+    for mandatory_group in mandatory_groups:
+        if mandatory_group not in user_groups:
+            error = (f'{user.name} is not a member of "{mandatory_group}", which is a '
+                     f'mandatory packager group')
+            request.errors.add('body', 'builds', error)
+            return
+
+    # If we try to create or edit a side-tag update, check if user owns the side-tag
+    if request.validated.get('from_tag') is not None:
+        sidetag = request.validated.get('from_tag')
+        # the validate_from_tag() must have set the sidetag_owner field
+        sidetag_owner = request.validated.get('sidetag_owner', None)
+        if sidetag_owner is None:
+            error = ('Update appear to be from side-tag, but we cannot determine '
+                     'the side-tag owner')
+            request.errors.add('body', 'builds', error)
+            return
+
+        if sidetag_owner != user.name:
+            request.errors.add('body',
+                               'builds',
+                               f'{user.name} does not own {sidetag} side-tag')
+            request.errors.status = 403
+        return
+
+    # For normal updates, check against every build
     for build in builds:
         # The whole point of the blocks inside this conditional is to determine
         # the "release" and "package" associated with the given build.  For raw
@@ -465,34 +503,7 @@ def validate_acls(request, **kwargs):
 
         # Now that we know the release and the package associated with this
         # build, we can ask our ACL system about it..
-
-        acl_system = config.get('acl_system')
-        user_groups = [group.name for group in user.groups]
         has_access = False
-
-        # Allow certain groups to push updates for any package
-        admin_groups = config['admin_packager_groups']
-        for group in admin_groups:
-            if group in user_groups:
-                log.debug('{} is in {} admin group'.format(user.name, group))
-                has_access = True
-                break
-
-        if has_access:
-            continue
-
-        # Make sure the user is in the mandatory packager groups. This is a
-        # safeguard in the event a user has commit access on the ACL system
-        # but isn't part of the mandatory groups.
-        mandatory_groups = config['mandatory_packager_groups']
-        for mandatory_group in mandatory_groups:
-            if mandatory_group not in user_groups:
-                error = ('{0} is not a member of "{1}", which is a '
-                         'mandatory packager group').format(
-                    user.name, mandatory_group)
-                request.errors.add('body', 'builds', error)
-                return
-
         if acl_system == 'pagure':
             try:
                 committers, groups = package.get_pkg_committers_from_pagure()
@@ -527,8 +538,7 @@ def validate_acls(request, **kwargs):
             # Check if this user is in a group that has access to this package
             for group in user_groups:
                 if group in groups:
-                    log.debug('{} is in {} group for {}'.format(
-                        user.name, group, package.name))
+                    log.debug(f'{user.name} is in {group} group for {package.name}')
                     has_access = True
                     break
 
@@ -1357,17 +1367,15 @@ def validate_from_tag(request: pyramid.request.Request, **kwargs: dict):
             request.errors.add('body', 'from_tag', "The supplied tag is not a side tag.")
             return
 
+        # store side-tag owner name to be validated in ACLs
+        request.validated['sidetag_owner'] = taginfo.get('extra', {}).get('sidetag_user', None)
+
         # add all the inherited tags of a sidetag to from_tag_inherited
         for tag in koji_client.getFullInheritance(koji_tag):
             request.from_tag_inherited.append(tag['name'])
 
         if request.validated.get('builds'):
-            # Builds were specified explicitly, verify that the tag exists in Koji.
-            if not taginfo:
-                request.errors.add('body', 'from_tag', "The supplied from_tag doesn't exist.")
-                return
-
-            # Flag that `builds` wasn't filled from the Koji tag.
+            # Builds were specified explicitly, flag that `builds` wasn't filled from the Koji tag.
             request.validated['builds_from_tag'] = False
         else:
             # Builds weren't specified explicitly, pull the list of latest NVRs here, as it is

--- a/news/4014.feature
+++ b/news/4014.feature
@@ -1,0 +1,1 @@
+Users which owns a side-tag can now create updates from that side-tag even if it contains builds for which they haven't commit access


### PR DESCRIPTION
This introduces some changes on ACLs validator. Since this is quite important change, here some explanation.

Firstly, I moved the check about user to be admin or packager out of the builds for loop. If the user is in an admin group, just validate they're rights; if the user is not in packager group, just fail. I see no reason to check that inside the for loop.

Then, the main change is when an update comes from a side-tag. Here we no more validate user rights against Pagure commit access on every build, but just check from Koji if the user is the creator of the side-tag. If user owns the side-tag, they can create the update from the side-tag even if there are builds for which they don't have commit access to. This will also prevents users from creating updates from side-tags they don't own (except provenpackagers).

The rationale here is that user A creates a side-tag and update a library into that. Then asks user B to rebuild a package that depends on that library inside the side-tag. When all dependent packages are rebuilt, user A can push a side-tag update which will update also packages they don't have commit access normally.

Fixes #4014 

Signed-off-by: Mattia Verga <mattia.verga@tiscali.it>