### PR TITLE
Fix some deprecation warnings from markdown

### DIFF
--- a/bodhi/tests/server/test_util.py
+++ b/bodhi/tests/server/test_util.py
@@ -1049,12 +1049,23 @@ class TestUtils(base.BasePyTestCase):
             '<script>alert("pants")</script>'
         )
         html = util.markup(None, text)
-        assert html == \
-            (
-                '<div class="markdown"><h1>this is a header</h1>\n'
-                '<p>this is some <strong>text</strong>\n'
-                '&lt;script&gt;alert("pants")&lt;/script&gt;</p></div>'
-            )
+
+        # Markdown has changed html parser between 3.2.2 and 3.3.0
+        from markdown import __version_info__ as mvi
+        if mvi[0] >= 3 and mvi[1] >= 3:
+            assert html == \
+                (
+                    '<div class="markdown"><h1>this is a header</h1>\n'
+                    '<p>this is some <strong>text</strong></p>\n'
+                    '&lt;script&gt;alert("pants")&lt;/script&gt;\n</div>'
+                )
+        else:
+            assert html == \
+                (
+                    '<div class="markdown"><h1>this is a header</h1>\n'
+                    '<p>this is some <strong>text</strong>\n'
+                    '&lt;script&gt;alert("pants")&lt;/script&gt;</p></div>'
+                )
 
     @mock.patch('bodhi.server.util.bleach.clean', return_value='cleaned text')
     def test_markup_with_bleach(self, clean):

--- a/bodhi/tests/server/views/test_generic.py
+++ b/bodhi/tests/server/views/test_generic.py
@@ -238,8 +238,14 @@ class TestGenericViews(base.BasePyTestCase):
         res = self.app.get('/markdown', {
             'text': '```\nsudo dnf install bodhi\n```',
         }, status=200)
-        assert res.json_body['html'] == \
-            '<div class="markdown"><pre><code>sudo dnf install bodhi\n</code></pre>\n</div>'
+        # Markdown has changed html parser between 3.2.2 and 3.3.0
+        from markdown import __version_info__ as mvi
+        if mvi[0] >= 3 and mvi[1] >= 3:
+            assert res.json_body['html'] == \
+                '<div class="markdown"><pre><code>sudo dnf install bodhi\n</code></pre></div>'
+        else:
+            assert res.json_body['html'] == \
+                '<div class="markdown"><pre><code>sudo dnf install bodhi\n</code></pre>\n</div>'
 
     def test_markdown_with_email_autolink(self):
         res = self.app.get('/markdown', {

--- a/news/PR4134.dependency
+++ b/news/PR4134.dependency
@@ -1,0 +1,1 @@
+Markdown >= 3.0 is now required

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ graphene
 graphene-sqlalchemy
 koji
 jinja2
-markdown
+markdown>=3.0
 prometheus_client
 psycopg2
 py3dns  # Should be required by pyLibravatar https://bugs.launchpad.net/pylibravatar/+bug/1661218


### PR DESCRIPTION
This will also change the minimum Markdown version requirement to 3.0 (published in Sept. 2018)

Signed-off-by: Mattia Verga <mattia.verga@tiscali.it>