### PR TITLE
Allow overriding `critpath.stable_after_days_without_negative_karma` …

### DIFF
--- a/bodhi/tests/server/test_models.py
+++ b/bodhi/tests/server/test_models.py
@@ -734,6 +734,34 @@ class TestRelease(ModelTest):
         """Test mandatory_days_in_testing() with a value that is 0."""
         assert self.obj.mandatory_days_in_testing == 0
 
+    @mock.patch.dict(config, {'critpath.stable_after_days_without_negative_karma': 11,
+                              'f11.current.critpath.stable_after_days_without_negative_karma': 42})
+    def test_critpath_mandatory_days_in_testing_no_status(self):
+        """
+        Test critpath_mandatory_days_in_testing() returns global default if
+        release has no status.
+        """
+        assert self.obj.critpath_mandatory_days_in_testing == 11
+
+    @mock.patch.dict(config, {'critpath.stable_after_days_without_negative_karma': 11,
+                              'f11.status': 'current'})
+    def test_critpath_mandatory_days_in_testing_status_default(self):
+        """
+        Test critpath_mandatory_days_in_testing() returns global default if
+        release has status, but no override set.
+        """
+        assert self.obj.critpath_mandatory_days_in_testing == 11
+
+    @mock.patch.dict(config, {'critpath.stable_after_days_without_negative_karma': 11,
+                              'f11.status': 'current',
+                              'f11.current.critpath.stable_after_days_without_negative_karma': 42})
+    def test_critpath_mandatory_days_in_testing_status_override(self):
+        """
+        Test critpath_mandatory_days_in_testing() returns override value if
+        release has status and override set.
+        """
+        assert self.obj.critpath_mandatory_days_in_testing == 42
+
     def test_setting_prefix(self):
         """Assert correct return value from the setting_prefix property."""
         assert self.obj.setting_prefix == 'f11'

--- a/devel/development.ini.example
+++ b/devel/development.ini.example
@@ -14,6 +14,7 @@ f7.status = post_beta
 f7.post_beta.mandatory_days_in_testing = 7
 f7.post_beta.critpath.num_admin_approvals = 0
 f7.post_beta.critpath.min_karma = 2
+f7.post_beta.critpath.stable_after_days_without_negative_karma = 3
 cors_origins_ro = *
 cors_origins_rw = http://0.0.0.0:6543
 cors_connect_src = http://0.0.0.0:6543 http://localhost:6543 https://*.fedoraproject.org/ wss://hub.fedoraproject.org:9939/

--- a/news/PR4135.feature
+++ b/news/PR4135.feature
@@ -1,0 +1,1 @@
+Allow overriding `critpath.stable_after_days_without_negative_karma` based on release status

--- a/production.ini
+++ b/production.ini
@@ -435,9 +435,11 @@ fedora_epel.mandatory_days_in_testing = 14
 #f28.pre_beta.mandatory_days_in_testing = 3
 #f28.pre_beta.critpath.num_admin_approvals = 0
 #f28.pre_beta.critpath.min_karma = 1
+#f28.pre_beta.critpath.stable_after_days_without_negative_karma = 3
 #f28.post_beta.mandatory_days_in_testing = 7
 #f28.post_beta.critpath.num_admin_approvals = 0
 #f28.post_beta.critpath.min_karma = 2
+#f28.post_beta.critpath.stable_after_days_without_negative_karma = 5
 
 
 ##


### PR DESCRIPTION
…based on release status

A different approach than #4108 
It turned out that `critpath.stable_after_days_without_negative_karma` can actually be overriden by release status (and in fact it is in ansible config template), but this is not used by Bodhi.

Signed-off-by: Mattia Verga <mattia.verga@tiscali.it>