### PR TITLE
fix typo in bodhi/server/config.py

### DIFF
--- a/bodhi/server/config.py
+++ b/bodhi/server/config.py
@@ -358,7 +358,7 @@ class BodhiConfig(dict):
             'validator': str},
         'important_groups': {
             # Defined in and tied to the Fedora Account System (limited to 16 characters)
-            'value': ['proventesters', 'provenpackager,' 'releng', 'security_respons', 'packager',
+            'value': ['proventesters', 'provenpackager', 'releng', 'security_respons', 'packager',
                       'bodhiadmin'],
             'validator': _generate_list_validator()},
         'initial_bug_msg': {


### PR DESCRIPTION
String literals are implicitly concatenated in a literal iterable definition when they are not separated by a comma.
361: 'value': ['proventesters', `'provenpackager,' 'releng',` 'security_respons', 'packager', 'bodhiadmin'] may lead to undesirable results.