### PR TITLE
Prevent comments to be orphaned of their update

### DIFF
--- a/bodhi/server/migrations/versions/559acf7e2c16_make_comments_update_not_nullable.py
+++ b/bodhi/server/migrations/versions/559acf7e2c16_make_comments_update_not_nullable.py
@@ -1,0 +1,51 @@
+# Copyright (c) 2020 Mattia Verga
+#
+# This file is part of Bodhi.
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+"""
+Make comments.update not nullable.
+
+Revision ID: 559acf7e2c16
+Revises: 1c97477e38ee
+Create Date: 2020-11-17 16:25:38.464821
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '559acf7e2c16'
+down_revision = '1c97477e38ee'
+
+
+def upgrade():
+    """Delete orphan objects and set comments.update_id not nullable."""
+    # We must drop all comments not referenced to any update
+    op.execute('DELETE FROM comments WHERE update_id IS NULL')
+    # Then we remove TestCaseKarma and BugKarma orphaned of their comment
+    op.execute('DELETE FROM comment_bug_assoc WHERE comment_id IS NULL')
+    op.execute('DELETE FROM comment_testcase_assoc WHERE comment_id IS NULL')
+
+    op.alter_column('comments', 'update_id',
+                    existing_type=sa.INTEGER(),
+                    nullable=False)
+
+
+def downgrade():
+    """Restore comments.update_id to be nullable."""
+    op.alter_column('comments', 'update_id',
+                    existing_type=sa.INTEGER(),
+                    nullable=True)

--- a/bodhi/server/models.py
+++ b/bodhi/server/models.py
@@ -1893,7 +1893,8 @@ class Update(Base):
         backref=backref('updates', passive_deletes=True, order_by='Update.date_submitted'))
 
     # One-to-many relationships
-    comments = relationship('Comment', backref='update', order_by='Comment.timestamp')
+    comments = relationship('Comment', backref='update', cascade="all,delete,delete-orphan",
+                            order_by='Comment.timestamp')
     builds = relationship('Build', backref='update', order_by='Build.nvr')
 
     # Many-to-many relationships
@@ -3340,11 +3341,9 @@ class Update(Base):
             user = User(name=author)
             session.add(user)
 
-        comment = Comment(text=text, karma=karma, karma_critpath=karma_critpath, user=user)
+        comment = Comment(text=text, karma=karma, karma_critpath=karma_critpath,
+                          update=self, user=user)
         session.add(comment)
-
-        self.comments.append(comment)
-        session.flush()
 
         if karma != 0:
             # Determine whether this user has already left karma, and if so what the most recent
@@ -4311,7 +4310,8 @@ class BugKarma(Base):
 
     # Many-to-one relationships
     comment_id = Column(Integer, ForeignKey('comments.id'))
-    comment = relationship("Comment", backref='bug_feedback')
+    comment = relationship("Comment", backref=backref('bug_feedback',
+                                                      cascade="all,delete,delete-orphan"))
 
     bug_id = Column(Integer, ForeignKey('bugs.bug_id'))
     bug = relationship("Bug", backref='feedback')
@@ -4334,7 +4334,8 @@ class TestCaseKarma(Base):
 
     # Many-to-one relationships
     comment_id = Column(Integer, ForeignKey('comments.id'))
-    comment = relationship("Comment", backref='testcase_feedback')
+    comment = relationship("Comment", backref=backref('testcase_feedback',
+                                                      cascade="all,delete,delete-orphan"))
 
     testcase_id = Column(Integer, ForeignKey('testcases.id'))
     testcase = relationship("TestCase", backref='feedback')
@@ -4369,7 +4370,7 @@ class Comment(Base):
     # testcase_feedback backref from TestCaseKarma
 
     # Many-to-one relationships
-    update_id = Column(Integer, ForeignKey('updates.id'), index=True)
+    update_id = Column(Integer, ForeignKey('updates.id'), nullable=False, index=True)
     # update backref from Update
     user_id = Column(Integer, ForeignKey('users.id'), nullable=False)
     # user backref from User

--- a/news/4155.bug
+++ b/news/4155.bug
@@ -1,0 +1,1 @@
+Some comments orphaned from their update where causing internal server errors. We now enforce a not null check so that a comment cannot be created without associating it to an update. The orphaned comments are removed from the database by the migration script.

--- a/news/summary.migration
+++ b/news/summary.migration
@@ -1,0 +1,1 @@
+The Comments.update_id column is now set to be not null. The comments orphaned from their update object are deleted from the database and so are BugKarma and TestCaseKarma objects orphaned from their Comment.


### PR DESCRIPTION
Fixes #4155 

We have to delete all orphaned comments (they're probably leftovers from few updates which were manually deleted in the past from the database).
Adding `cascade="all,delete,delete-orphan"` to update.comments will prevent future problems.

Signed-off-by: Mattia Verga <mattia.verga@tiscali.it>