### PR TITLE
Allow editing side-tag updates from cli for current releases

### DIFF
--- a/bodhi/client/__init__.py
+++ b/bodhi/client/__init__.py
@@ -543,13 +543,6 @@ def edit(user: str, password: str, url: str, debug: bool, openid_api: str, **kwa
                     " --addbuilds or --removebuilds.", err=True
                 )
                 sys.exit(1)
-            if former_update.get('release', {}).get('composed_by_bodhi'):
-                click.echo(
-                    "ERROR: The release of the update is composed by Bodhi, i.e. follows the normal"
-                    " update workflow. Please build packages normally, using build root overrides"
-                    " as required, and edit the update accordingly with these new builds.", err=True
-                )
-                sys.exit(1)
             kwargs['from_tag'] = former_update['from_tag']
             del kwargs['builds']
         else:

--- a/bodhi/server/templates/new_update.html
+++ b/bodhi/server/templates/new_update.html
@@ -382,7 +382,7 @@ value="${update.display_name | h}"
 <%block name="javascript">
 ${parent.javascript()}
 <script src="${request.static_url('bodhi:server/static/vendor/selectize/selectize-0.12.3.min.js')}"></script>
-% if update and update.from_tag and not update.release.composed_by_bodhi:
+% if update and update.from_tag:
   <script>var existing_sidetag_update = true;</script>
 % else:
   <script>var existing_sidetag_update = false;</script>

--- a/bodhi/tests/client/test___init__.py
+++ b/bodhi/tests/client/test___init__.py
@@ -1952,35 +1952,6 @@ class TestEdit:
 
     @mock.patch('bodhi.client.bindings.BodhiClient.csrf',
                 mock.MagicMock(return_value='a_csrf_token'))
-    @mock.patch('bodhi.client.bindings.BodhiClient.query',
-                return_value=client_test_data.EXAMPLE_QUERY_MUNCH, autospec=True)
-    def test_from_tag_flag_release_composed_by_bodhi(self, query):
-        """
-        Assert --from-tag bails out if the release is composed by Bodhi.
-        """
-        data = client_test_data.EXAMPLE_QUERY_MUNCH.copy()
-        data.updates[0]['from_tag'] = 'fake_tag'
-        data.updates[0]['release']['composed_by_bodhi'] = True
-        query.return_value = data
-        runner = testing.CliRunner()
-
-        result = runner.invoke(
-            client.edit, ['FEDORA-2017-c95b33872d', '--user', 'bowlofeggs',
-                          '--password', 's3kr3t', '--from-tag',
-                          '--notes', 'Updated package.',
-                          '--url', 'http://localhost:6543'])
-
-        assert result.exit_code == 1
-        assert result.output == ("ERROR: The release of the update is composed by Bodhi, i.e."
-                                 " follows the normal update workflow. Please build packages"
-                                 " normally, using build root overrides as required, and edit the"
-                                 " update accordingly with these new builds.\n")
-        bindings_client = query.mock_calls[0][1][0]
-        query.assert_called_with(
-            bindings_client, updateid='FEDORA-2017-c95b33872d')
-
-    @mock.patch('bodhi.client.bindings.BodhiClient.csrf',
-                mock.MagicMock(return_value='a_csrf_token'))
     @mock.patch('bodhi.client.bindings.BodhiClient.query', autospec=True)
     def test_from_tag_addbuilds(self, query):
         """


### PR DESCRIPTION
Now that side-tag updates are allowed for current releases, allow CLI to edit those updates.

Also include a small addition to #4126 for the webUI form page

Signed-off-by: Mattia Verga <mattia.verga@tiscali.it>