### PR TITLE
Remove koji from the python requirements.

### DIFF
--- a/devel/ci/integration/bodhi/Dockerfile-f32
+++ b/devel/ci/integration/bodhi/Dockerfile-f32
@@ -21,7 +21,7 @@ RUN dnf install -y \
 RUN groupadd -r bodhi && \
     useradd  -r -s /sbin/nologin -d /home/bodhi/ -m -c 'Bodhi Server' -g bodhi bodhi
 # Install it
-RUN python3 setup.py build && pip3 install --no-use-pep517 . && pip3 install koji
+RUN python3 setup.py build && pip3 install --no-use-pep517 .
 
 # Configuration
 RUN mkdir -p /etc/bodhi

--- a/devel/ci/integration/bodhi/Dockerfile-rawhide
+++ b/devel/ci/integration/bodhi/Dockerfile-rawhide
@@ -21,7 +21,7 @@ RUN dnf install -y \
 RUN groupadd -r bodhi && \
     useradd  -r -s /sbin/nologin -d /home/bodhi/ -m -c 'Bodhi Server' -g bodhi bodhi
 # Install it
-RUN python3 setup.py bdist_wheel && pip3 install ./dist/*.whl && pip3 install koji
+RUN python3 setup.py bdist_wheel && pip3 install ./dist/*.whl
 
 # Configuration
 RUN mkdir -p /etc/bodhi

--- a/devel/ci/integration/tests/test_bodhi_cli.py
+++ b/devel/ci/integration/tests/test_bodhi_cli.py
@@ -477,13 +477,8 @@ def test_updates_download(bodhi_container, db_container):
     # The bodhi CLI will execute the koji CLI. Replace that executable with
     # something we can track.
     koji_mock = "#!/bin/sh\necho TESTING CALL $0 $@\n"
-    # we mock-replace the executable in two places
-    # It's because of https://pagure.io/koji/issue/912
-    # Koji is installed from RPM isn't found because it doesn't provide egg info.
-    # So Bodhi will install Koji from Pypi and the Koji-Pypi executable is used.
     with replace_file(bodhi_container, "/usr/bin/koji", koji_mock):
-        with replace_file(bodhi_container, "/usr/local/bin/koji", koji_mock):
-            result = _run_cli(bodhi_container, cmd)
+        result = _run_cli(bodhi_container, cmd)
     assert result.exit_code == 0
     for update in updates:
         assert "Downloading packages from {}".format(update['alias']) in result.output

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,6 @@ fedora_messaging
 feedgen>=0.7.0
 graphene
 graphene-sqlalchemy
-koji
 jinja2
 markdown>=3.0
 prometheus_client

--- a/setup.py
+++ b/setup.py
@@ -111,7 +111,7 @@ client_setup = {
     'keywords': 'fedora',
     'packages': client_pkgs,
     'include_package_data': False,
-    'install_requires': ['click', 'python-fedora >= 0.9.0', 'koji'],
+    'install_requires': ['click', 'python-fedora >= 0.9.0'],
     'entry_points': '''
         [console_scripts]
         bodhi = bodhi.client:cli


### PR DESCRIPTION
Currently the koji rpm does not install all the files needed
to be a valid python module see (https://pagure.io/koji/issue/912)
So for the time being we should just drop that requirement

Signed-off-by: Clement Verna <cverna@tutanota.com>