### PR TITLE
WIP: Moved the reference of postgres image from dockerhub to quay

### DIFF
--- a/devel/ci/integration/tests/fixtures/db.py
+++ b/devel/ci/integration/tests/fixtures/db.py
@@ -37,7 +37,7 @@ def db_container(docker_backend, docker_network):
         conu.DockerContainer: The PostgreSQL container.
     """
     image = docker_backend.ImageClass(
-        os.environ.get("BODHI_INTEGRATION_POSTGRESQL_IMAGE", "postgres"),
+        os.environ.get("BODHI_INTEGRATION_POSTGRESQL_IMAGE", "quay.io/bodhi-ci/postgresql"),
         tag="latest"
     )
     params = DockerContainerParameters(env_variables={"POSTGRES_HOST_AUTH_METHOD": "trust"})


### PR DESCRIPTION
Moved the reference of postgres image from dockerhub to quay to avoid the rate-limiting.

For this purpose I have created https://quay.io/organization/bodhi-ci and pushed the postgres image there.

Right now I am admin, but as it is an organization, it should be easy to add more people.

And @pypingou should take note I had the great idea of using the packagerbot email address as the organization e-mail.

This should be merged only once we agree that
* this is a good idea
* who should have the admin rights to the organization 