### PR TITLE
We must pass a list of bug ids to work_on_bugs

### DIFF
--- a/bodhi/server/consumers/automatic_updates.py
+++ b/bodhi/server/consumers/automatic_updates.py
@@ -208,6 +208,7 @@ class AutomaticUpdateHandler:
                 log.error(f'Problem obsoleting older updates: {e}')
 
             alias = update.alias
+            buglist = [b.bug_id for b in update.bugs]
 
         # This must be run after dbsession is closed so changes are committed to db
-        work_on_bugs_task.delay(alias, closing_bugs)
+        work_on_bugs_task.delay(alias, buglist)

--- a/news/PR4170.bug
+++ b/news/PR4170.bug
@@ -1,0 +1,1 @@
+Fixed an error about handling bugs in automatic updates


### PR DESCRIPTION
Another error in the automatic updates handler when calling work_on_bugs celery task: we are passing a list of Bug objects, instead we must pass a list of bug ids.

Signed-off-by: Mattia Verga <mattia.verga@tiscali.it>