### PR TITLE
Remove side-tag from builds when the Update reaches stable

### DIFF
--- a/bodhi/server/tasks/composer.py
+++ b/bodhi/server/tasks/composer.py
@@ -633,6 +633,9 @@ class ComposerThread(threading.Thread):
             if update.request is UpdateRequest.stable:
                 update.remove_tag(update.release.pending_stable_tag,
                                   koji=koji)
+                if update.from_tag:
+                    # Remove the side-tag so that Koji gc can delete it if empty
+                    update.remove_tag(update.from_tag, koji=koji)
             elif update.request is UpdateRequest.testing:
                 update.remove_tag(update.release.pending_signing_tag,
                                   koji=koji)

--- a/news/PR4173.bug
+++ b/news/PR4173.bug
@@ -1,0 +1,1 @@
+Side-tag wheren't emptied when updates for current releases were pushed to stable


### PR DESCRIPTION
This is performed for pending releases in the approve_testing task, but it's missing in the composer.

Though, I don't have any idea how to test it. CI tests will probably fail due to missing coverage...

Signed-off-by: Mattia Verga <mattia.verga@tiscali.it>