### PR TITLE
Use Pagure's hascommit endpoint API to validate ACLs

### DIFF
--- a/bodhi/server/config.py
+++ b/bodhi/server/config.py
@@ -51,6 +51,37 @@ def get_configfile() -> typing.Optional[str]:
     return configfile
 
 
+def _generate_dict_validator(value: str) -> dict:
+    """Return a dict version of value.
+
+    This function accept a string with comma separated tuples in the form `key:value`
+    and ensure it can be correctly imported as a dict. It will return a dict.
+    If it cannot do that, it will raise ValueError.
+
+    Args:
+        value: The value to be validated as a dict.
+    Returns:
+        The dict interpretation of value.
+    Raises:
+        ValueError: If value cannot be interpreted as a dict.
+    """
+    if isinstance(value, str):
+        values_list = [idx.strip() for idx in value.split(',') if idx.strip()]
+        dictvalue = dict()
+        for v in values_list:
+            try:
+                k, v = v.split(':')
+                dictvalue[k.strip()] = v.strip()
+            except Exception:
+                raise ValueError(f'"{value}" cannot be interpreted as a dict.')
+        value = dictvalue
+
+    if not isinstance(value, dict):
+        raise ValueError(f'"{value}" cannot be interpreted as a dict.')
+
+    return value
+
+
 def _generate_list_validator(
         splitter: str = ' ', validator: typing.Callable[[typing.Any], typing.Any] = str) \
         -> typing.Callable[[typing.Union[str, typing.List]], typing.Any]:
@@ -457,8 +488,14 @@ class BodhiConfig(dict):
         'openid_template': {
             'value': '{username}.id.fedoraproject.org',
             'validator': str},
-        'pagure_flatpak_namespace': {
-            'value': 'modules',
+        'pagure_namespaces': {
+            'value': ('rpm:rpms, module:modules, container:container, flatpak:flatpaks'),
+            'validator': _generate_dict_validator},
+        'pagure_flatpak_main_branch': {
+            'value': 'stable',
+            'validator': str},
+        'pagure_module_main_branch': {
+            'value': 'master',
             'validator': str},
         'pagure_url': {
             'value': 'https://src.fedoraproject.org/pagure/',

--- a/bodhi/tests/server/test_config.py
+++ b/bodhi/tests/server/test_config.py
@@ -414,3 +414,30 @@ class TestValidateTLSURL:
 
         assert result == 'https://example.com'
         assert isinstance(result, str)
+
+
+class TestGenerateDictValidatorTests:
+    """Tests the _generate_dict_validator() function."""
+    def test_values_stripped(self):
+        """Test whitespaces are stripped from final keys - values."""
+        result = config._generate_dict_validator('key 1: value 1 , key 2 : value 2')
+        assert result == {'key 1': 'value 1', 'key 2': 'value 2'}
+
+    def test_with_dict(self):
+        """Test with a dict."""
+        result = config._generate_dict_validator({'key 1': 'value 1', 'key 2': 'value 2'})
+        assert result == {'key 1': 'value 1', 'key 2': 'value 2'}
+
+    def test_wrong_format(self):
+        """Test with values in wrong format."""
+        with pytest.raises(ValueError) as exc:
+            config._generate_dict_validator('key 1 value 1, key 2, value 2')
+
+        assert str(exc.value) == '"key 1 value 1, key 2, value 2" cannot be interpreted as a dict.'
+
+    def test_wrong_type(self):
+        """Test with a non string, non dict data type."""
+        with pytest.raises(ValueError) as exc:
+            config._generate_dict_validator(['lol', 'wut'])
+
+        assert str(exc.value) == '"[\'lol\', \'wut\']" cannot be interpreted as a dict.'

--- a/bodhi/tests/server/test_models.py
+++ b/bodhi/tests/server/test_models.py
@@ -1145,6 +1145,31 @@ class TestModulePackage(ModelTest):
             'expand_group=1',
             timeout=60)
 
+    @pytest.mark.parametrize('access', (False, True))
+    @mock.patch('bodhi.server.util.http_session')
+    def test_hascommitaccess_module(self, session, access):
+        """
+        Test call to Pagure to check if a user has access to this package/branch.
+        """
+        json_output = {
+            "args": {
+                "username": "mattia",
+                "branch": "master",
+                "project": {}
+            },
+            "hascommit": access
+        }
+        session.get.return_value.json.return_value = json_output
+        session.get.return_value.status_code = 200
+
+        rv = self.package.hascommitaccess('mattia', 'f33')
+
+        assert rv is access
+        session.get.assert_called_once_with(
+            'https://src.fedoraproject.org/pagure/api/0/modules/the-greatest-package/'
+            'hascommit?user=mattia&branch=master',
+            timeout=60)
+
 
 class TestContainerPackage(ModelTest):
     """Test the Container class."""
@@ -1198,6 +1223,31 @@ class TestContainerPackage(ModelTest):
              '?expand_group=1'),
             timeout=60)
 
+    @pytest.mark.parametrize('access', (False, True))
+    @mock.patch('bodhi.server.util.http_session')
+    def test_hascommitaccess_container(self, session, access):
+        """
+        Test call to Pagure to check if a user has access to this package/branch.
+        """
+        json_output = {
+            "args": {
+                "username": "mattia",
+                "branch": "f33",
+                "project": {}
+            },
+            "hascommit": access
+        }
+        session.get.return_value.json.return_value = json_output
+        session.get.return_value.status_code = 200
+
+        rv = self.obj.hascommitaccess('mattia', 'f33')
+
+        assert rv is access
+        session.get.assert_called_once_with(
+            'https://src.fedoraproject.org/pagure/api/0/container/docker-distribution/'
+            'hascommit?user=mattia&branch=f33',
+            timeout=60)
+
 
 class TestFlatpakPackage(ModelTest):
     klass = model.FlatpakPackage
@@ -1243,20 +1293,6 @@ class TestFlatpakPackage(ModelTest):
     @mock.patch('bodhi.server.util.http_session')
     def test_get_pkg_committers_from_pagure_modules(self, http_session):
         """Ensure correct return value from get_pkg_committers_from_pagure()."""
-        self.patch_http_session(http_session, namespace='modules')
-
-        rv = self.obj.get_pkg_committers_from_pagure()
-
-        assert rv == (['otaylor'], [])
-        http_session.get.assert_called_once_with(
-            ('https://src.fedoraproject.org/pagure/api/0/modules/flatpak-runtime'
-             '?expand_group=1'),
-            timeout=60)
-
-    @mock.patch.dict('bodhi.server.config.config', {'pagure_flatpak_namespace': 'flatpaks'})
-    @mock.patch('bodhi.server.util.http_session')
-    def test_get_pkg_committers_from_pagure_flatpaks(self, http_session):
-        """Check that the pagure_flatpak_namespace config key works."""
         self.patch_http_session(http_session, namespace='flatpaks')
 
         rv = self.obj.get_pkg_committers_from_pagure()
@@ -1265,6 +1301,31 @@ class TestFlatpakPackage(ModelTest):
         http_session.get.assert_called_once_with(
             ('https://src.fedoraproject.org/pagure/api/0/flatpaks/flatpak-runtime'
              '?expand_group=1'),
+            timeout=60)
+
+    @pytest.mark.parametrize('access', (False, True))
+    @mock.patch('bodhi.server.util.http_session')
+    def test_hascommitaccess_flatpak(self, http_session, access):
+        """
+        Test call to Pagure to check if a user has access to this package/branch.
+        """
+        json_output = {
+            "args": {
+                "username": "mattia",
+                "branch": "stable",
+                "project": {}
+            },
+            "hascommit": access
+        }
+        http_session.get.return_value.json.return_value = json_output
+        http_session.get.return_value.status_code = 200
+
+        rv = self.obj.hascommitaccess('mattia', 'f33')
+
+        assert rv is access
+        http_session.get.assert_called_once_with(
+            'https://src.fedoraproject.org/pagure/api/0/flatpaks/flatpak-runtime/'
+            'hascommit?user=mattia&branch=stable',
             timeout=60)
 
 
@@ -1481,6 +1542,31 @@ class TestRpmPackage(ModelTest):
         rv = self.package.get_pkg_committers_from_pagure()
 
         assert rv == (['mprahl'], ['factory2'])
+
+    @pytest.mark.parametrize('access', (False, True))
+    @mock.patch('bodhi.server.util.http_session')
+    def test_hascommitaccess_container_rpm(self, session, access):
+        """
+        Test call to Pagure to check if a user has access to this package/branch.
+        """
+        json_output = {
+            "args": {
+                "username": "mattia",
+                "branch": "f33",
+                "project": {}
+            },
+            "hascommit": access
+        }
+        session.get.return_value.json.return_value = json_output
+        session.get.return_value.status_code = 200
+
+        rv = self.package.hascommitaccess('mattia', 'f33')
+
+        assert rv is access
+        session.get.assert_called_once_with(
+            'https://src.fedoraproject.org/pagure/api/0/rpms/the-greatest-package/'
+            'hascommit?user=mattia&branch=f33',
+            timeout=60)
 
 
 class TestBuild(ModelTest):

--- a/news/PR4181.feature
+++ b/news/PR4181.feature
@@ -1,0 +1,1 @@
+Use Pagure's `hascommit` new endpoint API to check user's rights to create/edit updates. This allow collaborators to push updates for releases for which they have commit access.

--- a/production.ini
+++ b/production.ini
@@ -327,9 +327,9 @@ use = egg:bodhi-server
 ##
 # pagure_url = https://src.fedoraproject.org/pagure/
 
-# This is the namespace where we expect to find the git sources for a Flatpak.
-# The default - 'modules' instead of 'flatpaks' - is for backward compatibility
-# pagure_flatpak_namespace = modules
+# This is the namespace where we expect to find the git sources for packages.
+# Values are in the form `PackageType:PagureNamespace`
+# pagure_namespaces = rpm:rpms, module:modules, container:container, flatpak:flatpaks
 
 ##
 ## Product Definition Center (PDC)


### PR DESCRIPTION
This will allow collaborators which have access only to specific branches to create/edit updates for the releases where they have access to. Fixes https://pagure.io/fedora-infrastructure/issue/9510

Note that this requires the new Pagure endpoint API `hascommit` (https://pagure.io/pagure/pull-request/5087) and we'll need to wait for that to land in production.

Please also check carefully how we handle Pagure branch / release.branch association. As far as I know, we have:

- a 1:1 association for RPMs
- a 1:1 association for Containers (at least, this is what I observed)
- Flatpaks always use ~~master~~ **stable** branch (which is configurable in my PR)
- Modules don't have any association, so we just use master branch here (configurable) to mimic the old validation mechanism.

Is that right?
Also, https://pagure.io/fedora-infrastructure/issue/9566 needs to be fixed.

Signed-off-by: Mattia Verga <mattia.verga@tiscali.it>