### PR TITLE
Avoid daily increment of <updated_date>

### DIFF
--- a/bodhi/server/metadata.py
+++ b/bodhi/server/metadata.py
@@ -238,7 +238,8 @@ class UpdateInfoMetadata(object):
         if update.date_modified:
             rec.updated_date = update.date_modified
         else:
-            rec.updated_date = datetime.utcnow()
+            # If there is no date_modified, use date_submitted (#4189)
+            rec.updated_date = update.date_submitted
 
         col = cr.UpdateCollection()
         col.name = update.release.long_name.encode('utf-8')

--- a/bodhi/server/metadata.py
+++ b/bodhi/server/metadata.py
@@ -16,7 +16,6 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 """Create metadata files when composing repositories."""
-from datetime import datetime
 import logging
 import os
 import shelve
@@ -233,12 +232,12 @@ class UpdateInfoMetadata(object):
             # Sometimes we only set the date_pushed after it's pushed out, however,
             # it seems that Satellite does not like update entries without issued_date.
             # Since we know that we are pushing it now, and the next push will get the data
-            # correctly, let's just insert utcnow().
-            rec.issued_date = datetime.utcnow()
+            # correctly, let's just insert "date submitted".
+            rec.issued_date = update.date_submitted
         if update.date_modified:
             rec.updated_date = update.date_modified
         else:
-            # If there is no date_modified, use date_submitted (#4189)
+            # Likewise, if there is no date_modified, use date_submitted
             rec.updated_date = update.date_submitted
 
         col = cr.UpdateCollection()

--- a/bodhi/tests/server/test_metadata.py
+++ b/bodhi/tests/server/test_metadata.py
@@ -16,7 +16,7 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-from datetime import datetime, timedelta
+from datetime import datetime
 from hashlib import sha256
 from os.path import join, exists, basename
 from unittest import mock
@@ -125,38 +125,28 @@ class TestAddUpdate(UpdateInfoMetadataTestCase):
         assert pkg.filename == 'TurboGears-1.0.2.2-2.fc17.noarch.rpm'
 
     def test_date_modified_none(self):
-        """The metadata should use utcnow() if an update's date_modified is None."""
-        test_start_time = datetime.utcnow()
-        # The UpdateRecord's updated_date attribute strips microseconds, so let's force them to 0
-        # so our assertions at the end of this test will pass.
-        test_start_time = test_start_time - timedelta(microseconds=test_start_time.microsecond)
+        """The metadata should use date_submitted if an update's date_modified is None."""
         update = self.db.query(Update).one()
         update.date_modified = None
         md = UpdateInfoMetadata(update.release, update.request, self.db, self.temprepo,
                                 close_shelf=False)
-
         md.add_update(update)
-
         md.shelf.close()
+
         assert len(md.uinfo.updates) == 1
-        assert test_start_time <= md.uinfo.updates[0].updated_date <= datetime.utcnow()
+        assert md.uinfo.updates[0].updated_date == update.date_submitted
 
     def test_date_pushed_none(self):
-        """The metadata should use utcnow() if an update's date_pushed is None."""
-        test_start_time = datetime.utcnow()
-        # The UpdateRecord's updated_date attribute strips microseconds, so let's force them to 0
-        # so our assertions at the end of this test will pass.
-        test_start_time = test_start_time - timedelta(microseconds=test_start_time.microsecond)
+        """The metadata should use date_submitted if an update's date_pushed is None."""
         update = self.db.query(Update).one()
         update.date_pushed = None
         md = UpdateInfoMetadata(update.release, update.request, self.db, self.temprepo,
                                 close_shelf=False)
-
         md.add_update(update)
-
         md.shelf.close()
+
         assert len(md.uinfo.updates) == 1
-        assert test_start_time <= md.uinfo.updates[0].issued_date <= datetime.utcnow()
+        assert md.uinfo.updates[0].issued_date == update.date_submitted
 
     def test_rpm_with_arch(self):
         """Ensure that an RPM with a non 386 arch gets handled correctly."""

--- a/news/4189.bug
+++ b/news/4189.bug
@@ -1,0 +1,1 @@
+Avoid using datetime.utcnow() for the <updated_date> element of updateinfo metadata, use "date_submitted" instead.

--- a/news/4189.bug
+++ b/news/4189.bug
@@ -1,1 +1,1 @@
-Avoid using datetime.utcnow() for the <updated_date> element of updateinfo metadata, use "date_submitted" instead.
+Avoid using datetime.utcnow() for updateinfo <updated_date> and <issued_date> elements, use "date_submitted" instead.


### PR DESCRIPTION
When writing out the "updated_date" field in the metadata, if the update
has never been modified in Bodhi, rather than using utcnow(), fall back
to using issued_date. This avoids constant churn of the "updated_date".

closes #4189