### PR TITLE
Ensure updates with stable_comment are pushed to stable automatically

### DIFF
--- a/bodhi/server/models.py
+++ b/bodhi/server/models.py
@@ -3820,8 +3820,7 @@ class Update(Base):
         """
         for comment in self.comments_since_karma_reset:
             if comment.user.name == 'bodhi' and \
-               comment.text.startswith('This update ') and \
-               'can be pushed to stable now if the maintainer wishes' in comment.text:
+               comment.text == config.get('testing_approval_msg'):
                 return True
         return False
 

--- a/docs/user/testing.rst
+++ b/docs/user/testing.rst
@@ -35,4 +35,30 @@ updates. If this is enabled, the update's web page will display the current stat
 gating decision.
 
 
+Stable push
+===========
+
+An update can be pushed to stable repository either manually or automatically, through Bodhi's
+`autotime` or `autokarma` features.
+
+For becoming pushable to stable an update must fullfill some criteria set by the associated
+release. Tipically, each release has a `mandatory_days_in_testing` and a `critpath_min_karma`
+values that define the threshold after that the associated updates can be pushed to stable.
+The `mandatory_days_in_testing` define the minimum amount of days each update must spend in
+testing repository. The `critpath_min_karma` is the minimum karma that each update must reach.
+An update can be manually pushed to stable by its submitter whatever threshold is reached first.
+For example, if a release has a `critpath_min_karma` of +2, an update which reaches a +2 karma
+**can be pushed to stable even if it hasn't reached the `mandatory_days_in_testing`**.
+
+When submitting an update, the user can enable the `autotime` and the `autokarma` features and
+set the related values `stable_days` and `stable_karma` for that specific update.
+The `stable_days` value define the minimum amount of days each update must spend in
+testing repository before the autopush is performed. It must be equal or greater than the release
+`mandatory_days_in_testing`. The `stable_karma` is the minimum karma that each update must reach
+before the autopush is performed. It must be equal or greater than the release `critpath_min_karma`.
+For example, if a release has a `mandatory_days_in_testing` of 7, an update which has `autotime`
+enabled and `stable_days` set to 10 will be pushable after 7 days **by manual action**, but the
+autopush will be performed **after 3 more days**.
+
+
 .. _Greenwave: https://pagure.io/greenwave

--- a/news/4042.bug
+++ b/news/4042.bug
@@ -1,0 +1,1 @@
+Updates which already had a comment that they can be pushed to stable were not automatically pushed to stable when the `stable_days` threshold was reached


### PR DESCRIPTION
The `approve_testing` task was set to ignore updates which already had
stable_comment.
This was not correct and prevented some updates from being pushed to
stable when they reached the stable_days threshold.

As an example, consider an update for which the associated release has a
mandatory_days_in testing set to 7 and the update is created with a
stable_days threshold of 10.
After 7 days in testing, the update gets the stable_comment, since the
maintainer can now push it to stable.
The autopush is performed after 3 more days, but this didn't happen
because of the approve_testing task ignoring all updates with
stable_comment.

Fix #4042 

Signed-off-by: Mattia Verga <mattia.verga@tiscali.it>