### PR TITLE
Pin docutils<0.17 requirement in pip dockerfile

### DIFF
--- a/devel/ci/Dockerfile-pip
+++ b/devel/ci/Dockerfile-pip
@@ -29,6 +29,7 @@ RUN pip-3 install \
     alembic \
     cornice_sphinx \
     diff-cover \
+    "docutils<0.17" \
     flake8 \
     flake8-import-order \
     responses \


### PR DESCRIPTION
Provisional fix for pip-docs tests.

It seems there's some module (probably sphinx) not fully compatible with docutils 0.17 yet, so we just pin docutils<0.17 here.

Signed-off-by: Mattia Verga <mattia.verga@tiscali.it>