### PR TITLE
Updates check for expiration_date in order to resolve inconsistent refusal in case of maximum duration

### DIFF
--- a/bodhi/server/validators.py
+++ b/bodhi/server/validators.py
@@ -1200,12 +1200,12 @@ def validate_expiration_date(request, **kwargs):
         request (pyramid.request.Request): The current request.
         kwargs (dict): The kwargs of the related service definition. Unused.
     """
-    expiration_date = request.validated.get('expiration_date')
+    expiration_date = request.validated.get('expiration_date').date()
 
     if expiration_date is None:
         return
 
-    now = datetime.utcnow()
+    now = datetime.utcnow().date()
 
     if expiration_date <= now:
         request.errors.add('body', 'expiration_date',
@@ -1218,8 +1218,6 @@ def validate_expiration_date(request, **kwargs):
         request.errors.add('body', 'expiration_date',
                            'Expiration date may not be longer than %i' % days)
         return
-
-    request.validated['expiration_date'] = expiration_date
 
 
 @postschema_validator

--- a/bodhi/server/validators.py
+++ b/bodhi/server/validators.py
@@ -1200,11 +1200,12 @@ def validate_expiration_date(request, **kwargs):
         request (pyramid.request.Request): The current request.
         kwargs (dict): The kwargs of the related service definition. Unused.
     """
-    expiration_date = request.validated.get('expiration_date').date()
+    expiration_date = request.validated.get('expiration_date')
 
     if expiration_date is None:
         return
 
+    expiration_date = expiration_date.date()
     now = datetime.utcnow().date()
 
     if expiration_date <= now:

--- a/bodhi/tests/server/test_validators.py
+++ b/bodhi/tests/server/test_validators.py
@@ -17,7 +17,7 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 """This module contains tests for bodhi.server.validators."""
 from unittest import mock
-import datetime
+from datetime import datetime, timedelta
 
 from cornice.errors import Errors
 from fedora_messaging import api, testing as fml_testing
@@ -416,7 +416,7 @@ class TestValidateExpirationDate(BasePyTestCase):
         request = mock.Mock()
         request.errors = Errors()
         request.validated = {
-            'expiration_date': datetime.datetime.utcnow() - datetime.timedelta(days=1)}
+            'expiration_date': datetime.utcnow() - timedelta(days=1)}
 
         validators.validate_expiration_date(request)
 
@@ -426,6 +426,30 @@ class TestValidateExpirationDate(BasePyTestCase):
         ]
         assert request.errors.status == exceptions.HTTPBadRequest.code
 
+    def test_equaltoLimit(self):
+        """An expiration_date equal to the limit should pass the test."""
+        request = mock.Mock()
+        request.errors = Errors()
+        request.validated = {'expiration_date': datetime.utcnow() + timedelta(days=31)}
+
+        validators.validate_expiration_date(request)
+
+        assert not len(request.errors)
+
+    def test_higherthanLimit(self):
+        """An expiration_date higher than limit should report an error."""
+        request = mock.Mock()
+        request.errors = Errors()
+        request.validated = {
+            'expiration_date': datetime.utcnow() + timedelta(days=32)}
+
+        validators.validate_expiration_date(request)
+
+        assert request.errors == [
+            {'location': 'body', 'name': 'expiration_date',
+             'description': 'Expiration date is higher than limit.'}
+        ]
+        assert request.errors.status == exceptions.HTTPBadRequest.code
 
 class TestValidateOverrideNotes(BasePyTestCase):
     """Test the validate_override_notes() function."""

--- a/bodhi/tests/server/test_validators.py
+++ b/bodhi/tests/server/test_validators.py
@@ -447,7 +447,7 @@ class TestValidateExpirationDate(BasePyTestCase):
 
         assert request.errors == [
             {'location': 'body', 'name': 'expiration_date',
-             'description': 'Expiration date is higher than limit.'}
+             'description': 'Expiration date may not be longer than 31'}
         ]
         assert request.errors.status == exceptions.HTTPBadRequest.code
 

--- a/bodhi/tests/server/test_validators.py
+++ b/bodhi/tests/server/test_validators.py
@@ -451,6 +451,7 @@ class TestValidateExpirationDate(BasePyTestCase):
         ]
         assert request.errors.status == exceptions.HTTPBadRequest.code
 
+
 class TestValidateOverrideNotes(BasePyTestCase):
     """Test the validate_override_notes() function."""
 

--- a/news/4182.bug
+++ b/news/4182.bug
@@ -1,0 +1,1 @@
+Fixed an issue with validators that prevents inconsistent refusal of bodhi override with maximum duration


### PR DESCRIPTION
Hi :smile:,

This is my first time contributing to bodhi, please correct me if I'm wrong.
This PR is in regards to resolve issue #4182, the limit that is compared with expiration_date is updated by `timedelta(days=days+1)` so that it will correctly compare, as well the old error message that was creating confusion is updated.