### PR TITLE
Support for generating advisories with logout suggestions

### DIFF
--- a/bodhi/server/metadata.py
+++ b/bodhi/server/metadata.py
@@ -258,8 +258,8 @@ class UpdateInfoMetadata(object):
                     pkg.epoch = '0'
                 pkg.arch = rpm['arch']
 
-                # TODO: how do we handle UpdateSuggestion.logout, etc?
                 pkg.reboot_suggested = update.suggest is UpdateSuggestion.reboot
+                pkg.relogin_suggested = update.suggest is UpdateSuggestion.logout
 
                 filename = '%s.%s.rpm' % (rpm['nvr'], rpm['arch'])
                 pkg.filename = filename

--- a/bodhi/server/metadata.py
+++ b/bodhi/server/metadata.py
@@ -258,8 +258,8 @@ class UpdateInfoMetadata(object):
                     pkg.epoch = '0'
                 pkg.arch = rpm['arch']
 
-                pkg.reboot_suggested = update.suggest is UpdateSuggestion.reboot
-                pkg.relogin_suggested = update.suggest is UpdateSuggestion.logout
+                pkg.reboot_suggested = update.suggest == UpdateSuggestion.reboot
+                pkg.relogin_suggested = update.suggest == UpdateSuggestion.logout
 
                 filename = '%s.%s.rpm' % (rpm['nvr'], rpm['arch'])
                 pkg.filename = filename

--- a/bodhi/tests/server/test_metadata.py
+++ b/bodhi/tests/server/test_metadata.py
@@ -111,6 +111,7 @@ class TestAddUpdate(UpdateInfoMetadataTestCase):
              'TurboGears-1.0.2.2-2.fc17.src.rpm')
         assert pkg.version == '1.0.2.2'
         assert not pkg.reboot_suggested
+        assert not pkg.relogin_suggested
         assert pkg.arch == 'src'
         assert pkg.filename == 'TurboGears-1.0.2.2-2.fc17.src.rpm'
         pkg = col.packages[1]
@@ -121,6 +122,7 @@ class TestAddUpdate(UpdateInfoMetadataTestCase):
              'TurboGears-1.0.2.2-2.fc17.noarch.rpm')
         assert pkg.version == '1.0.2.2'
         assert not pkg.reboot_suggested
+        assert not pkg.relogin_suggested
         assert pkg.arch == 'noarch'
         assert pkg.filename == 'TurboGears-1.0.2.2-2.fc17.noarch.rpm'
 
@@ -367,6 +369,7 @@ class TestUpdateInfoMetadata(UpdateInfoMetadataTestCase):
                  'TurboGears-1.0.2.2-2.fc17.src.rpm')
             assert pkg.version == '1.0.2.2'
             assert not pkg.reboot_suggested
+            assert not pkg.relogin_suggested
             assert pkg.arch == 'src'
             assert pkg.filename == 'TurboGears-1.0.2.2-2.fc17.src.rpm'
 

--- a/news/4213.feature
+++ b/news/4213.feature
@@ -1,0 +1,1 @@
+Added support for setting flags in generated advisories to require logging out and logging back in for the update to take effect


### PR DESCRIPTION
Updateinfo metadata for RPM repositories can include information on whether
the user needs to log out and log back in. However, Bodhi only partially
supported this as a UI flag that wasn't set in the metadata. Now we
will propagate this into the metadata for clients to use.

Fixes #4213 