### PR TITLE
Better gating status

### DIFF
--- a/bodhi/server/models.py
+++ b/bodhi/server/models.py
@@ -19,7 +19,7 @@
 
 from collections import defaultdict
 from copy import copy
-from datetime import datetime
+from datetime import datetime, timedelta
 from textwrap import wrap
 import hashlib
 import json
@@ -2213,6 +2213,44 @@ class Update(Base):
         }
         return util.greenwave_api_post(self._greenwave_api_url, data)
 
+    @property
+    def _greenwave_requirements_generator(self):
+        """
+        Query Greenwave about this update and return satisfied and unsatisfied requirements.
+
+        Returns:
+            generator: An iterable of 2-tuples of lists of requirement dicts from each request
+            batch: first tuple item satisfied requirements, second item unsatisfied requirements.
+            Either list or both may be empty.
+
+        Raises:
+            BodhiException: When the ``greenwave_api_url`` is undefined in configuration.
+            RuntimeError: If Greenwave did not give us a 200 code, including if no applicable
+            policies were found.
+        """
+        for data in self.greenwave_request_batches(verbose=False):
+            response = util.greenwave_api_post(self._greenwave_api_url, data)
+            satisfied = response.get('satisfied_requirements', [])
+            unsatisfied = response.get('unsatisfied_requirements', [])
+            yield (satisfied, unsatisfied)
+
+    @property
+    def _unsatisfied_requirements(self):
+        """Query Greenwave about this update and return all unsatisfied requirements.
+
+        Returns:
+            list: A list of unsatisfied requirement dicts.
+
+        Raises:
+            BodhiException: When the ``greenwave_api_url`` is undefined in configuration.
+            RuntimeError: If Greenwave did not give us a 200 code, including if no applicable
+            policies were found.
+        """
+        ret = []
+        for (_, unsatisfied) in self._greenwave_requirements_generator:
+            ret.extend(unsatisfied)
+        return ret
+
     def _get_test_gating_status(self):
         """
         Query Greenwave about this update and return the information retrieved.
@@ -2220,35 +2258,38 @@ class Update(Base):
         Returns:
             TestGatingStatus:
                 - TestGatingStatus.ignored if no tests are required
-                - TestGatingStatus.failed if policies are not satisfied
-                - TestGatingStatus.passed if policies are satisfied, and there
-                  are required tests
+                - TestGatingStatus.passed if there are required tests and policies are satisfied
+                - TestGatingStatus.waiting if there are required tests that have not yet completed,
+                  no required test has failed, and update was last modified less than 2 hours ago
+                - TestGatingStatus.failed otherwise (failed required tests, missing required
+                  test results and last modified more than 2 hours ago)
 
         Raises:
             BodhiException: When the ``greenwave_api_url`` is undefined in configuration.
-            RuntimeError: If Greenwave did not give us a 200 code.
+            RuntimeError: If Greenwave did not give us a 200 code, including if no applicable
+            policies were found.
         """
-        # If an unrestricted policy is applied and no tests are required
-        # on this update, let's set the test gating as ignored in Bodhi.
-        status = TestGatingStatus.ignored
-        for data in self.greenwave_request_batches(verbose=False):
-            response = util.greenwave_api_post(self._greenwave_api_url, data)
-            if not response['policies_satisfied']:
-                return TestGatingStatus.failed
+        gotsat = False
+        gotunsat = False
+        recent = datetime.utcnow() - self.last_modified < timedelta(hours=2)
+        for (satisfied, unsatisfied) in self._greenwave_requirements_generator:
+            if satisfied:
+                gotsat = True
+            if unsatisfied:
+                gotunsat = True
+                if not recent or not all(req.get('type', '') == 'test-result-missing'
+                                         for req in unsatisfied):
+                    return TestGatingStatus.failed
 
-            if status != TestGatingStatus.ignored or response['summary'] != 'no tests are required':
-                status = TestGatingStatus.passed
+        if not gotsat and not gotunsat:
+            return TestGatingStatus.ignored
 
-        return status
+        if gotsat and not gotunsat:
+            return TestGatingStatus.passed
 
-    @property
-    def _unsatisfied_requirements(self):
-        unsatisfied_requirements = []
-        for data in self.greenwave_request_batches(verbose=False):
-            response = util.greenwave_api_post(self._greenwave_api_url, data)
-            unsatisfied_requirements.extend(response['unsatisfied_requirements'])
-
-        return unsatisfied_requirements
+        # here, we have unsatisfied requirements but we never bailed early
+        # in the for loop, so they are all 'missing' and update was recently modified
+        return TestGatingStatus.waiting
 
     @property
     def install_command(self) -> str:

--- a/bodhi/server/models.py
+++ b/bodhi/server/models.py
@@ -2373,12 +2373,17 @@ class Update(Base):
         log.debug(f"Triggering db commit for new update {up.alias}.")
         db.commit()
 
+        # track whether to set gating status shortly...
+        setgs = config.get('test_gating.required')
         # The request to testing for side-tag updates is set within the signed consumer
         if not data.get("from_tag"):
             log.debug(f"Setting request for new update {up.alias}.")
             up.set_request(db, req, request.user.name)
+            if req == UpdateRequest.testing:
+                # set_request will update gating status if necessary
+                setgs = False
 
-        if config.get('test_gating.required'):
+        if setgs:
             log.debug(
                 'Test gating required is enforced, marking the update as waiting on test gating')
             up.test_gating_status = TestGatingStatus.waiting

--- a/bodhi/tests/server/consumers/test_greenwave.py
+++ b/bodhi/tests/server/consumers/test_greenwave.py
@@ -40,6 +40,21 @@ class TestGreenwaveHandler(BasePyTestCase):
                 "subject_type": "koji_build",
                 'policies_satisfied': True,
                 'summary': "all tests have passed",
+                'applicable_policies': [
+                    'kojibuild_bodhipush_no_requirements',
+                    'kojibuild_bodhipush_remoterule',
+                    'bodhiupdate_bodhipush_no_requirements',
+                    'bodhiupdate_bodhipush_openqa'
+                ],
+                'satisfied_requirements': [
+                    {
+                        'result_id': 39603316,
+                        'subject_type': 'bodhi_update',
+                        'testcase': 'update.install_default_update_netinst',
+                        'type': 'test-result-passed'
+                    },
+                ],
+                'unsatisfied_requirements': []
             },
         )
         self.handler = greenwave.GreenwaveHandler()
@@ -72,6 +87,19 @@ class TestGreenwaveHandler(BasePyTestCase):
         update = self.single_build_update
 
         self.sample_message.body["policies_satisfied"] = False
+        self.sample_message.body["summary"] = "1 of 1 required tests failed"
+        self.sample_message.body["satisfied_requirements"] = []
+        self.sample_message.body["unsatisfied_requirements"] = [
+            {
+                'item': {
+                    'type': 'bodhi_update'
+                },
+                'scenario': 'fedora.updates-everything-boot-iso.x86_64.64bit',
+                'subject_type': 'bodhi_update',
+                'testcase': 'update.install_default_update_netinst',
+                'type': 'test-result-failed'
+            }
+        ]
         self.handler(self.sample_message)
         assert update.test_gating_status == models.TestGatingStatus.failed
 
@@ -84,6 +112,8 @@ class TestGreenwaveHandler(BasePyTestCase):
 
         self.sample_message.body["policies_satisfied"] = True
         self.sample_message.body["summary"] = "no tests are required"
+        self.sample_message.body["satisfied_requirements"] = []
+        self.sample_message.body["unsatisfied_requirements"] = []
         self.handler(self.sample_message)
         assert update.test_gating_status == models.TestGatingStatus.ignored
 
@@ -114,7 +144,22 @@ class TestGreenwaveHandler(BasePyTestCase):
         with mock.patch('bodhi.server.models.util.greenwave_api_post') as mock_greenwave:
             greenwave_response = {
                 'policies_satisfied': True,
-                'summary': "all tests have passed"
+                'summary': "All required tests passed",
+                'applicable_policies': [
+                    'kojibuild_bodhipush_no_requirements',
+                    'kojibuild_bodhipush_remoterule',
+                    'bodhiupdate_bodhipush_no_requirements',
+                    'bodhiupdate_bodhipush_openqa'
+                ],
+                'satisfied_requirements': [
+                    {
+                        'result_id': 39603316,
+                        'subject_type': 'bodhi_update',
+                        'testcase': 'update.install_default_update_netinst',
+                        'type': 'test-result-passed'
+                    },
+                ],
+                'unsatisfied_requirements': []
             }
             mock_greenwave.return_value = greenwave_response
             self.handler(self.sample_message)

--- a/bodhi/tests/server/consumers/test_signed.py
+++ b/bodhi/tests/server/consumers/test_signed.py
@@ -239,7 +239,22 @@ class TestSignedHandlerConsume(base.BasePyTestCase):
         with mock.patch('bodhi.server.models.util.greenwave_api_post') as mock_greenwave:
             greenwave_response = {
                 'policies_satisfied': True,
-                'summary': "all tests have passed"
+                'summary': "All required tests passed",
+                'applicable_policies': [
+                    'kojibuild_bodhipush_no_requirements',
+                    'kojibuild_bodhipush_remoterule',
+                    'bodhiupdate_bodhipush_no_requirements',
+                    'bodhiupdate_bodhipush_openqa'
+                ],
+                'satisfied_requirements': [
+                    {
+                        'result_id': 39603316,
+                        'subject_type': 'bodhi_update',
+                        'testcase': 'update.install_default_update_netinst',
+                        'type': 'test-result-passed'
+                    },
+                ],
+                'unsatisfied_requirements': []
             }
             mock_greenwave.return_value = greenwave_response
             with fml_testing.mock_sends(update_schemas.UpdateReadyForTestingV1):
@@ -276,7 +291,22 @@ class TestSignedHandlerConsume(base.BasePyTestCase):
         with mock.patch('bodhi.server.models.util.greenwave_api_post') as mock_greenwave:
             greenwave_response = {
                 'policies_satisfied': True,
-                'summary': "all tests have passed"
+                'summary': "All required tests passed",
+                'applicable_policies': [
+                    'kojibuild_bodhipush_no_requirements',
+                    'kojibuild_bodhipush_remoterule',
+                    'bodhiupdate_bodhipush_no_requirements',
+                    'bodhiupdate_bodhipush_openqa'
+                ],
+                'satisfied_requirements': [
+                    {
+                        'result_id': 39603316,
+                        'subject_type': 'bodhi_update',
+                        'testcase': 'update.install_default_update_netinst',
+                        'type': 'test-result-passed'
+                    },
+                ],
+                'unsatisfied_requirements': []
             }
             mock_greenwave.return_value = greenwave_response
             with fml_testing.mock_sends(update_schemas.UpdateRequestTestingV1):

--- a/bodhi/tests/server/services/test_updates.py
+++ b/bodhi/tests/server/services/test_updates.py
@@ -5843,7 +5843,7 @@ class TestWaiveTestResults(BasePyTestCase):
                     },
                     'scenario': None,
                     'testcase': 'dist.rpmdeplint',
-                    'type': 'test-result-missing'
+                    'type': 'test-result-failed'
                 }
             ],
         }
@@ -5912,7 +5912,7 @@ class TestWaiveTestResults(BasePyTestCase):
                     },
                     'scenario': None,
                     'testcase': 'dist.rpmdeplint',
-                    'type': 'test-result-missing'
+                    'type': 'test-result-failed'
                 },
                 {
                     'item': {
@@ -5921,7 +5921,7 @@ class TestWaiveTestResults(BasePyTestCase):
                     },
                     'scenario': None,
                     'testcase': 'atomic_ci_pipeline_results',
-                    'type': 'test-result-missing'
+                    'type': 'test-result-failed'
                 }
             ],
         }
@@ -6006,7 +6006,7 @@ class TestWaiveTestResults(BasePyTestCase):
                     },
                     'scenario': None,
                     'testcase': 'dist.rpmdeplint',
-                    'type': 'test-result-missing'
+                    'type': 'test-result-failed'
                 },
                 {
                     'item': {
@@ -6015,7 +6015,7 @@ class TestWaiveTestResults(BasePyTestCase):
                     },
                     'scenario': None,
                     'testcase': 'atomic_ci_pipeline_results',
-                    'type': 'test-result-missing'
+                    'type': 'test-result-failed'
                 }
             ],
         }
@@ -6088,7 +6088,7 @@ class TestWaiveTestResults(BasePyTestCase):
                     },
                     'scenario': None,
                     'testcase': 'dist.rpmdeplint',
-                    'type': 'test-result-missing'
+                    'type': 'test-result-failed'
                 },
                 {
                     'item': {
@@ -6097,7 +6097,7 @@ class TestWaiveTestResults(BasePyTestCase):
                     },
                     'scenario': None,
                     'testcase': 'atomic_ci_pipeline_results',
-                    'type': 'test-result-missing'
+                    'type': 'test-result-failed'
                 }
             ],
         }
@@ -6186,7 +6186,7 @@ class TestWaiveTestResults(BasePyTestCase):
                     },
                     'scenario': None,
                     'testcase': 'dist.rpmdeplint',
-                    'type': 'test-result-missing'
+                    'type': 'test-result-failed'
                 },
                 {
                     'item': {
@@ -6195,7 +6195,7 @@ class TestWaiveTestResults(BasePyTestCase):
                     },
                     'scenario': None,
                     'testcase': 'atomic_ci_pipeline_results',
-                    'type': 'test-result-missing'
+                    'type': 'test-result-failed'
                 }
             ],
         }

--- a/bodhi/tests/server/test_models.py
+++ b/bodhi/tests/server/test_models.py
@@ -1898,10 +1898,10 @@ class TestUpdateEdit(BasePyTestCase):
                     'unsatisfied_requirements': [
                         {'testcase': 'dist.rpmdeplint',
                          'item': {'item': 'bodhi-2.0-1.fc17', 'type': 'koji_build'},
-                         'type': 'test-result-missing', 'scenario': None},
+                         'type': 'test-result-failed', 'scenario': None},
                         {'testcase': 'dist.rpmdeplint',
                          'item': {'item': update.alias, 'type': 'bodhi_update'},
-                         'type': 'test-result-missing', 'scenario': None}]}
+                         'type': 'test-result-failed', 'scenario': None}]}
                 mock_greenwave.return_value = greenwave_response
                 model.Update.edit(request, data)
 
@@ -1928,10 +1928,10 @@ class TestUpdateEdit(BasePyTestCase):
                     'unsatisfied_requirements': [
                         {'testcase': 'dist.rpmdeplint',
                          'item': {'item': 'bodhi-2.0-1.fc17', 'type': 'koji_build'},
-                         'type': 'test-result-missing', 'scenario': None},
+                         'type': 'test-result-failed', 'scenario': None},
                         {'testcase': 'dist.rpmdeplint',
                          'item': {'item': update.alias, 'type': 'bodhi_update'},
-                         'type': 'test-result-missing', 'scenario': None}]}
+                         'type': 'test-result-failed', 'scenario': None}]}
                 mock_greenwave.return_value = greenwave_response
                 model.Update.edit(request, data)
 
@@ -1964,10 +1964,10 @@ class TestUpdateEdit(BasePyTestCase):
                     'unsatisfied_requirements': [
                         {'testcase': 'dist.rpmdeplint',
                          'item': {'item': 'bodhi-2.0-1.fc17', 'type': 'koji_build'},
-                         'type': 'test-result-missing', 'scenario': None},
+                         'type': 'test-result-failed', 'scenario': None},
                         {'testcase': 'dist.rpmdeplint',
                          'item': {'item': update.alias, 'type': 'bodhi_update'},
-                         'type': 'test-result-missing', 'scenario': None}]}
+                         'type': 'test-result-failed', 'scenario': None}]}
                 mock_greenwave.return_value = greenwave_response
                 model.Update.edit(request, data)
 
@@ -2000,10 +2000,10 @@ class TestUpdateEdit(BasePyTestCase):
                     'unsatisfied_requirements': [
                         {'testcase': 'dist.rpmdeplint',
                          'item': {'item': 'bodhi-2.0-1.fc17', 'type': 'koji_build'},
-                         'type': 'test-result-missing', 'scenario': None},
+                         'type': 'test-result-failed', 'scenario': None},
                         {'testcase': 'dist.rpmdeplint',
                          'item': {'item': update.alias, 'type': 'bodhi_update'},
-                         'type': 'test-result-missing', 'scenario': None}]}
+                         'type': 'test-result-failed', 'scenario': None}]}
                 mock_greenwave.return_value = greenwave_response
                 model.Update.edit(request, data)
 
@@ -2036,10 +2036,10 @@ class TestUpdateEdit(BasePyTestCase):
                     'unsatisfied_requirements': [
                         {'testcase': 'dist.rpmdeplint',
                          'item': {'item': 'bodhi-2.0-1.fc17', 'type': 'koji_build'},
-                         'type': 'test-result-missing', 'scenario': None},
+                         'type': 'test-result-failed', 'scenario': None},
                         {'testcase': 'dist.rpmdeplint',
                          'item': {'item': update.alias, 'type': 'bodhi_update'},
-                         'type': 'test-result-missing', 'scenario': None}]}
+                         'type': 'test-result-failed', 'scenario': None}]}
                 mock_greenwave.return_value = greenwave_response
                 model.Update.edit(request, data)
 
@@ -3710,10 +3710,10 @@ class TestUpdate(ModelTest):
                 'unsatisfied_requirements': [
                     {'testcase': 'dist.rpmdeplint',
                      'item': {'item': 'bodhi-2.0-1.fc17', 'type': 'koji_build'},
-                     'type': 'test-result-missing', 'scenario': None},
+                     'type': 'test-result-failed', 'scenario': None},
                     {'testcase': 'dist.rpmdeplint',
                      'item': {'item': self.obj.alias, 'type': 'bodhi_update'},
-                     'type': 'test-result-missing', 'scenario': None}]}
+                     'type': 'test-result-failed', 'scenario': None}]}
             mock_greenwave.return_value = greenwave_response
             with mock_sends(Message):
                 self.obj.set_request(self.db, UpdateRequest.testing, req.user.name)
@@ -3739,10 +3739,10 @@ class TestUpdate(ModelTest):
                 'unsatisfied_requirements': [
                     {'testcase': 'dist.rpmdeplint',
                      'item': {'item': 'bodhi-2.0-1.fc17', 'type': 'koji_build'},
-                     'type': 'test-result-missing', 'scenario': None},
+                     'type': 'test-result-failed', 'scenario': None},
                     {'testcase': 'dist.rpmdeplint',
                      'item': {'item': self.obj.alias, 'type': 'bodhi_update'},
-                     'type': 'test-result-missing', 'scenario': None}]}
+                     'type': 'test-result-failed', 'scenario': None}]}
             mock_greenwave.return_value = greenwave_response
             with mock_sends(Message):
                 self.obj.set_request(self.db, UpdateRequest.testing, req.user.name)

--- a/news/4221.bug
+++ b/news/4221.bug
@@ -1,0 +1,1 @@
+Avoid gating status ping-pong on update creation, assume status 'waiting' for 2 hours or until first failed test


### PR DESCRIPTION
This is an attempt to improve some issues around gating status for critical path updates, as reported in #4219 . Combined, these patches should mean we don't pingpong the state, and for the first two hours after an update is created or edited, the state will be 'waiting' if there are missing results but no failures.