### PR TITLE
Add "N" to the version model

### DIFF
--- a/bodhi/server/models.py
+++ b/bodhi/server/models.py
@@ -830,7 +830,7 @@ class Release(Base):
     composed_by_bodhi = Column(Boolean, default=True)
     create_automatic_updates = Column(Boolean, default=False)
 
-    _version_int_regex = re.compile(r'\D+(\d+)[CMF]?$')
+    _version_int_regex = re.compile(r'\D+(\d+)[CMFN]?$')
 
     package_manager = Column(PackageManager.db_type(), default=PackageManager.unspecified)
     testing_repository = Column(UnicodeText, nullable=True)

--- a/news/PR4222.feature
+++ b/news/PR4222.feature
@@ -1,0 +1,1 @@
+Added support for release names ending with "N" such as EPEL next


### PR DESCRIPTION
Fedora's bodhi just added a "EPEL-8N" release that has
epel8-next-updates and epel8-next-updates-testing. This is to build
against CentOS stream in those cases where normal EPEL packages are no
longer compatible due to stream changes. The bodhi module doesn't
understand the 'N' here and can't figure out the version. If we add it
into the model it's fine. :)

Signed-off-by: Kevin Fenzi <kevin@scrye.com>