### PR TITLE
Trying to fix pip CI tests

### DIFF
--- a/devel/ci/Dockerfile-pip
+++ b/devel/ci/Dockerfile-pip
@@ -1,4 +1,4 @@
-FROM registry.fedoraproject.org/fedora:33
+FROM registry.fedoraproject.org/fedora:34
 LABEL maintainer="Randy Barlow <bowlofeggs@fedoraproject.org>"
 
 RUN dnf install -y \
@@ -29,7 +29,7 @@ RUN pip-3 install \
     alembic \
     cornice_sphinx \
     diff-cover \
-    "docutils<0.17" \
+    docutils \
     flake8 \
     flake8-import-order \
     responses \
@@ -38,8 +38,7 @@ RUN pip-3 install \
     pytest-cov \
     "sphinx<4.0" \
     sqlalchemy_schemadisplay \
-# We can remove the following when python3-requests 2.25 will be available in Koji
-    "urllib3<1.26" \
+    urllib3 \
     webtest
 
 # Fake pungi being installed so we can avoid it and all its dependencies

--- a/devel/ci/Dockerfile-pip
+++ b/devel/ci/Dockerfile-pip
@@ -36,7 +36,7 @@ RUN pip-3 install \
     pydocstyle \
     pytest \
     pytest-cov \
-    sphinx \
+    "sphinx<4.0" \
     sqlalchemy_schemadisplay \
 # We can remove the following when python3-requests 2.25 will be available in Koji
     "urllib3<1.26" \


### PR DESCRIPTION
The PR aims to get pip CI tests pass again.

- celery currently requires Click<8.0, so we should set the same in Bodhi
- cornice_sphinx doesn't behave well with Sphinx 4, so let's pin Sphinx<4.0 in pip dockerfile. This is a temporary solution, I think we should move away from cornice_sphinx since it's not updated since years
- finally, update pip dockerfile base to F34

Signed-off-by: Mattia Verga <mattia.verga@tiscali.it>