### PR TITLE
Generate changelog for new packages

### DIFF
--- a/bodhi/server/models.py
+++ b/bodhi/server/models.py
@@ -1749,8 +1749,6 @@ class RpmBuild(Build):
                     timelimit = oldh['changelogtime']
                     if isinstance(timelimit, list):
                         timelimit = timelimit[0]
-            else:
-                return ""
 
         str = ""
         i = 0

--- a/bodhi/tests/server/tasks/test_composer.py
+++ b/bodhi/tests/server/tasks/test_composer.py
@@ -593,6 +593,26 @@ Useful details!
 --------------------------------------------------------------------------------
 ChangeLog:
 
+* Sat Aug  3 2013 Fedora Release Engineering <rel-eng@lists.fedoraproject.org> - 2.1.0-1
+- Rebuilt for https://fedoraproject.org/wiki/Fedora_20_Mass_Rebuild
+* Tue Jun 11 2013 Paul Moore <pmoore@redhat.com> - 2.1.0-0
+- New upstream version
+- Added support for the ARM architecture
+- Added the scmp_sys_resolver tool
+* Mon Jan 28 2013 Paul Moore <pmoore@redhat.com> - 2.0.0-0
+- New upstream version
+* Tue Nov 13 2012 Paul Moore <pmoore@redhat.com> - 1.0.1-0
+- New upstream version with several important fixes
+* Tue Jul 31 2012 Paul Moore <pmoore@redhat.com> - 1.0.0-0
+- New upstream version
+- Remove verbose build patch as it is no longer needed
+- Enable _smp_mflags during build stage
+* Thu Jul 19 2012 Fedora Release Engineering <rel-eng@lists.fedoraproject.org> - 0.1.0-2
+- Rebuilt for https://fedoraproject.org/wiki/Fedora_18_Mass_Rebuild
+* Tue Jul 10 2012 Paul Moore <pmoore@redhat.com> - 0.1.0-1
+- Limit package to x86/x86_64 platforms (RHBZ #837888)
+* Tue Jun 12 2012 Paul Moore <pmoore@redhat.com> - 0.1.0-0
+- Initial version
 --------------------------------------------------------------------------------
 References:
 
@@ -615,7 +635,21 @@ References:
              'libseccomp-2.1.0-1.fc20 (FEDORA-%s-a3bbe1a8f2)\n Enhanced seccomp library\n----------'
              '----------------------------------------------------------------------\nUpdate '
              'Information:\n\nUseful details!\n----------------------------------------------------'
-             '----------------------------\nChangeLog:\n\n-----------------------------------------'
+             '----------------------------\nChangeLog:\n\n* Sat Aug  3 2013 Fedora Release '
+             'Engineering <rel-eng@lists.fedoraproject.org> - 2.1.0-1\n- Rebuilt for '
+             'https://fedoraproject.org/wiki/Fedora_20_Mass_Rebuild\n* Tue Jun 11 2013 Paul Moore '
+             '<pmoore@redhat.com> - 2.1.0-0\n- New upstream version\n- Added support for the ARM '
+             'architecture\n- Added the scmp_sys_resolver tool\n* Mon Jan 28 2013 Paul Moore '
+             '<pmoore@redhat.com> - 2.0.0-0\n- New upstream version\n* Tue Nov 13 2012 Paul Moore '
+             '<pmoore@redhat.com> - 1.0.1-0\n- New upstream version with several important fixes\n'
+             '* Tue Jul 31 2012 Paul Moore <pmoore@redhat.com> - 1.0.0-0\n- New upstream version\n'
+             '- Remove verbose build patch as it is no longer needed\n- Enable _smp_mflags during '
+             'build stage\n* Thu Jul 19 2012 Fedora Release Engineering '
+             '<rel-eng@lists.fedoraproject.org> - 0.1.0-2\n- Rebuilt for '
+             'https://fedoraproject.org/wiki/Fedora_18_Mass_Rebuild\n* Tue Jul 10 2012 Paul Moore '
+             '<pmoore@redhat.com> - 0.1.0-1\n- Limit package to x86/x86_64 platforms '
+             '(RHBZ #837888)\n* Tue Jun 12 2012 Paul Moore <pmoore@redhat.com> - 0.1.0-0\n'
+             '- Initial version\n-----------------------------------------'
              '---------------------------------------\nReferences:\n\n  [ 1 ] Bug #12345 - None'
              '\n        https://bugzilla.redhat.com/show_bug.cgi?id=12345\n----------'
              '----------------------------------------------------------------------\n\n') % (

--- a/bodhi/tests/server/test_models.py
+++ b/bodhi/tests/server/test_models.py
@@ -1792,6 +1792,97 @@ class TestRpmBuild(ModelTest):
         assert exception.call_count == 0
         get_rpm_header.assert_called_once_with(self.obj.nvr)
 
+    @mock.patch('bodhi.server.models.log.exception')
+    def test_get_changelog_with_timelimit(self, exception):
+        """Test get_changelog() with time limit."""
+        rpm_header = {
+            'changelogtext': ['- Added a free money feature.', '- Make users ☺'],
+            'release': '1.fc20',
+            'version': '2.1.0',
+            'changelogtime': [1375531200, 1370952000],
+            'description': 'blah blah blah',
+            'changelogname': ['Fedora Releng <rel-eng@lists.fedoraproject.org> - 2.1.0-1',
+                              'Randy <bowlofeggs@fpo> - 2.0.1-2'],
+            'url': 'http://libseccomp.sourceforge.net',
+            'name': 'libseccomp',
+            'summary': 'Enhanced seccomp library'}
+
+        with mock.patch(
+                'bodhi.server.models.get_rpm_header', return_value=rpm_header) as get_rpm_header:
+            changelog = self.obj.get_changelog(timelimit=1371000000)
+
+        # Only one entry should be rendered.
+        assert changelog == (
+            ('* Sat Aug  3 2013 Fedora Releng <rel-eng@lists.fedoraproject.org> - 2.1.0-1\n- Added '
+             'a free money feature.\n'))
+        # No exception should have been logged.
+        assert exception.call_count == 0
+        get_rpm_header.assert_called_once_with(self.obj.nvr)
+
+    @mock.patch('bodhi.server.models.log.exception')
+    @mock.patch('bodhi.server.models.RpmBuild.get_latest', return_value='libseccomp-2.0.1-2.fc20')
+    def test_get_changelog_with_lastupdate(self, get_latest, exception):
+        """Test get_changelog() with lastupdate set to True."""
+        rpm_headers = [{
+            'changelogtext': ['- Added a free money feature.', '- Make users ☺'],
+            'release': '1.fc20',
+            'version': '2.1.0',
+            'changelogtime': [1375531200, 1370952000],
+            'description': 'blah blah blah',
+            'changelogname': ['Fedora Releng <rel-eng@lists.fedoraproject.org> - 2.1.0-1',
+                              'Randy <bowlofeggs@fpo> - 2.0.1-2'],
+            'url': 'http://libseccomp.sourceforge.net',
+            'name': 'libseccomp',
+            'summary': 'Enhanced seccomp library'},
+            {
+            'changelogtext': ['- Make users ☺'],
+            'release': '2.fc20',
+            'version': '2.0.1',
+            'changelogtime': [1370952000],
+            'description': 'blah blah blah',
+            'changelogname': ['Randy <bowlofeggs@fpo> - 2.0.1-2'],
+            'url': 'http://libseccomp.sourceforge.net',
+            'name': 'libseccomp',
+            'summary': 'Enhanced seccomp library'}]
+
+        with mock.patch('bodhi.server.models.get_rpm_header') as get_rpm_header:
+            get_rpm_header.side_effect = rpm_headers
+            changelog = self.obj.get_changelog(lastupdate=True)
+
+        # Only the newer entry should be rendered.
+        assert changelog == (
+            ('* Sat Aug  3 2013 Fedora Releng <rel-eng@lists.fedoraproject.org> - 2.1.0-1\n- Added '
+             'a free money feature.\n'))
+        # No exception should have been logged.
+        assert exception.call_count == 0
+
+    @mock.patch('bodhi.server.models.log.exception')
+    @mock.patch('bodhi.server.models.RpmBuild.get_latest', return_value=None)
+    def test_get_changelog_newpackage(self, get_latest, exception):
+        """Test get_changelog() with a new package."""
+        rpm_header = {
+            'changelogtext': ['- Added a free money feature.', '- Make users ☺'],
+            'release': '1.fc20',
+            'version': '2.1.0',
+            'changelogtime': [1375531200, 1370952000],
+            'description': 'blah blah blah',
+            'changelogname': ['Fedora Releng <rel-eng@lists.fedoraproject.org> - 2.1.0-1',
+                              'Randy <bowlofeggs@fpo> - 2.0.1-2'],
+            'url': 'http://libseccomp.sourceforge.net',
+            'name': 'libseccomp',
+            'summary': 'Enhanced seccomp library'}
+
+        with mock.patch('bodhi.server.models.get_rpm_header', return_value=rpm_header):
+            changelog = self.obj.get_changelog(lastupdate=True)
+
+        # The full changelog should be rendered, since no previous update exists.
+        assert changelog == (
+            ('* Sat Aug  3 2013 Fedora Releng <rel-eng@lists.fedoraproject.org> - 2.1.0-1\n- Added '
+             'a free money feature.\n* Tue Jun 11 2013 Randy <bowlofeggs@fpo> - 2.0.1-2\n- Make '
+             'users ☺\n'))
+        # No exception should have been logged.
+        assert exception.call_count == 0
+
     def test_release_relation(self):
         assert self.obj.release.name == "F11"
         assert len(self.obj.release.builds) == 1

--- a/news/4232.bug
+++ b/news/4232.bug
@@ -1,0 +1,1 @@
+For new packages submitted to repositories, the changelog was not generated and attached to the automatic Update. This prevented the bugs mentioned in the changelog to be closed by Bodhi


### PR DESCRIPTION
For new packages submitted to repositories, the changelog was not generated and attached to the automatic Update.
This prevented the bugs mentioned in the changelog to be closed by Bodhi

Fixes #4232 

Signed-off-by: Mattia Verga <mattia.verga@tiscali.it>