### PR TITLE
Do not allow edits on updates for archived releases

### DIFF
--- a/bodhi/server/services/updates.py
+++ b/bodhi/server/services/updates.py
@@ -34,7 +34,6 @@ from bodhi.server.models import (
     ContentType,
     UpdateRequest,
     UpdateStatus,
-    ReleaseState,
     Build,
     Package,
     Release,
@@ -198,11 +197,6 @@ def set_request(request):
     if update.locked:
         request.errors.add('body', 'request',
                            "Can't change request on a locked update")
-        return
-
-    if update.release.state is ReleaseState.archived:
-        request.errors.add('body', 'request',
-                           "Can't change request for an archived release")
         return
 
     if update.status == UpdateStatus.stable and action == UpdateRequest.testing:

--- a/bodhi/server/validators.py
+++ b/bodhi/server/validators.py
@@ -418,6 +418,9 @@ def validate_acls(request, **kwargs):
         builds = request.validated['builds']
 
     if 'update' in request.validated:
+        if request.validated['update'].release.state == ReleaseState.archived:
+            request.errors.add('body', 'update', 'cannot edit Update for an archived Release')
+            return
         builds = request.validated['update'].builds
 
     if not builds:

--- a/bodhi/tests/server/services/test_updates.py
+++ b/bodhi/tests/server/services/test_updates.py
@@ -1064,7 +1064,7 @@ class TestSetRequest(BasePyTestCase):
 
         assert res.json_body['status'] == 'error'
         assert res.json_body['errors'][0]['description'] == (
-            "Can't change request for an archived release"
+            "cannot edit Update for an archived Release"
         )
 
     @mock.patch(**mock_valid_requirements)
@@ -4096,7 +4096,7 @@ class TestUpdatesService(BasePyTestCase):
 
         assert resp.json['status'] == 'error'
         assert resp.json['errors'][0]['description'] == (
-            "Can't change request for an archived release"
+            "cannot edit Update for an archived Release"
         )
 
     @mock.patch(**mock_failed_taskotron_results)

--- a/bodhi/tests/server/test_validators.py
+++ b/bodhi/tests/server/test_validators.py
@@ -291,6 +291,20 @@ class TestValidateAcls(BasePyTestCase):
         validators.validate_acls(mock_request)
         assert not len(mock_request.errors)
 
+    @mock.patch.dict('bodhi.server.validators.config', {'acl_system': 'dummy'})
+    def test_validate_acls_archived_release(self):
+        """ Test validate_acls when trying to edit an Update for an archived Release.
+        """
+        mock_request = self.get_mock_request()
+        mock_request.validated['update'].release.state = models.ReleaseState.archived
+        validators.validate_acls(mock_request)
+        error = [{
+            'location': 'body',
+            'name': 'update',
+            'description': 'cannot edit Update for an archived Release'
+        }]
+        assert mock_request.errors == error
+
     @mock.patch.dict('bodhi.server.validators.config', {'acl_system': 'nonexistent'})
     def test_validate_acls_invalid_acl_system(self):
         """ Test validate_acls when the acl system is invalid.

--- a/news/PR4236.bug
+++ b/news/PR4236.bug
@@ -1,0 +1,1 @@
+Updates for archived releases cannot be edited anymore


### PR DESCRIPTION
After a release is archived we should avoid users from being able to edit/push to testing an update, even if that doesn't harm anything.

Signed-off-by: Mattia Verga <mattia.verga@tiscali.it>