### PR TITLE
Set a delta when quering datagrepper

### DIFF
--- a/bodhi/server/templates/user.html
+++ b/bodhi/server/templates/user.html
@@ -79,16 +79,22 @@ ${parent.javascript()}
         $('.hidejs').css('display', 'none');
         $(".spinner").html('<i class="fa fa-spinner fa-spin fa-fw"></i>');
         $.ajax(
-            'https://apps.fedoraproject.org/datagrepper/raw/?meta=date&user=${user['name']}&category=bodhi&order=desc&rows_per_page=1',
+            'https://apps.fedoraproject.org/datagrepper/raw/?meta=date&user=${user['name']}&category=bodhi&order=desc&rows_per_page=1&delta=2592000',
             {
                 dataType: 'jsonp',
                 success: function(e) {
-                    var date = e.raw_messages[0].meta.date;
-                    $('#lastactive').text('Last bodhi-related activity: ' + date);
+                    if (e.raw_messages.length > 0) {
+                        var date = e.raw_messages[0].meta.date;
+                        $('#lastactive').text('Last bodhi-related activity: ' + date);
+                    }
+                    else {
+                        $('#lastactive').text('No bodhi-related activity within the last month');
+                    }
                 },
                 error: function(e) {
                   $('#lastactive').text('Failed to query for activity status...')
                 },
+                timeout: 5000,
             });
         $.ajax(
             "${urls['recent_updates']}" + "&chrome=False&rows_per_page=12&display_user=False",

--- a/news/PR4255.feature
+++ b/news/PR4255.feature
@@ -1,0 +1,1 @@
+Set a `delta` parameter of 30 days when quering datagrepper for bodhi-related user activity


### PR DESCRIPTION
Based on recent datagrepper development, we should set a `delta` parameter when we query for bodhi-related user activity, so that we will not use datagrepper default (when the new datagrepper will be deployed in prod) and we don't stress datagrepper too much (I've set a delta of 30 days).
I've also modified the script to show a useful message if no recent activity is discovered and I've set a 5 seconds timout on the query.

Signed-off-by: Mattia Verga <mattia.verga@tiscali.it>