### PR TITLE
Correct tagging builds when editing side-tag update

### DIFF
--- a/bodhi/server/models.py
+++ b/bodhi/server/models.py
@@ -2540,30 +2540,34 @@ class Update(Base):
             data['karma_critipath'] = 0
             up.date_testing = None
 
-            # Remove all koji tags and change the status back to pending
-            if up.status is not UpdateStatus.pending:
+            if up.status != UpdateStatus.pending:
+                # Remove all koji tags and change the status back to pending
                 up.unpush(db)
                 caveats.append({
                     'name': 'status',
                     'description': 'Builds changed.  Your update is being '
                     'sent back to testing.',
                 })
+                builds_to_tag = [b.nvr for b in up.builds]
+            else:
+                # No need to unpush the update, just tag new builds
+                builds_to_tag = new_builds
 
-            # Add the pending_signing_tag to all new builds
+            # Add the pending_signing_tag to builds where needed
             tag = None
-            if up.from_tag:
+            if up.from_tag and not up.release.composed_by_bodhi:
                 tag = up.release.get_pending_signing_side_tag(up.from_tag)
             elif up.release.pending_signing_tag:
                 tag = up.release.pending_signing_tag
 
             if tag is not None:
-                tag_update_builds_task.delay(tag=tag, builds=new_builds)
+                tag_update_builds_task.delay(tag=tag, builds=builds_to_tag)
 
         new_bugs = up.update_bugs(data['bugs'], db)
         del(data['bugs'])
 
         req = data.pop("request", None)
-        if req is not None and not data.get("from_tag"):
+        if req is not None and up.release.composed_by_bodhi:
             up.set_request(db, req, request.user.name)
 
         for key, value in data.items():

--- a/news/PR4161.bug
+++ b/news/PR4161.bug
@@ -1,0 +1,1 @@
+Fix an issue that caused the builds in a side-tag update to not be tagged correctly when the build list of the update was modified


### PR DESCRIPTION
On creating a side-tag update for a release composed by Bodhi (current or branched), the tag history of all builds in the update is something like:

 - upon creation: f35-build-side-xxx + f35-updates-candidate + f35-pending-signing
 - autosign signs the build: f35-build-side-xxx + f35-updates-candidate + f35-testing-pending
 - bodhi compose the testing repo: f35-build-side-xxx + f35-updates-testing

Now, if the build list is updated, Bodhi unpushed the update, removes tags from builds and tries to tag the new builds in the -pending-signing related to the side-tag, which doesn't exist.
So, the builds will end in having `f35-build-side-xxx + f35-updates-candidate`, which means new builds are not marked as signed and the update gets stuck in pending state, until `check_signed_build` task runs.

This PR should solve this issue by:

1. Use the build-side-pending-signing only for Rawhide. Current and branched release will use pending-signing for the release
2. mark all builds as pending-signed, not only the newer ones. This isn't really necessary, but will cause the older builds to be marked testing-pending to be consistent with the newer builds. Since they're already signed it should not cause excessive workload for autosign (I think).

Please look if my comprehension of the tagging process is correct, things are really garbled when speaking about side-tag workflow in Bodhi...


Signed-off-by: Mattia Verga <mattia.verga@tiscali.it>