### PR TITLE
Remove Cgroups v1 tweak for vagrant machine

### DIFF
--- a/devel/ansible/roles/bodhi/tasks/main.yml
+++ b/devel/ansible/roles/bodhi/tasks/main.yml
@@ -69,13 +69,6 @@
       - zlib-devel
     state: present
 
-
-- name: Configure Cgroups v1 for docker in grub.cfg
-  command: sed -i '/^GRUB_CMDLINE_LINUX/ s/"$/ systemd.unified_cgroup_hierarchy=0"/' /etc/default/grub
-
-- name: Generate the new grub configuration with cgroups v1
-  command: grub2-mkconfig -o /boot/grub2/grub.cfg
-
 - name: Initialize PostgreSQL
   command: postgresql-setup initdb
   args:


### PR DESCRIPTION
We don't need anymore the Cgroups v1 tweak in the Vagrant development machine, since docker supports Cgroups v2 in F34.

Signed-off-by: Mattia Verga <mattia.verga@tiscali.it>