### PR TITLE
Do not override existing request when editing an update

### DIFF
--- a/bodhi/server/models.py
+++ b/bodhi/server/models.py
@@ -2452,6 +2452,8 @@ class Update(Base):
         buildinfo = request.buildinfo
         up = db.query(Update).filter_by(alias=data['edited']).first()
         del(data['edited'])
+        data.pop("request", None)
+        req = None
 
         caveats = []
         edited_builds = [build.nvr for build in up.builds]
@@ -2534,7 +2536,7 @@ class Update(Base):
 
         # Updates with new or removed builds always go back to testing
         if new_builds or removed_builds:
-            data['request'] = UpdateRequest.testing
+            req = UpdateRequest.testing
             # And, updates with new or removed builds always get their karma reset.
             # https://github.com/fedora-infra/bodhi/issues/511
             data['karma_critipath'] = 0
@@ -2562,7 +2564,6 @@ class Update(Base):
         new_bugs = up.update_bugs(data['bugs'], db)
         del(data['bugs'])
 
-        req = data.pop("request", None)
         if req is not None and not data.get("from_tag"):
             up.set_request(db, req, request.user.name)
 

--- a/news/4263.bug
+++ b/news/4263.bug
@@ -1,0 +1,1 @@
+Fixed an issue where editing Updates always caused to set the request to Testing


### PR DESCRIPTION
The `data['request']` value is always filled with a Testing request by Colander validator schema.
When editing an update we should drop this value, so as to not override existing Update request (if the builds list is changed, the request is overridden later in the code).

Fixes #4263 

Signed-off-by: Mattia Verga <mattia.verga@tiscali.it>