### PR TITLE
Do not override existing request when editing an update #2

### DIFF
--- a/bodhi/server/models.py
+++ b/bodhi/server/models.py
@@ -2448,8 +2448,6 @@ class Update(Base):
         buildinfo = request.buildinfo
         up = db.query(Update).filter_by(alias=data['edited']).first()
         del(data['edited'])
-        data.pop("request", None)
-        req = None
 
         caveats = []
         edited_builds = [build.nvr for build in up.builds]
@@ -2532,7 +2530,7 @@ class Update(Base):
 
         # Updates with new or removed builds always go back to testing
         if new_builds or removed_builds:
-            req = UpdateRequest.testing
+            data['request'] = UpdateRequest.testing
             # And, updates with new or removed builds always get their karma reset.
             # https://github.com/fedora-infra/bodhi/issues/511
             data['karma_critipath'] = 0

--- a/bodhi/server/schemas.py
+++ b/bodhi/server/schemas.py
@@ -198,11 +198,6 @@ class SaveUpdateSchema(CSRFProtectedSchema, colander.MappingSchema):
         colander.String(),
         validator=colander.OneOf(list(UpdateType.values())),
     )
-    request = colander.SchemaNode(
-        colander.String(),
-        validator=colander.OneOf(list(UpdateRequest.values())),
-        missing='testing',
-    )
     severity = colander.SchemaNode(
         colander.String(),
         validator=colander.OneOf(list(UpdateSeverity.values())),


### PR DESCRIPTION
#4267 was wrong and caused some tests to fail.
This will hopefully restore the correct behavior.

Signed-off-by: Mattia Verga <mattia.verga@tiscali.it>