### PR TITLE
Avoid serialization problem when loading testcases

### DIFF
--- a/bodhi/server/models.py
+++ b/bodhi/server/models.py
@@ -1056,7 +1056,7 @@ class TestCase(Base):
 
     __tablename__ = 'testcases'
     __get_by__ = ('name',)
-    __exclude_columns__ = ('builds',)
+    __exclude_columns__ = ('builds', 'feedback')
 
     name = Column(UnicodeText, nullable=False, unique=True)
 

--- a/news/PR4278.bug
+++ b/news/PR4278.bug
@@ -1,0 +1,1 @@
+Fixed an issue where JSON serialization of a TestCase object hangs the server


### PR DESCRIPTION
Currently, trying to load a `Build.testcases` list fetches all feedback received on that testcase, greatly slowing the query.

This change will avoid that, so `Update.test_cases` and `Update.full_test_cases` will not cause 500 Errors anymore (I hope).

Signed-off-by: Mattia Verga <mattia.verga@tiscali.it>