### PR TITLE
Do not call Koji listTagged with empty tag

### DIFF
--- a/bodhi/server/views/generic.py
+++ b/bodhi/server/views/generic.py
@@ -349,7 +349,8 @@ def latest_candidates(request):
             if testing:
                 koji.listTagged(release.testing_tag, **kwargs)
                 koji.listTagged(release.pending_testing_tag, **kwargs)
-                koji.listTagged(release.pending_signing_tag, **kwargs)
+                if release.pending_signing_tag:
+                    koji.listTagged(release.pending_signing_tag, **kwargs)
 
         response = koji.multiCall() or []  # Protect against None
         for taglist in response:
@@ -357,6 +358,7 @@ def latest_candidates(request):
             # in the reponse as dicts. Here we detect these, and log
             # the errors
             if isinstance(taglist, dict):
+                log.error('latest_candidates endpoint asked Koji about a non-existent tag:')
                 log.error(taglist)
             else:
                 for build in taglist[0]:

--- a/news/PR4280.bug
+++ b/news/PR4280.bug
@@ -1,0 +1,1 @@
+Fixed a possible call to Koji listTagged() passing an empty tag name


### PR DESCRIPTION
Some releases have `pending_signing_tag` set to an empty string. This will cause some errors to be logged.

This PR will add a check to avoid that and also outputs another error line to be more clear about where the error is detected.

Signed-off-by: Mattia Verga <mattia.verga@tiscali.it>