### PR TITLE
Correct misleading log comment

### DIFF
--- a/bodhi/server/services/updates.py
+++ b/bodhi/server/services/updates.py
@@ -207,10 +207,10 @@ def set_request(request):
     if action == UpdateRequest.stable:
         settings = request.registry.settings
         result, reason = update.check_requirements(request.db, settings)
-        log.info(
-            f'Unable to set request for {update.alias} to {action} due to failed requirements: '
-            f'{reason}')
         if not result:
+            log.info(
+                f'Unable to set request for {update.alias} to stable due to failed requirements: '
+                f'{reason}')
             request.errors.add('body', 'request',
                                'Requirement not met %s' % reason)
             return


### PR DESCRIPTION
We shouldn't log an 'Unable to set request' when the request is correctly set.

Signed-off-by: Mattia Verga <mattia.verga@tiscali.it>