### PR TITLE
Correct build tagging when editing an update

### DIFF
--- a/bodhi/tests/server/test_models.py
+++ b/bodhi/tests/server/test_models.py
@@ -3393,6 +3393,25 @@ class TestUpdate(ModelTest):
             ('dist-f11-updates-testing-pending', 'TurboGears-1.0.8-3.fc11'),
             ('dist-f11-updates-pending', 'TurboGears-1.0.8-3.fc11')]
 
+    def test_unpush_pending_stable_from_sidetag(self):
+        """Test unpush() on a pending stable tagged build originated from side-tag."""
+        release = self.obj.release
+        build = self.obj.builds[0]
+        koji = buildsys.get_session()
+        koji.__tagged__[build.nvr] = [
+            release.testing_tag, release.pending_signing_tag, release.pending_testing_tag,
+            release.pending_stable_tag, 'f35-build-side-12345',
+            # Add an unknown tag that we shouldn't touch
+            release.dist_tag + '-compose']
+
+        build.unpush(koji, from_side_tag=True)
+
+        assert koji.__untag__ == [
+            ('dist-f11-updates-testing', 'TurboGears-1.0.8-3.fc11'),
+            ('dist-f11-updates-testing-signing', 'TurboGears-1.0.8-3.fc11'),
+            ('dist-f11-updates-testing-pending', 'TurboGears-1.0.8-3.fc11'),
+            ('dist-f11-updates-pending', 'TurboGears-1.0.8-3.fc11')]
+
     @mock.patch('bodhi.server.models.log.info')
     def test_unpush_update(self, info):
         """Unpushing an update shouldn't clear the override tag from builds."""


### PR DESCRIPTION
When editing a sidetag update build list, we must not forget to tag the new builds in the release candidate tag together with the release pending signing tag. The release candidate tag is required by the composer to move the update to the testing repo.
When editing a sidetag update already pushed to testing, the update is unpushed and that takes care of re-tagging all the builds in the release candidate tag. For updates still in pending-testing, we need to take care in the edit() method.

This PR also ensures that unpushing a sidetag build do not leave the build in the release candidate tag, but only in the sidetag.

I've also added some tests which provides a minimum assurance of not screw things up again... as we're using a fake dev buildsystem in tests, it's really hard to test how builds are tagged at the end, so I've used log messages to see what's going on in the background.

Fixes #4284 

Signed-off-by: Mattia Verga <mattia.verga@tiscali.it>