### PR TITLE
Unstuck builds in pending signing

### DIFF
--- a/bodhi/server/buildsys.py
+++ b/bodhi/server/buildsys.py
@@ -153,6 +153,7 @@ class DevBuildsys:
         log.debug("moveBuild(%s, %s, %s)" % (from_tag, to_tag, build))
         DevBuildsys.__moved__.append((from_tag, to_tag, build))
 
+    @multicall_enabled
     def tagBuild(self, tag: str, build: str, *args, **kw):
         """Emulate Koji's tagBuild."""
         if tag is None:
@@ -160,6 +161,7 @@ class DevBuildsys:
         log.debug("tagBuild(%s, %s)" % (tag, build))
         DevBuildsys.__added__.append((tag, build))
 
+    @multicall_enabled
     def untagBuild(self, tag: str, build: str, *args, **kw):
         """Emulate Koji's untagBuild."""
         if tag is None:

--- a/news/PR4300.bug
+++ b/news/PR4300.bug
@@ -1,0 +1,1 @@
+Bodhi will now try to resubmit a build to signing if it detects that is stuck in pending signing for some time


### PR DESCRIPTION
Sometimes autosign misses messages, builds are not signed and an update gets stuck. For example [this update](https://bodhi.fedoraproject.org/updates/FEDORA-2021-532e4a87f3) has been in pending state for 2 weeks.
This will use our periodic task to try to resubmit a build for signing.

Signed-off-by: Mattia Verga <mattia.verga@tiscali.it>