### PR TITLE
Sphinx 4 doesn't like hardlinks

### DIFF
--- a/docs/user/2.x_release_notes.rst
+++ b/docs/user/2.x_release_notes.rst
@@ -12,9 +12,9 @@ Bugs
 ^^^^
 
 * Positive karma on stable updates no longer sends them back to batched
-  (`#1881 <https://github.com/fedora-infra/bodhi/issues/1881>`_).
+  (:issue:`1881`).
 * Push to batched buttons now appear on pushed updates when appropriate
-  (`#1875 <https://github.com/fedora-infra/bodhi/issues/1875>`_).
+  (:issue:`1875`).
 
 
 Release contributors
@@ -32,7 +32,7 @@ Bugs
 ^^^^
 
 * Use separate directories to clone the comps repositories
-  (`#1885 <https://github.com/fedora-infra/bodhi/pull/1885>`_).
+  (:pr:`1885`).
 
 
 Release contributors
@@ -51,16 +51,16 @@ Features
 ^^^^^^^^
 
 * Bodhi now asks Pagure to expand group membership when Pagure is used for ACLs
-  (`#1810 <https://github.com/fedora-infra/bodhi/issues/1810>`_).
+  (:issue:`1810`).
 * Bodhi now displays Atomic CI pipeline results
-  (`#1847 <https://github.com/fedora-infra/bodhi/pull/1847>`_).
+  (:pr:`1847`).
 
 
 Bugs
 ^^^^
 
 * Use generic superclass models where possible
-  (`#1793 <https://github.com/fedora-infra/bodhi/issues/1793>`_).
+  (:issue:`1793`).
 
 
 Release contributors
@@ -81,21 +81,21 @@ Features
 * Bodhi now batches non-urgent updates together for less frequent churn. There is a new
   ``bodhi-dequeue-stable`` CLI that is intended be added to cron that looks for batched updates and
   moves them to stable
-  (`#1157 <https://github.com/fedora-infra/bodhi/issues/1157>`_).
+  (:issue:`1157`).
 
 
 Bugs
 ^^^^
 
 * Improved bugtracker linking in markdown input
-  (`#1406 <https://github.com/fedora-infra/bodhi/issues/1406>`_).
+  (:issue:`1406`).
 * Don't disable autopush when the update is already requested for stable
-  (`#1570 <https://github.com/fedora-infra/bodhi/issues/1570>`_).
+  (:issue:`1570`).
 * There is now a timeout on fetching results from ResultsDB in the backend
-  (`#1597 <https://github.com/fedora-infra/bodhi/issues/1597>`_).
+  (:issue:`1597`).
 * Critical path updates now have positive days_to_stable and will only comment about pushing to
   stable when appropriate
-  (`#1708 <https://github.com/fedora-infra/bodhi/issues/1708>`_).
+  (:issue:`1708`).
 
 
 Development improvements
@@ -122,7 +122,7 @@ Bug fixes
 ^^^^^^^^^
 
 * Adjust the Greenwave subject query to include the original NVR of the builds
-  (`#1765 <https://github.com/fedora-infra/bodhi/pull/1765>`_).
+  (:pr:`1765`).
 
 
 Release contributors
@@ -151,15 +151,15 @@ inline.
 * Support for EL 5 has been removed in this release. Justification: EL 5 has become end of life.
 * The pkgtags feature has been removed. Justification: It did not work correctly and enabling it was
   devastating
-  (`#1634 <https://github.com/fedora-infra/bodhi/issues/1634>`_).
+  (:issue:`1634`).
 * Some bindings code that could log into Koji with TLS certificates was removed. Justification: It
   was unused
-  (`b4474676 <https://github.com/fedora-infra/bodhi/commit/b4474676>`_).
+  (:commit:`b4474676`).
 * Bodhi's short-lived ``ci_gating`` feature has been removed, in favor of the new
   Greenwave integration feature. Thus, the ``ci.required`` and ``ci.url`` settings no longer
   function in Bodhi. The ``bodhi-babysit-ci`` utility has also been removed. Justification: The
   feature was never completed and thus no functionality is lost
-  (`#1733 <https://github.com/fedora-infra/bodhi/pull/1733>`_).
+  (:pr:`1733`).
 
 
 Features
@@ -167,58 +167,58 @@ Features
 
 * There are new search endpoints in the REST API that perform ilike queries to support case
   insensitive searching. Bodhi's web interface now uses these endpoints
-  (`#997 <https://github.com/fedora-infra/bodhi/issues/997>`_).
+  (:issue:`997`).
 * It is now possible to search by update alias in the web interface
-  (`#1258 <https://github.com/fedora-infra/bodhi/issues/1258>`_).
+  (:issue:`1258`).
 * Exact matches are now sorted first in search results
-  (`#692 <https://github.com/fedora-infra/bodhi/issues/692>`_).
+  (:issue:`692`).
 * The CLI now has a ``--mine`` flag when searching for updates or overrides
-  (`#811 <https://github.com/fedora-infra/bodhi/issues/811>`_,
-  `#1382 <https://github.com/fedora-infra/bodhi/issues/1382>`_).
+  (:issue:`811`,
+  :issue:`1382`).
 * The CLI now has more search parameters when querying overrides
-  (`#1679 <https://github.com/fedora-infra/bodhi/issues/1679>`_).
+  (:issue:`1679`).
 * The new case insensitive search is also used when hitting enter in the search box in the web UI
-  (`#870 <https://github.com/fedora-infra/bodhi/issues/870>`_).
+  (:issue:`870`).
 * Bodhi is now able to query Pagure for FAS groups for ACL info
-  (`f9414601 <https://github.com/fedora-infra/bodhi/commit/f9414601>`_).
+  (:commit:`f9414601`).
 * The Python bindings' ``candidates()`` method now automatically initializes the username
-  (`6e8679b6 <https://github.com/fedora-infra/bodhi/commit/6e8679b6>`_).
+  (:commit:`6e8679b6`).
 * CLI errors are now printed in red text
-  (`431b9078 <https://github.com/fedora-infra/bodhi/commit/431b9078>`_).
+  (:commit:`431b9078`).
 * The graphs on the metrics page now have mouse hovers to indicate numerical values
-  (`#209 <https://github.com/fedora-infra/bodhi/issues/209>`_).
+  (:issue:`209`).
 * Bodhi now has support for using `Greenwave <https://pagure.io/greenwave/>`_ to gate updates based
   on test results. See the new ``test_gating.required``, ``test_gating.url``, and
   ``greenwave_api_url`` settings in ``production.ini`` for details on how to enable it. Note also
   that this feature introduces a new server CLI tool, ``bodhi-check-policies``, which is intended to
   be run via cron on a regular interval. This CLI tool communicates with Greenwave to determine if
   updates are passing required tests or not
-  (`#1733 <https://github.com/fedora-infra/bodhi/pull/1733>`_).
+  (:pr:`1733`).
 
 
 Bug fixes
 ^^^^^^^^^
 
 * The autokarma check box's value now persists when editing updates
-  (`#1692 <https://github.com/fedora-infra/bodhi/issues/1692>`_,
-  `#1482 <https://github.com/fedora-infra/bodhi/issues/1482>`_, and
-  `#1308 <https://github.com/fedora-infra/bodhi/issues/1308>`_).
+  (:issue:`1692`,
+  :issue:`1482`, and
+  :issue:`1308`).
 * The CLI now catches a variety of Exceptions and prints user readable errors instead of tracebacks
-  (`#1126 <https://github.com/fedora-infra/bodhi/issues/1126>`_,
-  `#1626 <https://github.com/fedora-infra/bodhi/issues/1626>`_).
+  (:issue:`1126`,
+  :issue:`1626`).
 * The Python bindings' ``get_releases()`` method now uses a GET request
-  (`#784 <https://github.com/fedora-infra/bodhi/issues/784>`_).
+  (:issue:`784`).
 * The HTML sanitization code has been refactored, which fixed a couple of issues where Bodhi didn't
   correctly escape things like e-mail addresses
-  (`#1656 <https://github.com/fedora-infra/bodhi/issues/1656>`_,
-  `#1721 <https://github.com/fedora-infra/bodhi/issues/1721>`_).
+  (:issue:`1656`,
+  :issue:`1721`).
 * The bindings' docstring for the ``comment()`` method was corrected to state that the ``email``
   parameter is used to make anonymous comments, rather than to enable or disable sending of e-mails
-  (`#289 <https://github.com/fedora-infra/bodhi/issues/289>`_).
+  (:issue:`289`).
 * The web interface now links directly to libravatar's login page instead of POSTing to it
-  (`#1674 <https://github.com/fedora-infra/bodhi/issues/1674>`_).
+  (:issue:`1674`).
 * The new/edit update form in the web interface now works with the new typeahead library
-  (`#1731 <https://github.com/fedora-infra/bodhi/issues/1731>`_).
+  (:issue:`1731`).
 
 
 Development improvements
@@ -247,8 +247,7 @@ The following developers contributed to Bodhi 2.10.0:
 2.9.1
 -----
 
-2.9.1 is a security release for
-`CVE-2017-1002152 <https://github.com/fedora-infra/bodhi/issues/1740>`_.
+2.9.1 is a security release for :issue:`1740`.
 
 Release contributors
 ^^^^^^^^^^^^^^^^^^^^
@@ -263,46 +262,46 @@ Features
 ^^^^^^^^
 
 * It is now possible to set required Taskotron tests with the ``--requirements`` CLI flag
-  (`#1319 <https://github.com/fedora-infra/bodhi/issues/1319>`_).
+  (:issue:`1319`).
 * The CLI now has tab completion in bash
-  (`#1188 <https://github.com/fedora-infra/bodhi/issues/1188>`_).
+  (:issue:`1188`).
 * Updates that are pending testing now go straight to stable if they reach required karma
-  (`#632 <https://github.com/fedora-infra/bodhi/issues/632>`_).
+  (:issue:`632`).
 * The automated tests tab now shows a count on info results
-  (`1de12f6a <https://github.com/fedora-infra/bodhi/commit/1de12f6a>`_).
+  (:commit:`1de12f6a`).
 * The UI now displays a spinner while a search is in progress
-  (`#436 <https://github.com/fedora-infra/bodhi/issues/436>`_).
+  (:issue:`436`).
 * It is now possible to middle click on search results in the web UI
-  (`#461 <https://github.com/fedora-infra/bodhi/issues/461>`_).
+  (:issue:`461`).
 * Pending releases are now displayed on the home page
-  (`#1619 <https://github.com/fedora-infra/bodhi/issues/1619>`_).
+  (:issue:`1619`).
 * Links without an explicit scheme can now be detected as links
-  (`#1721 <https://github.com/fedora-infra/bodhi/issues/1721>`_).
+  (:issue:`1721`).
 
 
 Bugs
 ^^^^
 
 * Wiki test cases are no longer duplicated
-  (`#780 <https://github.com/fedora-infra/bodhi/issues/780>`_).
+  (:issue:`780`).
 * The server bodhi-manage-releases script now uses the new Bodhi bindings
-  (`#1338 <https://github.com/fedora-infra/bodhi/issues/1338>`_).
+  (:issue:`1338`).
 * The server bodhi-manage-releases script now supports the ``--url`` flag
-  (`0181a344 <https://github.com/fedora-infra/bodhi/commit/0181a344>`_).
+  (:commit:`0181a344`).
 * The ``--help`` output from the Bodhi CLI is cleaner and more informative
-  (`#1457 <https://github.com/fedora-infra/bodhi/issues/1457>`_).
+  (:issue:`1457`).
 * The CLI now provides more informative error messages when creating duplicate overrides
-  (`#1377 <https://github.com/fedora-infra/bodhi/issues/1377>`_).
+  (:issue:`1377`).
 * E-mail subjects now include build versions again
-  (`#1635 <https://github.com/fedora-infra/bodhi/issues/1635>`_).
+  (:issue:`1635`).
 * Taskotron results with the same scenario key are now all displayed
-  (`d5b0bfa3 <https://github.com/fedora-infra/bodhi/commit/d5b0bfa3>`_).
+  (:commit:`d5b0bfa3`).
 * The front page UI elements now line up
-  (`#1659 <https://github.com/fedora-infra/bodhi/issues/1659>`_).
+  (:issue:`1659`).
 * The UI now properly urlencodes search URLs to properly escape characters such as "+"
-  (`#1015 <https://github.com/fedora-infra/bodhi/issues/1015>`_).
+  (:issue:`1015`).
 * e-mail addresses are now properly processed by the markdown system
-  (`#1656 <https://github.com/fedora-infra/bodhi/issues/1656>`_).
+  (:issue:`1656`).
 
 
 Development improvements
@@ -314,7 +313,7 @@ Development improvements
   https://github.com/twitter/typeahead.js/issues/1381
 * Docblocks were written for several more modules.
 * Bodhi now hard depends on rpm instead of conditionally importing it
-  (`#1166 <https://github.com/fedora-infra/bodhi/issues/1166>`_).
+  (:issue:`1166`).
 * Bodhi now has CI provided by CentOS that is able to test pull requests. Thanks to Brian Stinson
   and CentOS for providing this service to the Bodhi project!
 * Some ground work has been done in order to enable batched updates, so that medium and low priority
@@ -327,7 +326,7 @@ Development improvements
   Vagrantfile now uses 2 GB of RAM instead of 5 GB. It is likely possible to squeeze it down to 1 GB
   or so, if desired.
 * Bodhi now supports both the bleach 1 and bleach 2 APIs
-  (`#1718 <https://github.com/fedora-infra/bodhi/issues/1718>`_).
+  (:issue:`1718`).
 
 
 Release contributors
@@ -354,9 +353,9 @@ Bugs
 ^^^^
 
 * Restore defaults for three settings back to the values they had in Bodhi 2.7.0 (
-  `#1633 <https://github.com/fedora-infra/bodhi/pull/1633>`_,
-  `#1640 <https://github.com/fedora-infra/bodhi/pull/1640>`_, and
-  `#1641 <https://github.com/fedora-infra/bodhi/pull/1641>`_).
+  :pr:`1633`,
+  :pr:`1640`, and
+  :pr:`1641`).
 
 
 Release contributors
@@ -395,73 +394,73 @@ Features
 ^^^^^^^^
 
 * The API, fedmsg messages, bindings, and CLI now support non-RPM content (
-  `#1325 <https://github.com/fedora-infra/bodhi/issues/1325>`_,
-  `#1326 <https://github.com/fedora-infra/bodhi/issues/1326>`_,
-  `#1327 <https://github.com/fedora-infra/bodhi/issues/1327>`_, and
-  `#1328 <https://github.com/fedora-infra/bodhi/issues/1328>`_).
+  :issue:`1325`,
+  :issue:`1326`,
+  :issue:`1327`, and
+  :issue:`1328`).
   Bodhi now knows about Fedora's new module format, and is able to handle everything they need
   except publishing (which will appear in a later release). This release is also the first Bodhi
   release that is able to handle multiple content types.
 * Improved OpenQA support in the web UI
-  (`#1471 <https://github.com/fedora-infra/bodhi/issues/1471>`_).
+  (:issue:`1471`).
 * The type icons are now aligned in the web UI
-  (`4b6b7597 <https://github.com/fedora-infra/bodhi/commit/4b6b7597>`_ and
-  `d0940323 <https://github.com/fedora-infra/bodhi/commit/d0940323>`_).
+  (:commit:`4b6b7597` and
+  :commit:`d0940323`).
 * There is now a man page for ``bodhi-approve-testing``
-  (`cf8d897f <https://github.com/fedora-infra/bodhi/commit/cf8d897f>`_).
+  (:commit:`cf8d897f`).
 * Bodhi can now automatically detect whether to use DDL table locks if BDR is present during
-  migrations (`059b5ab7 <https://github.com/fedora-infra/bodhi/commit/059b5ab7>`_).
+  migrations (:commit:`059b5ab7`).
 * Locked updates now grey out the edit buttons with a tooltip to make the lock more obvious to the
-  user (`#1492 <https://github.com/fedora-infra/bodhi/issues/1492>`_).
+  user (:issue:`1492`).
 * Users can now do multi-line literal code blocks in comments
-  (`#1509 <https://github.com/fedora-infra/bodhi/issues/1509>`_).
+  (:issue:`1509`).
 * The web UI now has more descriptive placeholder text
-  (`1a7122cd <https://github.com/fedora-infra/bodhi/commit/1a7122cd>`_).
+  (:commit:`1a7122cd`).
 * All icons now have consistent width in the web UI
-  (`6dfe6ff3 <https://github.com/fedora-infra/bodhi/commit/6dfe6ff3>`_).
+  (:commit:`6dfe6ff3`).
 * The front page has a new layout
-  (`6afb6b07 <https://github.com/fedora-infra/bodhi/commit/6afb6b07>`_).
+  (:commit:`6afb6b07`).
 * Bodhi is now able to use Pagure and PDC as sources for ACL and package information
-  (`59551861 <https://github.com/fedora-infra/bodhi/commit/59551861>`_).
+  (:commit:`59551861`).
 * Bodhi's configuration loader now validates all values and centralizes defaults. Thus, it is now
   possible to comment most of Bodhi's settings file and achieve sane defaults. Some settings are
   still required, see the default ``production.ini`` file for documentation of all settings and
   their defaults. A few unused settings were removed
-  (`#1488 <https://github.com/fedora-infra/bodhi/issues/1488>`_,
-  `#1489 <https://github.com/fedora-infra/bodhi/issues/1489>`_, and
-  `263b7b7f <https://github.com/fedora-infra/bodhi/commit/263b7b7f>`_).
+  (:issue:`1488`,
+  :issue:`1489`, and
+  :commit:`263b7b7f`).
 * The web UI now displays the content type of the update
-  (`#1329 <https://github.com/fedora-infra/bodhi/issues/1329>`_).
+  (:issue:`1329`).
 * Bodhi now has a new ``ci.required`` setting that defaults to False. If enabled. updates will gate
   based on Continuous Integration test results and will not proceed to updates-testing unless the
   tests pass
-  (`0fcb73f8 <https://github.com/fedora-infra/bodhi/commit/0fcb73f8>`_).
+  (:commit:`0fcb73f8`).
 * Update builds are now sorted by NVR
-  (`#1441 <https://github.com/fedora-infra/bodhi/issues/1441>`_).
+  (:issue:`1441`).
 * The backend code is reworked to allow gating on resultsdb data and requirement validation
   performance is improved
-  (`#1550 <https://github.com/fedora-infra/bodhi/issues/1550>`_).
+  (:issue:`1550`).
 * Bodhi is now able to map distgit commits to Builds, which helps map CI results to Builds. There is
   a new ``bodhi-babysit-ci`` CLI that must be run periodically in cron if ``ci.required`` is
   ``True``
-  (`ae01e5d1 <https://github.com/fedora-infra/bodhi/commit/ae01e5d1>`_).
+  (:commit:`ae01e5d1`).
 
 
 Bugs
 ^^^^
 
 * A half-hidden button is now fully visible on mobile devices
-  (`#1467 <https://github.com/fedora-infra/bodhi/issues/1467>`_).
+  (:issue:`1467`).
 * The signing status is again visible on the update page
-  (`#1469 <https://github.com/fedora-infra/bodhi/issues/1469>`_).
+  (:issue:`1469`).
 * The edit update form will not be presented to users who are not auth'd
-  (`#1521 <https://github.com/fedora-infra/bodhi/issues/1521>`_).
+  (:issue:`1521`).
 * The CLI ``--autokarma`` flag now works correctly
-  (`#1378 <https://github.com/fedora-infra/bodhi/issues/1378>`_).
+  (:issue:`1378`).
 * E-mail subjects are now shortened like the web UI titles
-  (`#882 <https://github.com/fedora-infra/bodhi/issues/882>`_).
+  (:issue:`882`).
 * The override editing form is no longer displayed unless the user is logged in
-  (`#1541 <https://github.com/fedora-infra/bodhi/issues/1541>`_).
+  (:issue:`1541`).
 
 
 Development improvements
@@ -476,11 +475,11 @@ Development improvements
 * A new ``bresetdb`` development alias will reset the database to the same state as when
   ``vagrant up`` completed.
 * Some unused code was removed
-  (`afe5bd8c <https://github.com/fedora-infra/bodhi/commit/afe5bd8c>`_).
+  (:commit:`afe5bd8c`).
 * Test coverage was raised significantly, from 85% to 88%.
 * The development environment now has httpie by default.
 * The default Vagrant memory was raised
-  (`#1588 <https://github.com/fedora-infra/bodhi/issues/1588>`_).
+  (:issue:`1588`).
 * Bodhi now has a Jenkins Job Builder template for use with CentOS CI.
 * A new ``bdiff-cover`` development alias helps compare test coverage in current branch to the
   ``develop`` branch, and will alert the developer if there are any lines missing coverage.
@@ -511,26 +510,26 @@ Features
 ^^^^^^^^
 
 * The bodhi CLI now supports editing an override.
-  (`#1049 <https://github.com/fedora-infra/bodhi/issues/1049>`_).
+  (:issue:`1049`).
 * The Update model is now capable of being associated with different Build types
-  (`#1394 <https://github.com/fedora-infra/bodhi/issues/1394>`_).
+  (:issue:`1394`).
 * The bodhi CLI now supports editing an update using the update alias.
-  (`#1409 <https://github.com/fedora-infra/bodhi/issues/1409>`_).
+  (:issue:`1409`).
 * The web UI now uses Fedora 26 in its example text instead of Fedora 20
-  (`ec0c619a <https://github.com/fedora-infra/bodhi/commit/ec0c619a>`_).
+  (:commit:`ec0c619a`).
 * The Build model is now polymorphic to support non-RPM content
-  (`#1393 <https://github.com/fedora-infra/bodhi/issues/1393>`_).
+  (:issue:`1393`).
 
 
 Bugs
 ^^^^
 
 * Correctly calculate days to stable for critical path updates
-  (`#1386 <https://github.com/fedora-infra/bodhi/issues/1386>`_).
+  (:issue:`1386`).
 * Bodhi now logs some messages at info instead of error
-  (`#1412 <https://github.com/fedora-infra/bodhi/issues/1412>`_).
+  (:issue:`1412`).
 * Only show openQA results since last update modification
-  (`#1435 <https://github.com/fedora-infra/bodhi/issues/1435>`_).
+  (:issue:`1435`).
 
 
 Development improvements
@@ -569,11 +568,11 @@ Bugs
 ^^^^
 
 * The CLI is now able to appropriately handle expiring sessions
-  (`#1474 <https://github.com/fedora-infra/bodhi/issues/1474>`_).
+  (:issue:`1474`).
 * The CLI now only prompts for a password when needed
-  (`#1500 <https://github.com/fedora-infra/bodhi/pull/1500>`_).
+  (:pr:`1500`).
 * Don't traceback if the user doesn't use the ``--user`` flag
-  (`#1505 <https://github.com/fedora-infra/bodhi/pull/1505>`_).
+  (:pr:`1505`).
 
 
 Release contributors
@@ -594,12 +593,12 @@ Bugs
 ^^^^
 
 * Web requests now use the correct session for transactions
-  (`#1470 <https://github.com/fedora-infra/bodhi/issues/1470>`_,
-  `#1473 <https://github.com/fedora-infra/bodhi/issues/1473>`_).
+  (:issue:`1470`,
+  :issue:`1473`).
 * fedmsgs are now converted to dictionaries before queuing
-  (`#1472 <https://github.com/fedora-infra/bodhi/issues/1472>`_).
+  (:issue:`1472`).
 * Error messages are still logged if rolling back the transaction raises an Exception
-  (`#1475 <https://github.com/fedora-infra/bodhi/issues/1475>`_).
+  (:issue:`1475`).
 
 
 Release contributors
@@ -629,7 +628,7 @@ Dependency adjustments
 ^^^^^^^^^^^^^^^^^^^^^^
 
 * zope.sqlalchemy is no longer a required dependency
-  (`#1414 <https://github.com/fedora-infra/bodhi/pull/1414>`_).
+  (:pr:`1414`).
 * WebOb is no longer a directly required dependency, though it is still indirectly required through
   pyramid.
 
@@ -638,30 +637,30 @@ Features
 ^^^^^^^^
 
 * The web UI footer has been restyled to fit better with the new theme
-  (`#1366 <https://github.com/fedora-infra/bodhi/pull/1366>`_).
+  (:pr:`1366`).
 * A link to documentation has been added to the web UI footer
-  (`#1321 <https://github.com/fedora-infra/bodhi/issues/1321>`_).
+  (:issue:`1321`).
 * The bodhi CLI now supports editing updates
-  (`#937 <https://github.com/fedora-infra/bodhi/issues/937>`_).
+  (:issue:`937`).
 * The CLI's ``USERNAME`` environment variable is now documented, and its ``--user`` flag is
-  clarified (`28dd380a <https://github.com/fedora-infra/bodhi/commit/28dd380a>`_).
+  clarified (:commit:`28dd380a`).
 * The icons that we introduced in the new theme previously didn't have titles.
   Consequently, a user might not have know what these icons meant. Now if a user
   hovers over these icons, they get a description of what they mean, for
   example: "This is a bugfix update" or "This update is in the critical path"
-  (`#1362 <https://github.com/fedora-infra/bodhi/issues/1362>`_).
+  (:issue:`1362`).
 * Update pages with lots of updates look cleaner
-  (`#1351 <https://github.com/fedora-infra/bodhi/issues/1351>`_).
+  (:issue:`1351`).
 * Update page titles are shorter now for large updates
-  (`#957 <https://github.com/fedora-infra/bodhi/issues/957>`_).
+  (:issue:`957`).
 * Add support for alternate architectures to the MasherThread.wait_for_sync()
-  (`#1343 <https://github.com/fedora-infra/bodhi/issues/1343>`_).
+  (:issue:`1343`).
 * Update lists now also include type icons next to the updates
-  (`5983d99c <https://github.com/fedora-infra/bodhi/commit/5983d99c>`_).
+  (:commit:`5983d99c`).
 * Testing updates use a consistent label color now
-  (`62330644 <https://github.com/fedora-infra/bodhi/commit/62330644>`_).
+  (:commit:`62330644`).
 * openQA results are now displayed in the web ui
-  (`450dbafe <https://github.com/fedora-infra/bodhi/commit/450dbafe>`_).
+  (:commit:`450dbafe`).
 * Bodhi cookies now expire. There is a new ``authtkt.timeout`` setting that sets Bodhi's session
   lifetime, defaulting to 1 day.
 
@@ -670,19 +669,19 @@ Bugs
 ^^^^
 
 * Comments that don't carry karma don't count as a user's karma vote
-  (`#829 <https://github.com/fedora-infra/bodhi/issues/829>`_).
+  (:issue:`829`).
 * The web UI now uses the update alias instead of the title so editors of large updates can click
-  the edit button (`#1161 <https://github.com/fedora-infra/bodhi/issues/1161>`_).
+  the edit button (:issue:`1161`).
 * Initialize the bugtracker in ``main()`` instead of on import so that docs can be built without
-  installing Bodhi (`#1359 <https://github.com/fedora-infra/bodhi/pull/1359>`_).
+  installing Bodhi (:pr:`1359`).
 * Make the release graph easier to read when there are many datapoints
-  (`#1172 <https://github.com/fedora-infra/bodhi/issues/1172>`_).
+  (:issue:`1172`).
 * Optimize the JavaScript that loads automated test results from ResultsDB
-  (`#983 <https://github.com/fedora-infra/bodhi/issues/983>`_).
+  (:issue:`983`).
 * Bodhi's testing approval comment now respects the karma reset event
-  (`#1310 <https://github.com/fedora-infra/bodhi/issues/1310>`_).
+  (:issue:`1310`).
 * ``pop`` and ``copy`` now lazily load the configuration
-  (`#1423 <https://github.com/fedora-infra/bodhi/issues/1423>`_).
+  (:issue:`1423`).
 
 
 Development improvements
@@ -693,18 +692,18 @@ Development improvements
   eventually. A few modules have now been documented.
 * Test coverage is now 84%.
 * The Vagrant environment now has vim with a simple vim config to make sure spaces are used instead
-  of tabs (`#1372 <https://github.com/fedora-infra/bodhi/pull/1372>`_).
+  of tabs (:pr:`1372`).
 * The Package database model has been converted into a single-table inheritance model, which will
   aid in adding multi-type support to Bodhi. A new RpmPackage model has been added.
-  (`#1392 <https://github.com/fedora-infra/bodhi/pull/1392>`_).
+  (:pr:`1392`).
 * The database initialization code is unified
-  (`e9a26042 <https://github.com/fedora-infra/bodhi/commit/e9a26042>`_).
+  (:commit:`e9a26042`).
 * The base model class now has a helpful query property
-  (`8167f262 <https://github.com/fedora-infra/bodhi/commit/8167f262>`_).
+  (:commit:`8167f262`).
 * .pyc files are now removed when running the tests in the dev environment
-  (`9e9adb61 <https://github.com/fedora-infra/bodhi/commit/9e9adb61>`_).
+  (:commit:`9e9adb61`).
 * An unused inherited column has been dropped from the builds table
-  (`e8a95b12 <https://github.com/fedora-infra/bodhi/commit/e8a95b12>`_).
+  (:commit:`e8a95b12`).
 
 
 Release contributors
@@ -735,39 +734,39 @@ Features
 * The web interface now uses the Fedora Bootstrap theme. The layout of the
   update page has also been revamped to display the information about an update
   in a clearer manner.
-  (`#1313 <https://github.com/fedora-infra/bodhi/issues/1313>`_).
+  (:issue:`1313`).
 * The ``bodhi`` CLI now has a ``--url`` flag that can be used to switch which Bodhi server it
   communicates with. The ``BODHI_URL`` environment can also be used to configure this flag.
 * The documentation has been reorganized.
 * The Python bindings are now documented.
 * Bodhi will now announce that karma has been reset to 0 when builds are added or removed from
-  updates (`6d6de4bc <https://github.com/fedora-infra/bodhi/commit/6d6de4bc>`_).
+  updates (:commit:`6d6de4bc`).
 * Bodhi will now announce that autokarma has been disabled when an update received negative karma
-  (`d3ccc579 <https://github.com/fedora-infra/bodhi/commit/d3ccc579>`_).
+  (:commit:`d3ccc579`).
 * The docs theme is now Alabaster
-  (`57a80f42 <https://github.com/fedora-infra/bodhi/commit/57a80f42>`_).
+  (:commit:`57a80f42`).
 * The Bodhi documentation now has a description of Bodhi on the landing page
-  (`#1322 <https://github.com/fedora-infra/bodhi/issues/1322>`_).
+  (:issue:`1322`).
 * The REST API is now documented
-  (`#1323 <https://github.com/fedora-infra/bodhi/issues/1323>`_).
+  (:issue:`1323`).
 * The client Python bindings can now accept a ``base_url`` that doesn't end in a slash
-  (`1087939b <https://github.com/fedora-infra/bodhi/commit/1087939b>`_).
+  (:commit:`1087939b`).
 
 
 Bugs
 ^^^^
 * The position of the Add Comment button is now the bottom right.
-  (`#902 <https://github.com/fedora-infra/bodhi/issues/902>`_).
+  (:issue:`902`).
 * An unusuable ``--request`` flag has been removed from a CLI command
-  (`#1187 <https://github.com/fedora-infra/bodhi/issues/1187>`_).
+  (:issue:`1187`).
 * The cursor is now a pointer when hovering over Releases button
-  (`#1296 <https://github.com/fedora-infra/bodhi/issues/1296>`_).
+  (:issue:`1296`).
 * The number of days to stable is now correctly calculated on updates
-  (`#1305 <https://github.com/fedora-infra/bodhi/issues/1305>`_).
+  (:issue:`1305`).
 * Fix a query regular expression so that Fedora update ids work
-  (`d5bec3fa <https://github.com/fedora-infra/bodhi/commit/d5bec3fa>`_).
+  (:commit:`d5bec3fa`).
 * Karma thresholds can now be set when autopush is disabled
-  (`#1033 <https://github.com/fedora-infra/bodhi/issues/1033>`_).
+  (:issue:`1033`).
 
 
 Development improvements
@@ -802,11 +801,11 @@ Bodhi 2.4.0 is a feature and bugfix release.
 Features
 ^^^^^^^^
 * The web interface now displays whether an update has autopush enabled
-  (`#999 <https://github.com/fedora-infra/bodhi/issues/999>`_).
+  (:issue:`999`).
 * Autopush is now disabled on any update that receives authenticated negative karma
-  (`#1191 <https://github.com/fedora-infra/bodhi/issues/1191>`_).
+  (:issue:`1191`).
 * Bodhi now links to Koji builds via TLS instead of plaintext
-  (`#1246 <https://github.com/fedora-infra/bodhi/issues/1246>`_).
+  (:issue:`1246`).
 * Some usage examples have been added to the ``bodhi`` man page.
 * Bodhi's server package has a new script called ``bodhi-clean-old-mashes`` that can recursively
   delete any folders with names that end in a dash followed by a string that can be interpreted as a
@@ -822,31 +821,31 @@ Features
 Bugs
 ^^^^
 * Users' e-mail addresses will now be updated when they log in to Bodhi
-  (`#902 <https://github.com/fedora-infra/bodhi/issues/902>`_).
+  (:issue:`902`).
 * The masher now tests for ``repomd.xml`` instead of the directory that contains it
-  (`#908 <https://github.com/fedora-infra/bodhi/issues/908>`_).
+  (:issue:`908`).
 * Users can now only upvote an update once
-  (`#1018 <https://github.com/fedora-infra/bodhi/issues/1018>`_).
+  (:issue:`1018`).
 * Only comment on non-autokarma updates when they meet testing requirements
-  (`#1009 <https://github.com/fedora-infra/bodhi/issues/1009>`_).
+  (:issue:`1009`).
 * Autokarma can no longer be set to NULL
-  (`#1048 <https://github.com/fedora-infra/bodhi/issues/1048>`_).
+  (:issue:`1048`).
 * Users can now be more fickle than ever about karma
-  (`#1064 <https://github.com/fedora-infra/bodhi/issues/1064>`_).
+  (:issue:`1064`).
 * Critical path updates can now be free of past negative karma ghosts
-  (`#1065 <https://github.com/fedora-infra/bodhi/issues/1065>`_).
+  (:issue:`1065`).
 * Bodhi now comments on non-autokarma updates after enough time has passed
-  (`#1094 <https://github.com/fedora-infra/bodhi/issues/1094>`_).
+  (:issue:`1094`).
 * ``bodhi-push`` now does not crash when users abort a push
-  (`#1107 <https://github.com/fedora-infra/bodhi/issues/1107>`_).
+  (:issue:`1107`).
 * ``bodhi-push`` now does not print updates when resuming a push
-  (`#1113 <https://github.com/fedora-infra/bodhi/issues/1113>`_).
+  (:issue:`1113`).
 * Bodhi now says "Log in" and "Log out" instead of "Login" and "Logout"
-  (`#1146 <https://github.com/fedora-infra/bodhi/issues/1146>`_).
+  (:issue:`1146`).
 * Bodhi now configures the Koji client to retry, which should help make the masher more reliable
-  (`#1201 <https://github.com/fedora-infra/bodhi/issues/1201>`_).
+  (:issue:`1201`).
 * Bodhi is now compatible with Pillow-4.0.0
-  (`#1262 <https://github.com/fedora-infra/bodhi/issues/1262>`_).
+  (:issue:`1262`).
 * The bodhi cli no longer prints update JSON when setting the request
   (`#1408195 <https://bugzilla.redhat.com/show_bug.cgi?id=1408195>`_).
 * Bodhi's signed handler now skips builds that were not assigned to a release.
@@ -898,9 +897,9 @@ The following contributors submitted patches for Bodhi 2.4.0:
 Bodhi 2.3.3 converts koji auth to be done with krb5 and fixes one bug:
 
 * Use krb5 for koji
-  (`#1129 <https://github.com/fedora-infra/bodhi/pull/1129>`_).
+  (:pr:`1129`).
 * Disable caching koji sessions during mashing process
-  (`#1134 <https://github.com/fedora-infra/bodhi/pull/1134>`_).
+  (:pr:`1134`).
 
 
 Thanks to Patrick Uiterwijk for contributing both of these commits!
@@ -912,21 +911,21 @@ Thanks to Patrick Uiterwijk for contributing both of these commits!
 Bodhi 2.3.2 is a bugfix release that addresses the following issues:
 
 * ``push.py`` now defaults to the current releases
-  (`#1071 <https://github.com/fedora-infra/bodhi/issues/1071>`_).
+  (:issue:`1071`).
 * Fixed a typo in the masher in sending an ostree compose message
-  (`#1072 <https://github.com/fedora-infra/bodhi/pull/1072>`_).
+  (:pr:`1072`).
 * Fixed a typo in looking up an e-mail template
-  (`#1073 <https://github.com/fedora-infra/bodhi/issues/1073>`_).
+  (:issue:`1073`).
 * The fedmsg name is now passed explicitly
-  (`#1079 <https://github.com/fedora-infra/bodhi/pull/1079>`_).
+  (:pr:`1079`).
 * The man page was corrected to state that builds should be comma separated
-  (`#1095 <https://github.com/fedora-infra/bodhi/pull/1095>`_).
+  (:pr:`1095`).
 * Fixed a race condition between robosignatory and the signed handler
-  (`#1111 <https://github.com/fedora-infra/bodhi/issues/1111>`_).
+  (:issue:`1111`).
 * Fix querying the updates for resumption in ``push.py``
-  (`e7cb3f13 <https://github.com/fedora-infra/bodhi/commit/e7cb3f13>`_).
+  (:commit:`e7cb3f13`).
 * ``push.py`` now prompts for the username if not given
-  (`abeca57e <https://github.com/fedora-infra/bodhi/commit/abeca57e>`_).
+  (:commit:`abeca57e`).
 
 
 Release contributors
@@ -941,7 +940,7 @@ The following contributors authored patches for 2.3.2:
 2.3.1
 -----
 
-Bodhi 2.3.1 fixes `#1067 <https://github.com/fedora-infra/bodhi/issues/1067>`_,
+Bodhi 2.3.1 fixes :issue:`1067`,
 such that edited updates now tag new builds into the ``pending_signing_tag``
 instead of the ``pending_testing_tag``. This is needed for automatic signing
 gating to work.
@@ -956,38 +955,38 @@ Features
 ^^^^^^^^
 
 * The package input field is now autofocused when creating new updates
-  (`#876 <https://github.com/fedora-infra/bodhi/pull/876>`_).
+  (:pr:`876`).
 * Releases now have a ``pending_signing_tag``
-  (`3fe3e219 <https://github.com/fedora-infra/bodhi/commit/3fe3e219>`_).
+  (:commit:`3fe3e219`).
 * fedmsg notifications are now sent during ostree compositions
-  (`b972cad0 <https://github.com/fedora-infra/bodhi/commit/b972cad0>`_).
+  (:commit:`b972cad0`).
 * Critical path updates will have autopush disabled if they receive negative karma
-  (`b1f71006 <https://github.com/fedora-infra/bodhi/commit/b1f71006>`_).
+  (:commit:`b1f71006`).
 * The e-mail templates reference dnf for Fedora and yum for Enterprise Linux
-  (`1c1f2ab7 <https://github.com/fedora-infra/bodhi/commit/1c1f2ab7>`_).
+  (:commit:`1c1f2ab7`).
 * Updates are now obsoleted if they reach the unstable threshold while pending
-  (`f033c74c <https://github.com/fedora-infra/bodhi/commit/f033c74c>`_).
+  (:commit:`f033c74c`).
 * Bodhi now gates Updates based on whether they are signed yet or not
-  (`#1011 <https://github.com/fedora-infra/bodhi/pull/1011>`_).
+  (:pr:`1011`).
 
 
 Bugs
 ^^^^
 
 * Candidate builds and bugs are no longer duplicated while searching
-  (`#897 <https://github.com/fedora-infra/bodhi/issues/897>`_).
+  (:issue:`897`).
 * The Bugzilla connection is only initialized when needed
-  (`950eee2c <https://github.com/fedora-infra/bodhi/commit/950eee2c>`_).
+  (:commit:`950eee2c`).
 * A sorting issue was fixed on the metrics page so the data is presented correctly
-  (`487acaaf <https://github.com/fedora-infra/bodhi/commit/487acaaf>`_).
+  (:commit:`487acaaf`).
 * The Copyright date in the footer of the web interface is updated
-  (`1447b6c7 <https://github.com/fedora-infra/bodhi/commit/1447b6c7>`_).
+  (:commit:`1447b6c7`).
 * Bodhi will comment with the required time instead of the elapsed time on updates
-  (`#1017 <https://github.com/fedora-infra/bodhi/issues/1017>`_).
+  (:issue:`1017`).
 * Bodhi will only comment once to say that non-autopush updates have reached the threshold
-  (`#1009 <https://github.com/fedora-infra/bodhi/issues/1009>`_).
+  (:issue:`1009`).
 * ``/masher/`` is now allowed in addition to ``/masher`` for GET requests
-  (`cdb621ba <https://github.com/fedora-infra/bodhi/commit/cdb621ba>`_).
+  (:commit:`cdb621ba`).
 
 
 Dependencies
@@ -1003,17 +1002,17 @@ Bodhi 2.3.0 also has a few improvements to the development environment that make
 contribute to Bodhi or improve Bodhi's automated tests:
 
 * Documentation was added to describe how to connect development Bodhi to staging Koji
-  (`7f3b5fa2 <https://github.com/fedora-infra/bodhi/commit/7f3b5fa2>`_).
+  (:commit:`7f3b5fa2`).
 * An unused ``locked_date_for_update()`` method was removed
-  (`b87a6395 <https://github.com/fedora-infra/bodhi/commit/b87a6395>`_).
+  (:commit:`b87a6395`).
 * The development.ini.example base_address was changed to localhost so requests would be allowed
-  (`0fd5901d <https://github.com/fedora-infra/bodhi/commit/0fd5901d>`_).
+  (:commit:`0fd5901d`).
 * The ``setup.py`` file has more complete metadata, making it more suitable for submission to PyPI
-  (`5c201ac2 <https://github.com/fedora-infra/bodhi/commit/5c201ac2>`_).
+  (:commit:`5c201ac2`).
 * The #bodhi and #fedora-apps channels are now documented in the readme file
-  (`52093069 <https://github.com/fedora-infra/bodhi/commit/52093069>`_).
+  (:commit:`52093069`).
 * A new test has been added to enforce PEP-8 style and a few modules have been converted to conform
-  (`bbafc9e6 <https://github.com/fedora-infra/bodhi/commit/bbafc9e6>`_).
+  (:commit:`bbafc9e6`).
 
 
 Release contributors
@@ -1034,16 +1033,16 @@ The following contributors authored patches for 2.3.0:
 
 This release fixes two issues:
 
-* `#989 <https://github.com/fedora-infra/bodhi/issues/989>`_, where Karma on
+* :issue:`989`, where Karma on
   non-autopush updates would reset the request to None.
-* `#994 <https://github.com/fedora-infra/bodhi/issues/994>`_, allowing Bodhi to
+* :issue:`994`, allowing Bodhi to
   be built on setuptools-28.
 
 
 2.2.3
 -----
 
-This release fixes `#951 <https://github.com/fedora-infra/bodhi/issues/951>`_, which prevented
+This release fixes :issue:`951`, which prevented
 updates with large numbers of packages to be viewable in web browsers.
 
 
@@ -1054,11 +1053,11 @@ This is another in a series of bug fix releases for Bodhi this week. In this rel
 the following issues:
 
 * Disallow comment text to be set to the NULL value in the database
-  (`#949 <https://github.com/fedora-infra/bodhi/issues/949>`_).
+  (:issue:`949`).
 * Fix autopush on updates that predate the 2.2.0 release
-  (`#950 <https://github.com/fedora-infra/bodhi/issues/950>`_).
+  (:issue:`950`).
 * Don't wait on mashes when there aren't any
-  (`68de510c <https://github.com/fedora-infra/bodhi/commit/68de510c>`_).
+  (:commit:`68de510c`).
 
 
 2.2.1
@@ -1066,19 +1065,16 @@ the following issues:
 
 Bodhi 2.2.1 is a bug fix release, primarily focusing on mashing issues:
 
-* Register date locked during mashing (`#952
-  <https://github.com/fedora-infra/bodhi/issues/952>`_).
-* UTF-8 encode the updateinfo before writing it to disk (`#955
-  <https://github.com/fedora-infra/bodhi/issues/955>`_).
-* Improved logging during updateinfo generation (`#956
-  <https://github.com/fedora-infra/bodhi/issues/956>`_).
+* Register date locked during mashing (:issue:`952`).
+* UTF-8 encode the updateinfo before writing it to disk (:issue:`955`).
+* Improved logging during updateinfo generation (:issue:`956`).
 * Removed some unused code
-  (`07ff664f <https://github.com/fedora-infra/bodhi/commit/07ff664f>`_).
+  (:commit:`07ff664f`).
 * Fix some incorrect imports
-  (`9dd5bdbc <https://github.com/fedora-infra/bodhi/commit/9dd5bdbc>`_ and
-  `b1cc12ad <https://github.com/fedora-infra/bodhi/commit/b1cc12ad>`_).
+  (:commit:`9dd5bdbc` and
+  :commit:`b1cc12ad`).
 * Rely on self.skip_mash to detect when it is ok to skip a mash
-  (`ad65362e <https://github.com/fedora-infra/bodhi/commit/ad65362e>`_).
+  (:commit:`ad65362e`).
 
 
 2.2.0
@@ -1090,9 +1086,9 @@ Bodhi 2.2.0 is a security and feature release, with a few bug fixes as well.
 Security
 ^^^^^^^^
 
-This update addresses `CVE-2016-1000008 <https://github.com/fedora-infra/bodhi/pull/857>`_ by
-disallowing the re-use of solved captchas. Additionally, the captcha is
-`warped <https://github.com/fedora-infra/bodhi/commit/f0122855>`_ to make it more difficult to
+This update addresses :pr:`857` by
+disallowing the re-use of solved captchas. Additionally, the captcha is warped
+(:commit:`f0122855`) to make it more difficult to
 solve through automation. Thanks to Patrick Uiterwijk for discovering and reporting this issue.
 
 
@@ -1101,47 +1097,47 @@ Features
 
 * Bodhi's ``approve_testing.py`` script will now comment on updates when they have reached a stable
   karma threshold
-  (`5b0d1c7c <https://github.com/fedora-infra/bodhi/commit/5b0d1c7c>`_).
+  (:commit:`5b0d1c7c`).
 * The web interface now displays a push to stable button when the karma reaches the right level when
   autokarma is disabled
-  (`#772 <https://github.com/fedora-infra/bodhi/issues/772>`_ and
-  `#796 <https://github.com/fedora-infra/bodhi/issues/796>`_).
+  (:issue:`772` and
+  :issue:`796`).
 * Masher messages now have an "agent", so it is possible to tell which user ran the mash
-  (`45e4fc9f <https://github.com/fedora-infra/bodhi/commit/45e4fc9f>`_).
+  (:commit:`45e4fc9f`).
 * Locked updates now list the time they were locked
-  (`#831 <https://github.com/fedora-infra/bodhi/issues/831>`_).
+  (:issue:`831`).
 * Bugs are closed and commented on in the same Bugzilla POST
-  (`#404 <https://github.com/fedora-infra/bodhi/issues/404>`_).
+  (:issue:`404`).
 * Karma values equal to 0 are no longer displayed with a green background to better distinguish them
-  from positive karma reports (`#799 <https://github.com/fedora-infra/bodhi/issues/799>`_).
+  from positive karma reports (:issue:`799`).
 * Updates display a link to the feedback guidelines
-  (`#865 <https://github.com/fedora-infra/bodhi/issues/865>`_).
+  (:issue:`865`).
 * The new CLI now has a man page
-  (`95574831 <https://github.com/fedora-infra/bodhi/commit/95574831>`_).
-* The CLI now has a ``--version`` flag (`#895 <https://github.com/fedora-infra/bodhi/issues/895>`_).
+  (:commit:`95574831`).
+* The CLI now has a ``--version`` flag (:issue:`895`).
 
 
 Bugs
 ^^^^
 
 * Locked updates that aren't part of a current push will now be pushed and warnings will be logged
-  (`bf4bdeef <https://github.com/fedora-infra/bodhi/commit/bf4bdeef>`_). This should help us to fix
-  `#838 <https://github.com/fedora-infra/bodhi/issues/838>`_.
+  (:commit:`bf4bdeef`). This should help us to fix
+  :issue:`838`.
 * Don't show users an option to push to stable on obsoleted updates
-  (`#848 <https://github.com/fedora-infra/bodhi/issues/848>`_).
+  (:issue:`848`).
 * taskotron updates are shown per build, rather than per update
-  (`ce2394c6 <https://github.com/fedora-infra/bodhi/commit/ce2394c6>`_,
-  `8e199668 <https://github.com/fedora-infra/bodhi/commit/8e199668>`_).
+  (:commit:`ce2394c6`,
+  :commit:`8e199668`).
 * The Sphinx documentation now builds again
-  (`b3f80b1b <https://github.com/fedora-infra/bodhi/commit/b3f80b1b>`_).
+  (:commit:`b3f80b1b`).
 * Validator messages are now more useful and helpful
-  (`#630 <https://github.com/fedora-infra/bodhi/issues/630>`_).
+  (:issue:`630`).
 * The Bodhi CLI no longer depends on the server code to function
-  (`#900 <https://github.com/fedora-infra/bodhi/issues/900>`_).
+  (:issue:`900`).
 * Private bugs will no longer prevent the updates consumer from continuing
-  (`#905 <https://github.com/fedora-infra/bodhi/issues/905>`_).
+  (:issue:`905`).
 * bootstrap is now included in the setuptools manifest for the server package
-  (`#919 <https://github.com/fedora-infra/bodhi/issues/919>`_).
+  (:issue:`919`).
 
 
 Commit log

--- a/docs/user/3.x_release_notes.rst
+++ b/docs/user/3.x_release_notes.rst
@@ -1182,7 +1182,7 @@ Development improvements
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
 * The database migrations are now shipped as part of the Python distribution
-  (`#1777 <https://github.com/fedora-infra/bodhi/pull/1777>`_).
+  (:pr:`1777`).
 * The developer docs pertaining to using virtualenvs have been corrected and improved
   (:issue:`1797`).
 * The ``test_utils.py`` tests now use the ``BaseTestCase``, which allows them to pass when run by
@@ -1239,7 +1239,7 @@ Backwards incompatible changes
 * Support for the ``USERNAME`` environment variable in all of Bodhi's CLI tools has been dropped, as
   it conflicts with GDM's variable by the same name. Many users do not have the same FAS username as
   they use on their desktop, and this variable causes confusion in the CLI
-  (`#1789 <https://github.com/fedora-infra/bodhi/issues/1789>`_).
+  (:issue:`1789`).
 * The layout of the repositories after mash is now different.
 * The following settings have been removed from Bodhi, as Pungi now manages
   comps files instead of Bodhi::
@@ -1303,27 +1303,27 @@ deliver update repositories for modules, but in general all of Pungi's feature s
 for Bodhi to use.
 
 * Bodhi now supports non-RPM artifacts, namely, modules
-  (`#653 <https://github.com/fedora-infra/bodhi/issues/653>`_,
-  `#1330 <https://github.com/fedora-infra/bodhi/issues/1330>`_).
+  (:issue:`653`,
+  :issue:`1330`).
 * Via Pungi, Bodhi is now able to use Koji signed repos
-  (`#909 <https://github.com/fedora-infra/bodhi/issues/909>`_).
+  (:issue:`909`).
 * Via Pungi, Bodhi is now able to generate OSTrees that are more consistent with Fedora's release
   day OSTrees
-  (`#1182 <https://github.com/fedora-infra/bodhi/issues/1182>`_).
+  (:issue:`1182`).
 * Bodhi now uses Pungi instead of the retiring mash project
-  (`#1219 <https://github.com/fedora-infra/bodhi/issues/1219>`_).
+  (:issue:`1219`).
 
 
 Bugs
 ^^^^
 
 * Bodhi, via Pungi, will now reliably produce repomd files
-  (`#887 <https://github.com/fedora-infra/bodhi/issues/887>`_).
+  (:issue:`887`).
 * Bodhi's CLI no longer uses USERNAME, which conflicted with GDM for users who use a different local
   system username than their FAS username. For such users, there was no workaround other than to
   constantly use the ``--user`` flag, and the environment variable wasn't particularly useful
   anymore now that the Bodhi CLI remembers usernames after one successful authentication
-  (`#1789 <https://github.com/fedora-infra/bodhi/issues/1789>`_).
+  (:issue:`1789`).
 
 
 Release contributors


### PR DESCRIPTION
Replacing all hardlinks in old release notes should make pip-docs test happy again.

Signed-off-by: Mattia Verga <mattia.verga@tiscali.it>