### PR TITLE
Fix resultsdb consumer for data dict items being lists

### DIFF
--- a/bodhi/server/consumers/util.py
+++ b/bodhi/server/consumers/util.py
@@ -42,6 +42,10 @@ def update_from_db_message(msgid: str, itemdict: dict):
     if not itemtype:
         log.error(f"Couldn't find item type in message {msgid}")
         return None
+    if isinstance(itemtype, list):
+        # In resultsdb.result.new messages, the values are all lists
+        # for some reason
+        itemtype = itemtype[0]
     if itemtype not in ("koji_build", "bodhi_update"):
         log.debug(f"Irrelevant item type {itemtype}")
         return None
@@ -49,6 +53,8 @@ def update_from_db_message(msgid: str, itemdict: dict):
     # find the update
     if itemtype == "bodhi_update":
         updateid = itemdict.get("item")
+        if isinstance(updateid, list):
+            updateid = updateid[0]
         if not updateid:
             log.error(f"Couldn't find update ID in message {msgid}")
             return None
@@ -58,6 +64,8 @@ def update_from_db_message(msgid: str, itemdict: dict):
             return None
     else:
         nvr = itemdict.get("nvr", itemdict.get("item"))
+        if isinstance(nvr, list):
+            nvr = nvr[0]
         if not nvr:
             log.error(f"Couldn't find nvr in message {msgid}")
             return None

--- a/bodhi/tests/server/consumers/test_resultsdb.py
+++ b/bodhi/tests/server/consumers/test_resultsdb.py
@@ -45,10 +45,10 @@ class TestResultsdbHandler(BasePyTestCase):
         if not passed:
             outcome = "FAILED"
         if typ == "bodhi_update":
-            data = {"item": self.single_build_update.alias, "type": "bodhi_update"}
+            data = {"item": [self.single_build_update.alias], "type": ["bodhi_update"]}
         elif typ == "koji_build":
             nvr = self.single_build_update.builds[0].nvr
-            data = {"nvr": nvr, "item": nvr, "type": "koji_build"}
+            data = {"nvr": [nvr], "item": [nvr], "type": ["koji_build"]}
         return Message(
             topic="org.fedoraproject.prod.resultsdb.result.new",
             body={
@@ -279,7 +279,7 @@ class TestResultsdbHandler(BasePyTestCase):
         build nvr in the DB.
         """
         testmsg = self.get_sample_message(typ="koji_build", passed=True)
-        testmsg.body["data"]["nvr"] = "notapackage-2.0-1.fc17"
+        testmsg.body["data"]["nvr"] = ["notapackage-2.0-1.fc17"]
         self.handler(testmsg)
         assert mock_log.error.call_count == 1
         mock_log.error.assert_called_with("Couldn't find build notapackage-2.0-1.fc17 in DB")
@@ -303,7 +303,7 @@ class TestResultsdbHandler(BasePyTestCase):
         update ID in the DB.
         """
         testmsg = self.get_sample_message(typ="bodhi_update", passed=True)
-        testmsg.body["data"]["item"] = "NOTANUPDATE"
+        testmsg.body["data"]["item"] = ["NOTANUPDATE"]
         self.handler(testmsg)
         assert mock_log.error.call_count == 1
         mock_log.error.assert_called_with("Couldn't find update NOTANUPDATE in DB")


### PR DESCRIPTION
We noticed yesterday that the resultsdb consumer wasn't working
right in production - Bodhi was never updating gating status in
response to resultsdb.result.new messages, even when it should.
nirik and I figured out the problem: in resultsdb.result.new
messages, the values in the "data" dict are single-item lists
for some reason. The consumer code expected them to be strings,
as the equivalent values are in waiverdb.waiver.new messages.
The tests didn't catch this because I used the wrong format in
the sample messages used in the tests.

This updates `update_from_db_message` to handle the values being
lists, and makes the sample messages in the tests *be* lists to
better match the real-world case.

Signed-off-by: Adam Williamson <awilliam@redhat.com>