### PR TITLE
fix vagrant setup not working out of the box

### DIFF
--- a/devel/ansible/roles/bodhi/tasks/main.yml
+++ b/devel/ansible/roles/bodhi/tasks/main.yml
@@ -222,6 +222,12 @@
       group: root
       mode: 644
 
+- name: Link the bodhi bash completion script
+  file:
+    src: /home/vagrant/bodhi/bodhi-complete.sh
+    dest: /etc/bash_completion.d/bodhi-complete.sh
+    state: link
+
 - name: Start and enable the bodhi-related services
   service:
       name: "{{ item }}"
@@ -233,12 +239,3 @@
       - celery
       - fm-consumer@config
       - print-messages
-
-- name: Link the bodhi bash completion script
-  file:
-    src: /home/vagrant/bodhi/bodhi-complete.sh
-    dest: /etc/bash_completion.d/bodhi-complete.sh
-    state: link
-
-- name: Reboot the vagrant box
-  reboot:


### PR DESCRIPTION
previously, after doing the initial provisioning, the bodhi and celery
services in the vagrant setup were failing. This fixes this issue

Signed-off-by: Ryan Lerch <rlerch@redhat.com>