### PR TITLE
Build RPMs in ci

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -91,3 +91,32 @@ jobs:
       fail-fast: false
       matrix:
         release: [f34,f35,pip,rawhide]
+
+  rpms:
+    name: Build the RPMS
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install deps
+        run: pip install click conu pytest pytest-cov munch psycopg2 fedora-messaging
+
+      - name: Build the rpms
+        run: devel/ci/bodhi-ci rpm -r ${{ matrix.release }} -m ${{ matrix.module }}
+      
+      - name: Upload built rpms
+        uses: actions/upload-artifact@v2
+        with:
+          name: ${{ matrix.release }} ${{ matrix.module }} RPM
+          path: test_results/${{ matrix.release }}-rpm/*.noarch.rpm
+
+      - name: Upload source rpms
+        uses: actions/upload-artifact@v2
+        with:
+          name: ${{ matrix.release }} ${{ matrix.module }} SRPM
+          path: test_results/${{ matrix.release }}-rpm/*.src.rpm
+    strategy:
+      fail-fast: false
+      matrix:
+        release: [f34,f35,rawhide]
+        module: [bodhi-client, bodhi-messages, bodhi-server]

--- a/bodhi-client/bodhi-client.spec
+++ b/bodhi-client/bodhi-client.spec
@@ -1,0 +1,44 @@
+# Created by pyp2rpm-3.3.7
+%global pypi_name bodhi-client
+%global pypi_version 5.7.4+devel
+
+Name:           %{pypi_name}
+Version:        %{pypi_version}
+Release:        1%{?dist}
+Summary:        Bodhi client
+
+License:        GPLv2+
+URL:            https://github.com/fedora-infra/bodhi
+Source0:        %{pypi_name}-%{pypi_version}.tar.gz
+BuildArch:      noarch
+
+BuildRequires:  python3-devel
+BuildRequires:  python3dist(click)
+BuildRequires:  python3dist(koji)
+BuildRequires:  python3dist(python-fedora) >= 0.9
+BuildRequires:  python3dist(setuptools)
+
+%description
+
+
+%prep
+%autosetup -n %{pypi_name}-%{pypi_version}
+# Remove bundled egg-info
+rm -rf %{pypi_name}.egg-info
+
+%build
+%py3_build
+
+%install
+%py3_install
+
+%files -n %{pypi_name}
+%exclude %{python3_sitelib}/tests
+%{_bindir}/bodhi
+%{python3_sitelib}/bodhi
+%{python3_sitelib}/bodhi_client-%{pypi_version}-py%{python3_version}-*.pth
+%{python3_sitelib}/bodhi_client-%{pypi_version}-py%{python3_version}.egg-info
+
+%changelog
+* Tue Feb 01 2022 vagrant - 5.7.4-1
+- Initial package.

--- a/bodhi-client/bodhi/client/__init__.py
+++ b/bodhi-client/bodhi/client/__init__.py
@@ -34,7 +34,7 @@ import munch
 from bodhi.client import bindings
 
 
-__version__ = "5.7.4"
+__version__ = "5.7.4+devel"
 
 log = logging.getLogger(__name__)
 

--- a/bodhi-messages/bodhi-messages.spec
+++ b/bodhi-messages/bodhi-messages.spec
@@ -1,0 +1,44 @@
+# Created by pyp2rpm-3.3.7
+%global pypi_name bodhi-messages
+%global pypi_version 5.7.4+devel
+
+Name:           %{pypi_name}
+Version:        %{pypi_version}
+Release:        1%{?dist}
+Summary:        JSON schema for messages sent by Bodhi
+
+License:        GPLv2+
+URL:            https://github.com/fedora-infra/bodhi
+Source0:        %{pypi_name}-%{pypi_version}.tar.gz
+BuildArch:      noarch
+
+BuildRequires:  python3-devel
+BuildRequires:  python3dist(fedora-messaging)
+BuildRequires:  python3dist(setuptools)
+
+%description
+Bodhi Messages This package contains the schema for messages published by
+Bodhi.
+
+
+%prep
+%autosetup -n %{pypi_name}-%{pypi_version}
+# Remove bundled egg-info
+rm -rf %{pypi_name}.egg-info
+
+%build
+%py3_build
+
+%install
+%py3_install
+
+%files -n %{pypi_name}
+%exclude %{python3_sitelib}/tests
+%doc README.rst
+%{python3_sitelib}/bodhi
+%{python3_sitelib}/bodhi_messages-%{pypi_version}-py%{python3_version}-*.pth
+%{python3_sitelib}/bodhi_messages-%{pypi_version}-py%{python3_version}.egg-info
+
+%changelog
+* Tue Feb 01 2022 vagrant - 5.7.4-1
+- Initial package.

--- a/bodhi-messages/bodhi/messages/__init__.py
+++ b/bodhi-messages/bodhi/messages/__init__.py
@@ -16,4 +16,4 @@
 """This package defines Bodhi's messages."""
 
 
-__version__ = "5.7.4"
+__version__ = "5.7.4+devel"

--- a/bodhi-server/bodhi-server.spec
+++ b/bodhi-server/bodhi-server.spec
@@ -1,0 +1,84 @@
+# Created by pyp2rpm-3.3.7
+%global pypi_name bodhi-server
+%global pypi_version 5.7.4+devel
+
+Name:           %{pypi_name}
+Version:        %{pypi_version}
+Release:        1%{?dist}
+Summary:        Bodhi server
+
+License:        GPLv2+
+URL:            https://github.com/fedora-infra/bodhi
+Source0:        %{pypi_name}-%{pypi_version}.tar.gz
+BuildArch:      noarch
+
+BuildRequires:  python3-devel
+BuildRequires:  python3dist(alembic)
+BuildRequires:  python3dist(arrow)
+BuildRequires:  python3dist(backoff)
+BuildRequires:  python3dist(bleach)
+BuildRequires:  python3dist(celery) >= 4.2
+BuildRequires:  python3dist(click)
+BuildRequires:  python3dist(colander)
+BuildRequires:  python3dist(cornice) >= 3.1
+BuildRequires:  python3dist(dogpile.cache)
+BuildRequires:  python3dist(fedora-messaging)
+BuildRequires:  python3dist(feedgen) >= 0.7
+BuildRequires:  python3dist(jinja2)
+BuildRequires:  python3dist(koji)
+BuildRequires:  python3dist(markdown)
+BuildRequires:  python3dist(prometheus-client)
+BuildRequires:  python3dist(psycopg2)
+BuildRequires:  python3dist(py3dns)
+BuildRequires:  python3dist(pyasn1-modules)
+BuildRequires:  python3dist(pylibravatar)
+BuildRequires:  python3dist(pyramid) >= 1.7
+BuildRequires:  python3dist(pyramid-fas-openid)
+BuildRequires:  python3dist(pyramid-mako)
+BuildRequires:  python3dist(python-bugzilla)
+BuildRequires:  python3dist(python-fedora)
+BuildRequires:  python3dist(pyyaml)
+BuildRequires:  python3dist(requests)
+BuildRequires:  python3dist(responses)
+BuildRequires:  python3dist(setuptools)
+BuildRequires:  python3dist(simplemediawiki) = 1.2~b2
+BuildRequires:  python3dist(sqlalchemy)
+BuildRequires:  python3dist(waitress)
+BuildRequires:  python3dist(whitenoise)
+
+%description
+
+
+%prep
+%autosetup -n %{pypi_name}-%{pypi_version}
+# Remove bundled egg-info
+rm -rf %{pypi_name}.egg-info
+
+%build
+%py3_build
+
+%install
+%py3_install
+
+
+%files -n %{pypi_name}
+%exclude %{python3_sitelib}/tests
+%doc README.rst bodhi/server/migrations/README.rst bodhi/server/static/vendor/fedora-bootstrap/README.rst
+%{_bindir}/bodhi-approve-testing
+%{_bindir}/bodhi-check-policies
+%{_bindir}/bodhi-clean-old-composes
+%{_bindir}/bodhi-expire-overrides
+%{_bindir}/bodhi-push
+%{_bindir}/bodhi-sar
+%{_bindir}/bodhi-shell
+%{_bindir}/bodhi-skopeo-lite
+%{_bindir}/bodhi-untag-branched
+%{_bindir}/initialize_bodhi_db
+%{python3_sitelib}/apache
+%{python3_sitelib}/bodhi
+%{python3_sitelib}/bodhi_server-%{pypi_version}-py%{python3_version}-*.pth
+%{python3_sitelib}/bodhi_server-%{pypi_version}-py%{python3_version}.egg-info
+
+%changelog
+* Mon Jan 31 2022 ryanlerch - 5.7.4-1
+- Initial package.

--- a/bodhi-server/bodhi/server/__init__.py
+++ b/bodhi-server/bodhi/server/__init__.py
@@ -36,7 +36,7 @@ from bodhi.server import bugs, buildsys
 from bodhi.server.config import config as bodhi_config
 
 
-__version__ = "5.7.4"
+__version__ = "5.7.4+devel"
 
 # This is a regular expression used to match username mentions in comments.
 MENTION_RE = r'(?<!\S)(@\w+)'

--- a/devel/ci/Dockerfile-f34
+++ b/devel/ci/Dockerfile-f34
@@ -18,6 +18,7 @@ RUN dnf install -y \
     python3-colander \
     python3-cornice \
     python3-createrepo_c \
+    python3-devel \
     python3-diff-cover \
     python3-dnf \
     python3-dogpile-cache \
@@ -48,7 +49,8 @@ RUN dnf install -y \
     python3-webtest \
     python3-wheel \
     python3-whitenoise \
-    python3-yaml
+    python3-yaml \
+    rpm-build
 
 # Fake pungi being installed so we can avoid it and all its dependencies
 RUN ln -s /usr/bin/true /usr/bin/pungi-koji

--- a/devel/ci/Dockerfile-f35
+++ b/devel/ci/Dockerfile-f35
@@ -21,6 +21,7 @@ RUN dnf install -y \
     python3-colander \
     python3-cornice \
     python3-createrepo_c \
+    python3-devel \
     python3-diff-cover \
     python3-dnf \
     python3-dogpile-cache \
@@ -51,7 +52,8 @@ RUN dnf install -y \
     python3-webtest \
     python3-wheel \
     python3-whitenoise \
-    python3-yaml
+    python3-yaml \
+    rpm-build
 
 # Fake pungi being installed so we can avoid it and all its dependencies
 RUN ln -s /usr/bin/true /usr/bin/pungi-koji

--- a/devel/ci/Dockerfile-rawhide
+++ b/devel/ci/Dockerfile-rawhide
@@ -21,6 +21,7 @@ RUN dnf install -y \
     python3-colander \
     python3-cornice \
     python3-createrepo_c \
+    python3-devel \
     python3-diff-cover \
     python3-dnf \
     python3-dogpile-cache \
@@ -51,7 +52,8 @@ RUN dnf install -y \
     python3-webtest \
     python3-wheel \
     python3-whitenoise \
-    python3-yaml
+    python3-yaml \
+    rpm-build
 
 # Fake pungi being installed so we can avoid it and all its dependencies
 RUN ln -s /usr/bin/true /usr/bin/pungi-koji

--- a/devel/ci/bodhi_ci/cli.py
+++ b/devel/ci/bodhi_ci/cli.py
@@ -242,5 +242,21 @@ def integration(ctx, releases):
     Runner(options=ctx.obj).run_jobs(["integration"], releases=releases)
 
 
+@cli.command()
+@concurrency_option
+@container_runtime_option
+@failfast_option
+@no_build_option
+@releases_option
+@tty_option
+@archive_option
+@archive_path_option
+@modules_option
+@click.pass_context
+def rpm(ctx, releases):
+    """Build the rpms."""
+    Runner(options=ctx.obj).run_jobs(["rpm"], releases=releases)
+
+
 if __name__ == "__main__":
     cli()

--- a/devel/ci/bodhi_ci/job_registry.py
+++ b/devel/ci/bodhi_ci/job_registry.py
@@ -25,6 +25,7 @@ from .integration import (IntegrationBuildJob, IntegrationCleanJob,
                           IntegrationJob)
 from .job import BuildJob, CleanJob, Job
 from .linting import PreCommitJob
+from .rpm import RPMJob
 from .unit import DiffCoverJob, UnitJob
 
 AVAILABLE_JOBS: typing.Dict[str, typing.Type['Job']] = {
@@ -37,6 +38,7 @@ AVAILABLE_JOBS: typing.Dict[str, typing.Type['Job']] = {
     "integration-build": IntegrationBuildJob,
     "clean": CleanJob,
     "integration-clean": IntegrationCleanJob,
+    "rpm": RPMJob,
 }
 
 

--- a/devel/ci/bodhi_ci/rpm.py
+++ b/devel/ci/bodhi_ci/rpm.py
@@ -1,0 +1,67 @@
+# Copyright © 2018-2019 Red Hat, Inc.
+#
+# This file is part of Bodhi.
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+"""Documentation build job."""
+
+from .job import BuildJob, Job
+
+
+class RPMJob(Job):
+    """
+    Define a Job for building the RPMs.
+
+    See the Job superclass's docblock for details about its attributes.
+    """
+
+    _label = 'rpm'
+    skip_releases = ['pip']
+    _dependencies = [BuildJob]
+
+    def __init__(self, *args, **kwargs):
+        """
+        Initialize the RPMJob.
+
+        See the superclass's docblock for details about accepted parameters.
+
+        Args:
+            archive (bool): If True, set up the volume mount so we can retrieve the test results
+                from the container.
+            archive_path (str): A path on the host to share as a volume into the container for
+                its /results path.
+        """
+        super(RPMJob, self).__init__(*args, **kwargs)
+
+        self._command = [
+            '/usr/bin/bash', '-c',
+            (
+                'mkdir -p ~/rpmbuild/{BUILD,BUILDROOT,RPMS,SOURCES,SPECS,SRPMS} &&'
+                'for submodule in ' + ' '.join(self.options["modules"]) + '; do '
+                'cd $submodule &&'
+                '/usr/bin/python3 setup.py sdist &&'
+                'cp dist/* ~/rpmbuild/SOURCES/ &&'
+                'cp $submodule.spec ~/rpmbuild/SPECS/ &&'
+                'rpmbuild -bs ~/rpmbuild/SPECS/$submodule.spec &&'
+                'rpmbuild -ba ~/rpmbuild/SPECS/$submodule.spec &&'
+                'cp ~/rpmbuild/SRPMS/$submodule*.src.rpm /results/ &&'
+                'cp ~/rpmbuild/RPMS/noarch/$submodule*.rpm /results/ &&'
+                'cd ..; '
+                'done'
+
+            )]
+
+        self._convert_command_for_container()

--- a/devel/ci/integration/bodhi/Dockerfile-f34
+++ b/devel/ci/integration/bodhi/Dockerfile-f34
@@ -15,18 +15,24 @@ RUN dnf install -y \
     python3-mod_wsgi \
     python3-pip \
     skopeo \
+    rpm-build \
     /usr/bin/koji
 
 # Create bodhi user
 RUN groupadd -r bodhi && \
     useradd  -r -s /sbin/nologin -d /home/bodhi/ -m -c 'Bodhi Server' -g bodhi bodhi
-# Install it
+# setup rpmbuild
+RUN mkdir -p ~/rpmbuild/{BUILD,BUILDROOT,RPMS,SOURCES,SPECS,SRPMS}
+# Build the RPMs and Install them
 RUN \
     for pkg in bodhi-client bodhi-messages bodhi-server; do \
         cd $pkg && \
-        python3 setup.py bdist_wheel && \
-        pip3 install ./dist/*.whl && \
-        cd -; \
+        python3 setup.py sdist && \
+        cp dist/* ~/rpmbuild/SOURCES/ && \
+        cp $pkg.spec ~/rpmbuild/SPECS/ && \
+        rpmbuild -ba ~/rpmbuild/SPECS/$pkg.spec && \
+        dnf install -y $(ls ~/rpmbuild/RPMS/noarch/$pkg*.rpm) && \
+        cd ..; \
     done
 
 # Configuration

--- a/devel/ci/integration/bodhi/Dockerfile-f35
+++ b/devel/ci/integration/bodhi/Dockerfile-f35
@@ -15,18 +15,24 @@ RUN dnf install -y \
     python3-mod_wsgi \
     python3-pip \
     skopeo \
+    rpm-build \
     /usr/bin/koji
 
 # Create bodhi user
 RUN groupadd -r bodhi && \
     useradd  -r -s /sbin/nologin -d /home/bodhi/ -m -c 'Bodhi Server' -g bodhi bodhi
-# Install it
+# setup rpmbuild
+RUN mkdir -p ~/rpmbuild/{BUILD,BUILDROOT,RPMS,SOURCES,SPECS,SRPMS}
+# Build the RPMs and Install them
 RUN \
     for pkg in bodhi-client bodhi-messages bodhi-server; do \
         cd $pkg && \
-        python3 setup.py bdist_wheel && \
-        pip3 install ./dist/*.whl && \
-        cd -; \
+        python3 setup.py sdist && \
+        cp dist/* ~/rpmbuild/SOURCES/ && \
+        cp $pkg.spec ~/rpmbuild/SPECS/ && \
+        rpmbuild -ba ~/rpmbuild/SPECS/$pkg.spec && \
+        dnf install -y $(ls ~/rpmbuild/RPMS/noarch/$pkg*.rpm) && \
+        cd ..; \
     done
 
 # Configuration

--- a/devel/ci/integration/bodhi/Dockerfile-rawhide
+++ b/devel/ci/integration/bodhi/Dockerfile-rawhide
@@ -15,18 +15,24 @@ RUN dnf install -y \
     python3-mod_wsgi \
     python3-pip \
     skopeo \
+    rpm-build \
     /usr/bin/koji
 
 # Create bodhi user
 RUN groupadd -r bodhi && \
     useradd  -r -s /sbin/nologin -d /home/bodhi/ -m -c 'Bodhi Server' -g bodhi bodhi
-# Install it
+# setup rpmbuild
+RUN mkdir -p ~/rpmbuild/{BUILD,BUILDROOT,RPMS,SOURCES,SPECS,SRPMS}
+# Build the RPMs and Install them
 RUN \
     for pkg in bodhi-client bodhi-messages bodhi-server; do \
         cd $pkg && \
-        python3 setup.py bdist_wheel && \
-        pip3 install ./dist/*.whl && \
-        cd -; \
+        python3 setup.py sdist && \
+        cp dist/* ~/rpmbuild/SOURCES/ && \
+        cp $pkg.spec ~/rpmbuild/SPECS/ && \
+        rpmbuild -ba ~/rpmbuild/SPECS/$pkg.spec && \
+        dnf install -y $(ls ~/rpmbuild/RPMS/noarch/$pkg*.rpm) && \
+        cd ..; \
     done
 
 # Configuration


### PR DESCRIPTION
Add a new command to bodhi-ci to allow creation of RPMs and SRPMs. and
provide them back to the host if archive option is enabled.

Also, changes the integration tests for fedora releases (f35,f34, and
rawhide) to build the RPMs and install them in the container to test
from the RPMs.

Signed-off-by: Ryan Lerch <rlerch@redhat.com>