### PR TITLE
Make the path to the bodhi docs configurable

### DIFF
--- a/bodhi-server/bodhi/server/__init__.py
+++ b/bodhi-server/bodhi/server/__init__.py
@@ -368,5 +368,5 @@ def main(global_config, testing=None, session=None, **settings):
 
     log.info('Bodhi ready and at your service!')
     app = config.make_wsgi_app()
-    app = WhiteNoise(app, root="/usr/share/doc/bodhi-docs/html/", prefix="/docs", index_file=True)
+    app = WhiteNoise(app, root=bodhi_config["docs_path"], prefix="/docs", index_file=True)
     return app

--- a/bodhi-server/bodhi/server/config.py
+++ b/bodhi-server/bodhi/server/config.py
@@ -372,6 +372,9 @@ class BodhiConfig(dict):
                 'Bodhi is disabling automatic push to stable due to negative karma. The '
                 'maintainer may push manually if they determine that the issue is not severe.'),
             'validator': str},
+        'docs_path': {
+            'value': '/usr/share/doc/bodhi-docs/html/',
+            'validator': str},
         'dogpile.cache.arguments.filename': {
             'value': '/var/cache/bodhi-dogpile-cache.dbm',
             'validator': str},

--- a/bodhi-server/production.ini
+++ b/bodhi-server/production.ini
@@ -557,6 +557,9 @@ cache.long_term.expire = 3600
 # Celery configuration file
 celery_config = /etc/bodhi/celeryconfig.py
 
+# Documentation
+docs_path = /usr/share/doc/bodhi-docs/html/
+
 
 [server:main]
 use = egg:waitress#main

--- a/devel/development.ini.example
+++ b/devel/development.ini.example
@@ -72,6 +72,9 @@ test_gating.required = True
 waiverdb_api_url = http://bodhi_user:pass@localhost:6544/api/v1.0
 greenwave_api_url = http://localhost:6545/api/v1.0
 
+# Documentation
+docs_path = %(here)s/../docs/_build/html/
+
 [server:main]
 use = egg:waitress#main
 host = 0.0.0.0


### PR DESCRIPTION
The filesystem path to the built docs was hardcoded, make it a config value to avoid error when running in development.