### PR TITLE
Fix rpm building

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -118,5 +118,5 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        release: [f34,f35,pip,rawhide]
+        release: [f34,f35,rawhide]
         module: [bodhi-client, bodhi-messages, bodhi-server]

--- a/devel/ci/bodhi_ci/rpm.py
+++ b/devel/ci/bodhi_ci/rpm.py
@@ -46,7 +46,9 @@ class RPMJob(Job):
         super().__init__(*args, **kwargs)
 
         self._command = [
-            '/usr/bin/bash', '-c', './devel/ci/build-rpms.sh'
-        ] + list(self.options["modules"])
+            '/usr/bin/bash',
+            '-c',
+            ('./devel/ci/build-rpms.sh ' + ' '.join(self.options["modules"]))
+        ]
 
         self._convert_command_for_container(include_git=True)


### PR DESCRIPTION
* Previously, the command to call the script to build the rpms wasincorrectly formatted, and the RPMs were actually not getting built.
* We don't really need to build the RPMS in the pip release target. soremoving that from the rpm build matrix