### PR TITLE
Fix unit test CI job to actually die when tests fail (#4382)

### DIFF
--- a/devel/ci/bodhi_ci/unit.py
+++ b/devel/ci/bodhi_ci/unit.py
@@ -55,9 +55,10 @@ class UnitJob(Job):
             f'for submodule in {modules}; do '
             '  mkdir -p /results/$submodule; '
             '  cd $submodule; '
-            f' /usr/bin/python3 -m pytest {pytest_flags} && '
-            '    cp *.xml /results/$submodule/ || '
-            '    (cp *.xml /results/$submodule/ && exit 1); '
+            f' /usr/bin/python3 -m pytest {pytest_flags}; '
+            '  exitcode=$?; '
+            '  cp *.xml /results/$submodule/; '
+            '  test $exitcode -gt 0 && exit 1; '
             '  cd ..; '
             'done'
         )


### PR DESCRIPTION
This should fix the command used to run unit tests in `UnitJob`
to actually die (exit 1) if any of the module unit tests it
runs fails. The existing command does not, for reasons explained
in #4382.

Signed-off-by: Adam Williamson <awilliam@redhat.com>