### PR TITLE
Prepare the client for the switch to OIDC

### DIFF
--- a/bodhi-client/bodhi/client/bindings.py
+++ b/bodhi-client/bodhi/client/bindings.py
@@ -35,7 +35,9 @@ import re
 import textwrap
 import typing
 
-from fedora.client import AuthError, OpenIdBaseClient, FedoraClientError, ServerError
+from fedora.client import AuthError, FedoraClientError, OpenIdBaseClient, ServerError
+
+
 try:
     import dnf
 except ImportError:  # pragma: no cover
@@ -44,6 +46,7 @@ except ImportError:  # pragma: no cover
 import fedora.client.openidproxyclient
 import koji
 import requests.exceptions
+
 
 if typing.TYPE_CHECKING:  # pragma: no cover
     import munch  # noqa: 401
@@ -203,8 +206,9 @@ class BodhiClient(OpenIdBaseClient):
         if base_url[-1] != '/':
             base_url = base_url + '/'
 
-        super(BodhiClient, self).__init__(base_url, login_url=base_url + 'login', username=username,
-                                          **kwargs)
+        super(BodhiClient, self).__init__(
+            base_url, login_url=base_url + 'login?method=openid', username=username, **kwargs
+        )
 
         self._password = password
         self.csrf_token = ''

--- a/bodhi-client/tests/test_bindings.py
+++ b/bodhi-client/tests/test_bindings.py
@@ -25,6 +25,7 @@ import munch
 import pytest
 
 from bodhi.client import bindings
+
 from . import fixtures as client_test_data
 from .utils import compare_output
 
@@ -50,7 +51,7 @@ class TestBodhiClient___init__:
             staging=False, timeout=60, openid_api='https://example.com/api/v1/')
 
         assert client.base_url == 'http://example.com/bodhi/'
-        assert client.login_url == 'http://example.com/bodhi/login'
+        assert client.login_url == 'http://example.com/bodhi/login?method=openid'
         assert client.username == 'some_user'
         assert client.timeout == 60
         assert client._password == 's3kr3t'
@@ -65,7 +66,7 @@ class TestBodhiClient___init__:
                                       password='s3kr3t', staging=False, timeout=60)
 
         assert client.base_url == 'http://example.com/bodhi/'
-        assert client.login_url == 'http://example.com/bodhi/login'
+        assert client.login_url == 'http://example.com/bodhi/login?method=openid'
         assert client.username == 'some_user'
         assert client.timeout == 60
         assert client._password == 's3kr3t'
@@ -81,7 +82,7 @@ class TestBodhiClient___init__:
             staging=True, retries=5, openid_api='ignored')
 
         assert client.base_url == bindings.STG_BASE_URL
-        assert client.login_url == bindings.STG_BASE_URL + 'login'
+        assert client.login_url == bindings.STG_BASE_URL + 'login?method=openid'
         assert client.username == 'some_user'
         assert client.timeout is None
         assert client.retries == 5

--- a/news/PR4391.feature
+++ b/news/PR4391.feature
@@ -1,0 +1,1 @@
+Prepare the Bodhi client to be compatible with an OIDC-enabled server.


### PR DESCRIPTION
This change prepares the client to be compatible with an OIDC-enabled server. It is also compatible with the current server, because bodhi-server currently ignores the new `method` parameter.

We should widely deploy the client with this change before deploying the OIDC-enabled server.