### PR TITLE
new github workflow to build rpms in koji infra tag

### DIFF
--- a/.github/workflows/koji.conf
+++ b/.github/workflows/koji.conf
@@ -1,0 +1,8 @@
+# this is used in the staging workflow to push and build
+# RPMS on koji
+[koji]
+server = https://koji.fedoraproject.org/kojihub
+weburl = https://koji.fedoraproject.org/koji
+topurl = https://kojipkgs.fedoraproject.org
+authtype = kerberos
+use_fast_upload = yes

--- a/.github/workflows/krb5.conf
+++ b/.github/workflows/krb5.conf
@@ -1,0 +1,20 @@
+# this is used in the staging workflow to push and build
+# RPMS on koji
+[libdefaults]
+        default_realm = FEDORAPROJECT.ORG
+        dns_lookup_realm = false
+        ticket_lifetime = 24h
+        renew_lifetime = 7d
+        forwardable = true
+        rdns = false
+        spake_preauth_groups = edwards25519
+        dns_canonicalize_hostname = false
+        qualify_shortname = ""
+        default_ccache_name = KEYRING:persistent:%{uid}
+[realms]
+        FEDORAPROJECT.ORG = {
+                kdc = https://id.fedoraproject.org/KdcProxy
+        }
+[domain_realm]
+        .fedoraproject.org = FEDORAPROJECT.ORG
+        fedoraproject.org = FEDORAPROJECT.ORG

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -1,0 +1,57 @@
+on:
+  push:
+    branches:
+      - staging
+
+name: Build in koji
+
+jobs:
+
+  build:
+    name: Build in koji
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: staging
+
+      - name: install Deps with apt
+        run: sudo apt-get install krb5-k5tls krb5-user krb5-config libkrb5-dev
+
+      - name: Install Deps with PIP
+        run: pip install click conu pytest pytest-cov munch psycopg2 fedora-messaging koji
+
+      - name: Get Fedora Project IPA CA
+        run: sudo curl https://pagure.io/fedora-packager/raw/main/f/ipa_ca/fedoraproject_ipa_ca.crt -o /usr/local/share/ca-certificates/fedoraproject_ipa_ca.crt
+
+      - name: Update CA Certificates
+        run:  sudo update-ca-certificates
+
+      - name: Copy krb5.conf
+        run: sudo cp .github/workflows/krb5.conf /etc/krb5.conf
+
+      - name: Copy koji.conf
+        run: sudo cp .github/workflows/koji.conf /etc/koji.conf
+
+      # the keytab in the secret was generated with:
+      # $ ktutil
+      # ktutil:   addent -password -p bodhidev-bot@FEDORAPROJECT.ORG -k 1 -e rc4-hmac
+      # ktutil:   wkt bodhidev-bot.keytab
+      #
+      # then encoded in base64 and added to github actions secrets with
+      # $ base64 bodhidev-bot.keytab > bodhidev-bot.keytab.base64
+      - name: get and decode keytab
+        env:
+          KEYTAB: ${{ secrets.KEYTAB }}
+        run: echo $KEYTAB | base64 --decode > bodhidev-bot.keytab
+
+      - name: Build the rpms with bodhi-ci (just to get the SRPMS)
+        run: devel/ci/bodhi-ci rpm -r ${{ matrix.release }} -m ${{ matrix.module }}
+
+      - name: Build on Koji
+        run: koji --keytab=bodhidev-bot.keytab --principal=bodhidev-bot@FEDORAPROJECT.ORG build --wait ${{ matrix.release }}-infra test_results/${{ matrix.release }}-rpm/*${{ matrix.module }}*.src.rpm
+    strategy:
+      fail-fast: false
+      matrix:
+        release: [f34]
+        module: [bodhi-client, bodhi-messages, bodhi-server]

--- a/bodhi-client/bodhi-client.spec
+++ b/bodhi-client/bodhi-client.spec
@@ -12,6 +12,7 @@ URL:            https://github.com/fedora-infra/bodhi
 Source0:        %{pypi_name}-%{pypi_version}.tar.gz
 BuildArch:      noarch
 
+BuildRequires:  make
 BuildRequires:  python3-devel
 BuildRequires:  python3-sphinx
 BuildRequires:  python3dist(click)

--- a/bodhi-server/bodhi-server.spec
+++ b/bodhi-server/bodhi-server.spec
@@ -12,6 +12,7 @@ URL:            https://github.com/fedora-infra/bodhi
 Source0:        %{pypi_name}-%{pypi_version}.tar.gz
 BuildArch:      noarch
 
+BuildRequires:  make
 BuildRequires:  python3-devel
 BuildRequires:  python3-sphinx
 BuildRequires:  python3dist(alembic)


### PR DESCRIPTION
This adds a new workflow that builds development snapshot RPMS in
koji whenever any changes are pushed to the staging branch.

Signed-off-by: Ryan Lerch <rlerch@redhat.com>