### PR TITLE
More updates to the RPM layout

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -107,14 +107,11 @@ jobs:
       - name: Upload built rpms
         uses: actions/upload-artifact@v2
         with:
-          name: ${{ matrix.release }} ${{ matrix.module }} RPM
-          path: test_results/${{ matrix.release }}-rpm/*.noarch.rpm
+          name: ${{ matrix.release }} RPMs
+          path: | 
+            test_results/${{ matrix.release }}-rpm/*.noarch.rpm
+            test_results/${{ matrix.release }}-rpm/*.src.rpm
 
-      - name: Upload source rpms
-        uses: actions/upload-artifact@v2
-        with:
-          name: ${{ matrix.release }} ${{ matrix.module }} SRPM
-          path: test_results/${{ matrix.release }}-rpm/*.src.rpm
     strategy:
       fail-fast: false
       matrix:

--- a/bodhi-client/bodhi-client.spec
+++ b/bodhi-client/bodhi-client.spec
@@ -19,6 +19,10 @@ BuildRequires:  python3dist(koji)
 BuildRequires:  python3dist(python-fedora) >= 0.9
 BuildRequires:  python3dist(setuptools)
 
+Requires: /usr/bin/koji
+Requires: python3-dnf
+Requires: python3-koji
+
 %py_provides python3-bodhi-client
 
 %description

--- a/bodhi-server/bodhi-server.spec
+++ b/bodhi-server/bodhi-server.spec
@@ -47,9 +47,54 @@ BuildRequires:  python3dist(sqlalchemy)
 BuildRequires:  python3dist(waitress)
 BuildRequires:  python3dist(whitenoise)
 
+Requires: bodhi-client == %{version}-%{release}
+Requires: python3-bodhi-messages == %{version}-%{release}
+Requires: fedora-messaging
+Requires: git
+Requires: httpd
+Requires: intltool
+Requires: python3-koji
+Requires: python3-librepo
+Requires: python3-mod_wsgi
+
+Provides:  bundled(aajohan-comfortaa-fonts)
+Provides:  bundled(abattis-cantarell-fonts)
+Provides:  bundled(bootstrap) = 3.0.1
+Provides:  bundled(bootstrap) = 3.0.2
+Provides:  bundled(bootstrap) = 3.1.1
+Provides:  bundled(chrissimpkins-hack-fonts)
+Provides:  bundled(fedora-bootstrap) = 1.0.1
+Provides:  bundled(fontawesome-fonts-web) = 4.4.0
+Provides:  bundled(js-chart)
+Provides:  bundled(js-excanvas)
+Provides:  bundled(js-jquery) = 1.10.2
+Provides:  bundled(js-jquery) = 2.0.3
+Provides:  bundled(js-messenger)
+Provides:  bundled(js-moment)
+Provides:  bundled(js-typeahead.js) = 1.1.1
+Provides:  bundled(nodejs-flot)
+Provides:  bundled(open-sans-fonts)
+Provides:  bundled(xstatic-bootstrap-datepicker-common)
+
 %py_provides python3-bodhi-server
 
 %description
+Bodhi is a modular framework that facilitates the process of publishing
+updates for a software distribution.
+
+
+%package -n bodhi-composer
+Summary: Bodhi composer backend
+
+Requires: %{py3_dist jinja2}
+Requires: bodhi-server == %{version}-%{release}
+Requires: pungi >= 4.1.20
+Requires: python3-createrepo_c
+Requires: skopeo
+
+%description -n bodhi-composer
+The Bodhi composer is the component that publishes Bodhi artifacts to
+repositories.
 
 
 %prep
@@ -83,6 +128,20 @@ install -pm0644 docs/_build/*.1 %{buildroot}%{_mandir}/man1/
 %{python3_sitelib}/bodhi_server-%{pypi_version}-py%{python3_version}.egg-info
 %{_mandir}/man1/bodhi-*.1*
 %{_mandir}/man1/initialize_bodhi_db.1*
+# These excluded files are in the bodhi-composer package so don't include them here.
+%exclude %{python3_sitelib}/bodhi/server/tasks/composer.py
+%exclude %{python3_sitelib}/bodhi/server/tasks/__pycache__/composer.*
+%exclude %{python3_sitelib}/bodhi/server/metadata.py
+%exclude %{python3_sitelib}/bodhi/server/__pycache__/metadata.*
+
+%files -n bodhi-composer
+%license COPYING
+%doc README.rst
+%{python3_sitelib}/bodhi/server/tasks/composer.py
+# The __pycache__ folder itself is owned by bodhi-server.
+%{python3_sitelib}/bodhi/server/tasks/__pycache__/composer.*
+%{python3_sitelib}/bodhi/server/metadata.py
+%{python3_sitelib}/bodhi/server/__pycache__/metadata.*
 
 %changelog
 * Mon Jan 24 2022 Lenka Segura <lsegura@redhat.com> - 5.7.4-2

--- a/devel/ci/build-rpms.sh
+++ b/devel/ci/build-rpms.sh
@@ -19,7 +19,7 @@ for submodule in ${MODULES}; do
     sed -i "s/^Version:.*/Version:%{pypi_version}^$(date -u +%Y%m%d%H%M)git$githash/g" ~/rpmbuild/SPECS/$submodule.spec
     rpmdev-bumpspec ~/rpmbuild/SPECS/$submodule.spec
     rpmbuild -ba ~/rpmbuild/SPECS/$submodule.spec
-    cp ~/rpmbuild/SRPMS/*$submodule*.src.rpm /results/
-    cp ~/rpmbuild/RPMS/noarch/*$submodule*.rpm /results/
     cd ..
 done
+cp --verbose ~/rpmbuild/SRPMS/*.src.rpm /results/
+cp --verbose ~/rpmbuild/RPMS/noarch/*.rpm /results/

--- a/devel/ci/integration/bodhi/Dockerfile-f34
+++ b/devel/ci/integration/bodhi/Dockerfile-f34
@@ -33,7 +33,8 @@ RUN \
         rpmbuild -ba ~/rpmbuild/SPECS/$pkg.spec && \
         dnf install -y $(ls ~/rpmbuild/RPMS/noarch/*$pkg*.rpm) && \
         cd ..; \
-    done
+    done; \
+    dnf install -y $(ls ~/rpmbuild/RPMS/noarch/*bodhi-composer*.rpm)
 
 # Configuration
 RUN mkdir -p /etc/bodhi

--- a/devel/ci/integration/bodhi/Dockerfile-f35
+++ b/devel/ci/integration/bodhi/Dockerfile-f35
@@ -33,7 +33,8 @@ RUN \
         rpmbuild -ba ~/rpmbuild/SPECS/$pkg.spec && \
         dnf install -y $(ls ~/rpmbuild/RPMS/noarch/*$pkg*.rpm) && \
         cd ..; \
-    done
+    done; \
+    dnf install -y $(ls ~/rpmbuild/RPMS/noarch/*bodhi-composer*.rpm)
 
 # Configuration
 RUN mkdir -p /etc/bodhi

--- a/devel/ci/integration/bodhi/Dockerfile-rawhide
+++ b/devel/ci/integration/bodhi/Dockerfile-rawhide
@@ -33,7 +33,8 @@ RUN \
         rpmbuild -ba ~/rpmbuild/SPECS/$pkg.spec && \
         dnf install -y $(ls ~/rpmbuild/RPMS/noarch/*$pkg*.rpm) && \
         cd ..; \
-    done
+    done; \
+    dnf install -y $(ls ~/rpmbuild/RPMS/noarch/*bodhi-composer*.rpm)
 
 # Configuration
 RUN mkdir -p /etc/bodhi


### PR DESCRIPTION
Clean up the rpms with the following 3 commits:

#### [split out bodhi-composer package in RPMs](https://github.com/fedora-infra/bodhi/pull/4394/commits/606877367d563a42ec81910dd358360f7270acba)
this splits out the bodhi-composer into it's own seperate sub package,
as this is how it was done before the modules split.

#### [group artifacts better when uploading RPMs to github](https://github.com/fedora-infra/bodhi/pull/4394/commits/f7bb9c6eb3c2dffba88ed282fbcbf23c9a6eadd5)
previously we had 18 different zip files with one rpm in each. this
commit groups into the release, so we have 3 artifacts with all the rpms
and srpms for each release.

#### [Add missing requires for bodhi-client rpm](https://github.com/fedora-infra/bodhi/pull/4394/commits/193bc35d01ca4d26b12c2bbd82af71b42459cff1)
bodhi-client specfile was missing the requires that were in the old specfile. this adds them