### PR TITLE
Make footer copyright year always current year

### DIFF
--- a/bodhi-server/bodhi/server/templates/master.html
+++ b/bodhi-server/bodhi/server/templates/master.html
@@ -144,8 +144,12 @@
 
     <div class="footer py-5">
       <div class="container">
+        <%
+        from datetime import datetime
+        current_year=datetime.now().year
+        %>
         <p class="text-light text-center">
-          Copyright &copy; 2007-2019 Red Hat, Inc. and
+          Copyright &copy; 2007-${current_year} Red Hat, Inc. and
           <a href="https://github.com/fedora-infra/bodhi/graphs/contributors" class="text-white-50">
           others</a>.
         </p>

--- a/news/4401.bug
+++ b/news/4401.bug
@@ -1,0 +1,1 @@
+Fix the copyright year in the footer going stale by programatially setting the year.


### PR DESCRIPTION
Previously, the copyright year in the master template was hardcoded to
the year. If this failed to be manually updated, it would go stale at
the time it was 2019 instead of 2022.

THis commit programatically sets the copyright year to the current year
in the template.

Resolves: #4401

Signed-off-by: Ryan Lerch <rlerch@redhat.com>