### PR TITLE
Don't show duplicate test results on critpath updates (#4320)

### DIFF
--- a/bodhi-server/bodhi/server/templates/update.html
+++ b/bodhi-server/bodhi/server/templates/update.html
@@ -826,7 +826,12 @@ ${parent.javascript()}
                   waivers[waiver.testcase].push(waiver);
                 });
                 handle_unsatisfied_requirements(data);
-                handle_results(data.results, request.subject);
+                // we don't want to generate result rows for both the
+                // critpath and non-critpath decision contexts, as both
+                // queries return the same set of test results
+                if (!(request.decision_context.endsWith("critpath")) {
+                    handle_results(data.results, request.subject);
+                }
                 after_success();
             },
             error: function (jqxhr, status, error) {


### PR DESCRIPTION
Since b933a07 , we query on two Greenwave 'decision contexts'
for critical path updates. A query with a different decision
context but the same subjects will always return the same set
of test results. So we wind up showing every test result twice,
on the Automated Test Results tab, because we just send the
output from every Greenwave query that gets run through
`handle_results`.

To avoid this, let's skip `handle_results` when the decision
context ended in "_critpath". We know we would always also run
the non-critpath query, so we will get the results from that
query. We do *not* skip `handle_unsatisfied_requirements`,
because whether any requirements are unsatisfied can and will
differ between queries with the same subject(s) but different
decision contexts (which is why we run two queries in the first
place).

Signed-off-by: Adam Williamson <awilliam@redhat.com>