### PR TITLE
Fix a warning when staging is set on the bodhi-client CLI

### DIFF
--- a/bodhi-client/bodhi/client/cli.py
+++ b/bodhi-client/bodhi/client/cli.py
@@ -51,16 +51,21 @@ def _warn_staging_overrides(
     Returns:
         The value of the option being handled.
     """
-    if ctx.params.get('staging', False) and (param.name in ['url', 'id_provider']) and \
-            value is not None:
-        click.echo(f'\nWarning: {param.name} and staging flags are '
-                   f'both set. {param.name} will be ignored.\n',
-                   err=True)
+    if ctx.params.get('staging', False):
+        if (
+            param.name == 'url' and value != constants.BASE_URL
+            or param.name == 'id_provider' and value != constants.IDP
+        ):
+            click.echo(
+                f'\nWarning: {param.name} and staging flags are '
+                f'both set. {param.name} will be ignored.\n',
+                err=True
+            )
     if param.name == 'staging' and value:
-        if ctx.params.get('url', False):
+        if ctx.params.get('url', constants.BASE_URL) != constants.BASE_URL:
             click.echo('\nWarning: url and staging flags are both set. url will be ignored.\n',
                        err=True)
-        if ctx.params.get('id_provider', False):
+        if ctx.params.get('id_provider', constants.IDP) != constants.IDP:
             click.echo('\nWarning: id_provider and staging flags '
                        'are both set. id_provider will be ignored.\n',
                        err=True)

--- a/bodhi-client/tests/test_cli.py
+++ b/bodhi-client/tests/test_cli.py
@@ -1482,6 +1482,38 @@ class TestWarnIfUrlOrOpenidAndStagingSet:
         assert result == 'http://localhost:6543'
         assert echo.call_count == 0
 
+    def test_staging_and_default_url(self, mocker):
+        """
+        Nothing should be printed when staging is True and the URL is the default.
+        """
+        echo = mocker.patch('bodhi.client.cli.click.echo')
+        ctx = mock.MagicMock()
+        ctx.params = {'staging': True}
+        param = mock.MagicMock()
+        param.name = 'url'
+
+        result = cli._warn_staging_overrides(
+            ctx, param, constants.BASE_URL)
+
+        assert result == constants.BASE_URL
+        assert echo.call_count == 0
+
+    def test_staging_and_default_idp(self, mocker):
+        """
+        Nothing should be printed when staging is True and the id_provider is the default.
+        """
+        echo = mocker.patch('bodhi.client.cli.click.echo')
+        ctx = mock.MagicMock()
+        ctx.params = {'staging': True}
+        param = mock.MagicMock()
+        param.name = 'id_provider'
+
+        result = cli._warn_staging_overrides(
+            ctx, param, constants.IDP)
+
+        assert result == constants.IDP
+        assert echo.call_count == 0
+
     def test_staging_true(self, mocker):
         """
         A warning should be printed to stderr when staging is True and url/openid provided.


### PR DESCRIPTION
This removes a warning that was always set when `--staging` is set on the bodhi-client CLI. Now it's only emitted when relevant.