### PR TITLE
do the 3 koji builds concurrently

### DIFF
--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -3,18 +3,37 @@ on:
     branches:
       - staging
 
-name: Build in koji
+name: Build Staging Snapshot in Koji
 
 jobs:
 
-  build:
-    name: Build in koji
+  generate_srpms:
+    name: Generate SRPMS
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
         with:
           ref: staging
+      - name: Build the rpms with bodhi-ci (just to get the SRPMS)
+        run: devel/ci/bodhi-ci rpm -r ${{ matrix.release }}
+      - name: Upload srpms
+        uses: actions/upload-artifact@v2
+        with:
+          name: ${{ matrix.release }}-SRPMs
+          path: test_results/${{ matrix.release }}-rpm/*.src.rpm
+    strategy:
+      fail-fast: false
+      matrix:
+        release: [f34]
 
+  build:
+    name: Build ${{matrix.module}} on ${{matrix.release}} in Koji
+    runs-on: ubuntu-latest
+    needs: generate_srpms
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: staging
       - name: install Deps with apt
         run: sudo apt-get install krb5-k5tls krb5-user krb5-config libkrb5-dev
 
@@ -45,18 +64,14 @@ jobs:
           KEYTAB: ${{ secrets.KEYTAB }}
         run: echo $KEYTAB | base64 --decode > bodhidev-bot.keytab
 
-      - name: Build the rpms with bodhi-ci (just to get the SRPMS)
-        run: devel/ci/bodhi-ci rpm -r ${{ matrix.release }}
+      - name: Download artifacts
+        uses: actions/download-artifact@v2
 
-      - name: Build bodhi-client on Koji
-        run: koji --keytab=bodhidev-bot.keytab --principal=bodhidev-bot@FEDORAPROJECT.ORG build --wait ${{ matrix.release }}-infra test_results/${{ matrix.release }}-rpm/*bodhi-client*.src.rpm
+      - name: Build ${{matrix.module}} on Koji
+        run: koji --keytab=bodhidev-bot.keytab --principal=bodhidev-bot@FEDORAPROJECT.ORG build --wait ${{ matrix.release }}-infra ${{ matrix.release }}-SRPMs/*${{matrix.module}}*.src.rpm
 
-      - name: Build bodhi-messages on Koji
-        run: koji --keytab=bodhidev-bot.keytab --principal=bodhidev-bot@FEDORAPROJECT.ORG build --wait ${{ matrix.release }}-infra test_results/${{ matrix.release }}-rpm/*bodhi-messages*.src.rpm
-      
-      - name: Build bodhi-server on Koji
-        run: koji --keytab=bodhidev-bot.keytab --principal=bodhidev-bot@FEDORAPROJECT.ORG build --wait ${{ matrix.release }}-infra test_results/${{ matrix.release }}-rpm/*bodhi-server*.src.rpm
     strategy:
       fail-fast: false
       matrix:
+        module: [bodhi-client, bodhi-messages, bodhi-server]
         release: [f34]


### PR DESCRIPTION
Previously, we were building the koji builds concurrently using the
github matrix, but when we were doing this, we were also building the
SRPMs individually for each job -- which was causing issues because we
encode the time in the RPMS version.

So to fix this, we removed the matrix, and sent the builds to koji
sequentially. This worked but was slow, as we had to wait for each koji
build to finish -- so it took about 12 minutes or so.

In this commit, we build the SRPMs in a seperate job, then upload them
as artifacts, then use them to kick off the koji builds sequentially.
Now building in koji takes about 3-4 minutes.

Signed-off-by: Ryan Lerch <rlerch@redhat.com>