### PR TITLE
build docs to gh-pages

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,34 @@
+on:
+  push:
+    branches:
+      - develop
+    paths:
+      - docs/**
+
+name: Build Docs and push to gh-pages
+
+jobs:
+  docs:
+    name: Build Documentation
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: develop
+
+      - name: Install deps
+        run: pip install click -r docs/requirements.txt
+
+      - name: Build the docs
+        run: devel/ci/bodhi-ci docs -r ${{ matrix.release }}
+      
+      - name: Deploy
+        uses: JamesIves/github-pages-deploy-action@v4.2.5
+        with:
+          branch: docs # The branch the action should deploy to.
+          folder: test_results/${{ matrix.release }}-docs/html # The folder the action should deploy.
+          target-folder: .
+    strategy:
+      fail-fast: false
+      matrix:
+        release: [pip]


### PR DESCRIPTION
This commit adds a github action that automatically builds the
documentation with sphinx (using the bodhi-ci tool), and
uploads the results to the orphan docs branch, which will then
be published at: https://fedora-infra.github.io/bodhi/

the trigger is currently set up to rebuild the docs anytime the docs/
directory in the develop branch is pushed to.

Signed-off-by: Ryan Lerch <rlerch@redhat.com>