### PR TITLE
Extend `save_override()` to set the expiration date of an override directly

### DIFF
--- a/bodhi-client/bodhi/client/cli.py
+++ b/bodhi-client/bodhi/client/cli.py
@@ -128,7 +128,7 @@ new_edit_options = [
     click.option('--bugs', help='Comma-separated list of bug numbers', default=''),
     click.option('--close-bugs', is_flag=True, help='Automatically close bugs'),
     click.option('--request', help='Requested repository',
-                 type=click.Choice(['testing', 'stable', 'unpush'])),
+                 type=click.Choice(constants.REQUEST_TYPES)),
     click.option('--autotime', is_flag=True, help='Enable stable push base on time in testing'),
     click.option('--stable-days', type=click.INT,
                  help='Days in testing required to push to stable'),
@@ -408,7 +408,7 @@ def require_severity_for_security_update(type: str, severity: str):
 
 @updates.command()
 @click.option('--type', default='bugfix', help='Update type', required=True,
-              type=click.Choice(['security', 'bugfix', 'enhancement', 'newpackage']))
+              type=click.Choice(constants.UPDATE_TYPES))
 @add_options(new_edit_options)
 @click.argument('builds_or_tag')
 @click.option('--file', help='A text file containing all the update details')
@@ -498,7 +498,7 @@ def _validate_edit_update(
 
 @updates.command()
 @click.option('--type', help='Update type',
-              type=click.Choice(['security', 'bugfix', 'enhancement', 'newpackage']))
+              type=click.Choice(constants.UPDATE_TYPES))
 @click.option('--addbuilds', help='Add Comma-separated list of build nvr')
 @click.option('--removebuilds', help='Remove Comma-separated list of build nvr')
 @add_options(new_edit_options)
@@ -616,7 +616,7 @@ def edit(url: str, id_provider: str, client_id: str, debug: bool, **kwargs):
 @click.option('--releases', help='Updates for specific releases')
 @click.option('--locked', help='Updates that are in a locked state')
 @click.option('--request', help='Updates with a specific request',
-              type=click.Choice(['testing', 'stable', 'unpush']))
+              type=click.Choice(constants.REQUEST_TYPES))
 @click.option('--severity', help='Updates with a specific severity',
               type=click.Choice(['unspecified', 'urgent', 'high', 'medium', 'low']))
 @click.option('--submitted-since',
@@ -629,7 +629,7 @@ def edit(url: str, id_provider: str, client_id: str, debug: bool, **kwargs):
 @click.option('--suggest', help='Filter by post-update user suggestion',
               type=click.Choice(['logout', 'reboot']))
 @click.option('--type', default=None, help='Filter by update type',
-              type=click.Choice(['newpackage', 'security', 'bugfix', 'enhancement']))
+              type=click.Choice(constants.UPDATE_TYPES))
 @click.option('--user', help='Updates submitted by a specific user')
 @click.option('--mine', is_flag=True, help='Show only your updates')
 @add_options(openid_options)

--- a/bodhi-client/bodhi/client/constants.py
+++ b/bodhi-client/bodhi/client/constants.py
@@ -13,3 +13,5 @@ SCOPE = " ".join([
     "https://id.fedoraproject.org/scope/groups",
     "https://id.fedoraproject.org/scope/agreements",
 ])
+UPDATE_TYPES = ['security', 'bugfix', 'enhancement', 'newpackage']
+REQUEST_TYPES = ['testing', 'stable', 'unpush']

--- a/bodhi-client/tests/test_bindings.py
+++ b/bodhi-client/tests/test_bindings.py
@@ -772,6 +772,54 @@ class TestSaveOverride(BodhiClientTestCase):
         expected_expiration = now + timedelta(days=2)
         assert (actual_expiration - expected_expiration) < timedelta(minutes=5)
 
+    def test_save_override_expiration_date(self, mocker):
+        """
+        Test the save_override() method with an explicit expiration date.
+        """
+        client = bindings.BodhiClient()
+        client.send_request = mocker.MagicMock(return_value='return_value')
+        client.csrf_token = 'a token'
+        now = datetime.utcnow()
+        response = client.save_override(nvr='python-pyramid-1.5.6-3.el7',
+                                        expiration_date=now,
+                                        notes='This is needed to build bodhi-2.4.0.')
+
+        assert response == 'return_value'
+        client.send_request.assert_called_once_with(
+            'overrides/', verb='POST', auth=True,
+            data={'nvr': 'python-pyramid-1.5.6-3.el7',
+                  'expiration_date': now,
+                  'csrf_token': 'a token', 'notes': 'This is needed to build bodhi-2.4.0.'})
+
+    def test_save_override_no_expiration(self, mocker):
+        """
+        Test the save_override() method without duration or expiration date.
+        """
+        client = bindings.BodhiClient()
+        client.send_request = mocker.MagicMock(return_value='return_value')
+        client.csrf_token = 'a token'
+        with pytest.raises(TypeError):
+            client.save_override(
+                nvr='python-pyramid-1.5.6-3.el7',
+                notes='This is needed to build bodhi-2.4.0.'
+            )
+
+    def test_save_override_both_expirations(self, mocker):
+        """
+        Test the save_override() method with duration and expiration date.
+        """
+        client = bindings.BodhiClient()
+        client.send_request = mocker.MagicMock(return_value='return_value')
+        client.csrf_token = 'a token'
+        now = datetime.utcnow()
+        with pytest.raises(TypeError):
+            client.save_override(
+                nvr='python-pyramid-1.5.6-3.el7',
+                notes='This is needed to build bodhi-2.4.0.',
+                duration=1,
+                expiration_date=now,
+            )
+
     def test_save_override_edit(self, mocker):
         """
         Test the save_override() method with the edit argument.

--- a/news/PR4431.feature
+++ b/news/PR4431.feature
@@ -1,0 +1,1 @@
+Extend ``save_override()`` to set the expiration date of an override directly.


### PR DESCRIPTION
The fedpkg tool needs to extend the lifetime of overrides, let's make it easier for them and add the feature here.