### PR TITLE
Add --refresh to install command

### DIFF
--- a/bodhi-server/bodhi/server/models.py
+++ b/bodhi-server/bodhi/server/models.py
@@ -2335,11 +2335,12 @@ class Update(Base):
                 or self.release.testing_repository is None:
             return ''
 
-        command = 'sudo {} {}{} --advisory={}{}'.format(
+        command = 'sudo {} {}{}{} --advisory={}{}'.format(
             self.release.package_manager.value,
             'install' if self.type == UpdateType.newpackage else 'upgrade',
             (' --enablerepo=' + self.release.testing_repository)
             if self.status == UpdateStatus.testing else '',
+            ' --refresh' if self.release.package_manager.value == 'dnf' else '',
             self.alias,
             r' \*' if self.type == UpdateType.newpackage else '')
         return command

--- a/bodhi-server/tests/test_models.py
+++ b/bodhi-server/tests/test_models.py
@@ -2298,7 +2298,7 @@ class TestUpdateInstallCommand(BasePyTestCase):
         update.release.testing_repository = 'updates-testing'
 
         assert update.install_command == (
-            f'sudo dnf upgrade --enablerepo=updates-testing --advisory={update.alias}')
+            f'sudo dnf upgrade --enablerepo=updates-testing --refresh --advisory={update.alias}')
 
     def test_upgrade_in_stable(self):
         """Update is an enhancement, a security or a bugfix and is in stable."""
@@ -2308,7 +2308,7 @@ class TestUpdateInstallCommand(BasePyTestCase):
         update.release.package_manager = PackageManager.dnf
         update.release.testing_repository = 'updates-testing'
 
-        assert update.install_command == f'sudo dnf upgrade --advisory={update.alias}'
+        assert update.install_command == f'sudo dnf upgrade --refresh --advisory={update.alias}'
 
     def test_newpackage_in_testing(self):
         """Update is a newpackage and is in testing."""
@@ -2319,7 +2319,8 @@ class TestUpdateInstallCommand(BasePyTestCase):
         update.release.testing_repository = 'updates-testing'
 
         assert update.install_command == (
-            r'sudo dnf install --enablerepo=updates-testing --advisory={} \*'.format(update.alias))
+            r'sudo dnf install --enablerepo=updates-testing --refresh '
+            r'--advisory={} \*'.format(update.alias))
 
     def test_newpackage_in_stable(self):
         """Update is a newpackage and is in stable."""
@@ -2329,7 +2330,8 @@ class TestUpdateInstallCommand(BasePyTestCase):
         update.release.package_manager = PackageManager.dnf
         update.release.testing_repository = 'updates-testing'
 
-        assert update.install_command == r'sudo dnf install --advisory={} \*'.format(update.alias)
+        assert update.install_command == r'sudo dnf install --refresh ' \
+                                         r'--advisory={} \*'.format(update.alias)
 
     def test_cannot_install(self):
         """Update is out of stable or testing repositories."""


### PR DESCRIPTION
Under some circumstances, if a user follows the install command, the
metadata for that install command might not be uptodate. So we add the
--refresh flag to the dnf command to make it download the new metadata

Resolves: #4428

Signed-off-by: Ryan Lerch <rlerch@redhat.com>