### PR TITLE
check for suitable vagrant setup / tinystage

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -57,13 +57,12 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
  # This allows developers to view message queues at http://localhost:15672/
  config.vm.network "forwarded_port", guest: 15672, host: 15672
 
- # This is an optional plugin that, if installed, updates the host's /etc/hosts
+ # This is a plugin that updates the host's /etc/hosts
  # file with the hostname of the guest VM. In Fedora it is packaged as
  # ``vagrant-hostmanager``
- if Vagrant.has_plugin?("vagrant-hostmanager")
-     config.hostmanager.enabled = true
-     config.hostmanager.manage_host = true
- end
+ config.hostmanager.enabled = true
+ config.hostmanager.manage_host = true
+ 
 
  # Vagrant can share the source directory using rsync, NFS, or SSHFS (with the vagrant-sshfs
  # plugin). Consult the Vagrant documentation if you do not want to use SSHFS.

--- a/devel/ansible/playbook.yml
+++ b/devel/ansible/playbook.yml
@@ -4,5 +4,15 @@
   become_method: sudo
   vars:
       ansible_python_interpreter: /usr/bin/python3
+  pre_tasks:
+    - name: Check if ipsilon.tinystage.test is reachable
+      shell: "ping -c 5 ipsilon.tinystage.test"
+      ignore_errors: yes
+      register: ping_response
+    
+    - name: Give reason for failure
+      fail:
+        msg: Provisioning bodhi requires the base tinystage setup to be running.
+      when: ping_response.rc != 0
   roles:
     - bodhi


### PR DESCRIPTION
1. checks to see if tinystage is reachable before trying to provision
   the bodhi machine.
2. remove the contidional on the hostmanager. it is pretty much required
   now because of the use of ipsilon tinystage

Signed-off-by: Ryan Lerch <rlerch@redhat.com>