### PR TITLE
In Vagrant, don't put development.ini inside the repo

### DIFF
--- a/devel/ansible/roles/bodhi/files/bodhi.service
+++ b/devel/ansible/roles/bodhi/files/bodhi.service
@@ -6,7 +6,7 @@ Wants=network-online.target
 [Service]
 Environment=PYTHONWARNINGS=once
 User=vagrant
-ExecStart=/usr/bin/pserve-3 /home/vagrant/bodhi/bodhi-server/development.ini --reload
+ExecStart=/usr/bin/pserve-3 /home/vagrant/development.ini --reload
 
 [Install]
 WantedBy=multi-user.target

--- a/devel/ansible/roles/bodhi/files/motd
+++ b/devel/ansible/roles/bodhi/files/motd
@@ -17,7 +17,7 @@ bstopdeps:   Stop WaiverDB and Greenwave docker services
 bremovedeps: Destroy WaiverDB and Greenwave docker services
 
 
-The BODHI_URL environment variable is set to http://localhost:6543 so the
-bodhi client will use the local development server.
+The BODHI_URL environment variable is set to https://bodhi-dev.example.com/
+so the bodhi client will use the local development server.
 
 Happy hacking!

--- a/devel/ansible/roles/bodhi/tasks/configure_stg.yml
+++ b/devel/ansible/roles/bodhi/tasks/configure_stg.yml
@@ -1,42 +1,42 @@
 ---
 - name: change config to use the koji buildsystem
   ini_file:
-    path: /home/vagrant/bodhi/bodhi-server/development.ini
+    path: /home/vagrant/development.ini
     section: app:main
     option: buildsystem
     value: koji
 
 - name: change config to use the stg kojihub
   ini_file:
-    path: /home/vagrant/bodhi/bodhi-server/development.ini
+    path: /home/vagrant/development.ini
     section: app:main
     option: koji_hub
     value: https://koji.stg.fedoraproject.org/kojihub
 
 - name: change config to use the stg koji
   ini_file:
-    path: /home/vagrant/bodhi/bodhi-server/development.ini
+    path: /home/vagrant/development.ini
     section: app:main
     option: koji_web_url
     value: https://koji.stg.fedoraproject.org/koji/
 
 - name: change config to use the stg kerberos
   ini_file:
-    path: /home/vagrant/bodhi/bodhi-server/development.ini
+    path: /home/vagrant/development.ini
     section: app:main
     option: krb_principal
     value: "{{ staging_fas }}@STG.FEDORAPROJECT.ORG"
 
 - name: change config to use the pagure for acls
   ini_file:
-    path: /home/vagrant/bodhi/bodhi-server/development.ini
+    path: /home/vagrant/development.ini
     section: app:main
     option: acl_system
     value: pagure
 
 - name: change config to use stg pagure for acls
   ini_file:
-    path: /home/vagrant/bodhi/bodhi-server/development.ini
+    path: /home/vagrant/development.ini
     section: app:main
     option: pagure_url
     value: https://src.stg.fedoraproject.org/

--- a/devel/ansible/roles/bodhi/tasks/main.yml
+++ b/devel/ansible/roles/bodhi/tasks/main.yml
@@ -147,9 +147,9 @@
   args:
       creates: /home/vagrant/.db-imported
 
-- command: cp /home/vagrant/bodhi/devel/development.ini.example /home/vagrant/bodhi/bodhi-server/development.ini
+- command: cp /home/vagrant/bodhi/devel/development.ini.example /home/vagrant/development.ini
   args:
-      creates: /home/vagrant/bodhi/bodhi-server/development.ini
+      creates: /home/vagrant/development.ini
 
 - name: Change development.ini to make bodhi use the staging infrastructure
   import_tasks: configure_stg.yml
@@ -303,7 +303,7 @@
 - name: Start and enable the bodhi-related services
   service:
       name: "{{ item }}"
-      state: started
+      state: restarted
       enabled: yes
   with_items:
       - bodhi

--- a/devel/register-with-ipsilon.py
+++ b/devel/register-with-ipsilon.py
@@ -8,7 +8,7 @@ from oidc_register import discovery, registration
 
 REDIRECT_URI = "https://bodhi-dev.example.com/oidc/authorize"
 PROVIDER_URL = "https://ipsilon.tinystage.test/idp/openidc/"
-CONFIG_FILE = "/home/vagrant/bodhi/bodhi-server/development.ini"
+CONFIG_FILE = "/home/vagrant/development.ini"
 PLACEHOLDERS = {
     "client_id": "oidc-client_id",
     "client_secret": "oidc-client_secret",

--- a/docs/developer/vagrant_vscode.rst
+++ b/docs/developer/vagrant_vscode.rst
@@ -50,7 +50,7 @@ When inside the SSH remote set the debug configuration in `launch.json` for Pyra
           "request": "launch",
           "module": "pyramid.scripts.pserve",
           "args": [
-              "/home/vagrant/bodhi/development.ini"
+              "/home/vagrant/development.ini"
           ],
           "pyramid": true,
           "jinja": false,
@@ -82,8 +82,7 @@ The issue is currently tracked in https://github.com/microsoft/vscode-python/iss
 
 After configuring you sould be able to populate the test-explorer with unit-tests and start debugging :-)
 
-Debugging celery 
+Debugging celery
 ===========================
 If you want to debug code running in hte celery worker, you first need to stop the celery service and then start celery from inside vs-code,
 in simmilar fashion as you'd run `pserve` in previous example.
-


### PR DESCRIPTION
This leads to errors when changing branches and rebuilding the Vagrant
machine, because the `development.ini` gets reused.

In existing Vagrant boxes, just move your `bodhi-server/development.ini`
file to `/home/vagrant/development.ini`.
