### PR TITLE
Use namespace packages from this decade, avoid needless .pth files

### DIFF
--- a/bodhi-client/bodhi-client.spec
+++ b/bodhi-client/bodhi-client.spec
@@ -48,7 +48,6 @@ install -pm0644 docs/_build/bodhi.1 %{buildroot}%{_mandir}/man1/
 %files -n %{pypi_name}
 %{_bindir}/bodhi
 %{python3_sitelib}/bodhi
-%{python3_sitelib}/bodhi_client-%{pypi_version}-py%{python3_version}-*.pth
 %{python3_sitelib}/bodhi_client-%{pypi_version}-py%{python3_version}.egg-info
 %{_mandir}/man1/bodhi.1*
 

--- a/bodhi-client/setup.cfg
+++ b/bodhi-client/setup.cfg
@@ -25,7 +25,6 @@ classifiers =
 zip_safe = False
 include_package_data = False
 packages = find_namespace:
-namespace_packages = bodhi
 install_requires =
     click
     koji

--- a/bodhi-messages/bodhi-messages.spec
+++ b/bodhi-messages/bodhi-messages.spec
@@ -39,7 +39,6 @@ rm -rf %{pypi_name}.egg-info
 %files -n python3-%{pypi_name}
 %doc README.rst
 %{python3_sitelib}/bodhi
-%{python3_sitelib}/bodhi_messages-%{pypi_version}-py%{python3_version}-*.pth
 %{python3_sitelib}/bodhi_messages-%{pypi_version}-py%{python3_version}.egg-info
 
 %changelog

--- a/bodhi-messages/setup.cfg
+++ b/bodhi-messages/setup.cfg
@@ -25,7 +25,6 @@ classifiers =
 zip_safe = False
 include_package_data = False
 packages = find_namespace:
-namespace_packages = bodhi
 install_requires =
     fedora_messaging
 

--- a/bodhi-server/bodhi-server.spec
+++ b/bodhi-server/bodhi-server.spec
@@ -141,7 +141,6 @@ install -pm0644 docs/_build/*.1 %{buildroot}%{_mandir}/man1/
 %config(noreplace) %{_sysconfdir}/httpd/conf.d/bodhi.conf
 %dir %{_sysconfdir}/bodhi/
 %{python3_sitelib}/bodhi
-%{python3_sitelib}/bodhi_server-%{pypi_version}-py%{python3_version}-*.pth
 %{python3_sitelib}/bodhi_server-%{pypi_version}-py%{python3_version}.egg-info
 %{_mandir}/man1/bodhi-*.1*
 %{_mandir}/man1/initialize_bodhi_db.1*

--- a/bodhi-server/setup.cfg
+++ b/bodhi-server/setup.cfg
@@ -32,7 +32,6 @@ message_extractors =
 zip_safe = False
 include_package_data = True
 packages = find_namespace:
-namespace_packages = bodhi
 install_requires =
     alembic
     arrow


### PR DESCRIPTION
The `namespace_packages` setuptools options is for pkg_resources-style
namespace packages [1]. It is no longer needed nor recommended by setuptools.

Avoid `bodhi/__init__.py` and `*.pth` files altogether and use Python-native
(PEP 420) namespace packages [2] instead.

Warning: This change requires that all 3 affected packages are updated,
it is not possible to combine a bodhi package from before this change with
another bodhi package from after this change.

[1] https://packaging.python.org/en/latest/guides/packaging-namespace-packages/#pkg-resources-style-namespace-packages
[2] https://packaging.python.org/en/latest/guides/packaging-namespace-packages/#native-namespace-packages

----------


This might be complete moot considering I believe that https://github.com/fedora-infra/bodhi/pull/4376 will result in the same outcome. But OTOH maybe merging this before https://github.com/fedora-infra/bodhi/pull/4376 will make the change more explicit and allow making the poetry transition less magical (at least in this regard).

Untested, hence a draft. Will see what does the :fox_face: say, erhm... CI.