### PR TITLE
copy severity when obsoleting a security update

### DIFF
--- a/bodhi-server/bodhi/server/models.py
+++ b/bodhi-server/bodhi/server/models.py
@@ -2793,6 +2793,7 @@ class Update(Base):
                         'since it obsoletes another security update'
                     })
                     self.type = UpdateType.security
+                    self.severity = oldBuild.update.severity
 
                 if obsoletable:
                     log.info('%s is obsoletable' % oldBuild.nvr)

--- a/bodhi-server/tests/services/test_updates.py
+++ b/bodhi-server/tests/services/test_updates.py
@@ -928,6 +928,7 @@ class TestNewUpdate(BasePyTestCase):
         # Assert that the type of the new update is security.
         up = self.db.query(Build).filter_by(nvr='bodhi-2.0.0-3.fc17').one().update
         assert up.type == UpdateType.security
+        assert up.severity == UpdateSeverity.high
 
     @mock.patch(**mock_valid_requirements)
     def test_obsoletion_security_update(self, *args):


### PR DESCRIPTION
Previously, If a packager obsoletes a security update with a
non-security update type, the newer update is automatically
set to a security update. However, the severity of an update is
validated to be required on security updates.

This commit copies the severity of the obsoleted update to the new
update when changing the new update to a security update.

Resolves: #4441

Signed-off-by: Ryan Lerch <rlerch@redhat.com>