### PR TITLE
Exclude `composes` from Release serialization

### DIFF
--- a/bodhi-server/bodhi/server/models.py
+++ b/bodhi-server/bodhi/server/models.py
@@ -843,7 +843,7 @@ class Release(Base):
     """
 
     __tablename__ = 'releases'
-    __exclude_columns__ = ('id', 'builds')
+    __exclude_columns__ = ('id', 'builds', 'composes')
     __get_by__ = ('name', 'long_name', 'dist_tag')
 
     name = Column(Unicode(10), unique=True, nullable=False)

--- a/news/4447.bug
+++ b/news/4447.bug
@@ -1,0 +1,1 @@
+Exclude the `composes` property when serializing the Release object to avoid recursion


### PR DESCRIPTION
This may be the cause of compose failures when an update is ejected from the push.

Signed-off-by: Mattia Verga <mattia.verga@tiscali.it>