### PR TITLE
We can't switch to JSONSerializer until we drop OpenID support

### DIFF
--- a/bodhi-server/bodhi/server/__init__.py
+++ b/bodhi-server/bodhi/server/__init__.py
@@ -26,7 +26,7 @@ from pyramid.authentication import AuthTktAuthenticationPolicy
 from pyramid.authorization import ACLAuthorizationPolicy
 from pyramid.config import Configurator
 from pyramid.renderers import JSONP
-from pyramid.session import JSONSerializer, SignedCookieSessionFactory
+from pyramid.session import SignedCookieSessionFactory, PickleSerializer
 from pyramid.tweens import EXCVIEW
 from sqlalchemy import engine_from_config, event
 from sqlalchemy.orm import scoped_session, sessionmaker
@@ -250,7 +250,7 @@ def main(global_config, testing=None, session=None, **settings):
     # Sessions & Caching
     session_factory = SignedCookieSessionFactory(
         bodhi_config['session.secret'],
-        serializer=JSONSerializer(),
+        serializer=PickleSerializer(),
     )
 
     # Construct a list of all groups we're interested in


### PR DESCRIPTION
Otherwise we get exceptions such as `Object of type YadisServiceManager is not JSON serializable`