### PR TITLE
Don't redirect to the login page in a loop

### DIFF
--- a/bodhi-server/bodhi/server/auth/utils.py
+++ b/bodhi-server/bodhi/server/auth/utils.py
@@ -152,11 +152,14 @@ def get_final_redirect(request: 'pyramid.request.Request'):
     Returns:
         HTTPFound: An HTTP 302 response redirecting to the right URL.
     """
-    came_from = request.session.get('came_from', '/')
+    came_from = request.session.get('came_from', request.route_path("home"))
     request.session.pop('came_from', None)
 
     # Mitigate "Covert Redirect"
     if not came_from.startswith(request.host_url):
-        came_from = '/'
+        came_from = request.route_path("home")
+    # Don't redirect endlessly to the login view
+    if came_from.startswith(request.route_url('login')):
+        came_from = request.route_path("home")
 
     return HTTPFound(location=came_from)

--- a/devel/ci/bodhi_ci/unit.py
+++ b/devel/ci/bodhi_ci/unit.py
@@ -59,6 +59,7 @@ class UnitJob(Job):
             '  pushd "/tmp/${VERSION[0]}-${VERSION[1]}"; '
             '  python setup.py develop; '
             '  popd; '
+            '  popd; '
             'done; '
             # Run the tests in each submodule
             f'for submodule in {modules}; do '


### PR DESCRIPTION
Without this PR, `came_from` could be the login URL, resulting in a redirect loop.