### PR TITLE
Fix critical path determination for Rawhide updates (#4480)

### DIFF
--- a/bodhi-server/bodhi/server/consumers/automatic_updates.py
+++ b/bodhi-server/bodhi/server/consumers/automatic_updates.py
@@ -183,6 +183,10 @@ class AutomaticUpdateHandler:
                             closing_bugs.append(bug)
             else:
                 notes = f"Automatic update for {bnvr}."
+            if rel.composed_by_bodhi:
+                branch = rel.branch
+            else:
+                branch = 'rawhide'
             update = Update(
                 release=rel,
                 builds=[build],
@@ -194,7 +198,7 @@ class AutomaticUpdateHandler:
                 autokarma=False,
                 user=user,
                 status=UpdateStatus.pending,
-                critpath=Update.contains_critpath_component([build], rel.branch),
+                critpath=Update.contains_critpath_component([build], branch),
             )
 
             # Comment on the update that it was automatically created.

--- a/bodhi-server/bodhi/server/models.py
+++ b/bodhi-server/bodhi/server/models.py
@@ -2415,8 +2415,12 @@ class Update(Base):
         user = User.get(request.user.name)
         data['user'] = user
         caveats = []
+        if data['release'].composed_by_bodhi:
+            branch = data['release'].branch
+        else:
+            branch = 'rawhide'
         data['critpath'] = cls.contains_critpath_component(
-            data['builds'], data['release'].branch)
+            data['builds'], branch)
 
         # Be sure to not add an empty string as alternative title
         # and strip whitespaces from it
@@ -2582,8 +2586,11 @@ class Update(Base):
                     # an override
                     db.delete(b)
 
-        data['critpath'] = cls.contains_critpath_component(
-            up.builds, up.release.branch)
+        if up.release.composed_by_bodhi:
+            branch = up.release.branch
+        else:
+            branch = 'rawhide'
+        data['critpath'] = cls.contains_critpath_component(up.builds, branch)
 
         del(data['builds'])
 


### PR DESCRIPTION
Currently Rawhide updates are never marked as critical path,
because we always use the release's `branch` as the `name` in
the PDC query, but for Rawhide this is incorrect. Bodhi's `branch`
for the release number that's currently Rawhide will be f37 (or
f38, f39... in future), but when querying PDC for the release
that's currently Rawhide, the `name` parameter must be "rawhide".
This fixes that, using the convention used elsewhere of the
release's `composed_by_bodhi` property indicating whether it's
Rawhide.

Signed-off-by: Adam Williamson <awilliam@redhat.com>