### PR TITLE
Highlight comments with negative karma

### DIFF
--- a/bodhi-server/bodhi/server/static/css/site.css
+++ b/bodhi-server/bodhi/server/static/css/site.css
@@ -242,6 +242,14 @@ padding-bottom: 2em;
     box-shadow: 0 0 5px 0px #eee;
 }
 
+.card.user-comment.negative-karma-comment {
+    border-color: #dc3545!important;
+}
+
+.negative-karma-comment .card-header {
+    background-color: #ffc9c9;
+}
+
 .custom-select{
     -webkit-appearance: none;
 }

--- a/bodhi-server/bodhi/server/templates/fragments.html
+++ b/bodhi-server/bodhi/server/templates/fragments.html
@@ -91,7 +91,11 @@ ${statusmap[status]}\
 % else:
 <div class="row my-2">
   <div class="col-md-12">
+  % if comment.karma and comment.karma < 0:
+    <div class="card my-2 user-comment negative-karma-comment">
+  % else:
     <div class="card my-2 user-comment">
+  % endif
       <div class="card-header p-2 text-muted">
         <div class="row no-gutters">
           <div class="col font-size-09">

--- a/news/4500.bug
+++ b/news/4500.bug
@@ -1,0 +1,1 @@
+Updates comments with negative karma are now highlighted in red in the webUI


### PR DESCRIPTION
Fixes #4500 

Comments with negative karma have now highlighted header and borders:
![immagine](https://user-images.githubusercontent.com/17218209/167260023-3e8785bc-fca2-4f2f-9512-dfcd24f7b686.png)


Signed-off-by: Mattia Verga <mattia.verga@tiscali.it>