### PR TITLE
Make karma thumb show presence of negative reports

### DIFF
--- a/bodhi-server/bodhi/server/static/css/site.css
+++ b/bodhi-server/bodhi/server/static/css/site.css
@@ -228,6 +228,12 @@ padding-bottom: 2em;
 .min-width-3{
     min-width: 3em;
 }
+.min-width-4{
+    min-width: 4em;
+}
+.min-width-5{
+    min-width: 5em;
+}
 
 .min-width-35{
     min-width: 3.5em;

--- a/bodhi-server/bodhi/server/templates/fragments.html
+++ b/bodhi-server/bodhi/server/templates/fragments.html
@@ -1,6 +1,6 @@
 <%namespace name="util" module="bodhi.server.util"/>
 
-<%def name="karma(karma, show_digit=False, optional_text=None, zero_thumbsup=True)">
+<%def name="karma(karma, show_digit=False, optional_text=None, zero_thumbsup=True, show_details=None)">
   <%doc>
   Return a span with the karma thumbsup icon, and an optional count of the karma.
 
@@ -13,26 +13,47 @@
       optional_text (str): a string to place after the icon
       zero_thumbsup: if true, and karma is 0, show the thumbsup. otherwise if false,
                      and karma is zero, show thumbsdown.
+      show_details: 2-tuple of the positive and negative karma of an update,
+                    usually provided by _composite_karma property.
   
   </%doc>
-  
+  % if show_details == (0,0):
+    <% show_details = None %>\
+  % endif
   % if karma < 0:
-    <span class="text-danger"><i class="fa fa-thumbs-down pr-1"></i> 
+    <span class="text-danger">
+    <span class="min-width-3 d-inline-block text-center">
+    % if show_details and show_details[0] > 0:
+      <sup class="text-success"><i class="fa fa-thumbs-up"></i></sup>
+    % endif
+    <i class="fa fa-thumbs-down pr-1"></i>
   % elif karma > 0:
-    <span class="text-success"><i class="fa fa-thumbs-up pr-1"></i> 
+    <span class="text-success">
+    <span class="min-width-3 d-inline-block text-center">
+    % if show_details and show_details[1] < 0:
+      <i class="fa fa-thumbs-up"></i>
+      <sub class="text-danger"><i class="fa fa-thumbs-down pr-1"></i></sub>
+    % else:
+      <i class="fa fa-thumbs-up pr-1"></i>
+    % endif
   % else:
     <span class="text-muted">
-    % if zero_thumbsup:
+    <span class="min-width-3 d-inline-block text-center">
+    % if zero_thumbsup and not show_details:
       <i class="fa fa-thumbs-up text-muted pr-1"></i>
-    % else:
+    % elif not show_details:
       <i class="fa fa-thumbs-down text-muted pr-1"></i>
+    % else:
+      <sup class="text-success"><i class="fa fa-thumbs-up"></i></sup>
+      <sub class="text-danger"><i class="fa fa-thumbs-down pr-1"></i></sub>
     % endif
   %endif
+  </span>
   % if optional_text:
     ${optional_text} 
   % endif
   % if show_digit:
-    ${karma}
+      ${karma}
   % endif
   </span>
 </%def>
@@ -209,8 +230,8 @@ ${statusmap[status]}\
               </div>
             %endif
             %if display_karma:
-            <div class="col-auto min-width-3 font-weight-bold mr-3">
-                <div>${karma(update.karma, show_digit=True)}</div>
+            <div class="col-auto min-width-5 font-weight-bold mr-3">
+                <div>${karma(update.karma, show_digit=True, show_details=update._composite_karma)}</div>
             </div>
             %endif
       </div>

--- a/bodhi-server/bodhi/server/templates/update.html
+++ b/bodhi-server/bodhi/server/templates/update.html
@@ -358,7 +358,7 @@ if can_edit and update.release.composed_by_bodhi:
                   <div class="row">
                     <div class="col font-weight-bold text-muted">Karma</div>
                     <div class="col-xs-auto font-weight-bold">
-                        ${self.fragments.karma(update.karma, show_digit=True)}
+                        ${self.fragments.karma(update.karma, show_digit=True, show_details=update._composite_karma)}
                     </div>
                   </div>
               </div>

--- a/news/4501.bug
+++ b/news/4501.bug
@@ -1,0 +1,1 @@
+The "karma thumb" now will show any mixed combination of positive/negative votes, rather than the overall count


### PR DESCRIPTION
Fixes #4501 

The overall karma thumb icon will now show if there are any negative reports when the overall karma is positive and on the other side it will show any positive report when overall karma is negative.
When the karma is zero, it will be possible to distinguish between the absence of reports or a null sum.
Some examples:
![immagine](https://user-images.githubusercontent.com/17218209/167289026-162421dd-7a96-45e0-8585-44b75c57f090.png)

![immagine](https://user-images.githubusercontent.com/17218209/167289053-6690f2f2-24a5-4300-8386-5741b6017e0b.png)

![immagine](https://user-images.githubusercontent.com/17218209/167289070-146d4626-1346-420d-b5b8-11701d9adec3.png)


Signed-off-by: Mattia Verga <mattia.verga@tiscali.it>