### PR TITLE
Small tweaks for enhanced visibility on mobile

### DIFF
--- a/bodhi-server/bodhi/server/templates/fragments.html
+++ b/bodhi-server/bodhi/server/templates/fragments.html
@@ -200,7 +200,7 @@ ${statusmap[status]}\
 <%def name="update(update, display_user=True, display_karma=True, display_commentcount=True)">
   <div class="list-group-item p-1">
       <div class="row align-items-center no-gutters">
-          <div class="col-md">
+          <div class="col-md mb-1 mb-md-0">
               <div class="media">
                   ${util.type2icon(update['type'])|n}
                   <div class="media-body ml-2">
@@ -223,7 +223,7 @@ ${statusmap[status]}\
                   </div>
               </div>
             </div>
-            <div class="col-auto">
+            <div class="col-auto mr-3 mr-md-0">
                 <div>
                   <span class="mr-3 font-size-09 p-1 font-weight-normal badge badge-${status_context(update.status.value)}">${status_text(update)}</span>
                 </div>

--- a/bodhi-server/bodhi/server/templates/update.html
+++ b/bodhi-server/bodhi/server/templates/update.html
@@ -49,33 +49,7 @@ if can_edit and update.release.composed_by_bodhi:
   <div class="col-md-12">
     <div class="h3">
       <div class="row">
-        <div class="col">
-            <div class="media">
-              <div class="text-center">
-                % if update.type:
-                  ${self.util.type2icon(update.type) | n}
-                % endif
-                % if update.critpath:
-                <br/><span data-toggle="tooltip" title="This update is in the critical path" class="ml-n2 text-muted"><small> <i class="fa fa-fw fa-fire"></i></small></span>
-                % endif
-            </div>
-                <div class="media-body ml-0">
-                    <div class="font-weight-bold">
-                      <a href="${request.route_url('update', id=update['alias'])}">
-                      ${update.get_title(amp=True,nvr=True,beautify=True) | h}
-                      </a>
-                    </div>
-                    <div class="h5 mt-1">
-                        ${update.alias} created by <a href="${request.route_url('user', name=update['user']['name'])}"> ${update['user']['name']}</a>
-                        <span title="${update['date_submitted']} UTC"> ${self.util.age(update['date_submitted'])} </span>
-                        for <a href="${request.route_url('release', name=update['release']['name'])}">${update['release']['long_name']}
-                        </a>
-                      </div>
-                </div>
-            </div>
-
-        </div>
-        <div class="col-x-auto">
+        <div class="col-md-auto order-md-last text-right mb-1 mb-md-0">
             % if can_edit and (not update.locked and update.status.value != 'stable'):
               <a id='edit' href="javascript:void(0)" class="btn btn-outline-primary border-0 btn-sm"><span class="fa fa-fw fa-pencil-square-o"></span> Edit</a>
             % elif update.locked and update.date_locked:
@@ -108,6 +82,31 @@ if can_edit and update.release.composed_by_bodhi:
                 </div>
               </div>
             % endif
+        </div>
+        <div class="col-md">
+            <div class="media">
+              <div class="text-center">
+                % if update.type:
+                  ${self.util.type2icon(update.type) | n}
+                % endif
+                % if update.critpath:
+                <br/><span data-toggle="tooltip" title="This update is in the critical path" class="ml-n2 text-muted"><small> <i class="fa fa-fw fa-fire"></i></small></span>
+                % endif
+            </div>
+                <div class="media-body ml-0">
+                    <div class="font-weight-bold">
+                      <a href="${request.route_url('update', id=update['alias'])}">
+                      ${update.get_title(amp=True,nvr=True,beautify=True) | h}
+                      </a>
+                    </div>
+                    <div class="h5 mt-1">
+                        ${update.alias} created by <a href="${request.route_url('user', name=update['user']['name'])}"> ${update['user']['name']}</a>
+                        <span title="${update['date_submitted']} UTC"> ${self.util.age(update['date_submitted'])} </span>
+                        for <a href="${request.route_url('release', name=update['release']['name'])}">${update['release']['long_name']}
+                        </a>
+                      </div>
+                </div>
+            </div>
         </div>
       </div>
     </div>
@@ -165,7 +164,7 @@ if can_edit and update.release.composed_by_bodhi:
   <div class="tab-content">
     <div class="tab-pane active" id="details" role="tabpanel">
       <div class="row">
-        <div class="col-9">
+        <div class="col-md-9">
 
           % if update.notes:
           ${self.util.markup(update.notes) | n}
@@ -326,12 +325,12 @@ if can_edit and update.release.composed_by_bodhi:
           </div>
           %endif
         </div>
-        <div class="col-3 font-size-09">
+        <div class="col-md-3 font-size-09">
             <div class="mt-3">
               <div class="h5 d-flex align-items-center font-weight-bold border-bottom">
                   <div class="py-2 text-uppercase font-size-09">Metadata</div>
               </div>
-              
+
               % if update.type:
               <div class="pb-1">
                   <div class="row">
@@ -473,7 +472,7 @@ if can_edit and update.release.composed_by_bodhi:
                     </div>
                   </div>
               </div>
-              
+
               <div class="pb-1">
                 <div class="row">
                   <div class="col font-weight-bold text-muted">Stable by Time</div>


### PR DESCRIPTION
On mobile devices the update page is too cluttered, this will make some columns to be put on separate rows to enhance visibility.

Note that the "metadata" column will be pushed at the end of the page (after all comments). I couldn't find a way to make it show between the update description and the comments without breaking the page layout on non mobile devices.

Signed-off-by: Mattia Verga <mattia.verga@tiscali.it>