### PR TITLE
Be sure to add release-candidate tag to new builds when editing a sid…

### DIFF
--- a/bodhi-server/bodhi/server/models.py
+++ b/bodhi-server/bodhi/server/models.py
@@ -2621,24 +2621,22 @@ class Update(Base):
                     'sent back to testing.',
                 })
                 builds_to_tag = [b.nvr for b in up.builds]
-                if up.from_tag and not up.release.composed_by_bodhi:
-                    tags = [up.release.get_pending_signing_side_tag(up.from_tag)]
-                elif up.release.pending_signing_tag:
-                    tags = [up.release.pending_signing_tag]
             else:
                 # No need to unpush the update, just tag new builds
                 # into the appropriate pending-signing tag
+                # and release-candidate tag if builds are in side-tag
                 builds_to_tag = new_builds
-                if up.from_tag and not up.release.composed_by_bodhi:
-                    tags = [up.release.get_pending_signing_side_tag(up.from_tag)]
-                elif up.from_tag:
-                    tags = [up.release.candidate_tag]
-                    if up.release.pending_signing_tag:
-                        tags.append(up.release.pending_signing_tag)
-                else:
-                    # For normal updates the builds already have candidate_tag
-                    if up.release.pending_signing_tag:
-                        tags = [up.release.pending_signing_tag]
+
+            if up.from_tag and not up.release.composed_by_bodhi:
+                tags = [up.release.get_pending_signing_side_tag(up.from_tag)]
+            elif up.from_tag:
+                tags = [up.release.candidate_tag]
+                if up.release.pending_signing_tag:
+                    tags.append(up.release.pending_signing_tag)
+            else:
+                # For normal updates the builds already have candidate_tag
+                if up.release.pending_signing_tag:
+                    tags = [up.release.pending_signing_tag]
 
             for tag in tags:
                 tag_update_builds_task.delay(tag=tag, builds=builds_to_tag)

--- a/news/4551.bug
+++ b/news/4551.bug
@@ -1,0 +1,1 @@
+Fixed a tagging problem when updating the builds list in a side-tag update


### PR DESCRIPTION
…e-tag update

Signed-off-by: Mattia Verga <mattia.verga@tiscali.it>