### PR TITLE
Do not disable autopush or set request on rawhide updates

### DIFF
--- a/bodhi-server/bodhi/server/models.py
+++ b/bodhi-server/bodhi/server/models.py
@@ -3801,8 +3801,10 @@ class Update(Base):
         if self.status not in (UpdateStatus.testing, UpdateStatus.pending):
             return
         # If an update receives negative karma disable autopush
+        # exclude rawhide updates see #4566
         if (self.autokarma or self.autotime) and self._composite_karma[1] != 0 and self.status is \
-                UpdateStatus.testing and self.request is not UpdateRequest.stable:
+                UpdateStatus.testing and self.request is not UpdateRequest.stable and \
+                self.release.composed_by_bodhi:
             log.info("Disabling Auto Push since the update has received negative karma")
             self.autokarma = False
             self.autotime = False

--- a/bodhi-server/tests/services/test_updates.py
+++ b/bodhi-server/tests/services/test_updates.py
@@ -5257,8 +5257,9 @@ class TestUpdatesService(BasePyTestCase):
         assert 'text/html' in resp.headers['Content-Type']
         assert 'kernel-3.11.5-300.fc17' in resp
 
-    @mock.patch(**mock_valid_requirements)
-    def test_disable_autopush_non_critical_update_with_negative_karma(self, *args):
+    @unused_mock_patch(**mock_valid_requirements)
+    @pytest.mark.parametrize('rawhide_workflow', (True, False))
+    def test_disable_autopush_non_critical_update_with_negative_karma(self, rawhide_workflow):
         """Disable autokarma on non-critical updates upon negative comment."""
         user = User(name='bob')
         self.db.add(user)
@@ -5276,6 +5277,8 @@ class TestUpdatesService(BasePyTestCase):
         assert resp.json['request'] == 'testing'
         up = self.db.query(Update).filter_by(alias=resp.json['alias']).one()
         up.status = UpdateStatus.testing
+        if rawhide_workflow:
+            up.release.composed_by_bodhi = False
         # Clear pending messages
         self.db.info['messages'] = []
         self.db.commit()
@@ -5283,8 +5286,12 @@ class TestUpdatesService(BasePyTestCase):
         up.comment(self.db, 'Failed to work', author='ralph', karma=-1)
         up = self.db.query(Update).filter_by(alias=resp.json['alias']).one()
 
-        expected_comment = config.get('disable_automatic_push_to_stable')
-        assert up.comments[3].text == expected_comment
+        if not rawhide_workflow:
+            expected_comment = config.get('disable_automatic_push_to_stable')
+            assert len(up.comments) == 4
+            assert up.comments[-1].text == expected_comment
+        else:
+            assert len(up.comments) == 3
 
         up.comment(self.db, 'LGTM Now', author='ralph', karma=1)
         up = self.db.query(Update).filter_by(alias=resp.json['alias']).one()
@@ -5296,11 +5303,18 @@ class TestUpdatesService(BasePyTestCase):
         up = self.db.query(Update).filter_by(alias=resp.json['alias']).one()
 
         assert up.karma == 3
-        assert up.autokarma is False
+        if not rawhide_workflow:
+            assert up.autokarma is False
+        else:
+            assert up.autokarma is True
 
         # Request and Status remains testing since the autopush is disabled
         up = self.db.query(Update).filter_by(alias=resp.json['alias']).one()
-        assert up.request == UpdateRequest.testing
+        if not rawhide_workflow:
+            assert up.request == UpdateRequest.testing
+        else:
+            assert up.request == UpdateRequest.stable
+
         assert up.status == UpdateStatus.testing
 
     @mock.patch(**mock_valid_requirements)

--- a/news/4566.bug
+++ b/news/4566.bug
@@ -1,0 +1,1 @@
+In very peculiar circumstances, side-tag Rawhide updates may remain stuck if a user posts a negative karma or tries to set a request before Bodhi automatically pushes the update to stable


### PR DESCRIPTION
Fixes #4566 

All Rawhide updates (or for any release which is not composed by Bodhi) relies on separate, automatic workflow and we should avoid disabling autopush or setting a request to not break the workflow.