### PR TITLE
Run the integration tests with the same python as in Fedora

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -51,16 +51,16 @@ jobs:
 
   integration_tests:
     name: Integration Tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v2
 
       - name: Install deps
-        run: pip install click -r devel/ci/integration/requirements.txt
+        run: pip3 install click -r devel/ci/integration/requirements.txt
 
       - name: Run the integration tests
-        run: devel/ci/bodhi-ci integration -r ${{ matrix.release }}
+        run: python3 devel/ci/bodhi-ci integration -r ${{ matrix.release }}
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
In Python 3.10, the textwrap.wrap() command wraps differently from previous versions of Python when hyphens are involved.