### PR TITLE
Always run the diff-cover check

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,6 +32,8 @@ jobs:
     name: Diff-cover check
     runs-on: ubuntu-latest
     needs: unit_tests
+    # Run diff-cover even if the unit tests failed on rawhide:
+    if: always()
     steps:
       - uses: actions/checkout@v2
         with:


### PR DESCRIPTION
The unit tests are allowed to fail on Rawhide, but they should not block the diff-cover check from running.