### PR TITLE
Include scenario when waiving test results

### DIFF
--- a/bodhi-server/bodhi/server/models.py
+++ b/bodhi-server/bodhi/server/models.py
@@ -3189,6 +3189,7 @@ class Update(Base):
             data = {
                 'subject': requirement['item'],
                 'testcase': requirement['testcase'],
+                'scenario': requirement.get('scenario', None),
                 'product_version': self.product_version,
                 'waived': True,
                 'username': username,

--- a/bodhi-server/tests/services/test_updates.py
+++ b/bodhi-server/tests/services/test_updates.py
@@ -6179,6 +6179,7 @@ class TestWaiveTestResults(BasePyTestCase):
                 'waived': True,
                 'product_version': 'fedora-17',
                 'testcase': 'dist.rpmdeplint',
+                'scenario': None,
                 'subject': {
                     'item': 'bodhi-2.0-1.fc17', 'type': 'koji_build'
                 }
@@ -6258,6 +6259,7 @@ class TestWaiveTestResults(BasePyTestCase):
                     'waived': True,
                     'product_version': 'fedora-17',
                     'testcase': 'dist.rpmdeplint',
+                    'scenario': None,
                     'subject': {
                         'item': 'bodhi-2.0-1.fc17', 'type': 'koji_build'
                     }
@@ -6271,6 +6273,7 @@ class TestWaiveTestResults(BasePyTestCase):
                     'waived': True,
                     'product_version': 'fedora-17',
                     'testcase': 'atomic_ci_pipeline_results',
+                    'scenario': None,
                     'subject': {
                         'item': 'bodhi-2.0-1.fc17', 'type': 'koji_build'
                     }
@@ -6355,6 +6358,7 @@ class TestWaiveTestResults(BasePyTestCase):
                 'waived': True,
                 'product_version': 'fedora-17',
                 'testcase': 'atomic_ci_pipeline_results',
+                'scenario': None,
                 'subject': {
                     'item': 'bodhi-2.0-1.fc17', 'type': 'koji_build'
                 }
@@ -6438,6 +6442,7 @@ class TestWaiveTestResults(BasePyTestCase):
                     'waived': True,
                     'product_version': 'fedora-17',
                     'testcase': 'dist.rpmdeplint',
+                    'scenario': None,
                     'subject': {
                         'item': 'bodhi-2.0-1.fc17', 'type': 'koji_build'
                     }
@@ -6451,6 +6456,7 @@ class TestWaiveTestResults(BasePyTestCase):
                     'waived': True,
                     'product_version': 'fedora-17',
                     'testcase': 'atomic_ci_pipeline_results',
+                    'scenario': None,
                     'subject': {
                         'item': 'bodhi-2.0-1.fc17', 'type': 'koji_build'
                     }
@@ -6535,6 +6541,7 @@ class TestWaiveTestResults(BasePyTestCase):
                 'waived': True,
                 'product_version': 'fedora-17',
                 'testcase': 'dist.rpmdeplint',
+                'scenario': None,
                 'subject': {
                     'item': 'bodhi-2.0-1.fc17', 'type': 'koji_build'
                 }

--- a/bodhi-server/tests/test_models.py
+++ b/bodhi-server/tests/test_models.py
@@ -4809,6 +4809,7 @@ class TestUpdate(ModelTest):
                 "username": "foo", "comment": "this is not true!", "waived": True,
                 "product_version": "{}".format(self.obj.product_version),
                 "testcase": "{}".format(test),
+                "scenario": None,
                 "subject": {"item": "bodhi-3.6.0-1.fc28", "type": "koji_build"}}
             expected_calls.append(mock.call(
                 '{}/waivers/'.format(config.get('waiverdb_api_url')),
@@ -4847,6 +4848,7 @@ class TestUpdate(ModelTest):
                     'item': {"item": "%s" % update.builds[0].nvr, "type": "koji_build"},
                     'result_id': "123",
                     'testcase': 'dist.depcheck',
+                    'scenario': 'kde',
                     'type': 'test-result-failed'
                 }
             ]
@@ -4860,6 +4862,7 @@ class TestUpdate(ModelTest):
         wdata = {
             'subject': {"item": "%s" % update.builds[0].nvr, "type": "koji_build"},
             'testcase': 'dist.depcheck',
+            'scenario': 'kde',
             'product_version': update.product_version,
             'waived': True,
             'username': 'foo',

--- a/news/4270.bug
+++ b/news/4270.bug
@@ -1,0 +1,1 @@
+Scenario is now included in request data when waiving test results


### PR DESCRIPTION
Waivers should include the test 'scenario' if the gating policy
specifies one. If they don't, they're overbroad (they may match
more results than intended) and trigger an issue in Greenwave
which ultimately means Bodhi won't respect the waiver:

https://pagure.io/greenwave/issue/664

We should fix that issue in Greenwave, but it's also more correct
for Bodhi-issued waivers to include the scenario.

Signed-off-by: Adam Williamson <awilliam@redhat.com>