### PR TITLE
Web UI test result view: generalize 'flavor' discovery for openQA

### DIFF
--- a/bodhi-server/bodhi/server/templates/update.html
+++ b/bodhi-server/bodhi/server/templates/update.html
@@ -970,11 +970,10 @@ ${parent.javascript()}
           }
 
           var flavor;
-          if (scenario.includes("updates-server")) {
-            flavor = "server";
-          }
-          else if (scenario.includes("updates-workstation")) {
-            flavor = "workstation";
+          if (scenario.includes("fedora.updates-")) {
+            // this gets a correct flavor from an openQA scenario, e.g.
+            // 'kde' from 'fedora.updates-kde.x86_64.64bit'
+            flavor = scenario.split(".")[1].slice(8);
           }
 
           table.append(make_row(


### PR DESCRIPTION
We have rather more 'flavors' than just server and workstation; some tests run on server, workstation and kde, so cannot be properly distinguished if we're only tagging server and workstation. This should be a general way to get a correct 'flavor' string for openQA results, and because we check for "fedora.updates-" in the scenario string, it shouldn't do anything weird for results from CI that don't follow the same conventions.

Signed-off-by: Adam Williamson <awilliam@redhat.com>