### PR TITLE
Builds from side-tag must never be tagged with release candidate-tag

### DIFF
--- a/bodhi-server/bodhi/server/models.py
+++ b/bodhi-server/bodhi/server/models.py
@@ -2612,7 +2612,11 @@ class Update(Base):
             data['karma_critipath'] = 0
             up.date_testing = None
 
-            if up.status != UpdateStatus.pending:
+            if (
+                (up.status != UpdateStatus.pending and not up.from_tag)
+                or (up.status != UpdateStatus.pending and up.from_tag
+                    and up.release.composed_by_bodhi)
+            ):
                 # Remove all koji tags and change the status back to pending
                 up.unpush(db)
                 caveats.append({

--- a/news/PR4745.bug
+++ b/news/PR4745.bug
@@ -1,0 +1,1 @@
+Editing a stuck Rawhide side-tag update (usually when gating tests fail) will no more cause builds to be tagged with the release candidate-tag to prevent the automatic update consumer from creating an automatic update and breaking the side-tag update


### PR DESCRIPTION
When editing a rawhide side-tag update stuck due to failed gating, the unpush command causes all the builds to be tagged in release candidate tag, but that can trigger the automatic update consumer and a new update for the tagged build is created.

See https://pagure.io/fedora-infrastructure/issue/10900

Signed-off-by: Mattia Verga <mattia.verga@tiscali.it>