### PR TITLE
When possible, use grouped critpath data for greenwave queries and show it in UI tooltips

### DIFF
--- a/bodhi-client/.coveragerc
+++ b/bodhi-client/.coveragerc
@@ -2,10 +2,7 @@
 branch = True
 source = bodhi
 omit =
-    bodhi/scripts/*
-    bodhi/server/static/__init__.py
-    bodhi/tests/*
-    bodhi/server/migrations/*
+    tests/*
 
 [report]
 precision = 2

--- a/bodhi-messages/.coveragerc
+++ b/bodhi-messages/.coveragerc
@@ -1,0 +1,16 @@
+[run]
+branch = True
+source = bodhi
+omit =
+    tests/*
+
+[report]
+precision = 2
+fail_under = 99
+exclude_lines =
+    pragma: no cover
+    class DevBuildsys
+    def __repr__
+    def multicall_enabled
+    if __name__ == .__main__.:
+show_missing = True

--- a/bodhi-server/.coveragerc
+++ b/bodhi-server/.coveragerc
@@ -1,0 +1,19 @@
+[run]
+branch = True
+source = bodhi
+omit =
+    bodhi/server/scripts/*
+    bodhi/server/static/__init__.py
+    tests/*
+    bodhi/server/migrations/*
+
+[report]
+precision = 2
+fail_under = 98
+exclude_lines =
+    pragma: no cover
+    class DevBuildsys
+    def __repr__
+    def multicall_enabled
+    if __name__ == .__main__.:
+show_missing = True

--- a/bodhi-server/bodhi/server/consumers/automatic_updates.py
+++ b/bodhi-server/bodhi/server/consumers/automatic_updates.py
@@ -183,6 +183,12 @@ class AutomaticUpdateHandler:
                             closing_bugs.append(bug)
             else:
                 notes = f"Automatic update for {bnvr}."
+            try:
+                critpath_groups = Update.get_critpath_groups([build], rel.branch)
+                critpath = bool(critpath_groups)
+            except ValueError:
+                critpath_groups = None
+                critpath = Update.contains_critpath_component([build], rel.branch)
             update = Update(
                 release=rel,
                 builds=[build],
@@ -194,7 +200,8 @@ class AutomaticUpdateHandler:
                 autokarma=False,
                 user=user,
                 status=UpdateStatus.pending,
-                critpath=Update.contains_critpath_component([build], rel.branch),
+                critpath_groups=critpath_groups,
+                critpath=critpath,
             )
 
             # Comment on the update that it was automatically created.

--- a/bodhi-server/bodhi/server/migrations/versions/f393d006559b_add_critpath_groups_to_update.py
+++ b/bodhi-server/bodhi/server/migrations/versions/f393d006559b_add_critpath_groups_to_update.py
@@ -1,0 +1,41 @@
+# Copyright (c) 2022 Mattia Verga
+#
+# This file is part of Bodhi.
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+"""
+Add critpath_groups to Update.
+
+Revision ID: f393d006559b
+Revises: d399493275b6
+Create Date: 2022-10-10 12:08:18.583231
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'f393d006559b'
+down_revision = 'd399493275b6'
+
+
+def upgrade():
+    """Add new critpath_groups column to updates table."""
+    op.add_column('updates', sa.Column('critpath_groups', sa.UnicodeText(), nullable=True))
+
+
+def downgrade():
+    """Remove critpath_groups column from updates table."""
+    op.drop_column('updates', 'critpath_groups')

--- a/bodhi-server/bodhi/server/models.py
+++ b/bodhi-server/bodhi/server/models.py
@@ -76,10 +76,12 @@ from bodhi.server.util import avatar as get_avatar
 from bodhi.server.util import (
     build_evr,
     get_critpath_components,
+    get_grouped_critpath_components,
     get_rpm_header,
     header,
     pagure_api_get,
     tokenize,
+    build_names_by_type,
 )
 
 
@@ -1883,6 +1885,10 @@ class Update(Base):
             :class:`Package`. Critical path packages are packages that are required for
             basic functionality. For example, the kernel :class:`RpmPackage` is a critical
             path package.
+        critpath_groups (str): Space-separated list of critical path groups the package(s)
+            in this update are members of. More detailed version of critpath. Empty string
+            means "no groups" (same as critpath=False); None/null means "feature not supported"
+            (i.e. the configured critpath.type doesn't give grouped critpath info).
         close_bugs (bool): Indicates whether the Bugzilla bugs that this update is related
             to should be closed automatically when the update is pushed to stable.
         date_submitted (DateTime): The date that the update was created.
@@ -1942,6 +1948,7 @@ class Update(Base):
     locked = Column(Boolean, default=False)
     pushed = Column(Boolean, default=False)
     critpath = Column(Boolean, default=False)
+    critpath_groups = Column(UnicodeText, nullable=True)
 
     # Bug settings
     close_bugs = Column(Boolean, default=True)
@@ -2162,6 +2169,31 @@ class Update(Base):
         return comments_since_karma_reset
 
     @staticmethod
+    def get_critpath_groups(builds, release_branch):
+        """
+        Determine which (if any) critpath groups the builds passed in are part of.
+
+        Args:
+            builds (list): :class:`Builds <Build>` to be considered.
+            release_branch (str): The name of the git branch associated to the release,
+                such as "f25" or "master".
+        Returns:
+            str: A space-separated list of the critpath groups. Will be empty if none.
+        Raises:
+            ValueError: If the configured critpath.type does not list by group.
+        """
+        components = build_names_by_type(builds)
+        groups = []
+
+        for ptype in components:
+            groups.extend(
+                get_grouped_critpath_components(
+                    release_branch, ptype, frozenset(components[ptype])
+                )
+            )
+        return " ".join(groups)
+
+    @staticmethod
     def contains_critpath_component(builds, release_branch):
         """
         Determine if there is a critpath component in the builds passed in.
@@ -2175,12 +2207,7 @@ class Update(Base):
         Raises:
             RuntimeError: If the PDC did not give us a 200 code.
         """
-        components = defaultdict(list)
-        # Get the mess down to a dict of ptype -> [pname]
-        for build in builds:
-            ptype = build.package.type.value
-            pname = build.package.name
-            components[ptype].append(pname)
+        components = build_names_by_type(builds)
 
         for ptype in components:
             if get_critpath_components(release_branch, ptype, frozenset(components[ptype])):
@@ -2416,8 +2443,14 @@ class Update(Base):
         user = User.get(request.user.name)
         data['user'] = user
         caveats = []
-        data['critpath'] = cls.contains_critpath_component(
-            data['builds'], data['release'].branch)
+        try:
+            data['critpath_groups'] = cls.get_critpath_groups(
+                data['builds'], data['release'].branch)
+            data['critpath'] = bool(data['critpath_groups'])
+        except ValueError:
+            data['critpath_groups'] = None
+            data['critpath'] = cls.contains_critpath_component(
+                data['builds'], data['release'].branch)
 
         # Be sure to not add an empty string as alternative title
         # and strip whitespaces from it
@@ -2583,8 +2616,14 @@ class Update(Base):
                     # an override
                     db.delete(b)
 
-        data['critpath'] = cls.contains_critpath_component(
-            up.builds, up.release.branch)
+        try:
+            data['critpath_groups'] = cls.get_critpath_groups(
+                up.builds, up.release.branch)
+            data['critpath'] = bool(data['critpath_groups'])
+        except ValueError:
+            data['critpath_groups'] = None
+            data['critpath'] = cls.contains_critpath_component(
+                up.builds, up.release.branch)
 
         del data['builds']
 

--- a/bodhi-server/bodhi/server/templates/update.html
+++ b/bodhi-server/bodhi/server/templates/update.html
@@ -89,7 +89,9 @@ if can_edit and update.release.composed_by_bodhi:
                 % if update.type:
                   ${self.util.type2icon(update.type) | n}
                 % endif
-                % if update.critpath:
+                % if update.critpath_groups:
+                <br/><span data-bs-toggle="tooltip" title="This update is in critical path groups ${update.critpath_groups}" class="ms-n2 text-muted"><small> <i class="fa fa-fw fa-fire"></i></small></span>
+                % elif update.critpath:
                 <br/><span data-bs-toggle="tooltip" title="This update is in the critical path" class="ms-n2 text-muted"><small> <i class="fa fa-fw fa-fire"></i></small></span>
                 % endif
               </div>

--- a/bodhi-server/tests/services/test_updates.py
+++ b/bodhi-server/tests/services/test_updates.py
@@ -6764,9 +6764,12 @@ class TestGetTestResults(BasePyTestCase):
     def test_get_test_results_calling_greenwave(self, call_api, *args):
         """
         Ensure if all conditions are met we do try to call greenwave with the proper
-        argument.
+        argument for a non-critical-path update, without critical path group
+        support.
         """
         update = Build.query.filter_by(nvr='bodhi-2.0-1.fc17').one().update
+        update.critpath = False
+        update.critpath_groups = None
         call_api.return_value = {"foo": "bar"}
 
         res = self.app.get(f'/updates/{update.alias}/get-test-results')
@@ -6798,6 +6801,7 @@ class TestGetTestResults(BasePyTestCase):
         """
         update = Build.query.filter_by(nvr='bodhi-2.0-1.fc17').one().update
         update.critpath = True
+        update.critpath_groups = None
         call_api.return_value = {"foo": "bar"}
 
         res = self.app.get(f'/updates/{update.alias}/get-test-results')
@@ -6821,6 +6825,78 @@ class TestGetTestResults(BasePyTestCase):
         ]
 
         assert res.json_body == {'decisions': [{'foo': 'bar'}, {'foo': 'bar'}]}
+
+    @mock.patch.dict(config, [('greenwave_api_url', 'https://greenwave.api')])
+    @mock.patch('bodhi.server.util.call_api')
+    def test_get_test_results_calling_greenwave_critpath_groups(self, call_api, *args):
+        """
+        Ensure if all conditions are met we do try to call greenwave with the proper
+        arguments for a critical path update when critical path group support
+        is present.
+        """
+        update = Build.query.filter_by(nvr='bodhi-2.0-1.fc17').one().update
+        update.critpath = True
+        update.critpath_groups = 'core critical-path-apps'
+        call_api.return_value = {"foo": "bar"}
+
+        res = self.app.get(f'/updates/{update.alias}/get-test-results')
+
+        assert call_api.call_args_list == [
+            mock.call(
+                'https://greenwave.api/decision',
+                data={
+                    'product_version': 'fedora-17',
+                    'decision_context': context,
+                    'subject': [
+                        {'item': 'bodhi-2.0-1.fc17', 'type': 'koji_build'},
+                        {'item': update.alias, 'type': 'bodhi_update'}
+                    ],
+                    'verbose': True,
+                },
+                method='POST',
+                retries=3,
+                service_name='Greenwave'
+            ) for context in (
+                'bodhi_update_push_testing_critical-path-apps_critpath',
+                'bodhi_update_push_testing_core_critpath',
+                'bodhi_update_push_testing',
+            )
+        ]
+
+        assert res.json_body == {'decisions': [{'foo': 'bar'}, {'foo': 'bar'}, {'foo': 'bar'}]}
+
+    @mock.patch.dict(config, [('greenwave_api_url', 'https://greenwave.api')])
+    @mock.patch('bodhi.server.util.call_api')
+    def test_get_test_results_calling_greenwave_critpath_groups_empty(self, call_api, *args):
+        """
+        Ensure if all conditions are met we do try to call greenwave with the proper
+        arguments for a critical path update when critical path group support
+        is present, but the update is not in any groups.
+        """
+        update = Build.query.filter_by(nvr='bodhi-2.0-1.fc17').one().update
+        update.critpath = False
+        update.critpath_groups = ''
+        call_api.return_value = {"foo": "bar"}
+
+        res = self.app.get(f'/updates/{update.alias}/get-test-results')
+
+        call_api.assert_called_once_with(
+            'https://greenwave.api/decision',
+            data={
+                'product_version': 'fedora-17',
+                'decision_context': 'bodhi_update_push_testing',
+                'subject': [
+                    {'item': 'bodhi-2.0-1.fc17', 'type': 'koji_build'},
+                    {'item': update.alias, 'type': 'bodhi_update'}
+                ],
+                'verbose': True,
+            },
+            method='POST',
+            retries=3,
+            service_name='Greenwave'
+        )
+
+        assert res.json_body == {'decisions': [{'foo': 'bar'}]}
 
     @mock.patch('bodhi.server.util.call_api')
     def test_get_test_results_calling_greenwave_no_session(self, call_api, *args):

--- a/bodhi-server/tests/tasks/test_check_policies.py
+++ b/bodhi-server/tests/tasks/test_check_policies.py
@@ -53,7 +53,7 @@ class TestCheckPolicies(BaseTaskTestCase):
         """Assert correct behavior when the policies enforced by Greenwave are satisfied"""
         update = self.db.query(models.Update).all()[0]
         update.status = models.UpdateStatus.testing
-        update.critpath = True
+        update.critpath_groups = "core"
         # Clear pending messages
         self.db.info['messages'] = []
         self.db.commit()
@@ -103,7 +103,7 @@ class TestCheckPolicies(BaseTaskTestCase):
                     {'item': 'FEDORA-{}-a3bbe1a8f2'.format(datetime.datetime.utcnow().year),
                      'type': 'bodhi_update'}],
                 'verbose': False
-            } for context in ('bodhi_update_push_stable_critpath', 'bodhi_update_push_stable')
+            } for context in ('bodhi_update_push_stable_core_critpath', 'bodhi_update_push_stable')
         ]
         expected_calls = [
             call(config['greenwave_api_url'] + '/decision', query) for query in expected_queries
@@ -116,7 +116,7 @@ class TestCheckPolicies(BaseTaskTestCase):
         greenwave with the ``bodhi_update_push_testing`` decision context. """
         update = self.db.query(models.Update).all()[0]
         update.status = models.UpdateStatus.pending
-        update.critpath = True
+        update.critpath_groups = "core"
         self.db.commit()
         with patch('bodhi.server.models.util.greenwave_api_post') as mock_greenwave:
             greenwave_responses = [
@@ -165,7 +165,9 @@ class TestCheckPolicies(BaseTaskTestCase):
                     {'item': 'FEDORA-{}-a3bbe1a8f2'.format(datetime.datetime.utcnow().year),
                      'type': 'bodhi_update'}],
                 'verbose': False,
-            } for context in ('bodhi_update_push_testing_critpath', 'bodhi_update_push_testing')
+            } for context in (
+                'bodhi_update_push_testing_core_critpath', 'bodhi_update_push_testing'
+            )
         ]
         expected_calls = [
             call(config['greenwave_api_url'] + '/decision', query) for query in expected_queries
@@ -180,7 +182,7 @@ class TestCheckPolicies(BaseTaskTestCase):
         """
         update = self.db.query(models.Update).all()[0]
         update.status = models.UpdateStatus.testing
-        update.critpath = True
+        update.critpath_groups = "core"
         # Clear pending messages
         self.db.info['messages'] = []
         update.date_submitted = datetime.datetime.utcnow()
@@ -249,7 +251,7 @@ class TestCheckPolicies(BaseTaskTestCase):
                     {'item': 'FEDORA-{}-a3bbe1a8f2'.format(datetime.datetime.utcnow().year),
                      'type': 'bodhi_update'}],
                 'verbose': False
-            } for context in ('bodhi_update_push_stable_critpath', 'bodhi_update_push_stable')
+            } for context in ('bodhi_update_push_stable_core_critpath', 'bodhi_update_push_stable')
         ]
         expected_calls = [
             call(config['greenwave_api_url'] + '/decision', query) for query in expected_queries
@@ -264,7 +266,7 @@ class TestCheckPolicies(BaseTaskTestCase):
         """
         update = self.db.query(models.Update).all()[0]
         update.status = models.UpdateStatus.testing
-        update.critpath = True
+        update.critpath_groups = "core"
         # Clear pending messages
         self.db.info['messages'] = []
         update.date_submitted = datetime.datetime.utcnow() - datetime.timedelta(days=1)
@@ -326,7 +328,8 @@ class TestCheckPolicies(BaseTaskTestCase):
             assert update.comments[-1].text == expected_comment
 
         expected_query = {
-            'product_version': 'fedora-17', 'decision_context': 'bodhi_update_push_stable_critpath',
+            'product_version': 'fedora-17',
+            'decision_context': 'bodhi_update_push_stable_core_critpath',
             'subject': [
                 {'item': 'bodhi-2.0-1.fc17', 'type': 'koji_build'},
                 {'item': 'FEDORA-{}-a3bbe1a8f2'.format(datetime.datetime.utcnow().year),
@@ -350,7 +353,7 @@ class TestCheckPolicies(BaseTaskTestCase):
         """
         update = self.db.query(models.Update).all()[0]
         update.status = models.UpdateStatus.testing
-        update.critpath = True
+        update.critpath_groups = "core"
         update.date_submitted = datetime.datetime.utcnow()
         # Clear pending messages
         self.db.info['messages'] = []
@@ -421,7 +424,7 @@ class TestCheckPolicies(BaseTaskTestCase):
                     {'item': 'FEDORA-{}-a3bbe1a8f2'.format(datetime.datetime.utcnow().year),
                      'type': 'bodhi_update'}],
                 'verbose': False
-            } for context in ('bodhi_update_push_stable_critpath', 'bodhi_update_push_stable')
+            } for context in ('bodhi_update_push_stable_core_critpath', 'bodhi_update_push_stable')
         ]
         expected_calls = [
             call(config['greenwave_api_url'] + '/decision', query) for query in expected_queries
@@ -467,6 +470,9 @@ class TestCheckPolicies(BaseTaskTestCase):
         update.status = models.UpdateStatus.testing
         # Clear pending messages
         self.db.info['messages'] = []
+        # note: this test is intentionally on the 'older' codepath using
+        # non-grouped critpath info to ensure that path works.
+        update.critpath_groups = None
         update.critpath = True
         update.pushed = True
         self.db.commit()

--- a/bodhi-server/tests/test_models.py
+++ b/bodhi-server/tests/test_models.py
@@ -3432,6 +3432,27 @@ class TestUpdate(ModelTest):
             branch='fc25', version='25')
         assert not update.contains_critpath_component(update.builds, update.release.name)
 
+    def test_critpath_groups(self, critpath_json_config):
+        (tempdir, _) = critpath_json_config
+        config.update({
+            'critpath.type': 'json',
+            'critpath.jsonpath': tempdir
+        })
+        update = self.get_update()
+        update.release = model.Release(
+            name='F36', long_name='Fedora 36',
+            id_prefix='FEDORA', dist_tag='f36',
+            stable_tag='f36-updates',
+            testing_tag='f36-updates-testing',
+            candidate_tag='f36-updates-candidate',
+            pending_signing_tag='f36-updates-testing-signing',
+            pending_testing_tag='f36-updates-testing-pending',
+            pending_stable_tag='f36-updates-pending',
+            override_tag='f36-override',
+            branch='f36', version='36')
+        groups = update.get_critpath_groups(update.builds, update.release.branch)
+        assert groups == "core"
+
     def test_unpush_build(self):
         assert len(self.obj.builds) == 1
         b = self.obj.builds[0]

--- a/bodhi-server/tests/test_models.py
+++ b/bodhi-server/tests/test_models.py
@@ -3083,13 +3083,21 @@ class TestUpdate(ModelTest):
         for critpath update with multiple batches.
         """
         with mock.patch.dict('bodhi.server.models.config', {'greenwave_batch_size': 1}):
-            self.obj.critpath = True
+            self.obj.critpath_groups = "core critical-path-apps"
             assert self.obj.greenwave_subject_batch_size == 1
             assert self.obj.greenwave_request_batches(verbose=True) == (
                 [
                     {
                         'product_version': 'fedora-11',
-                        'decision_context': 'bodhi_update_push_testing_critpath',
+                        'decision_context': 'bodhi_update_push_testing_critical-path-apps_critpath',
+                        'verbose': True,
+                        'subject': [
+                            {'item': 'TurboGears-1.0.8-3.fc11', 'type': 'koji_build'},
+                        ]
+                    },
+                    {
+                        'product_version': 'fedora-11',
+                        'decision_context': 'bodhi_update_push_testing_core_critpath',
                         'verbose': True,
                         'subject': [
                             {'item': 'TurboGears-1.0.8-3.fc11', 'type': 'koji_build'},
@@ -3105,7 +3113,15 @@ class TestUpdate(ModelTest):
                     },
                     {
                         'product_version': 'fedora-11',
-                        'decision_context': 'bodhi_update_push_testing_critpath',
+                        'decision_context': 'bodhi_update_push_testing_critical-path-apps_critpath',
+                        'verbose': True,
+                        'subject': [
+                            {'item': self.obj.alias, 'type': 'bodhi_update'},
+                        ]
+                    },
+                    {
+                        'product_version': 'fedora-11',
+                        'decision_context': 'bodhi_update_push_testing_core_critpath',
                         'verbose': True,
                         'subject': [
                             {'item': self.obj.alias, 'type': 'bodhi_update'},

--- a/news/summary.migration
+++ b/news/summary.migration
@@ -1,0 +1,1 @@
+The `critpath_groups` column has been added to the Update model (pr:4759)


### PR DESCRIPTION
This builds on https://github.com/fedora-infra/bodhi/pull/4755 to actually use the grouped critpath data for useful things. Primarily, it splits up the greenwave critpath queries by group. As well as the non-critpath greenwave query we run for all updates, for critpath updates, we would now run as many additional queries as there are critpath groups represented in the update, one per group. The point of this is so we can have different gating policies for the different groups (which would also allow us to only *run* a subset of tests for updates which are e.g. only on the "server critpath"; currently we have to run all tests for all critpath updates, because all critpath updates are gated on the full set of tests).

The obvious drawback of this is we are running additional greenwave queries. It'd be nice if we could somehow group or batch them, but at least with current greenwave we can't. I might look at doing that on the greenwave end. I don't think this is a crucial problem, though. In production, Bodhi talking to Greenwave should be very fast as they're on the same network.

We also would show which critpath groups a critpath update includes packages from in the tooltip shown when you hover over the icon indicating an update is in in the critical path. It might be nice to make this information available more prominently too, but at least doing this was easy.

One thing I know is missing from this PR so far: it needs a database migration file, but I can't generate one as I haven't been able to successfully set up a Bodhi development environment with working postgres database. I could write one by hand easily enough, but not sure if it matters what it's called. If I just need to use a random string in the file name I can do that. Otherwise, if someone with a working dev env could generate the migration file for me, that'd be great.

One thing I think should be OK but I'm not 100% sure: I'd want the new critpath_groups property to be exposed in the API - i.e. when I ask the Bodhi API for an update, I want to know what critpath groups it's in (this will be necessary for the "only schedule the appropriate tests for the groups the update is in" part of this). I don't *think* I need to do anything extra to make this happen, but if I do, please let me know.