### PR TITLE
Add users for Bodhi development to tinystage

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -37,9 +37,9 @@ end
 VAGRANTFILE_API_VERSION = "2"
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
- config.vm.box_url = "https://download.fedoraproject.org/pub/fedora/linux/releases/35/Cloud/x86_64/images/Fedora-Cloud-Base-Vagrant-35-1.2.x86_64.vagrant-libvirt.box"
- config.vm.box = "f35-cloud-libvirt"
- config.vm.box_download_checksum = "239cbcd6143396e382ed4eafebf5ab870c80042c44a6a7cdb5d041f8fe35b1db"
+ config.vm.box_url = "https://download.fedoraproject.org/pub/fedora/linux/releases/36/Cloud/x86_64/images/Fedora-Cloud-Base-Vagrant-36-1.5.x86_64.vagrant-libvirt.box"
+ config.vm.box = "f36-cloud-libvirt"
+ config.vm.box_download_checksum = "afa6304fddb15aaa1a4877c251ac15482726877c86861ed23385ef9f7750f9c0"
  config.vm.box_download_checksum_type = "sha256"
 
  # Forward traffic on the host to the development server on the guest.
@@ -74,7 +74,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
  # to create and use a dnf cache directory
  #
  # Dir.mkdir('.dnf-cache') unless File.exists?('.dnf-cache')
- # config.vm.synced_folder ".dnf-cache", "/var/cache/dnf", type: "sshfs", sshfs_opts_append: "-o nonempty"
+ # config.vm.synced_folder ".dnf-cache", "/var/cache/dnf", type: "sshfs"
 
  # Comment this line if you would like to disable the automatic update during provisioning
  config.vm.provision "shell", inline: "sudo dnf upgrade -y"

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -6,35 +6,14 @@
 # cd bodhi
 # cp devel/Vagrantfile.example Vagrantfile
 # vagrant up
-
-# There is also an option when provisioning to setup bodhi
-# to use the fedora stg infratucture for koji and src.stg (for package acls)
-# To use this, use the command:
 #
-# vagrant --use-staging up
-#
-# vagrant will prompt you for for fas username for auth to koji. Additionally
-# after the box is finished, you will need to aquire a kerberos ticket periodically
-# with `kinit <fasusername>@STG.FEDORAPROJECT.ORG` for bodhi to be able to auth with
-# the stg koji.
+# remember to set the value of fas_username
 
 require 'etc'
 
-use_staging_infra = false
-
-# Don't use GetoptLong/OptionParser as it conflicts with options for the main program.
-if ARGV.include?('--use-staging')
-  use_staging_infra = true
-  ARGV.delete('--use-staging')
-end
-
-if use_staging_infra
-    print "Enter your FAS username for krb auth to staging: "
-    fasusername = STDIN.gets.chomp
-    print "\n"
-end
-
 VAGRANTFILE_API_VERSION = "2"
+
+fas_username = ""
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
  config.vm.box_url = "https://download.fedoraproject.org/pub/fedora/linux/releases/36/Cloud/x86_64/images/Fedora-Cloud-Base-Vagrant-36-1.5.x86_64.vagrant-libvirt.box"
@@ -82,14 +61,9 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
  # bootstrap and run with ansible
  config.vm.provision "ansible" do |ansible|
      ansible.playbook = "devel/ansible/playbook.yml"
-
-     # if vagrant is given a fas username, assume the user is using the stg infrastructure
-     if fasusername
-        ansible.extra_vars = {
-        staging_fas: fasusername,
-        use_staging_infra: true
-        }
-     end
+     ansible.extra_vars = {
+        fas_username: fas_username
+    }
  end
 
 

--- a/devel/ansible/roles/bodhi/tasks/main.yml
+++ b/devel/ansible/roles/bodhi/tasks/main.yml
@@ -151,14 +151,6 @@
   args:
     creates: /srv/venv/bin/python
 
-# Setuptools update to ensure the celery >=5.2.3 works well
-- name: Update python3-setuptools in the venv
-  command: poetry update setuptools
-  become: yes
-  become_user: vagrant
-  args:
-    chdir: /home/vagrant/bodhi/bodhi-server
-
 - name: Install bodhi with poetry
   command: poetry install
   become: yes

--- a/devel/ansible/roles/bodhi/tasks/main.yml
+++ b/devel/ansible/roles/bodhi/tasks/main.yml
@@ -43,8 +43,10 @@
       - python3-devel
       - python3-diff-cover
       - python3-dogpile-cache
+      - python3-faker
       - python3-flake8
       - python3-flake8-import-order
+      - python3-freeipa
       - python3-ipdb
       - python3-koji
       - python3-librepo
@@ -188,10 +190,6 @@
     - {key: "celery_config", value: "%(here)s/bodhi/bodhi-server/celeryconfig.py"}
     - {key: "pungi.basepath", value: "%(here)s/bodhi/devel/ci/integration/bodhi/"}
 
-- name: Change development.ini to make bodhi use the staging infrastructure
-  import_tasks: configure_stg.yml
-  when: (staging_fas is defined) and use_staging_infra
-
 - name: Creates /etc/bodhi directory
   file:
     path: /etc/bodhi
@@ -324,6 +322,20 @@
     insertbefore: "</VirtualHost>"
     regexp: "^RequestHeader set X-Forwarded-Proto https$"
     line: RequestHeader set X-Forwarded-Proto https
+
+- name: Copy the create users and groups script
+  template:
+      src: create-freeipa-users-grps.py
+      dest: /home/vagrant/create-freeipa-users-grps.py
+      mode: 0644
+      owner: vagrant
+      group: vagrant
+
+- name: Add development users to tinystage
+  shell: python create-freeipa-users-grps.py > users-creation.log
+  args:
+    chdir: /home/vagrant/
+    creates: users-creation.log
 
 - name: Setup httpd
   copy:

--- a/devel/ansible/roles/bodhi/templates/create-freeipa-users-grps.py
+++ b/devel/ansible/roles/bodhi/templates/create-freeipa-users-grps.py
@@ -1,0 +1,51 @@
+from faker import Faker
+
+import python_freeipa
+
+USER_PASSWORD = "password"
+
+fake = Faker()
+fake.seed_instance(0)
+
+ipa = python_freeipa.ClientLegacy(
+    host="ipa.tinystage.test", verify_ssl="/etc/ipa/ca.crt"
+)
+ipa.login("admin", "password")
+
+for group in ["packager", "provenpackager"]:
+    if ipa.group_find(cn=group).get('result') != []:
+        print(f"group {group} is already in tinystage")
+        continue
+    ipa.group_add(group, f"A group for {group}", fasgroup=True)
+    ipa._request("fasagreement_add_group", "FPCA", {"group": group})
+
+for username in ["tinystage_packager", "tinystage_provenpackager", "{{ fas_username }}"]:
+    if username == "":
+        continue
+    if ipa.user_find(uid=username).get('result') != []:
+        print(f"user {username} is already in tinystage")
+        continue
+    firstName = fake.first_name()
+    lastName = fake.last_name()
+    fullname = firstName + " " + lastName
+    print(f"adding user {username} - {fullname}")
+    try:
+        ipa.user_add(
+            username,
+            firstName,
+            lastName,
+            fullname,
+            disabled=False,
+            user_password=USER_PASSWORD,
+            fasircnick=[username, username + "_"],
+            faslocale="en-US",
+            fastimezone="Australia/Brisbane",
+            fasstatusnote="active",
+            fasgpgkeyid=[],
+        )
+        ipa._request("fasagreement_add_user", "FPCA", {"user": username})
+        ipa.group_add_member("packager", username)
+        if username == "tinystage_provenpackager":
+            ipa.group_add_member("provenpackager", username)
+    except python_freeipa.exceptions.FreeIPAError as e:
+        print(e)

--- a/docs/developer/vagrant.rst
+++ b/docs/developer/vagrant.rst
@@ -11,9 +11,9 @@ get started, simply use these commands::
     $ sudo systemctl enable libvirtd
     $ sudo systemctl start libvirtd
 
-As of 2022, bodhi now uses OpenID Connect (OIDC) for authentication. For the vagrant development environment, 
-this requires a running FreeIPA and Ipsilon instance. Running tinystage 
-(https://github.com/fedora-infra/tiny-stage) will set these up. Ensure that tinystage is running before trying 
+As of 2022, bodhi now uses OpenID Connect (OIDC) for authentication. For the vagrant development environment,
+this requires a running FreeIPA and Ipsilon instance. Running tinystage
+(https://github.com/fedora-infra/tiny-stage) will set these up. Ensure that tinystage is running before trying
 to provision bodhi with vagrant. To set up tinystage::
 
     $ git clone https://github.com/fedora-infra/tiny-stage
@@ -27,10 +27,16 @@ Next, check out the bodhi code and run ``vagrant up``::
     $ cd bodhi
     $ vagrant up
 
-Your newly provisioned bodhi development instance is now available at https://bodhi-dev.example.com/
+Your newly provisioned bodhi development instance is now available at https://bodhi-dev.example.com/.
+Two users are automatically added to the tinystage instance for enabling you to test Bodhi:
+``tinystage_packager`` and ``tinystage_provenpackager``, both with password ``password``. If you want
+to login with your username (or any username of your choice), just edit the ``fas_username`` variable
+in the Vagrantfile and re-provision the VM. Be advised that this will not be a copy of your real
+fas account, it will just have the same username with the default password ``password`` and fake
+complementary data.
 
-The Vagrant guest runs an AMQP message broker (RabbitMQ) which has a web interface for monitoring and 
-administration of the Fedora Messaging queue at http://bodhi-dev.example.com:15672/. The default username 
+The Vagrant guest runs an AMQP message broker (RabbitMQ) which has a web interface for monitoring and
+administration of the Fedora Messaging queue at http://bodhi-dev.example.com:15672/. The default username
 is ``guest`` and the password is ``guest``.
 
 


### PR DESCRIPTION
This PR will:
- update the base Vagrant machine to F36
- remove setup for use staging infrastructure (it doesn't work anyway)
- add users and groups to tinystage useful for Bodhi development (see updated docs)

Signed-off-by: Mattia Verga <mattia.verga@tiscali.it>