### PR TITLE
Query all greenwave decision contexts together

### DIFF
--- a/bodhi-server/bodhi/server/models.py
+++ b/bodhi-server/bodhi/server/models.py
@@ -2242,13 +2242,12 @@ class Update(Base):
         subjects = self.greenwave_subject
         data = []
         while count < len(subjects):
-            for context in self._greenwave_decision_contexts:
-                data.append({
-                    'product_version': self.product_version,
-                    'decision_context': context,
-                    'subject': subjects[count:count + batch_size],
-                    'verbose': verbose,
-                })
+            data.append({
+                'product_version': self.product_version,
+                'decision_context': self._greenwave_decision_contexts,
+                'subject': subjects[count:count + batch_size],
+                'verbose': verbose,
+            })
             count += batch_size
         return data
 

--- a/bodhi-server/bodhi/server/templates/update.html
+++ b/bodhi-server/bodhi/server/templates/update.html
@@ -863,12 +863,7 @@ ${parent.javascript()}
                 handle_unsatisfied_requirements(data);
                 reqs_counter += data['unsatisfied_requirements'].length;
                 reqs_counter += data['satisfied_requirements'].length;
-                // we don't want to generate result rows for both the
-                // critpath and non-critpath decision contexts, as both
-                // queries return the same set of test results
-                if (!(request.decision_context.endsWith("critpath"))) {
-                    handle_results(data.results, request.subject);
-                }
+                handle_results(data.results, request.subject);
                 after_success();
             },
             error: function (jqxhr, status, error) {

--- a/bodhi-server/tests/services/test_updates.py
+++ b/bodhi-server/tests/services/test_updates.py
@@ -1407,8 +1407,8 @@ class TestUpdatesService(BasePyTestCase):
 
         res = self.app.get(f'/updates/{u.alias}', status=200, headers={'Accept': 'text/html'})
 
-        assert '"decision_context": "bodhi_update_push_testing",' not in res
-        assert '"decision_context": "bodhi_update_push_stable",' in res
+        assert '"decision_context": ["bodhi_update_push_testing"],' not in res
+        assert '"decision_context": ["bodhi_update_push_stable"],' in res
 
     def test_decision_context_pending_testing(self):
         """The HTML should include the correct decision context for Pending/Testing updates."""
@@ -1418,8 +1418,8 @@ class TestUpdatesService(BasePyTestCase):
 
         res = self.app.get(f'/updates/{u.alias}', status=200, headers={'Accept': 'text/html'})
 
-        assert '"decision_context": "bodhi_update_push_stable",' not in res
-        assert '"decision_context": "bodhi_update_push_testing",' in res
+        assert '"decision_context": ["bodhi_update_push_stable"],' not in res
+        assert '"decision_context": ["bodhi_update_push_testing"],' in res
 
     def test_decision_context_testing(self):
         """The HTML should include the correct decision context for Testing updates."""
@@ -1431,8 +1431,8 @@ class TestUpdatesService(BasePyTestCase):
 
         res = self.app.get(f'/updates/{u.alias}', status=200, headers={'Accept': 'text/html'})
 
-        assert '"decision_context": "bodhi_update_push_testing",' not in res
-        assert '"decision_context": "bodhi_update_push_stable",' in res
+        assert '"decision_context": ["bodhi_update_push_testing"],' not in res
+        assert '"decision_context": ["bodhi_update_push_stable"],' in res
 
     def test_home_html_legal(self):
         """Test the home page HTML when a legal link is configured."""
@@ -6190,7 +6190,7 @@ class TestWaiveTestResults(BasePyTestCase):
             'https://greenwave-web-greenwave.app.os.fedoraproject.org/api/v1.0/decision',
             {
                 'product_version': 'fedora-17',
-                'decision_context': 'bodhi_update_push_testing',
+                'decision_context': ['bodhi_update_push_testing'],
                 'subject': [
                     {'item': 'bodhi-2.0-1.fc17', 'type': 'koji_build'},
                     {'item': up.alias, 'type': 'bodhi_update'}
@@ -6269,7 +6269,7 @@ class TestWaiveTestResults(BasePyTestCase):
             'https://greenwave-web-greenwave.app.os.fedoraproject.org/api/v1.0/decision',
             {
                 'product_version': 'fedora-17',
-                'decision_context': 'bodhi_update_push_testing',
+                'decision_context': ['bodhi_update_push_testing'],
                 'subject': [
                     {'item': 'bodhi-2.0-1.fc17', 'type': 'koji_build'},
                     {'item': up.alias, 'type': 'bodhi_update'}
@@ -6369,7 +6369,7 @@ class TestWaiveTestResults(BasePyTestCase):
             'https://greenwave-web-greenwave.app.os.fedoraproject.org/api/v1.0/decision',
             {
                 'product_version': 'fedora-17',
-                'decision_context': 'bodhi_update_push_testing',
+                'decision_context': ['bodhi_update_push_testing'],
                 'subject': [
                     {'item': 'bodhi-2.0-1.fc17', 'type': 'koji_build'},
                     {'item': up.alias, 'type': 'bodhi_update'}
@@ -6452,7 +6452,7 @@ class TestWaiveTestResults(BasePyTestCase):
             'https://greenwave-web-greenwave.app.os.fedoraproject.org/api/v1.0/decision',
             {
                 'product_version': 'fedora-17',
-                'decision_context': 'bodhi_update_push_testing',
+                'decision_context': ['bodhi_update_push_testing'],
                 'subject': [
                     {'item': 'bodhi-2.0-1.fc17', 'type': 'koji_build'},
                     {'item': up.alias, 'type': 'bodhi_update'}
@@ -6552,7 +6552,7 @@ class TestWaiveTestResults(BasePyTestCase):
             'https://greenwave-web-greenwave.app.os.fedoraproject.org/api/v1.0/decision',
             {
                 'product_version': 'fedora-17',
-                'decision_context': 'bodhi_update_push_testing',
+                'decision_context': ['bodhi_update_push_testing'],
                 'subject': [
                     {'item': 'bodhi-2.0-1.fc17', 'type': 'koji_build'},
                     {'item': up.alias, 'type': 'bodhi_update'}
@@ -6696,7 +6696,7 @@ class TestGetTestResults(BasePyTestCase):
             'https://greenwave.api/decision',
             data={
                 'product_version': 'fedora-17',
-                'decision_context': 'bodhi_update_push_testing',
+                'decision_context': ['bodhi_update_push_testing'],
                 'subject': [
                     {'item': 'bodhi-2.0-1.fc17', 'type': 'koji_build'},
                     {'item': update.alias, 'type': 'bodhi_update'}
@@ -6736,7 +6736,7 @@ class TestGetTestResults(BasePyTestCase):
             'https://greenwave.api/decision',
             data={
                 'product_version': 'fedora-17',
-                'decision_context': 'bodhi_update_push_testing',
+                'decision_context': ['bodhi_update_push_testing'],
                 'subject': [
                     {'item': 'bodhi-2.0-1.fc17', 'type': 'koji_build'},
                     {'item': update.alias, 'type': 'bodhi_update'}
@@ -6778,7 +6778,7 @@ class TestGetTestResults(BasePyTestCase):
             'https://greenwave.api/decision',
             data={
                 'product_version': 'fedora-17',
-                'decision_context': 'bodhi_update_push_testing',
+                'decision_context': ['bodhi_update_push_testing'],
                 'subject': [
                     {'item': 'bodhi-2.0-1.fc17', 'type': 'koji_build'},
                     {'item': update.alias, 'type': 'bodhi_update'}
@@ -6806,25 +6806,26 @@ class TestGetTestResults(BasePyTestCase):
 
         res = self.app.get(f'/updates/{update.alias}/get-test-results')
 
-        assert call_api.call_args_list == [
-            mock.call(
-                'https://greenwave.api/decision',
-                data={
-                    'product_version': 'fedora-17',
-                    'decision_context': context,
-                    'subject': [
-                        {'item': 'bodhi-2.0-1.fc17', 'type': 'koji_build'},
-                        {'item': update.alias, 'type': 'bodhi_update'}
-                    ],
-                    'verbose': True,
-                },
-                method='POST',
-                retries=3,
-                service_name='Greenwave'
-            ) for context in ('bodhi_update_push_testing_critpath', 'bodhi_update_push_testing')
-        ]
+        call_api.assert_called_once_with(
+            'https://greenwave.api/decision',
+            data={
+                'product_version': 'fedora-17',
+                'decision_context': [
+                    'bodhi_update_push_testing_critpath',
+                    'bodhi_update_push_testing'
+                ],
+                'subject': [
+                    {'item': 'bodhi-2.0-1.fc17', 'type': 'koji_build'},
+                    {'item': update.alias, 'type': 'bodhi_update'}
+                ],
+                'verbose': True,
+            },
+            method='POST',
+            retries=3,
+            service_name='Greenwave'
+        )
 
-        assert res.json_body == {'decisions': [{'foo': 'bar'}, {'foo': 'bar'}]}
+        assert res.json_body == {'decisions': [{'foo': 'bar'}]}
 
     @mock.patch.dict(config, [('greenwave_api_url', 'https://greenwave.api')])
     @mock.patch('bodhi.server.util.call_api')
@@ -6841,29 +6842,27 @@ class TestGetTestResults(BasePyTestCase):
 
         res = self.app.get(f'/updates/{update.alias}/get-test-results')
 
-        assert call_api.call_args_list == [
-            mock.call(
-                'https://greenwave.api/decision',
-                data={
-                    'product_version': 'fedora-17',
-                    'decision_context': context,
-                    'subject': [
-                        {'item': 'bodhi-2.0-1.fc17', 'type': 'koji_build'},
-                        {'item': update.alias, 'type': 'bodhi_update'}
-                    ],
-                    'verbose': True,
-                },
-                method='POST',
-                retries=3,
-                service_name='Greenwave'
-            ) for context in (
-                'bodhi_update_push_testing_critical-path-apps_critpath',
-                'bodhi_update_push_testing_core_critpath',
-                'bodhi_update_push_testing',
-            )
-        ]
+        call_api.assert_called_once_with(
+            'https://greenwave.api/decision',
+            data={
+                'product_version': 'fedora-17',
+                'decision_context': [
+                    'bodhi_update_push_testing_critical-path-apps_critpath',
+                    'bodhi_update_push_testing_core_critpath',
+                    'bodhi_update_push_testing'
+                ],
+                'subject': [
+                    {'item': 'bodhi-2.0-1.fc17', 'type': 'koji_build'},
+                    {'item': update.alias, 'type': 'bodhi_update'}
+                ],
+                'verbose': True,
+            },
+            method='POST',
+            retries=3,
+            service_name='Greenwave'
+        )
 
-        assert res.json_body == {'decisions': [{'foo': 'bar'}, {'foo': 'bar'}, {'foo': 'bar'}]}
+        assert res.json_body == {'decisions': [{'foo': 'bar'}]}
 
     @mock.patch.dict(config, [('greenwave_api_url', 'https://greenwave.api')])
     @mock.patch('bodhi.server.util.call_api')
@@ -6884,7 +6883,7 @@ class TestGetTestResults(BasePyTestCase):
             'https://greenwave.api/decision',
             data={
                 'product_version': 'fedora-17',
-                'decision_context': 'bodhi_update_push_testing',
+                'decision_context': ['bodhi_update_push_testing'],
                 'subject': [
                     {'item': 'bodhi-2.0-1.fc17', 'type': 'koji_build'},
                     {'item': update.alias, 'type': 'bodhi_update'}
@@ -6917,7 +6916,7 @@ class TestGetTestResults(BasePyTestCase):
             'https://greenwave.api/decision',
             data={
                 'product_version': 'fedora-17',
-                'decision_context': 'bodhi_update_push_testing',
+                'decision_context': ['bodhi_update_push_testing'],
                 'subject': [
                     {'item': 'bodhi-2.0-1.fc17', 'type': 'koji_build'},
                     {'item': update.alias, 'type': 'bodhi_update'}

--- a/bodhi-server/tests/tasks/test_check_policies.py
+++ b/bodhi-server/tests/tasks/test_check_policies.py
@@ -58,57 +58,43 @@ class TestCheckPolicies(BaseTaskTestCase):
         self.db.info['messages'] = []
         self.db.commit()
         with patch('bodhi.server.models.util.greenwave_api_post') as mock_greenwave:
-            greenwave_responses = [
-                {
-                    'policies_satisfied': True,
-                    'summary': 'All required tests passed',
-                    'applicable_policies': [
-                        'kojibuild_bodhipush_no_requirements',
-                        'kojibuild_bodhipush_remoterule',
-                        'bodhiupdate_bodhipush_no_requirements',
-                        'bodhiupdate_bodhipush_openqa'
-                    ],
-                    'satisfied_requirements': [
-                        {
-                            'result_id': 39603316,
-                            'subject_type': 'bodhi_update',
-                            'testcase': 'update.install_default_update_netinst',
-                            'type': 'test-result-passed'
-                        },
-                    ],
-                    'unsatisfied_requirements': []
-                },
-                {
-                    'policies_satisfied': True,
-                    'summary': 'no tests are required',
-                    'applicable_policies': [
-                        'kojibuild_bodhipush_no_requirements',
-                        'kojibuild_bodhipush_remoterule',
-                        'bodhiupdate_bodhipush_no_requirements'
-                    ],
-                    'satisfied_requirements': [],
-                    'unsatisfied_requirements': [],
-                }
-            ]
-            mock_greenwave.side_effect = greenwave_responses
+            greenwave_response = {
+                'policies_satisfied': True,
+                'summary': 'All required tests passed',
+                'applicable_policies': [
+                    'kojibuild_bodhipush_no_requirements',
+                    'kojibuild_bodhipush_remoterule',
+                    'bodhiupdate_bodhipush_no_requirements',
+                    'bodhiupdate_bodhipush_openqa'
+                ],
+                'satisfied_requirements': [
+                    {
+                        'result_id': 39603316,
+                        'subject_type': 'bodhi_update',
+                        'testcase': 'update.install_default_update_netinst',
+                        'type': 'test-result-passed'
+                    },
+                ],
+                'unsatisfied_requirements': []
+            }
+            mock_greenwave.return_value = greenwave_response
             check_policies_main()
             update = self.db.query(models.Update).filter(models.Update.id == update.id).one()
             assert update.test_gating_status == models.TestGatingStatus.passed
 
-        expected_queries = [
-            {
-                'product_version': 'fedora-17', 'decision_context': context,
-                'subject': [
-                    {'item': 'bodhi-2.0-1.fc17', 'type': 'koji_build'},
-                    {'item': 'FEDORA-{}-a3bbe1a8f2'.format(datetime.datetime.utcnow().year),
-                     'type': 'bodhi_update'}],
-                'verbose': False
-            } for context in ('bodhi_update_push_stable_core_critpath', 'bodhi_update_push_stable')
-        ]
-        expected_calls = [
-            call(config['greenwave_api_url'] + '/decision', query) for query in expected_queries
-        ]
-        assert mock_greenwave.call_args_list == expected_calls
+        query = {
+            'product_version': 'fedora-17',
+            'decision_context': [
+                'bodhi_update_push_stable_core_critpath',
+                'bodhi_update_push_stable'
+            ],
+            'subject': [
+                {'item': 'bodhi-2.0-1.fc17', 'type': 'koji_build'},
+                {'item': 'FEDORA-{}-a3bbe1a8f2'.format(datetime.datetime.utcnow().year),
+                 'type': 'bodhi_update'}],
+            'verbose': False
+        }
+        mock_greenwave.assert_called_once_with(config['greenwave_api_url'] + '/decision', query)
 
     @patch.dict(config, [('greenwave_api_url', 'http://domain.local')])
     def test_policies_pending_satisfied(self):
@@ -119,60 +105,43 @@ class TestCheckPolicies(BaseTaskTestCase):
         update.critpath_groups = "core"
         self.db.commit()
         with patch('bodhi.server.models.util.greenwave_api_post') as mock_greenwave:
-            greenwave_responses = [
-                {
-                    'policies_satisfied': True,
-                    'summary': 'All required tests passed',
-                    'applicable_policies': [
-                        'kojibuild_bodhipush_no_requirements',
-                        'kojibuild_bodhipush_remoterule',
-                        'bodhiupdate_bodhipush_no_requirements',
-                        'bodhiupdate_bodhipush_openqa'
-                    ],
-                    'satisfied_requirements': [
-                        {
-                            'result_id': 39603316,
-                            'subject_type': 'bodhi_update',
-                            'testcase': 'update.install_default_update_netinst',
-                            'type': 'test-result-passed'
-                        },
-                    ],
-                    'unsatisfied_requirements': []
-                },
-                {
-                    'policies_satisfied': True,
-                    'summary': 'no tests are required',
-                    'applicable_policies': [
-                        'kojibuild_bodhipush_no_requirements',
-                        'kojibuild_bodhipush_remoterule',
-                        'bodhiupdate_bodhipush_no_requirements'
-                    ],
-                    'satisfied_requirements': [],
-                    'unsatisfied_requirements': [],
-                }
-            ]
-            mock_greenwave.side_effect = greenwave_responses
+            greenwave_response = {
+                'policies_satisfied': True,
+                'summary': 'All required tests passed',
+                'applicable_policies': [
+                    'kojibuild_bodhipush_no_requirements',
+                    'kojibuild_bodhipush_remoterule',
+                    'bodhiupdate_bodhipush_no_requirements',
+                    'bodhiupdate_bodhipush_openqa'
+                ],
+                'satisfied_requirements': [
+                    {
+                        'result_id': 39603316,
+                        'subject_type': 'bodhi_update',
+                        'testcase': 'update.install_default_update_netinst',
+                        'type': 'test-result-passed'
+                    },
+                ],
+                'unsatisfied_requirements': []
+            }
+            mock_greenwave.return_value = greenwave_response
             check_policies_main()
             update = self.db.query(models.Update).filter(models.Update.id == update.id).one()
             assert update.test_gating_status == models.TestGatingStatus.passed
 
-        expected_queries = [
-            {
-                'product_version': 'fedora-17',
-                'decision_context': context,
-                'subject': [
-                    {'item': 'bodhi-2.0-1.fc17', 'type': 'koji_build'},
-                    {'item': 'FEDORA-{}-a3bbe1a8f2'.format(datetime.datetime.utcnow().year),
-                     'type': 'bodhi_update'}],
-                'verbose': False,
-            } for context in (
-                'bodhi_update_push_testing_core_critpath', 'bodhi_update_push_testing'
-            )
-        ]
-        expected_calls = [
-            call(config['greenwave_api_url'] + '/decision', query) for query in expected_queries
-        ]
-        assert mock_greenwave.call_args_list == expected_calls
+        query = {
+            'product_version': 'fedora-17',
+            'decision_context': [
+                'bodhi_update_push_testing_core_critpath',
+                'bodhi_update_push_testing'
+            ],
+            'subject': [
+                {'item': 'bodhi-2.0-1.fc17', 'type': 'koji_build'},
+                {'item': 'FEDORA-{}-a3bbe1a8f2'.format(datetime.datetime.utcnow().year),
+                 'type': 'bodhi_update'}],
+            'verbose': False,
+        }
+        mock_greenwave.assert_called_once_with(config['greenwave_api_url'] + '/decision', query)
 
     @patch.dict(config, [('greenwave_api_url', 'http://domain.local')])
     def test_policies_unsatisfied_waiting(self):
@@ -189,53 +158,40 @@ class TestCheckPolicies(BaseTaskTestCase):
         self.db.commit()
         with patch('bodhi.server.models.util.greenwave_api_post') as mock_greenwave:
             item = 'FEDORA-{}-a3bbe1a8f2'.format(datetime.datetime.utcnow().year)
-            greenwave_responses = [
-                {
-                    'policies_satisfied': False,
-                    'summary': '2 of 2 required test results missing',
-                    'applicable_policies': [
-                        'kojibuild_bodhipush_no_requirements',
-                        'kojibuild_bodhipush_remoterule',
-                        'bodhiupdate_bodhipush_no_requirements',
-                        'bodhiupdate_bodhipush_openqa'
-                    ],
-                    'satisfied_requirements': [],
-                    'unsatisfied_requirements': [
-                        {
-                            'item': {
-                                'item': item,
-                                'type': 'bodhi_update'
-                            },
-                            'scenario': 'fedora.updates-everything-boot-iso.x86_64.64bit',
-                            'subject_type': 'bodhi_update',
-                            'testcase': 'update.install_default_update_netinst',
-                            'type': 'test-result-missing'
+            greenwave_response = {
+                'policies_satisfied': False,
+                'summary': '2 of 2 required test results missing',
+                'applicable_policies': [
+                    'kojibuild_bodhipush_no_requirements',
+                    'kojibuild_bodhipush_remoterule',
+                    'bodhiupdate_bodhipush_no_requirements',
+                    'bodhiupdate_bodhipush_openqa'
+                ],
+                'satisfied_requirements': [],
+                'unsatisfied_requirements': [
+                    {
+                        'item': {
+                            'item': item,
+                            'type': 'bodhi_update'
                         },
-                        {
-                            'item': {
-                                'item': item,
-                                'type': 'bodhi_update'
-                            },
-                            'scenario': 'fedora.updates-everything-boot-iso.x86_64.uefi',
-                            'subject_type': 'bodhi_update',
-                            'testcase': 'update.install_default_update_netinst',
-                            'type': 'test-result-missing'
+                        'scenario': 'fedora.updates-everything-boot-iso.x86_64.64bit',
+                        'subject_type': 'bodhi_update',
+                        'testcase': 'update.install_default_update_netinst',
+                        'type': 'test-result-missing'
+                    },
+                    {
+                        'item': {
+                            'item': item,
+                            'type': 'bodhi_update'
                         },
-                    ]
-                },
-                {
-                    'policies_satisfied': True,
-                    'summary': 'no tests are required',
-                    'applicable_policies': [
-                        'kojibuild_bodhipush_no_requirements',
-                        'kojibuild_bodhipush_remoterule',
-                        'bodhiupdate_bodhipush_no_requirements'
-                    ],
-                    'satisfied_requirements': [],
-                    'unsatisfied_requirements': [],
-                }
-            ]
-            mock_greenwave.side_effect = greenwave_responses
+                        'scenario': 'fedora.updates-everything-boot-iso.x86_64.uefi',
+                        'subject_type': 'bodhi_update',
+                        'testcase': 'update.install_default_update_netinst',
+                        'type': 'test-result-missing'
+                    },
+                ]
+            }
+            mock_greenwave.return_value = greenwave_response
             check_policies_main()
             update = self.db.query(models.Update).filter(models.Update.id == update.id).one()
             assert update.test_gating_status == models.TestGatingStatus.waiting
@@ -243,20 +199,19 @@ class TestCheckPolicies(BaseTaskTestCase):
             expected_comment = "This update's test gating status has been changed to 'waiting'."
             assert update.comments[-1].text == expected_comment
 
-        expected_queries = [
-            {
-                'product_version': 'fedora-17', 'decision_context': context,
-                'subject': [
-                    {'item': 'bodhi-2.0-1.fc17', 'type': 'koji_build'},
-                    {'item': 'FEDORA-{}-a3bbe1a8f2'.format(datetime.datetime.utcnow().year),
-                     'type': 'bodhi_update'}],
-                'verbose': False
-            } for context in ('bodhi_update_push_stable_core_critpath', 'bodhi_update_push_stable')
-        ]
-        expected_calls = [
-            call(config['greenwave_api_url'] + '/decision', query) for query in expected_queries
-        ]
-        assert mock_greenwave.call_args_list == expected_calls
+        query = {
+            'product_version': 'fedora-17',
+            'decision_context': [
+                'bodhi_update_push_stable_core_critpath',
+                'bodhi_update_push_stable'
+            ],
+            'subject': [
+                {'item': 'bodhi-2.0-1.fc17', 'type': 'koji_build'},
+                {'item': 'FEDORA-{}-a3bbe1a8f2'.format(datetime.datetime.utcnow().year),
+                 'type': 'bodhi_update'}],
+            'verbose': False
+        }
+        mock_greenwave.assert_called_once_with(config['greenwave_api_url'] + '/decision', query)
 
     @patch.dict(config, [('greenwave_api_url', 'http://domain.local')])
     def test_policies_unsatisfied_waiting_too_long(self):
@@ -273,53 +228,40 @@ class TestCheckPolicies(BaseTaskTestCase):
         self.db.commit()
         with patch('bodhi.server.models.util.greenwave_api_post') as mock_greenwave:
             item = 'FEDORA-{}-a3bbe1a8f2'.format(datetime.datetime.utcnow().year)
-            greenwave_responses = [
-                {
-                    'policies_satisfied': False,
-                    'summary': '2 of 2 required test results missing',
-                    'applicable_policies': [
-                        'kojibuild_bodhipush_no_requirements',
-                        'kojibuild_bodhipush_remoterule',
-                        'bodhiupdate_bodhipush_no_requirements',
-                        'bodhiupdate_bodhipush_openqa'
-                    ],
-                    'satisfied_requirements': [],
-                    'unsatisfied_requirements': [
-                        {
-                            'item': {
-                                'item': item,
-                                'type': 'bodhi_update'
-                            },
-                            'scenario': 'fedora.updates-everything-boot-iso.x86_64.64bit',
-                            'subject_type': 'bodhi_update',
-                            'testcase': 'update.install_default_update_netinst',
-                            'type': 'test-result-missing'
+            greenwave_response = {
+                'policies_satisfied': False,
+                'summary': '2 of 2 required test results missing',
+                'applicable_policies': [
+                    'kojibuild_bodhipush_no_requirements',
+                    'kojibuild_bodhipush_remoterule',
+                    'bodhiupdate_bodhipush_no_requirements',
+                    'bodhiupdate_bodhipush_openqa'
+                ],
+                'satisfied_requirements': [],
+                'unsatisfied_requirements': [
+                    {
+                        'item': {
+                            'item': item,
+                            'type': 'bodhi_update'
                         },
-                        {
-                            'item': {
-                                'item': item,
-                                'type': 'bodhi_update'
-                            },
-                            'scenario': 'fedora.updates-everything-boot-iso.x86_64.uefi',
-                            'subject_type': 'bodhi_update',
-                            'testcase': 'update.install_default_update_netinst',
-                            'type': 'test-result-missing'
+                        'scenario': 'fedora.updates-everything-boot-iso.x86_64.64bit',
+                        'subject_type': 'bodhi_update',
+                        'testcase': 'update.install_default_update_netinst',
+                        'type': 'test-result-missing'
+                    },
+                    {
+                        'item': {
+                            'item': item,
+                            'type': 'bodhi_update'
                         },
-                    ]
-                },
-                {
-                    'policies_satisfied': True,
-                    'summary': 'no tests are required',
-                    'applicable_policies': [
-                        'kojibuild_bodhipush_no_requirements',
-                        'kojibuild_bodhipush_remoterule',
-                        'bodhiupdate_bodhipush_no_requirements'
-                    ],
-                    'satisfied_requirements': [],
-                    'unsatisfied_requirements': [],
-                }
-            ]
-            mock_greenwave.side_effect = greenwave_responses
+                        'scenario': 'fedora.updates-everything-boot-iso.x86_64.uefi',
+                        'subject_type': 'bodhi_update',
+                        'testcase': 'update.install_default_update_netinst',
+                        'type': 'test-result-missing'
+                    },
+                ]
+            }
+            mock_greenwave.return_value = greenwave_response
             check_policies_main()
             update = self.db.query(models.Update).filter(models.Update.id == update.id).one()
             assert update.test_gating_status == models.TestGatingStatus.failed
@@ -327,29 +269,27 @@ class TestCheckPolicies(BaseTaskTestCase):
             expected_comment = "This update's test gating status has been changed to 'failed'."
             assert update.comments[-1].text == expected_comment
 
-        expected_query = {
+        query = {
             'product_version': 'fedora-17',
-            'decision_context': 'bodhi_update_push_stable_core_critpath',
+            'decision_context': [
+                'bodhi_update_push_stable_core_critpath',
+                'bodhi_update_push_stable'
+            ],
             'subject': [
                 {'item': 'bodhi-2.0-1.fc17', 'type': 'koji_build'},
                 {'item': 'FEDORA-{}-a3bbe1a8f2'.format(datetime.datetime.utcnow().year),
                  'type': 'bodhi_update'}],
             'verbose': False
         }
-        # we only expect *one* call here because the *first* query
-        # (on the _critpath context) should be enough to conclude the
-        # status is failed: it would be wrong to needlessly run the
-        # second query. note the mock responses are in the order we
-        # expect the queries to be run, critpath first
-        mock_greenwave.assert_called_once_with(config['greenwave_api_url'] + '/decision',
-                                               expected_query)
+        mock_greenwave.assert_called_once_with(config['greenwave_api_url'] + '/decision', query)
 
-    @patch.dict(config, [('greenwave_api_url', 'http://domain.local')])
+    @patch.dict(config, [('greenwave_api_url', 'http://domain.local'), ('greenwave_batch_size', 1)])
     def test_policies_unsatisfied_failed(self):
         """Assert correct behavior when the policies enforced by Greenwave are unsatisfied:
         failed tests always means failed status. This also tests that we behave correctly
         even if the *first* query shows requirements satisfied, but the *second* query has
-        failed required tests.
+        failed required tests: that's why we set the batch size to 1, to ensure we get two
+        queries.
         """
         update = self.db.query(models.Update).all()[0]
         update.status = models.UpdateStatus.testing
@@ -358,13 +298,23 @@ class TestCheckPolicies(BaseTaskTestCase):
         # Clear pending messages
         self.db.info['messages'] = []
         self.db.commit()
+        # we use this a couple times
+        itemname = 'FEDORA-{}-a3bbe1a8f2'.format(datetime.datetime.utcnow().year)
         with patch('bodhi.server.models.util.greenwave_api_post') as mock_greenwave:
-            # here, we're mocking the scenario from
+            # here, we're approximately mocking the scenario from
             # https://pagure.io/fedora-ci/general/issue/263 , where
             # openQA tests passed, but a package in the update had a
             # local gating config that only specified the context
             # bodhi_update_push_stable (not _push_stable_critpath),
-            # and a test specified in that local policy failed
+            # and a test specified in that local policy failed.
+            # That exact scenario is no longer likely now we query
+            # all decision contexts together, but it's still possible
+            # to get multiple responses if there are more subjects
+            # than the specified batch size. In this case we set the
+            # batch size to 1 and emulate a scenario where the tests
+            # for the first subject - the Koji build - passed, but
+            # a test for the second subject - the Bodhi update -
+            # failed.
             greenwave_responses = [
                 {
                     'policies_satisfied': True,
@@ -378,8 +328,8 @@ class TestCheckPolicies(BaseTaskTestCase):
                     'satisfied_requirements': [
                         {
                             'result_id': 39603316,
-                            'subject_type': 'bodhi_update',
-                            'testcase': 'update.install_default_update_netinst',
+                            'subject_type': 'koji_build',
+                            'testcase': 'fedora-ci.koji-build.tier0.functional',
                             'type': 'test-result-passed'
                         },
                     ],
@@ -397,12 +347,12 @@ class TestCheckPolicies(BaseTaskTestCase):
                     'unsatisfied_requirements': [
                         {
                             'item': {
-                                'item': 'bodhi-2.0-1.fc17',
-                                'type': 'koji_build'
+                                'item': itemname,
+                                'type': 'bodhi_update'
                             },
                             'scenario': None,
-                            'subject_type': 'koji_build',
-                            'testcase': 'fedora-ci.koji-build.tier0.functional',
+                            'subject_type': 'bodhi_update',
+                            'testcase': 'update.install_default_update_netinst',
                             'type': 'test-result-failed'
                         },
                     ],
@@ -416,15 +366,26 @@ class TestCheckPolicies(BaseTaskTestCase):
             expected_comment = "This update's test gating status has been changed to 'failed'."
             assert update.comments[-1].text == expected_comment
 
+        expected_subjects = [
+            {
+                'item': 'bodhi-2.0-1.fc17',
+                'type': 'koji_build'
+            },
+            {
+                'item': itemname,
+                'type': 'bodhi_update'
+            }
+        ]
         expected_queries = [
             {
-                'product_version': 'fedora-17', 'decision_context': context,
-                'subject': [
-                    {'item': 'bodhi-2.0-1.fc17', 'type': 'koji_build'},
-                    {'item': 'FEDORA-{}-a3bbe1a8f2'.format(datetime.datetime.utcnow().year),
-                     'type': 'bodhi_update'}],
+                'product_version': 'fedora-17',
+                'decision_context': [
+                    'bodhi_update_push_stable_core_critpath',
+                    'bodhi_update_push_stable'
+                ],
+                'subject': [subject],
                 'verbose': False
-            } for context in ('bodhi_update_push_stable_core_critpath', 'bodhi_update_push_stable')
+            } for subject in expected_subjects
         ]
         expected_calls = [
             call(config['greenwave_api_url'] + '/decision', query) for query in expected_queries
@@ -452,16 +413,15 @@ class TestCheckPolicies(BaseTaskTestCase):
         update = self.db.query(models.Update).filter(models.Update.id == update.id).one()
         # The test_gating_status should still be None.
         assert update.test_gating_status is None
-        expected_query = {
-            'product_version': 'fedora-17', 'decision_context': 'bodhi_update_push_stable',
+        query = {
+            'product_version': 'fedora-17', 'decision_context': ['bodhi_update_push_stable'],
             'subject': [
                 {'item': 'bodhi-2.0-1.fc17', 'type': 'koji_build'},
                 {'item': 'FEDORA-{}-a3bbe1a8f2'.format(datetime.datetime.utcnow().year),
                  'type': 'bodhi_update'}],
             'verbose': False
         }
-        mock_greenwave.assert_called_once_with(config['greenwave_api_url'] + '/decision',
-                                               expected_query)
+        mock_greenwave.assert_called_once_with(config['greenwave_api_url'] + '/decision', query)
 
     @patch.dict(config, [('greenwave_api_url', 'http://domain.local')])
     def test_pushed_update(self):
@@ -478,69 +438,54 @@ class TestCheckPolicies(BaseTaskTestCase):
         self.db.commit()
         with patch('bodhi.server.models.util.greenwave_api_post') as mock_greenwave:
             item = 'FEDORA-{}-a3bbe1a8f2'.format(datetime.datetime.utcnow().year)
-            greenwave_responses = [
-                {
-                    'policies_satisfied': False,
-                    'summary': '1 of 2 required tests failed, 1 result missing',
-                    'applicable_policies': [
-                        'kojibuild_bodhipush_no_requirements',
-                        'kojibuild_bodhipush_remoterule',
-                        'bodhiupdate_bodhipush_no_requirements',
-                        'bodhiupdate_bodhipush_openqa'
-                    ],
-                    'satisfied_requirements': [],
-                    'unsatisfied_requirements': [
-                        {
-                            'item': {
-                                'item': item,
-                                'type': 'bodhi_update'
-                            },
-                            'scenario': 'fedora.updates-everything-boot-iso.x86_64.64bit',
-                            'subject_type': 'bodhi_update',
-                            'testcase': 'update.install_default_update_netinst',
-                            'type': 'test-result-failed'
+            greenwave_response = {
+                'policies_satisfied': False,
+                'summary': '1 of 2 required tests failed, 1 result missing',
+                'applicable_policies': [
+                    'kojibuild_bodhipush_no_requirements',
+                    'kojibuild_bodhipush_remoterule',
+                    'bodhiupdate_bodhipush_no_requirements',
+                    'bodhiupdate_bodhipush_openqa'
+                ],
+                'satisfied_requirements': [],
+                'unsatisfied_requirements': [
+                    {
+                        'item': {
+                            'item': item,
+                            'type': 'bodhi_update'
                         },
-                        {
-                            'item': {
-                                'item': item,
-                                'type': 'bodhi_update'
-                            },
-                            'scenario': 'fedora.updates-everything-boot-iso.x86_64.uefi',
-                            'subject_type': 'bodhi_update',
-                            'testcase': 'update.install_default_update_netinst',
-                            'type': 'test-result-missing'
+                        'scenario': 'fedora.updates-everything-boot-iso.x86_64.64bit',
+                        'subject_type': 'bodhi_update',
+                        'testcase': 'update.install_default_update_netinst',
+                        'type': 'test-result-failed'
+                    },
+                    {
+                        'item': {
+                            'item': item,
+                            'type': 'bodhi_update'
                         },
-                    ]
-                },
-                {
-                    'policies_satisfied': True,
-                    'summary': 'no tests are required',
-                    'applicable_policies': [
-                        'kojibuild_bodhipush_no_requirements',
-                        'kojibuild_bodhipush_remoterule',
-                        'bodhiupdate_bodhipush_no_requirements'
-                    ],
-                    'satisfied_requirements': [],
-                    'unsatisfied_requirements': [],
-                }
-            ]
-            mock_greenwave.side_effect = greenwave_responses
+                        'scenario': 'fedora.updates-everything-boot-iso.x86_64.uefi',
+                        'subject_type': 'bodhi_update',
+                        'testcase': 'update.install_default_update_netinst',
+                        'type': 'test-result-missing'
+                    },
+                ]
+            }
+            mock_greenwave.return_value = greenwave_response
 
             check_policies_main()
 
         update = self.db.query(models.Update).filter(models.Update.id == update.id).one()
         assert update.test_gating_status == models.TestGatingStatus.failed
-        expected_query = {
-            'product_version': 'fedora-17', 'decision_context': 'bodhi_update_push_stable_critpath',
+        query = {
+            'product_version': 'fedora-17',
+            'decision_context': ['bodhi_update_push_stable_critpath', 'bodhi_update_push_stable'],
             'subject': [{'item': 'bodhi-2.0-1.fc17', 'type': 'koji_build'},
                         {'item': 'FEDORA-{}-a3bbe1a8f2'.format(datetime.datetime.utcnow().year),
                          'type': 'bodhi_update'}],
             'verbose': False
         }
-        # we only expect *one* call here, as with the earlier
-        # 'failed' test
-        mock_greenwave.assert_called_once_with(config['greenwave_api_url'] + '/decision',
-                                               expected_query)
+        mock_greenwave.assert_called_once_with(config['greenwave_api_url'] + '/decision', query)
         # Check for the comment
         expected_comment = "This update's test gating status has been changed to 'failed'."
         assert update.comments[-1].text == expected_comment
@@ -573,16 +518,15 @@ class TestCheckPolicies(BaseTaskTestCase):
             expected_comment = "This update's test gating status has been changed to 'ignored'."
             assert update.comments[-1].text == expected_comment
 
-        expected_query = {
-            'product_version': 'fedora-17', 'decision_context': 'bodhi_update_push_stable',
+        query = {
+            'product_version': 'fedora-17', 'decision_context': ['bodhi_update_push_stable'],
             'subject': [
                 {'item': 'bodhi-2.0-1.fc17', 'type': 'koji_build'},
                 {'item': 'FEDORA-{}-a3bbe1a8f2'.format(datetime.datetime.utcnow().year),
                  'type': 'bodhi_update'}],
             'verbose': False
         }
-        mock_greenwave.assert_called_once_with(config['greenwave_api_url'] + '/decision',
-                                               expected_query)
+        mock_greenwave.assert_called_once_with(config['greenwave_api_url'] + '/decision', query)
 
     @patch.dict(config, [('greenwave_api_url', 'http://domain.local')])
     def test_archived_release_updates(self):

--- a/bodhi-server/tests/test_models.py
+++ b/bodhi-server/tests/test_models.py
@@ -2502,7 +2502,7 @@ class TestUpdateUpdateTestGatingStatus(BasePyTestCase):
         assert sleep.mock_calls == [mock.call(1), mock.call(1), mock.call(1)]
         expected_post = mock.call(
             'https://greenwave-web-greenwave.app.os.fedoraproject.org/api/v1.0/decision',
-            data={"product_version": "fedora-17", "decision_context": "bodhi_update_push_testing",
+            data={"product_version": "fedora-17", "decision_context": ["bodhi_update_push_testing"],
                   "subject": [{"item": f"{update.builds[0].nvr}", "type": "koji_build"},
                               {"item": f"{update.alias}", "type": "bodhi_update"}],
                   "verbose": False},
@@ -2545,7 +2545,7 @@ class TestUpdateUpdateTestGatingStatus(BasePyTestCase):
         assert sleep.mock_calls == []
         expected_post = mock.call(
             'https://greenwave-web-greenwave.app.os.fedoraproject.org/api/v1.0/decision',
-            data={"product_version": "fedora-17", "decision_context": "bodhi_update_push_testing",
+            data={"product_version": "fedora-17", "decision_context": ["bodhi_update_push_testing"],
                   "subject": [{"item": f"{update.builds[0].nvr}", "type": "koji_build"},
                               {"item": f"{update.alias}", "type": "bodhi_update"}],
                   "verbose": False},
@@ -3042,7 +3042,7 @@ class TestUpdate(ModelTest):
                 [
                     {
                         'product_version': 'fedora-11',
-                        'decision_context': 'bodhi_update_push_testing',
+                        'decision_context': ['bodhi_update_push_testing'],
                         'verbose': False,
                         'subject': [
                             {'item': 'TurboGears-1.0.8-3.fc11', 'type': 'koji_build'},
@@ -3060,7 +3060,7 @@ class TestUpdate(ModelTest):
                 [
                     {
                         'product_version': 'fedora-11',
-                        'decision_context': 'bodhi_update_push_testing',
+                        'decision_context': ['bodhi_update_push_testing'],
                         'verbose': True,
                         'subject': [
                             {'item': 'TurboGears-1.0.8-3.fc11', 'type': 'koji_build'},
@@ -3068,7 +3068,7 @@ class TestUpdate(ModelTest):
                     },
                     {
                         'product_version': 'fedora-11',
-                        'decision_context': 'bodhi_update_push_testing',
+                        'decision_context': ['bodhi_update_push_testing'],
                         'verbose': True,
                         'subject': [
                             {'item': self.obj.alias, 'type': 'bodhi_update'},
@@ -3089,7 +3089,11 @@ class TestUpdate(ModelTest):
                 [
                     {
                         'product_version': 'fedora-11',
-                        'decision_context': 'bodhi_update_push_testing_critical-path-apps_critpath',
+                        'decision_context': [
+                            'bodhi_update_push_testing_critical-path-apps_critpath',
+                            'bodhi_update_push_testing_core_critpath',
+                            'bodhi_update_push_testing'
+                        ],
                         'verbose': True,
                         'subject': [
                             {'item': 'TurboGears-1.0.8-3.fc11', 'type': 'koji_build'},
@@ -3097,45 +3101,16 @@ class TestUpdate(ModelTest):
                     },
                     {
                         'product_version': 'fedora-11',
-                        'decision_context': 'bodhi_update_push_testing_core_critpath',
-                        'verbose': True,
-                        'subject': [
-                            {'item': 'TurboGears-1.0.8-3.fc11', 'type': 'koji_build'},
-                        ]
-                    },
-                    {
-                        'product_version': 'fedora-11',
-                        'decision_context': 'bodhi_update_push_testing',
-                        'verbose': True,
-                        'subject': [
-                            {'item': 'TurboGears-1.0.8-3.fc11', 'type': 'koji_build'},
-                        ]
-                    },
-                    {
-                        'product_version': 'fedora-11',
-                        'decision_context': 'bodhi_update_push_testing_critical-path-apps_critpath',
+                        'decision_context': [
+                            'bodhi_update_push_testing_critical-path-apps_critpath',
+                            'bodhi_update_push_testing_core_critpath',
+                            'bodhi_update_push_testing'
+                        ],
                         'verbose': True,
                         'subject': [
                             {'item': self.obj.alias, 'type': 'bodhi_update'},
                         ]
-                    },
-                    {
-                        'product_version': 'fedora-11',
-                        'decision_context': 'bodhi_update_push_testing_core_critpath',
-                        'verbose': True,
-                        'subject': [
-                            {'item': self.obj.alias, 'type': 'bodhi_update'},
-                        ]
-                    },
-                    {
-                        'product_version': 'fedora-11',
-                        'decision_context': 'bodhi_update_push_testing',
-                        'verbose': True,
-                        'subject': [
-                            {'item': self.obj.alias, 'type': 'bodhi_update'},
-                        ]
-                    },
-
+                    }
                 ]
             )
 
@@ -3148,7 +3123,7 @@ class TestUpdate(ModelTest):
             [
                 {
                     'product_version': 'fedora-11',
-                    'decision_context': 'bodhi_update_push_testing',
+                    'decision_context': ['bodhi_update_push_testing'],
                     'verbose': True,
                     'subject': [
                         {'item': 'TurboGears-1.0.8-3.fc11', 'type': 'koji_build'},

--- a/news/PR4821.dev
+++ b/news/PR4821.dev
@@ -1,0 +1,1 @@
+For gating, Bodhi now queries all Greenwave 'decision contexts' together, reducing the number of queries needed.


### PR DESCRIPTION
Since https://github.com/release-engineering/greenwave/pull/95 , greenwave allows clients to query on multiple decision contexts at once. All relevant policies for all specified decision contexts are then applied to the decision. This means we no longer need to iterate over all relevant decision contexts and send a separate decision query for each one; we can just send one query (per `greenwave_batch_size` subjects, still) with all the decision contexts in it. This makes the code simpler and will make Bodhi more efficient.

Signed-off-by: Adam Williamson <awilliam@redhat.com>