### PR TITLE
Remove unused side_tag update statuses

### DIFF
--- a/bodhi-server/bodhi/server/migrations/versions/499ac8bbe09a_remove_unused_update_sidetag_statuses.py
+++ b/bodhi-server/bodhi/server/migrations/versions/499ac8bbe09a_remove_unused_update_sidetag_statuses.py
@@ -1,0 +1,76 @@
+# Copyright (c) 2022 Mattia Verga
+#
+# This file is part of Bodhi.
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+"""
+Remove unused update sidetag statuses.
+
+Revision ID: 499ac8bbe09a
+Revises: f393d006559b
+Create Date: 2022-11-11 13:01:33.598903
+"""
+from alembic import op
+from sqlalchemy import exc
+
+
+# revision identifiers, used by Alembic.
+revision = '499ac8bbe09a'
+down_revision = 'f393d006559b'
+
+
+def upgrade():
+    """Remove unused side-tag update statuses.
+
+    The 'side_tag_active' and 'side_tag_expired' update statuses were created
+    when the side-tag workflow was starting, but they were never used.
+    """
+    op.execute('COMMIT')  # See https://bitbucket.org/zzzeek/alembic/issue/123
+    try:
+        # This will raise a ProgrammingError if the DB server doesn't use BDR.
+        op.execute('SHOW bdr.permit_ddl_locking')
+        # This server uses BDR, so let's ask for a DDL lock.
+        op.execute('SET LOCAL bdr.permit_ddl_locking = true')
+    except exc.ProgrammingError:
+        # This server doesn't use BDR, so no problem.
+        pass
+
+    # These shouldn't be necessary, but let's stay safe
+    op.execute("UPDATE updates SET status = 'obsolete' WHERE status = 'side_tag_active'")
+    op.execute("UPDATE updates SET status = 'obsolete' WHERE status = 'side_tag_expired'")
+
+    op.execute("ALTER TYPE ck_update_status RENAME TO ck_update_status_old")
+    op.execute(
+        "CREATE TYPE ck_update_status AS ENUM('testing', "
+        "'obsolete', 'stable', 'unpushed', 'pending')")
+    op.execute(
+        "ALTER TABLE updates ALTER COLUMN status TYPE ck_update_status "
+        "USING status::text::ck_update_status")
+    op.execute("DROP TYPE ck_update_status_old")
+
+
+def downgrade():
+    """Add side-tag statuses back."""
+    op.execute('COMMIT')  # See https://bitbucket.org/zzzeek/alembic/issue/123
+    try:
+        # This will raise a ProgrammingError if the DB server doesn't use BDR.
+        op.execute('SHOW bdr.permit_ddl_locking')
+        # This server uses BDR, so let's ask for a DDL lock.
+        op.execute('SET LOCAL bdr.permit_ddl_locking = true')
+    except exc.ProgrammingError:
+        # This server doesn't use BDR, so no problem.
+        pass
+    op.execute("ALTER TYPE ck_update_status ADD VALUE 'side_tag_active' AFTER 'testing'")
+    op.execute("ALTER TYPE ck_update_status ADD VALUE 'side_tag_expired' AFTER 'side_tag_active'")

--- a/bodhi-server/bodhi/server/models.py
+++ b/bodhi-server/bodhi/server/models.py
@@ -612,8 +612,6 @@ class UpdateStatus(DeclEnum):
         stable (EnumSymbol): The update is in the stable repository.
         unpushed (EnumSymbol): The update had been in a testing repository, but has been removed.
         obsolete (EnumSymbol): The update has been obsoleted by another update.
-        side_tag_active (EnumSymbol): The update's side tag is currently active.
-        side_tag_expired (EnumSymbol): The update's side tag has expired.
     """
 
     pending = 'pending', 'pending'
@@ -621,8 +619,6 @@ class UpdateStatus(DeclEnum):
     stable = 'stable', 'stable'
     unpushed = 'unpushed', 'unpushed'
     obsolete = 'obsolete', 'obsolete'
-    side_tag_active = 'side_tag_active', 'Side tag active'
-    side_tag_expired = 'side_tag_expired', 'Side tag expired'
 
 
 class TestGatingStatus(DeclEnum):
@@ -2031,16 +2027,6 @@ class Update(Base):
         nvrs = [x.nvr for x in self.builds]
         builds = " ".join(sorted(nvrs))
         return hashlib.sha1(str(builds).encode('utf-8')).hexdigest()
-
-    @property
-    def side_tag_locked(self):
-        """
-        Return the lock state of the side tag.
-
-        Returns:
-            bool: True if sidetag is locked, False otherwise.
-        """
-        return self.status == UpdateStatus.side_tag_active and self.request is not None
 
     # WARNING: consumers/composer.py assumes that this validation is performed!
     @validates('builds')

--- a/bodhi-server/tests/test_models.py
+++ b/bodhi-server/tests/test_models.py
@@ -3272,20 +3272,6 @@ class TestUpdate(ModelTest):
 
         assert self.obj.requested_tag == self.obj.release.candidate_tag
 
-    def test_side_tag_locked_false(self):
-        """Test the side_tag_locked property when it is false."""
-        self.obj.status = model.UpdateStatus.side_tag_active
-        self.obj.request = None
-
-        assert not self.obj.side_tag_locked
-
-    def test_side_tag_locked_true(self):
-        """Test the side_tag_locked property when it is true."""
-        self.obj.status = model.UpdateStatus.side_tag_active
-        self.obj.request = model.UpdateRequest.stable
-
-        assert self.obj.side_tag_locked
-
     @mock.patch('bodhi.server.models.bugs.bugtracker.close')
     @mock.patch('bodhi.server.models.bugs.bugtracker.comment')
     def test_modify_bugs_stable_close(self, comment, close):

--- a/docs/user/update_states.rst
+++ b/docs/user/update_states.rst
@@ -14,14 +14,6 @@ Once submitted to Bodhi, updates move through the following states:
 
 :ref:`stable`: The package has been released to the main updates repository.
 
-:ref:`sidetag-active`: This update represents a side tag whose content can still be modified; i.e. in which packages can still be built.
-
-:ref:`sidetag-active-testing`: This update represents a side tag that has been requested to merge for testing.
-
-:ref:`sidetag-active-stable`: This update represents a side tag that has been requested to go stable.
-
-:ref:`sidetag-expired`: This update represents a side tag whose lifetime has expired and can no longer be modified.
-
 :ref:`obsolete`: The package has been obsoleted by a different update
 
 :ref:`revoked`: The update was removed before it reached the testing or stable repository.
@@ -98,48 +90,6 @@ Stable
 After an update is pushed to the stable repository, it is marked as stable in Bodhi. At this point,
 Bodhi will close associated bugs, and will send out update notices to the appropriate e-mail
 addresses.
-
-
-.. _sidetag-active:
-
-Side_tag_active
-===============
-
-An update can be created as a side tag. This corresponds to the request for a Koji side tag, which is
-a build target used to collect and iterate builds temporarily. This allows builds to be iterated without
-interfering with content in tags that ship to consumers. Once the builds are complete and correct, the
-side tag can then be merged into an existing tag.
-
-
-.. _sidetag-active-testing:
-
-Side_tag_active/Testing
-=======================
-
-The side tag enters this state when it is requested to merge. This happens for example when the
-release requires human feedback and the appropriate waiting period or karma threshold has been
-reached. When the merge completes, the side tag update's state passes to pending testing as with
-any other update.
-
-
-.. _sidetag-active-stable:
-
-Side_tag_active/Stable
-======================
-
-The side tag enters this state when requested to push to stable, for example, when it requests tests
-to be run on builds without human feedback. If the tests pass, Bodhi tries to merge the side tag. If
-that is successful, the update passes to the stable state.
-
-
-.. _sidetag-expired:
-
-Side_tag_expired
-================
-
-A side tag update has a specific lifetime that is set in Bodhi configuration.  After this update's
-lifetime has passed, its state is moved to expired, the underlying update object and all content is
-deleted, and the koji side tag is also deleted.
 
 
 .. _obsolete:

--- a/news/PR4823.dev
+++ b/news/PR4823.dev
@@ -1,0 +1,1 @@
+References to never used `side_tag_active` and `side_tag_expired` update statuses and the `Update.side_tag_locked` property have been removed

--- a/news/summary.migration
+++ b/news/summary.migration
@@ -1,1 +1,2 @@
 The `critpath_groups` column has been added to the Update model (pr:4759)
+The `side_tag_active` and `side_tag_expired` update statuses have been removed, since they were never used (pr:4823)


### PR DESCRIPTION
The `side_tag_active` and `side_tag_expired` statuses have never been used. Let's remove them to not generate confusion, as well as the `Update.side_tag_locked` property.

Signed-off-by: Mattia Verga <mattia.verga@tiscali.it>