### PR TITLE
Add support for frozen release state

### DIFF
--- a/bodhi-client/bodhi/client/cli.py
+++ b/bodhi-client/bodhi/client/cli.py
@@ -194,7 +194,7 @@ release_options = [
                  help='Koji pending signing tag (eg: f20-updates-pending-signing)'),
     click.option('--override-tag', help='Koji override tag (eg: f20-override)'),
     click.option('--state', type=click.Choice(['disabled', 'pending', 'current',
-                                               'archived']),
+                                               'frozen', 'archived']),
                  help='The state of the release'),
     click.option('--mail-template', help='Name of the email template for this release'),
     click.option('--composed-by-bodhi/--not-composed-by-bodhi', is_flag=True, default=None,

--- a/bodhi-server/bodhi/server/services/releases.py
+++ b/bodhi-server/bodhi/server/services/releases.py
@@ -265,7 +265,8 @@ def query_releases_html(request):
 
     release_updates_counts = {}
     releases = Release.all_releases()
-    for release in releases['current'] + releases['pending'] + releases['archived']:
+    for release in (releases['current'] + releases['pending'] + releases['archived']
+                    + releases['frozen']):
         release_updates_counts[release["name"]] = get_update_counts(release["name"])
 
     return {"release_updates_counts": release_updates_counts}

--- a/bodhi-server/bodhi/server/templates/fragments.html
+++ b/bodhi-server/bodhi/server/templates/fragments.html
@@ -384,3 +384,7 @@ __bold__
     </div>
   </div>
 </%def>
+
+<%def name="frozen_badge()">
+  <span class="badge bg-info ms-1" data-bs-toggle="tooltip" data-bs-placement="top" data-bs-title="This release is currently frozen and updates will not be pushed to stable until freeze is lifted">frozen</span>
+</%def>

--- a/bodhi-server/bodhi/server/templates/release.html
+++ b/bodhi-server/bodhi/server/templates/release.html
@@ -6,6 +6,9 @@
             <h3 class="fw-bold m-0"><a href="${request.route_url('releases')}">Releases</a>
               <span class="text-muted">/</span> 
               ${release['long_name']}
+              % if release.state.value == 'frozen':
+              ${self.fragments.frozen_badge()}
+              % endif
             </h3>
         </div>
       </div>
@@ -213,6 +216,13 @@
 <%block name="javascript">
 ${parent.javascript()}
 <script src="${request.static_url('bodhi.server:static/vendor/chartjs/chart.min.js')}"></script>
+
+<script>
+  $(document).ready(function() {
+    // Initialize tooltips
+    $('[data-bs-toggle="tooltip"]').tooltip()
+  });
+</script>
 
 <script type="text/javascript">
   $(document).ready(function() {

--- a/bodhi-server/bodhi/server/templates/releases.html
+++ b/bodhi-server/bodhi/server/templates/releases.html
@@ -7,11 +7,17 @@
 </%def>
 
 <%def name="release_list(release_status, stable_only=False)">
+<%
+if release_status == 'pending':
+  releases_list = request.releases['pending'] + request.releases['frozen']
+else:
+  releases_list = request.releases[release_status]
+%>\
 <ul class="list-group my-3">
     <li class="list-group-item bg-light">
         <div class="row">
             <div class="col fw-bold">
-                ${release_status.capitalize()} Releases <span class="badge rounded-pill text-bg-primary">${len(request.releases[release_status])}</span>
+                ${release_status.capitalize()} Releases <span class="badge rounded-pill text-bg-primary">${len(releases_list)}</span>
             </div>
             % if not stable_only:
             <div class="col-1 align-self-right fw-bold text-muted text-center">Pending</div>
@@ -22,11 +28,14 @@
           </div>
       
     </li>
-    % for r in request.releases[release_status]:
+    % for r in sorted(releases_list, key=lambda i: i['name'], reverse=True):
     <li class="list-group-item">
         <div class="row">
           <div class="col fw-bold">
             <a href="${request.route_url('releases')}${r['name']}">${r['long_name']}</a>
+            % if r['state'] == 'frozen':
+            ${self.fragments.frozen_badge()}
+            % endif
           </div>
           % if not stable_only:
           ${counts_box(r, "pending")}
@@ -53,3 +62,13 @@
     ${release_list('pending', stable_only=False)}
     ${release_list('archived', stable_only=True)}
 </div>
+
+<%block name="javascript">
+${parent.javascript()}
+<script>
+  $(document).ready(function() {
+    // Initialize tooltips
+    $('[data-bs-toggle="tooltip"]').tooltip()
+  });
+</script>
+</%block>

--- a/bodhi-server/bodhi/server/templates/update.html
+++ b/bodhi-server/bodhi/server/templates/update.html
@@ -212,7 +212,7 @@ if can_edit and update.release.composed_by_bodhi:
           <div id="new_comment">
           <input type="hidden" name="csrf_token" value="${request.session.get_csrf_token()}"/>
           <input type="hidden" name="update" value="${update.alias}"/>
-          <div class="card mt-5">
+          <div class="card mt-5 mb-3">
               <div class="card-header pb-0 pt-1 pe-0 bg-light">
                 <div class="row">
                   <div class="col pe-0">
@@ -313,7 +313,7 @@ if can_edit and update.release.composed_by_bodhi:
             </div>
           </div>
           % else:
-          <div class="alert alert-secondary bg-light mt-5 text-center text-muted">
+          <div class="alert alert-secondary bg-light mt-5 mb-3 text-center text-muted">
             <p>
             % if request.matched_route:
               Please <a href="${request.route_url('login') + '?came_from=' + request.current_route_url()}">login</a> to add feedback.
@@ -325,7 +325,18 @@ if can_edit and update.release.composed_by_bodhi:
           %endif
         </div>
         <div class="col-md-3 font-size-09">
-            <div class="mt-3">
+            <div>
+              % if update.release.state == models.ReleaseState.frozen and (update.status == models.UpdateStatus.pending or update.status == models.UpdateStatus.testing):
+              <div class="card border-info mb-1">
+                <div class="card-header text-bg-info h5 fw-bold">
+                  Frozen release
+                </div>
+                <div class="card-body">
+                  This update will not be pushed to stable until freeze is lifted from ${update.release.long_name}.
+                </div>
+              </div>
+              % endif
+
               <div class="h5 d-flex align-items-center fw-bold border-bottom">
                   <div class="py-2 text-uppercase font-size-09">Metadata</div>
               </div>

--- a/bodhi-server/tests/test_push.py
+++ b/bodhi-server/tests/test_push.py
@@ -226,6 +226,20 @@ Locking updates...
 Requesting a compose
 """
 
+TEST_BUILDS_FLAG_FROZEN_EXPECTED_OUTPUT = """
+
+===== <Compose: F37 stable> =====
+
+python-paste-deploy-1.5.2-8.fc37
+
+
+Push these 1 updates? [y/N]: y
+
+Locking updates...
+
+Requesting a compose
+"""
+
 TEST_YES_FLAG_EXPECTED_OUTPUT = """
 
 ===== <Compose: F17 testing> =====
@@ -287,6 +301,20 @@ python-paste-deploy-1.5.2-8.fc26
 
 
 Push these 2 updates? [y/N]: y
+
+Locking updates...
+
+Requesting a compose
+"""
+
+TEST_RELEASES_FLAG_FROZEN_RELEASE_EXPECTED_OUTPUT = """
+
+===== <Compose: F37 testing> =====
+
+python-paste-deploy-1.5.2-8.fc37
+
+
+Push these 1 updates? [y/N]: y
 
 Locking updates...
 
@@ -373,6 +401,25 @@ Requesting a compose
 TEST_BUILDS_AND_UPDATES_FLAG_EXPECTED_OUTPUT = (
     """ERROR: Must specify only one of --updates or --builds
 """)
+
+TEST_ONLY_TESTING_FROZEN_RELEASE_EXPECTED_OUTPUT = """
+
+===== <Compose: F36 stable> =====
+
+python-nose-1.3.7-11.fc36
+
+
+===== <Compose: F37 testing> =====
+
+python-paste-deploy-1.5.2-8.fc37
+
+
+Push these 2 updates? [y/N]: y
+
+Locking updates...
+
+Requesting a compose
+"""
 
 
 @mock.patch("bodhi.server.push.initialize_db", mock.Mock())
@@ -470,6 +517,63 @@ class TestPush(base.BasePyTestCase):
         assert not python_paste_deploy.locked
         assert python_paste_deploy.date_locked is None
 
+    def test_builds_flag_frozen_release(self):
+        """
+        Forcing a push to stable on a build for a frozen release is allowed.
+        """
+        f37 = models.Release(
+            name='F37', long_name='Fedora 37',
+            id_prefix='FEDORA', version='37',
+            dist_tag='f37', stable_tag='f37-updates',
+            testing_tag='f37-updates-testing',
+            candidate_tag='f37-updates-candidate',
+            pending_signing_tag='f37-updates-testing-signing',
+            pending_testing_tag='f37-updates-testing-pending',
+            pending_stable_tag='f37-updates-pending',
+            override_tag='f37-override',
+            branch='f37', state=models.ReleaseState.frozen)
+        self.db.add(f37)
+        self.db.commit()
+        python_nose = self.create_update(['python-nose-1.3.7-11.fc37'], 'F37')
+        python_paste_deploy = self.create_update(['python-paste-deploy-1.5.2-8.fc37'], 'F37')
+        python_nose.builds[0].signed = True
+        python_paste_deploy.builds[0].signed = True
+        python_nose.status = models.UpdateStatus.testing
+        python_paste_deploy.status = models.UpdateStatus.testing
+        python_nose.request = models.UpdateRequest.stable
+        python_paste_deploy.request = models.UpdateRequest.stable
+        self.db.commit()
+        cli = CliRunner()
+
+        with mock.patch('bodhi.server.push.transactional_session_maker',
+                        return_value=base.TransactionalSessionMaker(self.Session)):
+            with mock.patch('bodhi.server.push.compose_task') as compose_task:
+                result = cli.invoke(
+                    push.push,
+                    ['--username', 'bowlofeggs', '--builds', 'python-paste-deploy-1.5.2-8.fc37'],
+                    input='y')
+                f37_python_paste_deploy = self.db.query(models.Build).filter_by(
+                    nvr='python-paste-deploy-1.5.2-8.fc37').one().update
+                compose_task.delay.assert_called_with(
+                    api_version=2, agent="bowlofeggs", resume=False,
+                    composes=[
+                        f37_python_paste_deploy.compose.__json__(composer=True)
+                    ],
+                )
+
+        assert result.exit_code == 0
+        assert result.output == TEST_BUILDS_FLAG_FROZEN_EXPECTED_OUTPUT
+        f37_python_nose = self.db.query(models.Build).filter_by(
+            nvr='python-nose-1.3.7-11.fc37').one().update
+        assert not f37_python_nose.locked
+        assert f37_python_nose.date_locked is None
+        assert f37_python_nose.compose is None
+
+        assert f37_python_paste_deploy.locked
+        assert f37_python_paste_deploy.date_locked <= datetime.utcnow()
+        assert f37_python_paste_deploy.compose.release.id == f37.id
+        assert f37_python_paste_deploy.compose.request == models.UpdateRequest.stable
+
     def test_updates_flag(self):
         """
         Assert correct operation when the --updates flag is given.
@@ -509,6 +613,64 @@ class TestPush(base.BasePyTestCase):
             nvr='python-paste-deploy-1.5.2-8.fc17').one().update
         assert not python_paste_deploy.locked
         assert python_paste_deploy.date_locked is None
+
+    def test_updates_flag_frozen_release(self):
+        """
+        Forcing a push to stable on an update for a frozen release is allowed.
+        """
+        f37 = models.Release(
+            name='F37', long_name='Fedora 37',
+            id_prefix='FEDORA', version='37',
+            dist_tag='f37', stable_tag='f37-updates',
+            testing_tag='f37-updates-testing',
+            candidate_tag='f37-updates-candidate',
+            pending_signing_tag='f37-updates-testing-signing',
+            pending_testing_tag='f37-updates-testing-pending',
+            pending_stable_tag='f37-updates-pending',
+            override_tag='f37-override',
+            branch='f37', state=models.ReleaseState.frozen)
+        self.db.add(f37)
+        self.db.commit()
+        python_nose = self.create_update(['python-nose-1.3.7-11.fc37'], 'F37')
+        python_paste_deploy = self.create_update(['python-paste-deploy-1.5.2-8.fc37'], 'F37')
+        python_nose.builds[0].signed = True
+        python_paste_deploy.builds[0].signed = True
+        python_nose.status = models.UpdateStatus.testing
+        python_paste_deploy.status = models.UpdateStatus.testing
+        python_nose.request = models.UpdateRequest.stable
+        python_paste_deploy.request = models.UpdateRequest.stable
+        self.db.commit()
+        alias_python_paste_deploy = python_paste_deploy.alias
+        cli = CliRunner()
+
+        with mock.patch('bodhi.server.push.transactional_session_maker',
+                        return_value=base.TransactionalSessionMaker(self.Session)):
+            with mock.patch('bodhi.server.push.compose_task') as compose_task:
+                result = cli.invoke(
+                    push.push,
+                    ['--username', 'bowlofeggs', '--updates', alias_python_paste_deploy],
+                    input='y')
+                f37_python_paste_deploy = self.db.query(models.Build).filter_by(
+                    nvr='python-paste-deploy-1.5.2-8.fc37').one().update
+                compose_task.delay.assert_called_with(
+                    api_version=2, agent="bowlofeggs", resume=False,
+                    composes=[
+                        f37_python_paste_deploy.compose.__json__(composer=True)
+                    ],
+                )
+
+        assert result.exit_code == 0
+        assert result.output == TEST_BUILDS_FLAG_FROZEN_EXPECTED_OUTPUT
+        f37_python_nose = self.db.query(models.Build).filter_by(
+            nvr='python-nose-1.3.7-11.fc37').one().update
+        assert not f37_python_nose.locked
+        assert f37_python_nose.date_locked is None
+        assert f37_python_nose.compose is None
+
+        assert f37_python_paste_deploy.locked
+        assert f37_python_paste_deploy.date_locked <= datetime.utcnow()
+        assert f37_python_paste_deploy.compose.release.id == f37.id
+        assert f37_python_paste_deploy.compose.request == models.UpdateRequest.stable
 
     def test_updates_and_builds_flag(self):
         """
@@ -779,6 +941,98 @@ class TestPush(base.BasePyTestCase):
         assert f26_python_paste_deploy.compose.release.id == f26.id
         assert f26_python_paste_deploy.compose.request == models.UpdateRequest.testing
 
+    def test_releases_flag_frozen_release_testing_request(self):
+        """
+        Assert correct operation from the --releases flag with frozen release and testing request.
+        """
+        f37 = models.Release(
+            name='F37', long_name='Fedora 37',
+            id_prefix='FEDORA', version='37',
+            dist_tag='f37', stable_tag='f37-updates',
+            testing_tag='f37-updates-testing',
+            candidate_tag='f37-updates-candidate',
+            pending_signing_tag='f37-updates-testing-signing',
+            pending_testing_tag='f37-updates-testing-pending',
+            pending_stable_tag='f37-updates-pending',
+            override_tag='f37-override',
+            branch='f37', state=models.ReleaseState.frozen)
+        f36 = models.Release(
+            name='F36', long_name='Fedora 36',
+            id_prefix='FEDORA', version='36',
+            dist_tag='f36', stable_tag='f36-updates',
+            testing_tag='f36-updates-testing',
+            candidate_tag='f36-updates-candidate',
+            pending_signing_tag='f36-updates-testing-signing',
+            pending_testing_tag='f36-updates-testing-pending',
+            pending_stable_tag='f36-updates-pending',
+            override_tag='f36-override',
+            branch='f36', state=models.ReleaseState.current)
+        self.db.add(f37)
+        self.db.add(f36)
+        self.db.commit()
+        python_nose_f36 = self.create_update(['python-nose-1.3.7-11.fc36'], 'F36')
+        python_nose_f37 = self.create_update(['python-nose-1.3.7-11.fc37'], 'F37')
+        python_paste_deploy = self.create_update(['python-paste-deploy-1.5.2-8.fc37'], 'F37')
+        python_nose_f36.builds[0].signed = True
+        python_nose_f37.builds[0].signed = True
+        python_paste_deploy.builds[0].signed = True
+        python_nose_f36.status = models.UpdateStatus.testing
+        python_nose_f37.status = models.UpdateStatus.testing
+        python_paste_deploy.status = models.UpdateStatus.pending
+        python_nose_f36.request = models.UpdateRequest.stable
+        python_nose_f37.request = models.UpdateRequest.stable
+        python_paste_deploy.request = models.UpdateRequest.testing
+        self.db.commit()
+        cli = CliRunner()
+
+        with mock.patch('bodhi.server.push.transactional_session_maker',
+                        return_value=base.TransactionalSessionMaker(self.Session)):
+            with mock.patch('bodhi.server.push.compose_task') as compose_task:
+                result = cli.invoke(push.push, ['--username', 'bowlofeggs', '--releases', 'f37,f36',
+                                                '--request', 'testing'],
+                                    input='y')
+                # The call to push modifies the database, so we need to modify the expected call to
+                # suit.
+                f37_python_paste_deploy = self.db.query(models.Build).filter_by(
+                    nvr='python-paste-deploy-1.5.2-8.fc37').one().update
+                compose_task.delay.assert_called_with(
+                    api_version=2, agent="bowlofeggs", resume=False,
+                    composes=[
+                        f37_python_paste_deploy.compose.__json__(composer=True)
+                    ],
+                )
+
+        assert result.exit_code == 0
+        assert result.output == TEST_RELEASES_FLAG_FROZEN_RELEASE_EXPECTED_OUTPUT
+        # The Fedora 17 updates should not have been locked.
+        f17_python_nose = self.db.query(models.Build).filter_by(
+            nvr='python-nose-1.3.7-11.fc17').one().update
+        f17_python_paste_deploy = self.db.query(models.Build).filter_by(
+            nvr='python-paste-deploy-1.5.2-8.fc17').one().update
+        assert not f17_python_nose.locked
+        assert f17_python_nose.date_locked is None
+        assert f17_python_nose.compose is None
+        assert not f17_python_paste_deploy.locked
+        assert f17_python_paste_deploy.date_locked is None
+        assert f17_python_paste_deploy.compose is None
+        # These two should not have been locked and composed.
+        f36_python_nose = self.db.query(models.Build).filter_by(
+            nvr='python-nose-1.3.7-11.fc36').one().update
+        f37_python_nose = self.db.query(models.Build).filter_by(
+            nvr='python-nose-1.3.7-11.fc37').one().update
+        assert not f36_python_nose.locked
+        assert f36_python_nose.date_locked is None
+        assert f36_python_nose.compose is None
+        assert not f37_python_nose.locked
+        assert f37_python_nose.date_locked is None
+        assert f37_python_nose.compose is None
+        # The python-paste_deploy F37 should be locked.
+        assert f37_python_paste_deploy.locked
+        assert f37_python_paste_deploy.date_locked <= datetime.utcnow()
+        # ...and associated with the new Compose.
+        assert f37_python_paste_deploy.compose.release.id == f37.id
+        assert f37_python_paste_deploy.compose.request == models.UpdateRequest.testing
+
     def test_create_composes_for_releases_marked_as_composed_by_bodhi(self):
         """
         Assert that composes are created only for releases marked as 'composed_by_bodhi'.
@@ -864,6 +1118,102 @@ class TestPush(base.BasePyTestCase):
         assert f26_python_paste_deploy.compose.release.id == f26.id
         assert f26_python_paste_deploy.compose.request == models.UpdateRequest.testing
 
+    def test_only_testing_compose_for_frozen_release(self):
+        """
+        Assert that only testing requests are composed for frozen releases.
+        """
+        f37 = models.Release(
+            name='F37', long_name='Fedora 37',
+            id_prefix='FEDORA', version='37',
+            dist_tag='f37', stable_tag='f37-updates',
+            testing_tag='f37-updates-testing',
+            candidate_tag='f37-updates-candidate',
+            pending_signing_tag='f37-updates-testing-signing',
+            pending_testing_tag='f37-updates-testing-pending',
+            pending_stable_tag='f37-updates-pending',
+            override_tag='f37-override',
+            branch='f37', state=models.ReleaseState.frozen)
+        f36 = models.Release(
+            name='F36', long_name='Fedora 36',
+            id_prefix='FEDORA', version='36',
+            dist_tag='f36', stable_tag='f36-updates',
+            testing_tag='f36-updates-testing',
+            candidate_tag='f36-updates-candidate',
+            pending_signing_tag='f36-updates-testing-signing',
+            pending_testing_tag='f36-updates-testing-pending',
+            pending_stable_tag='f36-updates-pending',
+            override_tag='f36-override',
+            branch='f36', state=models.ReleaseState.current)
+        self.db.add(f37)
+        self.db.add(f36)
+        self.db.commit()
+        python_nose_f36 = self.create_update(['python-nose-1.3.7-11.fc36'], 'F36')
+        python_nose_f37 = self.create_update(['python-nose-1.3.7-11.fc37'], 'F37')
+        python_paste_deploy = self.create_update(['python-paste-deploy-1.5.2-8.fc37'], 'F37')
+        python_nose_f36.builds[0].signed = True
+        python_nose_f37.builds[0].signed = True
+        python_paste_deploy.builds[0].signed = True
+        python_nose_f36.status = models.UpdateStatus.testing
+        python_nose_f37.status = models.UpdateStatus.testing
+        python_paste_deploy.status = models.UpdateStatus.pending
+        python_nose_f36.request = models.UpdateRequest.stable
+        python_nose_f37.request = models.UpdateRequest.stable
+        python_paste_deploy.request = models.UpdateRequest.testing
+        # Let's mark Fedora 17 release as not composed by Bodhi
+        f17_release = self.db.query(models.Release).filter_by(
+            name='F17').one()
+        f17_release.composed_by_bodhi = False
+        self.db.commit()
+        cli = CliRunner()
+
+        with mock.patch('bodhi.server.push.transactional_session_maker',
+                        return_value=base.TransactionalSessionMaker(self.Session)):
+            with mock.patch('bodhi.server.push.compose_task') as compose_task:
+                result = cli.invoke(push.push, ['--username', 'bowlofeggs'], input='y')
+                # Calling push alters the database, so we need to update the expected call to
+                # reflect the changes.
+                f36_python_nose = self.db.query(models.Build).filter_by(
+                    nvr='python-nose-1.3.7-11.fc36').one().update
+                f37_python_paste_deploy = self.db.query(models.Build).filter_by(
+                    nvr='python-paste-deploy-1.5.2-8.fc37').one().update
+                compose_task.delay.assert_called_with(
+                    api_version=2, agent="bowlofeggs", resume=False,
+                    composes=[
+                        f36_python_nose.compose.__json__(composer=True),
+                        f37_python_paste_deploy.compose.__json__(composer=True)
+                    ],
+                )
+
+        assert result.exit_code == 0
+        assert result.output == TEST_ONLY_TESTING_FROZEN_RELEASE_EXPECTED_OUTPUT
+        # The Fedora 17 updates should not have been locked and composed.
+        f17_python_nose = self.db.query(models.Build).filter_by(
+            nvr='python-nose-1.3.7-11.fc17').one().update
+        f17_python_paste_deploy = self.db.query(models.Build).filter_by(
+            nvr='python-paste-deploy-1.5.2-8.fc17').one().update
+        assert not f17_python_nose.locked
+        assert f17_python_nose.date_locked is None
+        assert f17_python_nose.compose is None
+        assert not f17_python_paste_deploy.locked
+        assert f17_python_paste_deploy.date_locked is None
+        assert f17_python_paste_deploy.compose is None
+        # The python-nose F37 should not have been locked and composed.
+        f37_python_nose = self.db.query(models.Build).filter_by(
+            nvr='python-nose-1.3.7-11.fc37').one().update
+        assert not f37_python_nose.locked
+        assert f37_python_nose.date_locked is None
+        assert f37_python_nose.compose is None
+        # The python-nose F36 and python-paste_deploy F37 should both be locked.
+        assert f36_python_nose.locked
+        assert f36_python_nose.date_locked <= datetime.utcnow()
+        assert f37_python_paste_deploy.locked
+        assert f37_python_paste_deploy.date_locked <= datetime.utcnow()
+        # The two updates should also be associated with the new Composes.
+        assert f36_python_nose.compose.release.id == f36.id
+        assert f36_python_nose.compose.request == models.UpdateRequest.stable
+        assert f37_python_paste_deploy.compose.release.id == f37.id
+        assert f37_python_paste_deploy.compose.request == models.UpdateRequest.testing
+
     def test_request_flag(self):
         """
         Assert that the --request flag works correctly.
@@ -905,6 +1255,65 @@ class TestPush(base.BasePyTestCase):
                 assert u.compose.release.id == python_paste_deploy.release.id
                 assert u.compose.request == models.UpdateRequest.testing
                 assert u.compose.content_type == models.ContentType.rpm
+
+    def test_request_stable_flag(self):
+        """
+        Assert that the --request stable flag works correctly.
+        """
+        # Let's mark nose as a stable request so it gets composed when we request a stable update.
+        python_nose = self.db.query(models.Build).filter_by(
+            nvr='python-nose-1.3.7-11.fc17').one().update
+        python_nose.request = models.UpdateRequest.stable
+
+        f37 = models.Release(
+            name='F37', long_name='Fedora 37',
+            id_prefix='FEDORA', version='37',
+            dist_tag='f37', stable_tag='f37-updates',
+            testing_tag='f37-updates-testing',
+            candidate_tag='f37-updates-candidate',
+            pending_signing_tag='f37-updates-testing-signing',
+            pending_testing_tag='f37-updates-testing-pending',
+            pending_stable_tag='f37-updates-pending',
+            override_tag='f37-override',
+            branch='f37', state=models.ReleaseState.frozen)
+        self.db.add(f37)
+        self.db.commit()
+        python_nose_f37 = self.create_update(['python-nose-1.3.7-11.fc37'], 'F37')
+        python_nose_f37.builds[0].signed = True
+        python_nose_f37.status = models.UpdateStatus.testing
+        python_nose_f37.request = models.UpdateRequest.stable
+        self.db.commit()
+        cli = CliRunner()
+
+        with mock.patch('bodhi.server.push.transactional_session_maker',
+                        return_value=base.TransactionalSessionMaker(self.Session)):
+            with mock.patch('bodhi.server.push.compose_task') as compose_task:
+                result = cli.invoke(push.push, ['--username', 'bowlofeggs', '--request', 'stable'],
+                                    input='y')
+                # The call to push modifies the database, so we need to modify the expected call to
+                # suit.
+                python_nose = self.db.query(models.Build).filter_by(
+                    nvr='python-nose-1.3.7-11.fc17').one().update
+                compose_task.delay.assert_called_with(
+                    api_version=2, agent="bowlofeggs", resume=False, composes=[
+                        python_nose.compose.__json__(composer=True)
+                    ],
+                )
+
+            assert result.exit_code == 0
+            python_bodhi = self.db.query(models.Build).filter_by(
+                nvr='bodhi-2.0-1.fc17').one().update
+            assert not python_bodhi.locked
+            assert python_bodhi.date_locked is None
+            assert python_bodhi.compose is None
+            # Stable compose for frozen release should not be processed
+            assert not python_nose_f37.locked
+            assert python_nose_f37.date_locked is None
+            assert python_nose_f37.compose is None
+            # Stable compose for f17 should have been processed
+            assert python_nose.locked
+            assert python_nose.date_locked <= datetime.utcnow()
+            assert python_nose.compose.release.id == python_nose.release.id
 
     def test_resume_flag(self):
         """

--- a/news/4103.bug
+++ b/news/4103.bug
@@ -1,0 +1,1 @@
+Releases in frozen state will now be listed in the release page and a warning box will be showed for updates of those releases

--- a/news/4478.feature
+++ b/news/4478.feature
@@ -1,0 +1,1 @@
+Bodhi-push now defaults to push only testing composes for frozen releases

--- a/news/PR4831.feature
+++ b/news/PR4831.feature
@@ -1,0 +1,1 @@
+Frozen releases updates will now be forced into testing before being pushed to stable


### PR DESCRIPTION
The `frozen` release state has been available for a while, but it was never used in releng workflow. There are also many bits missing from Bodhi code to be functional. This PR will add those bits.

- display frozen releases in release list (fixes #4103  )
- show an info pane on updates pages informing user that the release is frozen
- allow bodhi CLI to edit a release state into `frozen` state
- make bodhi-push work with frozen releases
- force updates of frozen releases into testing before requesting them to stable

About bodhi-push, it now defaults to push stable composes for pending + current releases (just like before) and push testing composes for pending + current + frozen. This will avoid releng to stop the automatic cronjob in freeze periods (fixes #4478 ). It allows to push to stable specific updates or builds even if the release is frozen, though.
