### PR TITLE
Warn on new update form when release is approaching EOL

### DIFF
--- a/bodhi-server/bodhi/server/static/css/site.css
+++ b/bodhi-server/bodhi/server/static/css/site.css
@@ -33,10 +33,6 @@ a {
     margin-right: 0px;
 }
 
-ul {
-    list-style: none;
-}
-
 .table colgroup.strip {
     width: 10px !important;
 }

--- a/bodhi-server/bodhi/server/templates/new_update.html
+++ b/bodhi-server/bodhi/server/templates/new_update.html
@@ -1,6 +1,8 @@
 <%inherit file="master.html"/>
 <%
-  from bodhi.server.util import json_escape
+  from bodhi.server.util import json_escape, eol_releases
+
+  eol_list = eol_releases()
 %>
 
 <%block name="css">
@@ -45,6 +47,21 @@ ${parent.css()}
         interface tool</a>.</p>
     </div>
   </div>
+
+  % if eol_list:
+    <div class="row justify-content-center">
+      <div class="col-10 alert alert-info" role="alert">
+        <p>The following releases are appoaching End-Of-Life:<br/>
+        <ul>
+        % for release in eol_list:
+        <li><strong>${release[0] | n}</strong> will go EOL on ${release[1]}
+        % endfor
+        </ul>
+        Consider that before submitting any update for those releases!
+        </p>
+      </div>
+    </div>
+  % endif
 
   <div id="new-update-form" class="pt-3" style="display:none;">
     <div class="row justify-content-center">

--- a/news/PR4834.feature
+++ b/news/PR4834.feature
@@ -1,0 +1,1 @@
+The new update form UI will now display a warning when a release is approaching EOL


### PR DESCRIPTION
We now have EOL field for Release, let's warn users on the new update form when any active release is approaching its EOL.

Signed-off-by: Mattia Verga <mattia.verga@tiscali.it>