### PR TITLE
Fix metadata generation and update dates

### DIFF
--- a/bodhi-server/bodhi/server/migrations/versions/e3988e00b338_drop_date_pushed.py
+++ b/bodhi-server/bodhi/server/migrations/versions/e3988e00b338_drop_date_pushed.py
@@ -1,0 +1,51 @@
+# Copyright (c) 2022 Mattia Verga
+#
+# This file is part of Bodhi.
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+"""
+Drop date_pushed.
+
+Revision ID: e3988e00b338
+Revises: 499ac8bbe09a
+Create Date: 2022-11-23 17:59:20.906216
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+# revision identifiers, used by Alembic.
+revision = 'e3988e00b338'
+down_revision = '499ac8bbe09a'
+
+
+def upgrade():
+    """Drop date_pushed from Update model.
+
+    date_pushed is either date_stable, date_testing or None, so we will just replace it
+    with a Python property.
+    """
+    op.drop_column('updates', 'date_pushed')
+
+
+def downgrade():
+    """Re-create date_pushed.
+
+    date_pushed will be re-set to date_stable or date_testing.
+    """
+    op.add_column('updates', sa.Column('date_pushed', postgresql.TIMESTAMP(),
+                                       autoincrement=False, nullable=True))
+    op.execute("UPDATE updates SET date_pushed = GREATEST(date_stable,date_testing)")

--- a/bodhi-server/bodhi/server/models.py
+++ b/bodhi-server/bodhi/server/models.py
@@ -3889,6 +3889,7 @@ class Update(Base):
                 log.info("%s reached stable karma threshold, but does not meet gating "
                          "requirements", self.alias)
                 return
+            self.date_approved = datetime.utcnow()
             if self.autokarma:
                 log.info("Automatically marking %s as stable", self.alias)
                 self.set_request(db, UpdateRequest.stable, agent)

--- a/bodhi-server/bodhi/server/tasks/approve_testing.py
+++ b/bodhi-server/bodhi/server/tasks/approve_testing.py
@@ -101,6 +101,8 @@ def approve_update(update: Update, db: Session):
         # Do not add the release.pending_stable_tag if the update
         # was created from a side tag.
         if update.release.composed_by_bodhi:
+            if not update.date_approved:
+                update.date_approved = func.current_timestamp()
             update.set_request(db=db, action=UpdateRequest.stable, username="bodhi")
         # For updates that are not included in composes run by bodhi itself,
         # mark them as stable
@@ -131,7 +133,7 @@ def approve_update(update: Update, db: Session):
             update.status = UpdateStatus.stable
             update.request = None
             update.pushed = True
-            update.date_stable = func.current_timestamp()
+            update.date_stable = update.date_approved = func.current_timestamp()
             update.comment(db, "This update has been submitted for stable by bodhi",
                            author=u'bodhi')
             update.modify_bugs()

--- a/bodhi-server/bodhi/server/tasks/approve_testing.py
+++ b/bodhi-server/bodhi/server/tasks/approve_testing.py
@@ -131,7 +131,7 @@ def approve_update(update: Update, db: Session):
             update.status = UpdateStatus.stable
             update.request = None
             update.pushed = True
-            update.date_stable = update.date_pushed = func.current_timestamp()
+            update.date_stable = func.current_timestamp()
             update.comment(db, "This update has been submitted for stable by bodhi",
                            author=u'bodhi')
             update.modify_bugs()

--- a/bodhi-server/bodhi/server/tasks/composer.py
+++ b/bodhi-server/bodhi/server/tasks/composer.py
@@ -672,7 +672,6 @@ class ComposerThread(threading.Thread):
                 update.date_stable = now
                 if update.from_tag:
                     eol_sidetags.append(update.from_tag)
-            update.date_pushed = now
             update.pushed = True
 
         log.info('Deleting EOL side-tags.')

--- a/bodhi-server/tests/services/test_updates.py
+++ b/bodhi-server/tests/services/test_updates.py
@@ -2696,7 +2696,7 @@ class TestUpdatesService(BasePyTestCase):
         assert not body['updates']
 
         # Now approve one
-        self.db.query(Update).first().date_pushed = now
+        self.db.query(Update).first().date_stable = now
         self.db.commit()
 
         # And try again
@@ -2745,7 +2745,7 @@ class TestUpdatesService(BasePyTestCase):
         assert not body['updates']
 
         # Now approve one
-        self.db.query(Update).first().date_pushed = now
+        self.db.query(Update).first().date_stable = now
         self.db.commit()
 
         # And try again

--- a/bodhi-server/tests/test_metadata.py
+++ b/bodhi-server/tests/test_metadata.py
@@ -73,7 +73,6 @@ class TestAddUpdate(UpdateInfoMetadataTestCase):
         """
         update = self.db.query(Update).one()
         now = datetime(year=2018, month=2, day=8, hour=12, minute=41, second=4)
-        update.date_pushed = now
         update.date_modified = now
         md = UpdateInfoMetadata(update.release, update.request, self.db, self.temprepo,
                                 close_shelf=False)
@@ -202,7 +201,7 @@ class TestAddUpdate(UpdateInfoMetadataTestCase):
         expected = datetime(year=2022, month=11, day=23, hour=12, minute=41, second=4)
         update = self.db.query(Update).one()
         update.date_modified = date_modified
-        update.date_pushed = date_pushed
+        update.date_stable = date_pushed
         if not date_modified and not date_pushed:
             update.date_submitted = expected
         md = UpdateInfoMetadata(update.release, update.request, self.db, self.temprepo,
@@ -216,7 +215,7 @@ class TestAddUpdate(UpdateInfoMetadataTestCase):
     def test_date_pushed_none(self):
         """updated_date should use date_submitted if an update's date_pushed is None."""
         update = self.db.query(Update).one()
-        update.date_pushed = None
+        update.date_stable = update.date_testing = None
         md = UpdateInfoMetadata(update.release, update.request, self.db, self.temprepo,
                                 close_shelf=False)
         md.add_update(update)
@@ -277,7 +276,7 @@ class TestFetchUpdates(UpdateInfoMetadataTestCase):
     def test_build_unassociated(self, warning):
         """A warning should be logged if the Bodhi Build object is not associated with an Update."""
         update = self.db.query(Update).one()
-        update.date_pushed = None
+        update.date_stable = update.date_testing = None
         u = base.create_update(self.db, ['TurboGears-1.0.2.2-4.fc17'])
         u.builds[0].update = None
         self.db.flush()
@@ -397,7 +396,7 @@ class TestUpdateInfoMetadata(UpdateInfoMetadataTestCase):
         # Pretend it's pushed to testing
         update.status = UpdateStatus.testing
         update.request = None
-        update.date_pushed = datetime.utcnow()
+        update.date_testing = datetime.utcnow()
         DevBuildsys.__tagged__[update.title] = ['f17-updates-testing']
 
         # Generate the XML

--- a/news/2487.bug
+++ b/news/2487.bug
@@ -1,0 +1,1 @@
+Updateinfo.xml metadata generation has been changed in order to try to fix errors reported by yum on EPEL

--- a/news/4171.bug
+++ b/news/4171.bug
@@ -1,0 +1,1 @@
+The `date_approved` property of the `Update` model is now set when the update is ready to be pushed to stable

--- a/news/4837.dev
+++ b/news/4837.dev
@@ -1,0 +1,1 @@
+The `date_pushed` database column of the `Update` model has been dropped and replaced by a property, no change should be noticeable to users

--- a/news/summary.migration
+++ b/news/summary.migration
@@ -1,2 +1,3 @@
 The `critpath_groups` column has been added to the Update model (pr:4759)
 The `side_tag_active` and `side_tag_expired` update statuses have been removed, since they were never used (pr:4823)
+The `date_pushed` database column of the `Update` model has been dropped and replaced by a property


### PR DESCRIPTION
This PR was born to fix metadata generation in the Updateinfo.xml file and it then expanded to fix also update dates.

I have split the PR in three commits: the first one will change `status`, `issued_date` and `updated_date` for each entry in the updateinfo.xml file. The `status` reported was actually wrong, because the metadata is generated before the new update status is saved to database; `issued_date` is expected to never change, but before we used to update it to the date the update was pushed - and `date_pushed` was changing from `date_testing` to `None` to `date_stable`. I hope these changes will possibly fix #2487 

The second commit will drop the `date_pushed` column and change it to a sqlalchemy hybrid property. No change should be noticeable by users/consumers. Fixes #4837 

The last change will set `date_approved` when appropriate (fixes #4171 fixes #3077)

Signed-off-by: Mattia Verga <mattia.verga@tiscali.it>