### PR TITLE
Update Vagrant to F37

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -16,9 +16,9 @@ VAGRANTFILE_API_VERSION = "2"
 fas_username = ""
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
- config.vm.box_url = "https://download.fedoraproject.org/pub/fedora/linux/releases/36/Cloud/x86_64/images/Fedora-Cloud-Base-Vagrant-36-1.5.x86_64.vagrant-libvirt.box"
- config.vm.box = "f36-cloud-libvirt"
- config.vm.box_download_checksum = "afa6304fddb15aaa1a4877c251ac15482726877c86861ed23385ef9f7750f9c0"
+ config.vm.box_url = "https://download.fedoraproject.org/pub/fedora/linux/releases/37/Cloud/x86_64/images/Fedora-Cloud-Base-Vagrant-37-1.7.x86_64.vagrant-libvirt.box"
+ config.vm.box = "f37-cloud-libvirt"
+ config.vm.box_download_checksum = "a158ee99a4a078a94913716cb0b6453bf1da603d3b9376f33e68ab175974c60b"
  config.vm.box_download_checksum_type = "sha256"
 
  # Forward traffic on the host to the development server on the guest.

--- a/devel/ansible/roles/bodhi/tasks/main.yml
+++ b/devel/ansible/roles/bodhi/tasks/main.yml
@@ -25,7 +25,7 @@
       - pcaro-hermit-fonts
       - pcp-system-tools
       - pre-commit
-      - poetry
+      #- poetry
       - postgresql-devel
       - postgresql-server
       - python3-alembic
@@ -127,6 +127,11 @@
 - name: pip install jinja2-cli
   pip:
       name: jinja2-cli
+
+# The version packaged in Fedora 37 is not compatible with lockfile
+- name: pip install "poetry>=1.2"
+  pip:
+      name: "poetry>=1.2"
 
 - name: Fake a pungi install
   file:


### PR DESCRIPTION
Poetry in F36 is buggy, let's update Vagrant to use F37.
Note that vagrant appear now to misbehave  with mirrormanager redirects: https://github.com/fedora-infra/mirrormanager2/issues/315

Signed-off-by: Mattia Verga <mattia.verga@tiscali.it>