### PR TITLE
Explicitly add requests to bodhi-client dependencies

### DIFF
--- a/bodhi-client/pyproject.toml
+++ b/bodhi-client/pyproject.toml
@@ -46,6 +46,7 @@ click = ">=7.1.2"
 koji = ">=1.27.1"
 authlib = ">=0.15.4"
 munch = ">=2.5.0"
+requests = "^2.27"
 requests-kerberos = ">=0.12"
 
 [build-system]


### PR DESCRIPTION
Dependabot sometimes downgrades requests in lockfile to a really old version, let's pin it to 2.27+ so that it officially supports python 3.10.

Signed-off-by: Mattia Verga <mattia.verga@tiscali.it>