### PR TITLE
bodhi-client: do not run `koji wait-repo` when expiring a buildroot override

### DIFF
--- a/bodhi-client/bodhi/client/cli.py
+++ b/bodhi-client/bodhi/client/cli.py
@@ -300,7 +300,9 @@ def _save_override(url: str, staging: bool, edit: bool = False,
                                 edit=edit,
                                 expired=kwargs.get('expire', False))
 
-    if kwargs['wait']:
+    if kwargs.get('expire', False):
+        print_resp(resp, client, override_hint=False)
+    elif kwargs['wait']:
         print_resp(resp, client, override_hint=False)
         command = _generate_wait_repo_command(resp, client)
         if command:

--- a/bodhi-client/tests/test_cli.py
+++ b/bodhi-client/tests/test_cli.py
@@ -1979,13 +1979,14 @@ class TestEditBuildrootOverrides:
     Test the edit_buildroot_overrides() function.
     """
 
-    def test_expired_override(self, mocked_client_class):
+    def test_expire(self, mocked_client_class, mocker):
         """
         Assert that a successful overrides edit request expires the request
         when --expired flag is set.
         """
         mocked_client_class.send_request.return_value = \
             client_test_data.EXAMPLE_EXPIRED_OVERRIDE_MUNCH
+        call = mocker.patch('bodhi.client.cli.subprocess.call', return_value=0)
         runner = testing.CliRunner()
 
         result = runner.invoke(
@@ -1998,6 +1999,7 @@ class TestEditBuildrootOverrides:
 
         assert result.exit_code == 0
         assert result.output == client_test_data.EXPECTED_EXPIRED_OVERRIDES_OUTPUT
+        call.assert_not_called()
         # datetime is a C extension that can't be mocked, so let's just assert that the time is
         # about a week away.
         expire_time = mocked_client_class.send_request.mock_calls[0][2]['data']['expiration_date']

--- a/news/4830.bug
+++ b/news/4830.bug
@@ -1,0 +1,1 @@
+bodhi-client: do not run `koji wait-repo` when expiring a buildroot override


### PR DESCRIPTION
Fixes #4830 

Signed-off-by: Mattia Verga <mattia.verga@tiscali.it>