### PR TITLE
Add a marker to stop scanners from alerting on this false positive in docs

### DIFF
--- a/docs/developer/virtualenv.rst
+++ b/docs/developer/virtualenv.rst
@@ -79,7 +79,7 @@ Set the configuration key
 to point to the postgresql database. Something like:
 ::
 
-    sqlalchemy.url = postgresql://postgres:anypasswordworkslocally@localhost/bodhi2
+    sqlalchemy.url = postgresql://postgres:anypasswordworkslocally@localhost/bodhi2 # gitleaks:allow
 
 
 Upgrade the database


### PR DESCRIPTION
This should stop scanners from telling us that there is a real exposed password here, when there is clearly not.