### PR TITLE
bodhi-server: pin sqlalchemy to v1

### DIFF
--- a/bodhi-server/pyproject.toml
+++ b/bodhi-server/pyproject.toml
@@ -109,7 +109,7 @@ pyramid-mako = ">=1.0.2"
 python-bugzilla = ">=3.2.0"
 PyYAML = ">=5.4.1"
 requests = ">=2.25.1"
-SQLAlchemy = ">=1.3.24"
+SQLAlchemy = "^1.3.24"
 waitress = ">=1.4.4"
 
 [tool.pytest.ini_options]


### PR DESCRIPTION
Sqlalchemy-schemadisplay is not yet compatible with sqlalchemy v2, so for the moment let's pin the dependency to v1 to not break building docs.

Signed-off-by: Mattia Verga <mattia.verga@tiscali.it>