### PR TITLE
Set a limit to update.notes length

### DIFF
--- a/bodhi-server/bodhi/server/config.py
+++ b/bodhi-server/bodhi/server/config.py
@@ -605,6 +605,9 @@ class BodhiConfig(dict):
         'test_gating.url': {
             'value': '',
             'validator': str},
+        'update_notes_maxlength': {
+            'value': 10000,
+            'validator': int},
         'updateinfo_rights': {
             'value': 'Copyright (C) {} Red Hat, Inc. and others.'.format(datetime.now().year),
             'validator': str},

--- a/bodhi-server/bodhi/server/consumers/automatic_updates.py
+++ b/bodhi-server/bodhi/server/consumers/automatic_updates.py
@@ -167,9 +167,11 @@ class AutomaticUpdateHandler:
 ##### **Changelog**
 
 ```
-{changelog}
+{{}}
 ```"""
-
+                if len(changelog) > config.get('update_notes_maxlength') - len(notes):
+                    changelog = '[CHANGELOG OMITTED BECAUSE TOO LONG]'
+                notes = notes.format(changelog)
                 if rel.name not in config.get('bz_exclude_rels'):
                     for b in re.finditer(config.get('bz_regex'), changelog, re.IGNORECASE):
                         idx = int(b.group(1))

--- a/bodhi-server/bodhi/server/models.py
+++ b/bodhi-server/bodhi/server/models.py
@@ -2857,7 +2857,12 @@ class Update(Base):
 
                     # Also inherit the older updates notes as well and
                     # add a markdown separator between the new and old ones.
-                    self.notes += '\n\n----\n\n' + oldBuild.update.notes
+                    # If it's an automatic update, do not copy the changelog again.
+                    re_changelog = re.compile(r"(?s)\n##### \*\*Changelog\*\*\n\n```\n.*\n```")
+                    old_notes = re.sub(re_changelog, '', oldBuild.update.notes)
+                    new_notes = self.notes + '\n\n----\n\n' + old_notes
+                    if len(new_notes) <= config.get('update_notes_maxlength'):
+                        self.notes = new_notes
                     oldBuild.update.obsolete(db, newer=build)
                     template = ('This update has obsoleted %s, and has '
                                 'inherited its bugs and notes.')

--- a/bodhi-server/bodhi/server/schemas.py
+++ b/bodhi-server/bodhi/server/schemas.py
@@ -205,7 +205,7 @@ class SaveUpdateSchema(CSRFProtectedSchema, colander.MappingSchema):
     )
     notes = colander.SchemaNode(
         colander.String(),
-        validator=colander.Length(min=2),
+        validator=colander.Length(min=2, max=config.get('update_notes_maxlength')),
         missing_msg='A description is required for the update.'
     )
     autokarma = colander.SchemaNode(

--- a/bodhi-server/bodhi/server/templates/new_update.html
+++ b/bodhi-server/bodhi/server/templates/new_update.html
@@ -1,5 +1,6 @@
 <%inherit file="master.html"/>
 <%
+  from bodhi.server.config import config
   from bodhi.server.util import json_escape, eol_releases
 
   eol_list = eol_releases()
@@ -145,13 +146,18 @@ ${parent.css()}
                 </div>
               </div>
             </h6>
-            <textarea class="form-control" id="notes" name="notes" rows="6"
+            <textarea class="form-control" id="notes" name="notes" rows="6" maxlength="${config.get('update_notes_maxlength')}"
               placeholder="Update notes go here.  Please be as descriptive as possible.  Help testers know what to test, and users know why this update is available and what major changes it brings (if any)." required="true">
 % if update:
 ${update.notes}
 % endif
 </textarea>
-<p class="mb-1 text-right"><small>Description field uses <a href="#" data-bs-toggle="modal" data-bs-target="#markdown-help">Fedora-Flavored Markdown</a>.</small></p>
+<small>
+<p class="mb-1">
+<span id="notes_length" class="float-start fw-bold"></span>
+<span class="float-end">Description field uses <a href="#" data-bs-toggle="modal" data-bs-target="#markdown-help">Fedora-Flavored Markdown</a>.</span>
+</p>
+</small>
 
           </div>
           
@@ -420,5 +426,22 @@ ${parent.javascript()}
 
 <script>$("#js-warning").hide();$("#new-update-form").show();</script>
 <script> $(document).ready(function() { $('.panel-heading > span, dt').tooltip(); }); </script>
+<script>
+$(document).ready(function() {
+  var maxLength = $("#notes").attr("maxlength");
+  $("#notes_length").html($("#notes").val().length + "/" + maxLength);
+  $("#notes").bind('input propertychange', function() {
+    $("#notes_length").html($("#notes").val().length + "/" + maxLength);
+    if ($(this).val().length > maxLength) {
+      $("#notes_length").addClass('text-danger');
+      $("#notes").addClass('border-danger');
+    }
+    else {
+      $("#notes_length").removeClass('text-danger');
+      $("#notes").removeClass('border-danger');
+    }
+  })
+});
+</script>
 </%block>
 

--- a/bodhi-server/tests/services/test_updates.py
+++ b/bodhi-server/tests/services/test_updates.py
@@ -272,6 +272,15 @@ class TestNewUpdate(BasePyTestCase):
     @mock.patch.dict('bodhi.server.validators.config', {'acl_system': 'dummy'})
     @mock.patch(**mock_uuid4_version1)
     @mock.patch(**mock_valid_requirements)
+    def test_update_notes_exceed_maximum(self, *args):
+        update = self.get_update('bodhi-2.1-1.fc17')
+        update['notes'] = 'a' * 10001
+        res = self.app.post_json('/updates/', update, status=400)
+        assert 'Longer than maximum length 10000' in res
+
+    @mock.patch.dict('bodhi.server.validators.config', {'acl_system': 'dummy'})
+    @mock.patch(**mock_uuid4_version1)
+    @mock.patch(**mock_valid_requirements)
     def test_new_rpm_update(self, *args):
         with fml_testing.mock_sends(update_schemas.UpdateRequestTestingV1):
             r = self.app.post_json('/updates/', self.get_update('bodhi-2.0.0-2.fc17'))

--- a/news/4982.bug
+++ b/news/4982.bug
@@ -1,0 +1,1 @@
+Update notes are now capped to a default of 10k characters, the value can be customized in config


### PR DESCRIPTION
This will set a limit to update notes length (which defaults to 10k characters, but can easily customized in config).
It will ensure:
- that a user cannot submit an update if notes exceed maximum length; the web form now provides a character counter and trying to submit the update will cause a Colander validation failure, which should be enough for CLI also.
- that the automatic update service will not injects RPM changelog which will make notes to exceed maximum length.
- that obsoleting an older update do not inherit notes if the sum of new and old notes exceed maximum length.

Fixes #4982 

Signed-off-by: Mattia Verga <mattia.verga@tiscali.it>