### PR TITLE
Fix for waiverdb ci test failures

### DIFF
--- a/devel/ci/integration/tests/fixtures/waiverdb.py
+++ b/devel/ci/integration/tests/fixtures/waiverdb.py
@@ -50,7 +50,7 @@ def waiverdb_container(docker_backend, docker_network, db_container, rabbitmq_co
     container = image.run_via_binary(additional_opts=run_opts)
     container.start()
     # Add sample data in the database
-    container.execute(["waiverdb", "db", "upgrade"])
+    container.execute(["./entrypoint.sh", "waiverdb", "db", "upgrade"])
     # we need to wait for the webserver to start serving
     container.wait_for_port(8080, timeout=30)
     yield container


### PR DESCRIPTION
This will fix waiverdb container initialization in integration tests for f36/f37.
The rawhide failure is a different problem that needs a lot more work.

Signed-off-by: Mattia Verga <mattia.verga@tiscali.it>