### PR TITLE
Use information from greenwave/resultsdb on "queued" and "running" tests (#4853)

### DIFF
--- a/bodhi-server/bodhi/server/models.py
+++ b/bodhi-server/bodhi/server/models.py
@@ -2373,8 +2373,13 @@ class Update(Base):
                 gotsat = True
             if unsatisfied:
                 gotunsat = True
-                if not recent or not all(req.get('type', '') == 'test-result-missing'
-                                         for req in unsatisfied):
+                if not all(req.get('type', '') == 'test-result-missing' for req in unsatisfied):
+                    # some unsats must be failures
+                    return TestGatingStatus.failed
+                if not recent and not all(req.get('result_id') for req in unsatisfied):
+                    # all unsats are missing, but it's more than two
+                    # hours since the update was edited and we don't
+                    # have QUEUED or RUNNING results for all of them
                     return TestGatingStatus.failed
 
         if not gotsat and not gotunsat:

--- a/bodhi-server/bodhi/server/templates/update.html
+++ b/bodhi-server/bodhi/server/templates/update.html
@@ -785,6 +785,7 @@ ${parent.javascript()}
     var reqs_counter = 0;
     var unsatisfied_reqs_counter = 0;
     var missing_reqs_counter = 0;
+    var running_reqs_counter = 0;
     var greenwave_errors = 0;
 
     // handle Greenwave decision
@@ -792,10 +793,15 @@ ${parent.javascript()}
         $.each(data['unsatisfied_requirements'], function(i, requirement) {
             unsatisfied_reqs_counter++;
             if (requirement.type == 'test-result-missing') {
-                missing_reqs_counter++;
-                if (missing_tests[requirement.subject_identifier] === undefined)
-                    missing_tests[requirement.subject_identifier] = [];
-                missing_tests[requirement.subject_identifier].push(requirement);
+                if (requirement.result_id) {
+                    running_reqs_counter++;
+                }
+                else {
+                    missing_reqs_counter++;
+                    if (missing_tests[requirement.subject_identifier] === undefined)
+                        missing_tests[requirement.subject_identifier] = [];
+                    missing_tests[requirement.subject_identifier].push(requirement);
+                }
             }
             // the user may have already specified this in the required taskotron tests
             if ($.inArray(requirement.testcase, requirements) == -1) {
@@ -812,6 +818,9 @@ ${parent.javascript()}
         if (missing_reqs_counter > 0) {
           label_class = classes['ABSENT'];
           icon_class = icons['ABSENT'];
+        } else if (running_reqs_counter > 0) {
+          label_class = classes['RUNNING'];
+          icon_class = icons['RUNNING'];
         } else if (unsatisfied_reqs_counter > 0) {
           label_class = classes['FAILED'];
           icon_class = icons['FAILED'];
@@ -819,21 +828,25 @@ ${parent.javascript()}
           label_class = classes['PASSED'];
           icon_class = icons['PASSED'];
         }
-        var summary = '';
-        failed_reqs_counter = unsatisfied_reqs_counter - missing_reqs_counter;
+        var summary = [];
+        failed_reqs_counter = unsatisfied_reqs_counter - missing_reqs_counter - running_reqs_counter;
         if (reqs_counter == 0) {
-            summary = 'no tests are required';
-        } else if (failed_reqs_counter > 0 && missing_reqs_counter > 0) {
-            summary = failed_reqs_counter + ' of ' + reqs_counter + ' required tests failed, ' + missing_reqs_counter + ' results missing';
-        } else if (missing_reqs_counter > 0) {
-            summary = missing_reqs_counter + ' of ' + reqs_counter + ' required test results missing';
+            summary = ['no tests are required'];
+        } else {
+            if (failed_reqs_counter > 0) {
+                summary.push(failed_reqs_counter + ' of ' + reqs_counter + ' required tests failed');
+            }
+            if (running_reqs_counter > 0) {
+                summary.push(running_reqs_counter + ' of ' + reqs_counter + ' required tests running');
+            }
+            if (missing_reqs_counter > 0) {
+                summary.push(missing_reqs_counter + ' of ' + reqs_counter + ' required test results missing');
+            }
+            if (summary.length == 0) {
+                summary = ['All required tests passed'];
+            }
         }
-        else if (failed_reqs_counter > 0) {
-            summary = failed_reqs_counter + ' of ' + reqs_counter + ' required tests failed';
-        }
-        else {
-            summary = 'All required tests passed';
-        }
+        summary = summary.join(', ')
 
         var html = '<span class="badge text-bg-' + label_class + '">' +
           '<span class="fa fa-' + icon_class + '">' +

--- a/bodhi-server/bodhi/server/templates/update.html
+++ b/bodhi-server/bodhi/server/templates/update.html
@@ -757,6 +757,8 @@ ${parent.javascript()}
       ABORTED: 'warning',
       CRASHED: 'warning',
       ABSENT: 'danger',
+      QUEUED: 'info',
+      RUNNING: 'info',
     }
     var icons = {
       PASSED: 'check-circle',
@@ -766,6 +768,8 @@ ${parent.javascript()}
       ABORTED: 'trash',
       CRASHED: 'fire', // no joke.
       ABSENT: 'question-circle',
+      QUEUED: 'hourglass-top',
+      RUNNING: 'hourglass-split'
     }
 
     var update = '${update.alias}';

--- a/news/PR5139.feature
+++ b/news/PR5139.feature
@@ -1,0 +1,1 @@
+The automated tests tab will now display information about `queued` and `running` tests


### PR DESCRIPTION
These three changes together improve Bodhi's handling of QUEUED / RUNNING test results. For some months now it's been possible to submit a result to resultsdb that doesn't actually represent a *completed* test, but is a record that the test in question is queued or running.

Before these changes, for such results, Bodhi shows an unstyled row in the test results table (I think it *also* creates an ABSENT row for the same test, so until a test has completed at least once, we get duplicate rows in the table) and otherwise ignores the information.

After these changes, we should get a styled row in the results table more clearly indicating that the test is in-progress, there should not be a duplicate ABSENT row created, the backend gating status should be 'waiting' if we know all tests are queued/running even if it's been more than two hours since the update was edited, and the text gating status summary shown in the web UI will differentiate between missing and running tests.