### PR TITLE
Copy additional config files for pungi

### DIFF
--- a/bodhi-server/bodhi/server/tasks/composer.py
+++ b/bodhi-server/bodhi/server/tasks/composer.py
@@ -1364,6 +1364,14 @@ class RPMComposerThread(PungiComposerThread):
         with open(os.path.join(pungi_conf_dir, 'variants.xml'), 'w') as variantsfile:
             variantsfile.write(variants_template.render())
 
+        # Copy any remaining pungi config file
+        for file in os.listdir(config.get('pungi.basepath')):
+            if file.endswith('.conf'):
+                shutil.copy(
+                    os.path.join(config.get('pungi.basepath'), file),
+                    os.path.join(pungi_conf_dir, file)
+                )
+
 
 class ModuleComposerThread(PungiComposerThread):
     """Run Pungi with configs that produce module repositories."""
@@ -1392,6 +1400,14 @@ class ModuleComposerThread(PungiComposerThread):
             self._variants_file = template.render(modules=self._module_list,
                                                   moduledefs=self._module_defs)
             variantsfile.write(self._variants_file)
+
+        # Copy any remaining pungi config file
+        for file in os.listdir(config.get('pungi.basepath')):
+            if file.endswith('.conf'):
+                shutil.copy(
+                    os.path.join(config.get('pungi.basepath'), file),
+                    os.path.join(pungi_conf_dir, file)
+                )
 
     def generate_testing_digest(self):
         """Temporarily disable testing digests for modules.

--- a/news/PR5154.feature
+++ b/news/PR5154.feature
@@ -1,0 +1,1 @@
+Copy additional config files for pungi


### PR DESCRIPTION
When trying to create shared configs for pungi in bodhi deployment it failed to copy them and thus composes failed to start. This change copies over any additional pungi *.conf file that is in pungi.basepath.

See https://pagure.io/fedora-infrastructure/issue/10779 for additional info.