### PR TITLE
webui: fix icons for queued/running tests

### DIFF
--- a/bodhi-server/bodhi/server/templates/update.html
+++ b/bodhi-server/bodhi/server/templates/update.html
@@ -768,8 +768,8 @@ ${parent.javascript()}
       ABORTED: 'trash',
       CRASHED: 'fire', // no joke.
       ABSENT: 'question-circle',
-      QUEUED: 'hourglass-top',
-      RUNNING: 'hourglass-split'
+      QUEUED: 'hourglass-start',
+      RUNNING: 'hourglass-half'
     }
 
     var update = '${update.alias}';

--- a/news/PR5187.bug
+++ b/news/PR5187.bug
@@ -1,0 +1,1 @@
+Icons for tests in QUEUED and RUNNING states were not displayed in the webUI


### PR DESCRIPTION
I used the wrong icon names in 1e76ef2 - I think the names I used are from bootstrap, but we're actually using font-awesome here. These are the appropriate names for font-awesome. I tested changing these live with browser tools and it works (as of right now, on prod, no icons are shown; changing these names makes them show up).