### PR TITLE
resultsdb/waiverdb: skip updating gating status if it's ignored

### DIFF
--- a/bodhi-server/bodhi/server/consumers/resultsdb.py
+++ b/bodhi-server/bodhi/server/consumers/resultsdb.py
@@ -71,6 +71,7 @@ class ResultsdbHandler:
             if (
                 (passed and status == TestGatingStatus.passed)
                 or (not passed and status == TestGatingStatus.failed)
+                or status == TestGatingStatus.ignored
             ):
                 log.debug("Not updating test_gating_status as no chance of a change")
                 return

--- a/bodhi-server/bodhi/server/consumers/waiverdb.py
+++ b/bodhi-server/bodhi/server/consumers/waiverdb.py
@@ -60,8 +60,11 @@ class WaiverdbHandler:
         with self.db_factory():
             # find the update
             update = update_from_db_message(message.id, subject)
-            # update the gating status unless it's already "passed", a
-            # waiver can't change it from passed to anything else
-            if update and update.test_gating_status != TestGatingStatus.passed:
-                log.info(f"Updating the test_gating_status for: {update.alias}")
-                update.update_test_gating_status()
+            if update:
+                # update the gating status unless it's already "passed" (a
+                # waiver can't change it from passed to anything else) or
+                # "ignored" (that's not going to change either)
+                updtgs = update.test_gating_status
+                if updtgs not in (TestGatingStatus.passed, TestGatingStatus.ignored):
+                    log.info(f"Updating the test_gating_status for: {update.alias}")
+                    update.update_test_gating_status()

--- a/bodhi-server/tests/consumers/test_resultsdb.py
+++ b/bodhi-server/tests/consumers/test_resultsdb.py
@@ -101,10 +101,15 @@ class TestResultsdbHandler(BasePyTestCase):
             update.test_gating_status = models.TestGatingStatus.waiting
             self.handler(testmsg)
             assert update.test_gating_status == models.TestGatingStatus.passed
-            # now check we don't update if already passed
+            # now check we don't update if already passed...
             with mock.patch("bodhi.server.models.Update.update_test_gating_status") as updmock:
                 self.handler(testmsg)
                 assert updmock.call_count == 0
+                # ...or ignored
+                update.test_gating_status = models.TestGatingStatus.ignored
+                self.handler(testmsg)
+                assert updmock.call_count == 0
+                assert update.test_gating_status == models.TestGatingStatus.ignored
 
     def test_resultsdb_failed_koji_test(self):
         """
@@ -152,10 +157,15 @@ class TestResultsdbHandler(BasePyTestCase):
             update.test_gating_status = models.TestGatingStatus.waiting
             self.handler(testmsg)
             assert update.test_gating_status == models.TestGatingStatus.failed
-            # now check we don't update if already failed
+            # now check we don't update if already failed...
             with mock.patch("bodhi.server.models.Update.update_test_gating_status") as updmock:
                 self.handler(testmsg)
                 assert updmock.call_count == 0
+                # ...or ignored
+                update.test_gating_status = models.TestGatingStatus.ignored
+                self.handler(testmsg)
+                assert updmock.call_count == 0
+                assert update.test_gating_status == models.TestGatingStatus.ignored
 
     def test_resultsdb_bodhi_tests(self):
         """

--- a/bodhi-server/tests/consumers/test_waiverdb.py
+++ b/bodhi-server/tests/consumers/test_waiverdb.py
@@ -96,10 +96,15 @@ class TestWaiverdbHandler(BasePyTestCase):
             update.test_gating_status = models.TestGatingStatus.waiting
             self.handler(testmsg)
             assert update.test_gating_status == models.TestGatingStatus.passed
-            # now check we don't update if already passed
+            # now check we don't update if already passed...
             with mock.patch("bodhi.server.models.Update.update_test_gating_status") as updmock:
                 self.handler(testmsg)
                 assert updmock.call_count == 0
+                # ...or ignored
+                update.test_gating_status = models.TestGatingStatus.ignored
+                self.handler(testmsg)
+                assert updmock.call_count == 0
+                assert update.test_gating_status == models.TestGatingStatus.ignored
 
     def test_waiverdb_bodhi_waiver(self):
         """

--- a/news/PR5202.feature
+++ b/news/PR5202.feature
@@ -1,0 +1,1 @@
+Bodhi will not try to recalculate the gating status in response to a new result or a new waiver if the status is `ignored`


### PR DESCRIPTION
There's no point recalculating the gating status in response to a new result or a new waiver if the status is 'ignored', which means there are no requirements. Doing so just results in this kind of unnecessary pingpong:
https://bodhi.fedoraproject.org/updates/FEDORA-2023-0e548f86e7