### PR TITLE
Use F37 in resultsdb dockerfile

### DIFF
--- a/devel/ci/integration/resultsdb/Dockerfile
+++ b/devel/ci/integration/resultsdb/Dockerfile
@@ -1,4 +1,4 @@
-FROM fedora:latest
+FROM fedora:37
 LABEL \
   name="resultsdb" \
   vendor="Fedora Infrastructure" \


### PR DESCRIPTION
Resultsdb has been retired in F38 so let's use F37 in dockerfile while it's fixed.

Signed-off-by: Mattia Verga <mattia.verga@tiscali.it>