### PR TITLE
Hide by default inactive releases in releases webpage

### DIFF
--- a/bodhi-server/bodhi/server/schemas.py
+++ b/bodhi-server/bodhi/server/schemas.py
@@ -353,6 +353,12 @@ class ListReleaseSchema(PaginatedSchema):
         missing=None,
     )
 
+    active = colander.SchemaNode(
+        colander.Boolean(true_choices=('true', '1')),
+        location="querystring",
+        missing=True,
+    )
+
 
 class SaveReleaseSchema(CSRFProtectedSchema, colander.MappingSchema):
     """An API schema for bodhi.server.services.releases.save_release()."""

--- a/bodhi-server/bodhi/server/templates/releases.html
+++ b/bodhi-server/bodhi/server/templates/releases.html
@@ -52,15 +52,27 @@ else:
     <div class="container">
       <div class="row">
           <div class="col-md-6 col-md-offset-3">
-              <h3 class="fw-bold m-0">Releases</h3>
+              % if active:
+              <h3 class="fw-bold m-0 mb-2">Active Releases</h3>
+              <span>See here for <a href="${request.route_url('releases')}?active=false">Archived and disabled Releases</a></span>
+              % else:
+              <h3 class="fw-bold m-0 mb-2">Archived and disabled Releases</h3>
+              <span>See here for <a href="${request.route_url('releases')}">Active Releases</a></span>
+              % endif
           </div>
       </div>
     </div>
   </div>
 <div class="container pt-2">
-    ${release_list('current', stable_only=False)}
-    ${release_list('pending', stable_only=False)}
-    ${release_list('archived', stable_only=True)}
+    % if active:
+      ${release_list('current', stable_only=False)}
+      ${release_list('pending', stable_only=False)}
+    % else:
+      ${release_list('archived', stable_only=True)}
+      % if request.releases['disabled']:
+        ${release_list('disabled', stable_only=True)}
+      % endif
+    % endif
 </div>
 
 <%block name="javascript">

--- a/devel/ci/integration/tests/test_bodhi.py
+++ b/devel/ci/integration/tests/test_bodhi.py
@@ -192,7 +192,9 @@ def test_get_notfound_view(bodhi_container):
 def test_get_releases_view(bodhi_container, db_container):
     """Test ``/releases`` path"""
     # Fetch releases from DB
-    query = """SELECT long_name FROM releases"""
+    query = (
+        "SELECT long_name FROM releases "
+        "WHERE state NOT IN ('disabled', 'archived')")
     db_ip = db_container.get_IPv4s()[0]
     conn = psycopg2.connect("dbname=bodhi2 user=postgres host={}".format(db_ip))
     with conn:

--- a/news/PR5264.feature
+++ b/news/PR5264.feature
@@ -1,0 +1,1 @@
+The Releases list webpage now hide inactive (disabled or archived) releases by default


### PR DESCRIPTION
This will reduce the amount of queries issued to db when browsing the releases page.