### PR TITLE
Some Fedora Messaging schema fixes

### DIFF
--- a/bodhi-messages/bodhi/messages/schemas/update.py
+++ b/bodhi-messages/bodhi/messages/schemas/update.py
@@ -24,8 +24,10 @@ messages.
 import copy
 import typing
 
-from .base import BodhiMessage, BuildV1, ReleaseV1, SCHEMA_URL, UpdateV1, UserV1
+from fedora_messaging.message import DEBUG
+
 from ..utils import truncate
+from .base import BodhiMessage, BuildV1, ReleaseV1, SCHEMA_URL, UpdateV1, UserV1
 
 
 class UpdateMessage(BodhiMessage):
@@ -804,6 +806,7 @@ class UpdateReadyForTestingV1(BodhiMessage):
     }
 
     topic = "bodhi.update.status.testing.koji-build-group.build.complete"
+    severity = DEBUG
 
     @property
     def summary(self) -> str:

--- a/bodhi-messages/bodhi/messages/schemas/update.py
+++ b/bodhi-messages/bodhi/messages/schemas/update.py
@@ -234,7 +234,7 @@ class UpdateCompleteStableV1(UpdateMessage):
         """
         new_line = "\n"
         return (
-            f"{self.update.user.name}'s Bodhi update {self.update.alias}"
+            f"{self.update.user.name}'s Bodhi update {self.update.alias} "
             f"completed push to {self.update.status}\n"
             f"Builds:\n"
             f"{new_line.join([b.nvr for b in self.update.builds])} ")
@@ -649,7 +649,7 @@ class UpdateRequestObsoleteV1(UpdateRequestMessage):
 
 
 class UpdateRequirementsMetStableV1(UpdateMessage):
-    """Sent when all the update requirements are meant for stable."""
+    """Sent when all the update requirements are met for stable."""
 
     body_schema = {
         'id': f'{SCHEMA_URL}/v1/bodhi.update.requirements_met.stable#',
@@ -678,7 +678,28 @@ class UpdateRequirementsMetStableV1(UpdateMessage):
         Returns:
             A summary for this message.
         """
-        return f'{self.update.alias} has met stable testing requirements'
+        return (
+            f"{self.update.user.name}'s {truncate(' '.join([b.nvr for b in self.update.builds]))} "
+            f"bodhi update has met stable testing requirements"
+        )
+
+    def __str__(self) -> str:
+        """
+        Return a human-readable representation of this message.
+
+        This should provide a detailed representation of the message, much like the body
+        of an email.
+
+        Returns:
+            A human readable representation of this message.
+        """
+        new_line = "\n"
+        return (
+            f"{self.update.user.name}'s Bodhi update {self.update.alias}"
+            f" has met stable testing requirements.\n"
+            f"Builds:\n"
+            f"{new_line.join([b.nvr for b in self.update.builds])}"
+        )
 
 
 class UpdateReadyForTestingV1(BodhiMessage):

--- a/bodhi-messages/tests/test_update.py
+++ b/bodhi-messages/tests/test_update.py
@@ -17,21 +17,23 @@
 
 
 from bodhi.messages.schemas.base import BuildV1, ReleaseV1, UpdateV1, UserV1
-from bodhi.messages.schemas.update import (UpdateCommentV1,
-                                           UpdateCompleteStableV1,
-                                           UpdateCompleteTestingV1,
-                                           UpdateEditV1,
-                                           UpdateEditV2,
-                                           UpdateEjectV1,
-                                           UpdateKarmaThresholdV1,
-                                           UpdateReadyForTestingV1,
-                                           UpdateReadyForTestingV2,
-                                           UpdateRequestObsoleteV1,
-                                           UpdateRequestRevokeV1,
-                                           UpdateRequestStableV1,
-                                           UpdateRequestTestingV1,
-                                           UpdateRequestUnpushV1,
-                                           UpdateRequirementsMetStableV1)
+from bodhi.messages.schemas.update import (
+    UpdateCommentV1,
+    UpdateCompleteStableV1,
+    UpdateCompleteTestingV1,
+    UpdateEditV1,
+    UpdateEditV2,
+    UpdateEjectV1,
+    UpdateKarmaThresholdV1,
+    UpdateReadyForTestingV1,
+    UpdateReadyForTestingV2,
+    UpdateRequestObsoleteV1,
+    UpdateRequestRevokeV1,
+    UpdateRequestStableV1,
+    UpdateRequestTestingV1,
+    UpdateRequestUnpushV1,
+    UpdateRequirementsMetStableV1,
+)
 
 from .utils import check_message
 
@@ -99,7 +101,7 @@ class TestUpdateMessage:
                 "completed push to stable"
             ),
             "__str__": (
-                "eclipseo's Bodhi update FEDORA-2019-d64d0caab3completed push to stable"
+                "eclipseo's Bodhi update FEDORA-2019-d64d0caab3 completed push to stable"
                 "\nBuilds:\ngolang-github-SAP-go-hdb-0.14.1-1.fc29\ntexworks-0.6.3-1.fc29 "
             ),
             "app_icon": "https://apps.fedoraproject.org/img/icons/bodhi.png",
@@ -608,8 +610,15 @@ class TestUpdateMessage:
     def test_requirements_met_stable_v1(self):
         expected = {
             "topic": "bodhi.update.requirements_met.stable",
-            "summary": "FEDORA-2019-f1ca3c00e5 has met stable testing requirements",
-            "__str__": "FEDORA-2019-f1ca3c00e5 has met stable testing requirements",
+            "summary": (
+                "eclipseo's golang-github-Masterminds-semver-2.0.0-0… bodhi update has met "
+                "stable testing requirements"
+            ),
+            "__str__": (
+                "eclipseo's Bodhi update FEDORA-2019-f1ca3c00e5 has met stable testing "
+                "requirements.\nBuilds:\n"
+                "golang-github-Masterminds-semver-2.0.0-0.1.20190319git3c92f33.fc29"
+            ),
             "app_icon": "https://apps.fedoraproject.org/img/icons/bodhi.png",
             "app_name": "bodhi",
             "url": "https://bodhi.fedoraproject.org/updates/FEDORA-2019-f1ca3c00e5",


### PR DESCRIPTION
This PR changes two elements of the Bodhi schemas that I found annoying when subscribed to them:

---
![image](https://github.com/fedora-infra/bodhi/assets/95780/38f2630f-24b4-48ac-be03-6642fc462319)
→ the two messages always arrive together, so one should not generate a notification. For that, I set the most obscure one to severity DEBUG

--- 

![image](https://github.com/fedora-infra/bodhi/assets/95780/eda88297-b993-4d7c-8f05-209ddbe87dcf)
→ The subject and the body aren't particularly helpful. I've added the build names to the subject and defined a message body.