### PR TITLE
Fix integration tests on F38

### DIFF
--- a/devel/ci/integration/tests/test_bodhi_cli.py
+++ b/devel/ci/integration/tests/test_bodhi_cli.py
@@ -441,6 +441,7 @@ def test_updates_download(bodhi_container, db_container):
         with conn.cursor() as curs:
             curs.execute(query_updates)
             updates = [_db_record_to_munch(curs, record) for record in curs]
+            assert len(updates) > 0
             for update in updates:
                 curs.execute(query_builds, (update.id, ))
                 builds.extend([r[0] for r in curs])

--- a/devel/ci/integration/tests/utils.py
+++ b/devel/ci/integration/tests/utils.py
@@ -16,11 +16,11 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
+from contextlib import contextmanager
 import json
 import os
 import shutil
 import tempfile
-from contextlib import contextmanager
 
 from conu import ConuException
 from fedora_messaging import message
@@ -149,7 +149,7 @@ def run_cli(bodhi_container, args, **kwargs):
         kwargs["exec_create_kwargs"]["environment"] = {}
     kwargs["exec_create_kwargs"]["environment"]["PYTHONWARNINGS"] = "ignore"
     cmd = ["bodhi"] + args + [
-        "--url", "http://localhost:8080",
+        "--url", "http://localhost.localdomain:8080",
         "--id-provider", "https://id.dev.fedoraproject.org/openidc",
     ]
     try:


### PR DESCRIPTION
Turns out the authentication cookie is not properly sent to the server if the hostname is just `localhost`, it needs a FQDN such as `localhost.localdomain` to work.