### PR TITLE
Update subject identification for waivers, handle Greenwave gating.yaml failed requirements (#5361)

### DIFF
--- a/bodhi-server/bodhi/server/models.py
+++ b/bodhi-server/bodhi/server/models.py
@@ -3256,7 +3256,8 @@ class Update(Base):
                 continue
 
             data = {
-                'subject': requirement['item'],
+                'subject_type': requirement['subject_type'],
+                'subject_identifier': requirement['subject_identifier'],
                 'testcase': requirement['testcase'],
                 'scenario': requirement.get('scenario', None),
                 'product_version': self.product_version,

--- a/bodhi-server/bodhi/server/templates/update.html
+++ b/bodhi-server/bodhi/server/templates/update.html
@@ -786,8 +786,12 @@ ${parent.javascript()}
     // show the Greenwave decision
     var greenwave_api_url = '${request.registry.settings["greenwave_api_url"]}';
     var missing_tests = {};
-    var reqs_counter = 0;
+    var invalid_gating_repos = [];
+    var missing_gating_repos = [];
+    var failed_fetch_gating_repos = [];
+    var test_reqs_counter = 0;
     var unsatisfied_reqs_counter = 0;
+    var remoteerror_reqs_counter = 0;
     var missing_reqs_counter = 0;
     var running_reqs_counter = 0;
     var greenwave_errors = 0;
@@ -806,6 +810,17 @@ ${parent.javascript()}
                         missing_tests[requirement.subject_identifier] = [];
                     missing_tests[requirement.subject_identifier].push(requirement);
                 }
+            }
+            if (requirement.type.match('gating-yaml')) {
+                remoteerror_reqs_counter++;
+                // these aren't 'test results' exactly
+                test_reqs_counter--;
+                if (requirement.type == 'invalid-gating-yaml')
+                    invalid_gating_repos.push(requirement.subject_identifier);
+                if (requirement.type == 'missing-gating-yaml')
+                    missing_gating_repos.push(requirement.subject_identifier);
+                if (requirement.type == 'failed-fetch-gating-yaml')
+                    failed_fetch_gating_repos.push(requirement.subject_identifier);
             }
             // the user may have already specified this in the required taskotron tests
             if ($.inArray(requirement.testcase, requirements) == -1) {
@@ -833,18 +848,21 @@ ${parent.javascript()}
           icon_class = icons['PASSED'];
         }
         var summary = [];
-        failed_reqs_counter = unsatisfied_reqs_counter - missing_reqs_counter - running_reqs_counter;
-        if (reqs_counter == 0) {
+        failed_reqs_counter = unsatisfied_reqs_counter - missing_reqs_counter - running_reqs_counter - remoteerror_reqs_counter;
+        if (test_reqs_counter == 0) {
             summary = ['no tests are required'];
         } else {
             if (failed_reqs_counter > 0) {
-                summary.push(failed_reqs_counter + ' of ' + reqs_counter + ' required tests failed');
+                summary.push(failed_reqs_counter + ' of ' + test_reqs_counter + ' required tests failed');
             }
             if (running_reqs_counter > 0) {
-                summary.push(running_reqs_counter + ' of ' + reqs_counter + ' required tests running');
+                summary.push(running_reqs_counter + ' of ' + test_reqs_counter + ' required tests running');
             }
             if (missing_reqs_counter > 0) {
-                summary.push(missing_reqs_counter + ' of ' + reqs_counter + ' required test results missing');
+                summary.push(missing_reqs_counter + ' of ' + test_reqs_counter + ' required test results missing');
+            }
+            if (remoteerror_reqs_counter > 0) {
+                summary.push(remoteerror_reqs_counter + ' errors handling remote rules');
             }
             if (summary.length == 0) {
                 summary = ['All required tests passed'];
@@ -906,8 +924,8 @@ ${parent.javascript()}
                         requirements.push(requirement.testcase);
                     }
                 });
-                reqs_counter += data['unsatisfied_requirements'].length;
-                reqs_counter += data['satisfied_requirements'].length;
+                test_reqs_counter += data['unsatisfied_requirements'].length;
+                test_reqs_counter += data['satisfied_requirements'].length;
                 handle_results(data.results, request.subject);
                 after_success();
             },
@@ -1025,7 +1043,7 @@ ${parent.javascript()}
 
         var table = $("<table class='table table-hover'><tbody></tbody></table>").appendTo("#resultsdb");
 
-        // show missing tests first
+        // show missing tests and remote rule yaml problems first
         if (buildname in missing_tests) {
           $.each(missing_tests[buildname], function(i, result) {
             table.append(make_row(
@@ -1037,6 +1055,33 @@ ${parent.javascript()}
             ));
           });
         }
+        $.each(invalid_gating_repos, function (i, repo) {
+          table.append(make_row(
+            'FAILED',
+            repo,
+            'remote policy gating.yaml parsing failed',
+            '',
+            ''
+          ));
+        });
+        $.each(missing_gating_repos, function (i, repo) {
+          table.append(make_row(
+            'FAILED',
+            repo,
+            'remote policy gating.yaml missing',
+            '',
+            ''
+          ));
+        });
+        $.each(failed_fetch_gating_repos, function (i, repo) {
+          table.append(make_row(
+            'FAILED',
+            repo,
+            'remote policy gating.yaml retrieval failed',
+            '',
+            ''
+          ));
+        });
 
         $.each(results, function(i, result) {
           var scenario = 'no_scenario';

--- a/bodhi-server/tests/services/test_updates.py
+++ b/bodhi-server/tests/services/test_updates.py
@@ -6227,10 +6227,8 @@ class TestWaiveTestResults(BasePyTestCase):
         greenwave_api_post.return_value = {
             'unsatisfied_requirements': [
                 {
-                    'item': {
-                        'item': 'bodhi-2.0-1.fc17',
-                        'type': 'koji_build'
-                    },
+                    'subject_identifier': 'bodhi-2.0-1.fc17',
+                    'subject_type': 'koji_build',
                     'scenario': None,
                     'testcase': 'dist.rpmdeplint',
                     'type': 'test-result-failed'
@@ -6267,9 +6265,8 @@ class TestWaiveTestResults(BasePyTestCase):
                 'product_version': 'fedora-17',
                 'testcase': 'dist.rpmdeplint',
                 'scenario': None,
-                'subject': {
-                    'item': 'bodhi-2.0-1.fc17', 'type': 'koji_build'
-                }
+                'subject_identifier': 'bodhi-2.0-1.fc17',
+                'subject_type': 'koji_build'
             }
         )
 
@@ -6297,19 +6294,15 @@ class TestWaiveTestResults(BasePyTestCase):
         greenwave_api_post.return_value = {
             'unsatisfied_requirements': [
                 {
-                    'item': {
-                        'item': 'bodhi-2.0-1.fc17',
-                        'type': 'koji_build'
-                    },
+                    'subject_identifier': 'bodhi-2.0-1.fc17',
+                    'subject_type': 'koji_build',
                     'scenario': None,
                     'testcase': 'dist.rpmdeplint',
                     'type': 'test-result-failed'
                 },
                 {
-                    'item': {
-                        'item': 'bodhi-2.0-1.fc17',
-                        'type': 'koji_build'
-                    },
+                    'subject_identifier': 'bodhi-2.0-1.fc17',
+                    'subject_type': 'koji_build',
                     'scenario': None,
                     'testcase': 'atomic_ci_pipeline_results',
                     'type': 'test-result-failed'
@@ -6347,9 +6340,8 @@ class TestWaiveTestResults(BasePyTestCase):
                     'product_version': 'fedora-17',
                     'testcase': 'dist.rpmdeplint',
                     'scenario': None,
-                    'subject': {
-                        'item': 'bodhi-2.0-1.fc17', 'type': 'koji_build'
-                    }
+                    'subject_identifier': 'bodhi-2.0-1.fc17',
+                    'subject_type': 'koji_build'
                 }
             ),
             mock.call(
@@ -6361,9 +6353,8 @@ class TestWaiveTestResults(BasePyTestCase):
                     'product_version': 'fedora-17',
                     'testcase': 'atomic_ci_pipeline_results',
                     'scenario': None,
-                    'subject': {
-                        'item': 'bodhi-2.0-1.fc17', 'type': 'koji_build'
-                    }
+                    'subject_identifier': 'bodhi-2.0-1.fc17',
+                    'subject_type': 'koji_build'
                 }
             )
         ]
@@ -6393,19 +6384,15 @@ class TestWaiveTestResults(BasePyTestCase):
         greenwave_api_post.return_value = {
             'unsatisfied_requirements': [
                 {
-                    'item': {
-                        'item': 'bodhi-2.0-1.fc17',
-                        'type': 'koji_build'
-                    },
+                    'subject_identifier': 'bodhi-2.0-1.fc17',
+                    'subject_type': 'koji_build',
                     'scenario': None,
                     'testcase': 'dist.rpmdeplint',
                     'type': 'test-result-failed'
                 },
                 {
-                    'item': {
-                        'item': 'bodhi-2.0-1.fc17',
-                        'type': 'koji_build'
-                    },
+                    'subject_identifier': 'bodhi-2.0-1.fc17',
+                    'subject_type': 'koji_build',
                     'scenario': None,
                     'testcase': 'atomic_ci_pipeline_results',
                     'type': 'test-result-failed'
@@ -6446,9 +6433,8 @@ class TestWaiveTestResults(BasePyTestCase):
                 'product_version': 'fedora-17',
                 'testcase': 'atomic_ci_pipeline_results',
                 'scenario': None,
-                'subject': {
-                    'item': 'bodhi-2.0-1.fc17', 'type': 'koji_build'
-                }
+                'subject_identifier': 'bodhi-2.0-1.fc17',
+                'subject_type': 'koji_build'
             }
         )
 
@@ -6476,19 +6462,15 @@ class TestWaiveTestResults(BasePyTestCase):
         greenwave_api_post.return_value = {
             'unsatisfied_requirements': [
                 {
-                    'item': {
-                        'item': 'bodhi-2.0-1.fc17',
-                        'type': 'koji_build'
-                    },
+                    'subject_identifier': 'bodhi-2.0-1.fc17',
+                    'subject_type': 'koji_build',
                     'scenario': None,
                     'testcase': 'dist.rpmdeplint',
                     'type': 'test-result-failed'
                 },
                 {
-                    'item': {
-                        'item': 'bodhi-2.0-1.fc17',
-                        'type': 'koji_build'
-                    },
+                    'subject_identifier': 'bodhi-2.0-1.fc17',
+                    'subject_type': 'koji_build',
                     'scenario': None,
                     'testcase': 'atomic_ci_pipeline_results',
                     'type': 'test-result-failed'
@@ -6530,9 +6512,8 @@ class TestWaiveTestResults(BasePyTestCase):
                     'product_version': 'fedora-17',
                     'testcase': 'dist.rpmdeplint',
                     'scenario': None,
-                    'subject': {
-                        'item': 'bodhi-2.0-1.fc17', 'type': 'koji_build'
-                    }
+                    'subject_identifier': 'bodhi-2.0-1.fc17',
+                    'subject_type': 'koji_build'
                 }
             ),
             mock.call(
@@ -6544,9 +6525,8 @@ class TestWaiveTestResults(BasePyTestCase):
                     'product_version': 'fedora-17',
                     'testcase': 'atomic_ci_pipeline_results',
                     'scenario': None,
-                    'subject': {
-                        'item': 'bodhi-2.0-1.fc17', 'type': 'koji_build'
-                    }
+                    'subject_identifier': 'bodhi-2.0-1.fc17',
+                    'subject_type': 'koji_build'
                 }
             )
         ]
@@ -6576,19 +6556,15 @@ class TestWaiveTestResults(BasePyTestCase):
         greenwave_api_post.return_value = {
             'unsatisfied_requirements': [
                 {
-                    'item': {
-                        'item': 'bodhi-2.0-1.fc17',
-                        'type': 'koji_build'
-                    },
+                    'subject_identifier': 'bodhi-2.0-1.fc17',
+                    'subject_type': 'koji_build',
                     'scenario': None,
                     'testcase': 'dist.rpmdeplint',
                     'type': 'test-result-failed'
                 },
                 {
-                    'item': {
-                        'item': 'bodhi-2.0-1.fc17',
-                        'type': 'koji_build'
-                    },
+                    'subject_identifier': 'bodhi-2.0-1.fc17',
+                    'subject_type': 'koji_build',
                     'scenario': None,
                     'testcase': 'atomic_ci_pipeline_results',
                     'type': 'test-result-failed'
@@ -6629,9 +6605,8 @@ class TestWaiveTestResults(BasePyTestCase):
                 'product_version': 'fedora-17',
                 'testcase': 'dist.rpmdeplint',
                 'scenario': None,
-                'subject': {
-                    'item': 'bodhi-2.0-1.fc17', 'type': 'koji_build'
-                }
+                'subject_identifier': 'bodhi-2.0-1.fc17',
+                'subject_type': 'koji_build'
             }
         )
 

--- a/bodhi-server/tests/test_models.py
+++ b/bodhi-server/tests/test_models.py
@@ -4786,12 +4786,26 @@ class TestUpdate(ModelTest):
             "summary": "3 of 15 required tests failed",
             "applicable_policies": ["1"],
             "unsatisfied_requirements": [
-                {'item': {"item": "bodhi-3.6.0-1.fc28", "type": "koji_build"}, 'result_id': "123",
-                 'testcase': 'dist.depcheck', 'type': 'test-result-failed'},
-                {'item': {"item": "bodhi-3.6.0-1.fc28", "type": "koji_build"}, 'result_id': "124",
-                 'testcase': 'dist.rpmdeplint', 'type': 'test-result-failed'},
-                {'item': {"item": "bodhi-3.6.0-1.fc28", "type": "koji_build"}, 'result_id': "125",
-                 'testcase': 'dist.someothertest', 'type': 'test-result-failed'}]}
+                {
+                    'subject_identifier': "bodhi-3.6.0-1.fc28",
+                    'subject_type': "koji_build",
+                    'testcase': 'dist.depcheck',
+                    'type': 'test-result-failed'
+                },
+                {
+                    'subject_identifier': "bodhi-3.6.0-1.fc28",
+                    'subject_type': "koji_build",
+                    'testcase': 'dist.rpmdeplint',
+                    'type': 'test-result-failed'
+                },
+                {
+                    'subject_identifier': "bodhi-3.6.0-1.fc28",
+                    'subject_type': "koji_build",
+                    'testcase': 'dist.someothertest',
+                    'type': 'test-result-failed'
+                }
+            ]
+        }
         post.return_value.status_code = 200
 
         config.update({
@@ -4811,7 +4825,9 @@ class TestUpdate(ModelTest):
                 "product_version": "{}".format(self.obj.product_version),
                 "testcase": "{}".format(test),
                 "scenario": None,
-                "subject": {"item": "bodhi-3.6.0-1.fc28", "type": "koji_build"}}
+                "subject_identifier": "bodhi-3.6.0-1.fc28",
+                "subject_type": "koji_build"
+            }
             expected_calls.append(mock.call(
                 '{}/waivers/'.format(config.get('waiverdb_api_url')),
                 data=json.dumps(data),
@@ -4846,8 +4862,8 @@ class TestUpdate(ModelTest):
             "applicable_policies": ["1"],
             "unsatisfied_requirements": [
                 {
-                    'item': {"item": "%s" % update.builds[0].nvr, "type": "koji_build"},
-                    'result_id': "123",
+                    'subject_identifier': "%s" % update.builds[0].nvr,
+                    'subject_type': "koji_build",
                     'testcase': 'dist.depcheck',
                     'scenario': 'kde',
                     'type': 'test-result-failed'
@@ -4861,7 +4877,8 @@ class TestUpdate(ModelTest):
         })
         update.waive_test_results('foo', 'this is not true!')
         wdata = {
-            'subject': {"item": "%s" % update.builds[0].nvr, "type": "koji_build"},
+            'subject_identifier': "%s" % update.builds[0].nvr,
+            'subject_type': "koji_build",
             'testcase': 'dist.depcheck',
             'scenario': 'kde',
             'product_version': update.product_version,


### PR DESCRIPTION
These changes both relate to https://github.com/fedora-infra/bodhi/issues/5361 . As discussed there, we're using an 'old' method for subject identification when issuing waivers - Greenwave would prefer us to use subject_type and subject_identifier, not item. Also, our handling of unsatisfied requirements from Greenwave doesn't really account for one class of such requirements at all, ones that are about problems with the `gating.yaml` files in package repositories that implement the "remote rule" mechanism allowing packages to specify their own gating policies. This improves that in a few ways.

I don't think the tests really cover this, so I'll try and test it locally as I have before, by standing up pocket greenwave and Bodhi instances, if I can.