### PR TITLE
CI: base our container images off quay.io/fedora

### DIFF
--- a/devel/ci/Dockerfile-f37
+++ b/devel/ci/Dockerfile-f37
@@ -1,4 +1,4 @@
-FROM fedora:37
+FROM quay.io/fedora/fedora:37
 LABEL maintainer="Mattia Verga <mattia.verga@tiscali.it>"
 
 # RUN echo "fastestmirror=False" >> /etc/dnf/dnf.conf

--- a/devel/ci/Dockerfile-f38
+++ b/devel/ci/Dockerfile-f38
@@ -1,4 +1,4 @@
-FROM fedora:38
+FROM quay.io/fedora/fedora:38
 LABEL maintainer="Mattia Verga <mattia.verga@fedoraproject.org>"
 
 # RUN echo "fastestmirror=False" >> /etc/dnf/dnf.conf

--- a/devel/ci/Dockerfile-pip
+++ b/devel/ci/Dockerfile-pip
@@ -1,4 +1,4 @@
-FROM fedora:latest
+FROM quay.io/fedora/fedora:latest
 LABEL maintainer="Randy Barlow <bowlofeggs@fedoraproject.org>"
 
 RUN dnf install -y \

--- a/devel/ci/Dockerfile-rawhide
+++ b/devel/ci/Dockerfile-rawhide
@@ -1,4 +1,4 @@
-FROM fedora:rawhide
+FROM quay.io/fedora/fedora:rawhide
 LABEL maintainer="Mattia Verga <mattia.verga@fedoraproject.org>"
 
 # RUN echo "fastestmirror=False" >> /etc/dnf/dnf.conf

--- a/devel/ci/integration/ipsilon/Dockerfile
+++ b/devel/ci/integration/ipsilon/Dockerfile
@@ -1,4 +1,4 @@
-FROM fedora:latest
+FROM quay.io/fedora/fedora:latest
 RUN curl -o /etc/yum.repos.d/infra-tags.repo https://pagure.io/fedora-infra/ansible/raw/main/f/files/common/fedora-infra-tags.repo
 RUN dnf install -y ipsilon ipsilon-openid ipsilon-openidc patch git
 RUN git clone https://pagure.io/fedora-infra/ipsilon-fedora.git /opt/ipsilon-fedora

--- a/devel/ci/integration/rabbitmq/Dockerfile
+++ b/devel/ci/integration/rabbitmq/Dockerfile
@@ -1,4 +1,4 @@
-FROM fedora:latest
+FROM quay.io/fedora/fedora:latest
 LABEL \
   name="rabbitmq" \
   vendor="Fedora Infrastructure" \

--- a/devel/ci/integration/resultsdb/Dockerfile
+++ b/devel/ci/integration/resultsdb/Dockerfile
@@ -1,4 +1,4 @@
-FROM fedora:37
+FROM quay.io/fedora/fedora:37
 LABEL \
   name="resultsdb" \
   vendor="Fedora Infrastructure" \


### PR DESCRIPTION
The fedora repository on Docker Hub are updated infrequently, which can lead to problems like
https://pagure.io/fedora-infrastructure/issue/11358 . This should cause the images built by the CI process to base off quay.io/fedora instead, which is updated much more frequently.