### PR TITLE
Add some debugging help links to Automated Test Results tab

### DIFF
--- a/bodhi-server/bodhi/server/templates/update.html
+++ b/bodhi-server/bodhi/server/templates/update.html
@@ -639,6 +639,12 @@ if can_edit and update.release.composed_by_bodhi:
           <a class="gating-summary notblue">${update.test_gating_status}</a>
           <i class="fa spinner fa-spinner fa-spin fa-fw"></i>
         </div>
+        % if update.test_gating_status == models.TestGatingStatus.failed:
+        <div>
+          For help debugging failed Fedora CI tests (fedora-ci.*), contact <a href="https://web.libera.chat/?channels=#fedora-ci">#fedora-ci on Libera.chat</a><br/>
+          For help debugging failed openQA tests (update.*), contact <a href="https://matrix.to/#/#quality:fedoraproject.org">the Fedora Quality team</a>, who will usually investigate and diagnose all failures within 24 hours
+        </div>
+        % endif
       </div>
     </div>
 

--- a/bodhi-server/bodhi/server/templates/update.html
+++ b/bodhi-server/bodhi/server/templates/update.html
@@ -635,16 +635,16 @@ if can_edit and update.release.composed_by_bodhi:
     <div class="tab-pane" id="automatedtests-tab-pane" role="tabpanel" aria-labelledby="automatedtests-tab" tabindex="0">
       <div id="resultsdb">
         <h3>Automated Test Results</h3>
+        % if update.test_gating_status == models.TestGatingStatus.failed:
+        <div class="alert alert-danger" role="alert">
+          For help debugging failed Fedora CI tests (fedora-ci.*), contact <a href="https://web.libera.chat/?channels=#fedora-ci" target="_blank">#fedora-ci on Libera.chat</a><br/>
+          For help debugging failed openQA tests (update.*), contact <a href="https://matrix.to/#/#quality:fedoraproject.org" target="_blank">the Fedora Quality team</a>, who will usually investigate and diagnose all failures within 24 hours
+        </div>
+        % endif
         <div id="gating-summary-tab">
           <a class="gating-summary notblue">${update.test_gating_status}</a>
           <i class="fa spinner fa-spinner fa-spin fa-fw"></i>
         </div>
-        % if update.test_gating_status == models.TestGatingStatus.failed:
-        <div>
-          For help debugging failed Fedora CI tests (fedora-ci.*), contact <a href="https://web.libera.chat/?channels=#fedora-ci">#fedora-ci on Libera.chat</a><br/>
-          For help debugging failed openQA tests (update.*), contact <a href="https://matrix.to/#/#quality:fedoraproject.org">the Fedora Quality team</a>, who will usually investigate and diagnose all failures within 24 hours
-        </div>
-        % endif
       </div>
     </div>
 

--- a/news/PR5382.feature
+++ b/news/PR5382.feature
@@ -1,0 +1,1 @@
+If an update has got any failing test, an help box is displayed in the Automated Tests tab


### PR DESCRIPTION
As suggested by @ppisar, this adds some links for packagers to get help with debugging failures, if the update is in the 'gating failed' state.