### PR TITLE
updates.html: include satisfied requirements in the table

### DIFF
--- a/bodhi-server/bodhi/server/templates/update.html
+++ b/bodhi-server/bodhi/server/templates/update.html
@@ -900,6 +900,12 @@ ${parent.javascript()}
                   waivers[waiver.testcase].push(waiver);
                 });
                 handle_unsatisfied_requirements(data);
+                $.each(data['satisfied_requirements'], function(i, requirement) {
+                    // the user may have already specified this in the required taskotron tests
+                    if ($.inArray(requirement.testcase, requirements) == -1) {
+                        requirements.push(requirement.testcase);
+                    }
+                });
                 reqs_counter += data['unsatisfied_requirements'].length;
                 reqs_counter += data['satisfied_requirements'].length;
                 handle_results(data.results, request.subject);

--- a/news/PR5388.bug
+++ b/news/PR5388.bug
@@ -1,0 +1,1 @@
+On the Automated Tests tab, passed tests that are 'required' now correctly show as such


### PR DESCRIPTION
I noticed today that tests which are 'required' aren't marked as such in the Bodhi webUI if they passed. Only queued or failed or missing tests are shown as 'required' (as shown by the black asterisk with a mouseover comment, on the Automated Tests tab). This is because we're not pushing satifised requirements into the list that's used to track which tests are required.