### PR TITLE
Use `os.path.expanduser("~")` instead of `os.environ["HOME"]`

### DIFF
--- a/bodhi-client/bodhi/client/bindings.py
+++ b/bodhi-client/bodhi/client/bindings.py
@@ -199,7 +199,9 @@ class BodhiClient:
         self.base_url = base_url
         self.csrf_token = ''
         self.oidc_storage_path = (
-            oidc_storage_path or os.path.join(os.environ["HOME"], ".config", "bodhi", "client.json")
+            oidc_storage_path or os.path.join(
+                os.path.expanduser("~"), ".config", "bodhi", "client.json"
+            )
         )
         self._build_oidc_client(client_id, id_provider)
 

--- a/news/PR5398.bug
+++ b/news/PR5398.bug
@@ -1,0 +1,1 @@
+client: do not rely on `HOME` being defined in os.environ variables


### PR DESCRIPTION
On openQA staging, some code that runs `bodhi updates download` via `subprocess` was failing. Somehow in that context "HOME" wasn't in `os.environ`, so bodhi would crash, because it assumes that will be the case.

This should make it more robust, by using os.path.expanduser instead. As documented:
https://docs.python.org/3/library/os.path.html#os.path.expanduser it has fallback ways to get the path if the obvious one doesn't work.