### PR TITLE
Make sure canidate tag is present when pushing to testing

### DIFF
--- a/bodhi-server/bodhi/server/models.py
+++ b/bodhi-server/bodhi/server/models.py
@@ -3169,6 +3169,8 @@ class Update(Base):
         # If it's a new side-tag update, koji tags are managed by the celery task
         if action is UpdateRequest.testing and not self.from_tag:
             self.add_tag(self.release.pending_signing_tag)
+            if self.release.candidate_tag not in self.get_tags():
+                self.add_tag(self.release.candidate_tag)
         elif action is UpdateRequest.stable:
             self.add_tag(self.release.pending_stable_tag)
             if self.request == UpdateRequest.testing:
@@ -3178,8 +3180,6 @@ class Update(Base):
         # it to the pending state, and make sure it's tagged as a candidate
         if self.status in (UpdateStatus.obsolete, UpdateStatus.unpushed):
             self.status = UpdateStatus.pending
-            if self.release.candidate_tag not in self.get_tags():
-                self.add_tag(self.release.candidate_tag)
 
         self.request = action
 

--- a/bodhi-server/tests/test_models.py
+++ b/bodhi-server/tests/test_models.py
@@ -4006,6 +4006,35 @@ class TestUpdate(ModelTest):
         self.obj.remove_tag.assert_called_once_with(self.obj.release.pending_testing_tag)
 
     @mock.patch('bodhi.server.models.buildsys.get_session')
+    def test_set_request_testing_ejected(self, get_session):
+        """
+        Ensure that set_request() adds the candidate tag back to an update which was
+        previously ejected from push.
+        """
+        req = DummyRequest(user=DummyUser())
+        req.errors = cornice.Errors()
+        req.koji = get_session.return_value
+        self.obj.status = UpdateStatus.pending
+        self.obj.request = None
+        expected_message = update_schemas.UpdateRequestTestingV1.from_dict(
+            {'update': self.obj, 'agent': req.user.name})
+
+        with mock_sends(expected_message):
+            self.obj.set_request(self.db, 'testing', req.user.name)
+            # set_request alters the update a bit, so we need to adjust the expected message to
+            # reflect those changes so the mock_sends() check will pass.
+            expected_message.body['update']['status'] = 'pending'
+            expected_message.body['update']['request'] = 'testing'
+            expected_message.body['update']['comments'] = self.obj.__json__()['comments']
+            self.db.commit()
+
+        assert self.obj.status == UpdateStatus.pending
+        assert self.obj.request == UpdateRequest.testing
+        assert get_session.return_value.tagBuild.mock_calls == (
+            [mock.call(self.obj.release.pending_signing_tag, self.obj.builds[0].nvr, force=True),
+             mock.call(self.obj.release.candidate_tag, self.obj.builds[0].nvr, force=True)])
+
+    @mock.patch('bodhi.server.models.buildsys.get_session')
     def test_set_request_resubmit_candidate_tag_missing(self, get_session):
         """Ensure that set_request() adds the candidate tag back to a resubmitted build."""
         req = DummyRequest(user=DummyUser())

--- a/news/PR5400.bug
+++ b/news/PR5400.bug
@@ -1,0 +1,1 @@
+server: when resubmitting a pending update to testing, make sure the release candidate tag is applied to all builds


### PR DESCRIPTION
Case: a composer task fails after having moved builds from `-candidate` to `-testing` tag.
The next composer run will eject the update from the push because builds have not the `-candidate` tag.

Users now have to manually re-tag the builds in `-candidate`, then they can re-push the update in Bodhi, but this is not clear: they usually only push the update in Bodhi, so the next composer run will again eject the update.

This change will re-add the `-candidate` tag back when a user push the update to testing.