### PR TITLE
Unstuck updates ejected from composes

### DIFF
--- a/news/5396.bug
+++ b/news/5396.bug
@@ -1,0 +1,1 @@
+Updates ejected from the composes would remain stuck in pending state due to wrong tags applied to thei builds


### PR DESCRIPTION
Fixes #5396 

Enhance the `check_signed_builds` task to unstuck updates which are ejected from a compose and have wrong tags applied to builds.