### PR TITLE
Provide an endpoint to list critpath components

### DIFF
--- a/bodhi-server/bodhi/server/__init__.py
+++ b/bodhi-server/bodhi/server/__init__.py
@@ -297,6 +297,9 @@ def main(global_config, testing=None, session=None, **settings):
     config.add_route('liveness', '/healthz/live')
     config.add_route('readyness', '/healthz/ready')
 
+    # service endpoints
+    config.add_route('get_critpath_components', '/get_critpath_components')
+
     # Legacy: Redirect the previously self-hosted documentation
     # https://docs.pylonsproject.org/projects/pyramid/en/latest/narr/hybrid.html#using-subpath-in-a-route-pattern
     config.add_route("docs", "/docs/*subpath")

--- a/bodhi-server/bodhi/server/views/generic.py
+++ b/bodhi-server/bodhi/server/views/generic.py
@@ -622,3 +622,22 @@ def docs(request):
     subpath = "/".join(request.subpath)
     url = f"https://fedora-infra.github.io/bodhi/{major_minor_version}/{subpath}"
     raise HTTPMovedPermanently(url)
+
+
+@view_config(route_name='get_critpath_components', renderer='json')
+def get_critpath_components(request):
+    """
+    Return critical path components configured in bodhi.
+
+    Args:
+        request (pyramid.request.Request): The current request.
+    Returns:
+        dict: A dictionary with a "version" key indexing a string of the Bodhi version.
+    """
+    collection = request.params.get('collection', 'rawhide')
+    component_type = request.params.get('component_type', 'rpm')
+    components = request.params.get('components')
+    if components is not None:
+        components = components.split(',')
+    return bodhi.server.util.get_grouped_critpath_components(collection, component_type,
+                                                             components)

--- a/news/PR5484.feature
+++ b/news/PR5484.feature
@@ -1,0 +1,1 @@
+Server: added a `get_critpath_components` json endpoint to list critical path components configured for a Release


### PR DESCRIPTION
Let's have a way to provide information about what Bodhi consider to be in critical path.
WIP: I need to write some tests

@AdamWill If a user searches for `collection=rawhide` or `collection=f40` we need the code to redirect to `master.json`. Do we have convenient symlinks set up? Otherwise I can do that in [read_critpath_json](https://github.com/fedora-infra/bodhi/blob/f3342ba276aecaa489b7f7606412ed4c8489d479/bodhi-server/bodhi/server/util.py#L974)