### PR TITLE
Allow moving builds from unpushed updates to other updates

### DIFF
--- a/bodhi-server/bodhi/server/validators.py
+++ b/bodhi-server/bodhi/server/validators.py
@@ -286,19 +286,21 @@ def validate_builds(request, **kwargs):
         for nvr in builds:
             # Ensure it doesn't already exist in another update
             build = request.db.query(Build).filter_by(nvr=nvr).first()
-            if build and build.update is not None and up.alias != build.update.alias:
+            if (build and build.update is not None and up.alias != build.update.alias
+                    and build.update.status != UpdateStatus.unpushed):
                 request.errors.add('body', 'builds',
                                    "Update for {} already exists".format(nvr))
+                return
 
         return
 
     for nvr in builds:
         build = request.db.query(Build).filter_by(nvr=nvr).first()
-        if build and build.update is not None:
-            if build.update.status != UpdateStatus.unpushed:
-                request.errors.add('body', 'builds',
-                                   "Update for {} already exists".format(nvr))
-                return
+        if (build and build.update is not None
+                and build.update.status != UpdateStatus.unpushed):
+            request.errors.add('body', 'builds',
+                               "Update for {} already exists".format(nvr))
+            return
 
 
 @postschema_validator

--- a/news/5485.feature
+++ b/news/5485.feature
@@ -1,0 +1,1 @@
+Builds associated to unpushed updates can now be moved to other existing updates


### PR DESCRIPTION
We currently allow creating an update with a build already present in the database, but only if it is associated to an update in Unpushed status.

This PR attempts to also allow moving that build while editing an existent update, so that we can mimic the effect of "merging" two updates (just with an extra step of unpushing one before adding the build to the other).
If the unpushed update end up with no builds associated, it will be collected by an already existent cron task which purges these updates after some time.

Fixes #5485 