### PR TITLE
Container flatpak detection

### DIFF
--- a/bodhi-server/bodhi/server/buildsys.py
+++ b/bodhi-server/bodhi/server/buildsys.py
@@ -248,18 +248,20 @@ class DevBuildsys:
 
                 data['extra'] = {
                     'container_koji_task_id': 19708268,
-                    'image': {
-                        'index': {
-                            'pull': ['{registry}/{repository}@sha256:{hash}'
-                                     .format(**format_data),
-                                     '{registry}/{repository}:{version}-{release}'
-                                     .format(**format_data)],
-                        }
+                    'typeinfo': {
+                        'image': {
+                            'index': {
+                                'pull': ['{registry}/{repository}@sha256:{hash}'
+                                         .format(**format_data),
+                                         '{registry}/{repository}:{version}-{release}'
+                                         .format(**format_data)],
+                            }
+                        },
                     },
                 }
 
                 if token.endswith("flatpak"):
-                    data['extra']['image']['flatpak'] = True
+                    data['extra']['typeinfo']['image']['flatpak'] = True
 
                 break
 

--- a/bodhi-server/bodhi/server/buildsys.py
+++ b/bodhi-server/bodhi/server/buildsys.py
@@ -247,7 +247,6 @@ class DevBuildsys:
                     format_data['repository'] = "{}/{}".format(fedora_release, name)
 
                 data['extra'] = {
-                    'container_koji_task_id': 19708268,
                     'typeinfo': {
                         'image': {
                             'index': {

--- a/bodhi-server/bodhi/server/models.py
+++ b/bodhi-server/bodhi/server/models.py
@@ -593,7 +593,7 @@ class ContentType(DeclEnum):
         if 'module' in extra.get('typeinfo', {}):
             identity = cls.module
         elif 'container_koji_task_id' in extra:
-            if 'flatpak' in extra['image']:
+            if 'flatpak' in extra['typeinfo']['image']:
                 identity = cls.flatpak
             else:
                 identity = cls.container

--- a/bodhi-server/bodhi/server/models.py
+++ b/bodhi-server/bodhi/server/models.py
@@ -585,6 +585,8 @@ class ContentType(DeclEnum):
         Returns:
             BodhiBase: The type-specific child class of base that is appropriate to use with the
             given koji build.
+        Raises:
+            ValueError: If there is no appropriate child class
         """
         # Default value.  Overridden below if we find markers in the build info
         identity = cls.rpm
@@ -592,8 +594,14 @@ class ContentType(DeclEnum):
         extra = build.get('extra') or {}
         if 'module' in extra.get('typeinfo', {}):
             identity = cls.module
-        elif 'container_koji_task_id' in extra:
-            if 'flatpak' in extra['typeinfo']['image']:
+        elif 'image' in extra.get('typeinfo', {}):
+            image_info = extra['typeinfo']['image']
+            if 'pull' not in image_info.get('index', {}):
+                raise ValueError(
+                    (f"Image build {build['nvr']} cannot be used for update, "
+                     "it has no pull specs")
+                )
+            if 'flatpak' in image_info:
                 identity = cls.flatpak
             else:
                 identity = cls.container

--- a/bodhi-server/bodhi/server/util.py
+++ b/bodhi-server/bodhi/server/util.py
@@ -1153,7 +1153,7 @@ def _get_build_repository(build):
     koji = buildsys.get_session()
     koji_build = koji.getBuild(build.nvr)
 
-    pull_specs = koji_build['extra']['image']['index']['pull']
+    pull_specs = koji_build['extra']['typeinfo']['image']['index']['pull']
     # All the pull specs should have the same repository, so which one we use is arbitrary
     base, tag = re.compile(r'[:@]').split(pull_specs[0], 1)
     server, repository = base.split('/', 1)

--- a/bodhi-server/tests/test_util.py
+++ b/bodhi-server/tests/test_util.py
@@ -1235,9 +1235,11 @@ class TestCMDFunctions:
         session.return_value.getBuild.side_effect = [
             {
                 'extra': {
-                    'image': {
-                        'index': {
-                            'pull': [pullspec]
+                    'typeinfo': {
+                        'image': {
+                            'index': {
+                                'pull': [pullspec]
+                            }
                         }
                     }
                 }

--- a/news/PR5496.bug
+++ b/news/PR5496.bug
@@ -1,0 +1,1 @@
+Fixed the detection of Flatpak update type


### PR DESCRIPTION
This PR fixes a problem with the new system of building Flatpaks directly with on the builders, rather than using OSBS. The new koji-flatpak plugin doesn't set 'container_koji_task_id' in the extra metadata for the build, which broke content type detection.

See https://pagure.io/releng/issue/11697

There would be more simple ways of fixing things, but I tried to clean up a bit, rather than just leaving things broken so that unknown image types (all images aren't containers or Flatpaks...) were detected as RPM packages.

The cleanup only goes so far - I've left the test case for the new error catching a 500, rather than trying to cleanly catch this in the validatators. This was because I was pretty stumped at how to fit it in - there are multiple code paths that directly or indirectly call infer_content_class() (at least validate_acls and validate_build_uniqueness).

I've also switched the code from extra['image'] to extra['typeinfo']['image'], since that's been the preferred location for the metadata for quite some time.