### PR TITLE
Handle <version>-<release> strings that aren't valid container tags

### DIFF
--- a/bodhi-server/bodhi/server/buildsys.py
+++ b/bodhi-server/bodhi/server/buildsys.py
@@ -18,6 +18,7 @@
 """Define tools for interacting with the build system and a fake build system for development."""
 
 from functools import wraps
+import hashlib
 from threading import Lock
 import logging
 import os
@@ -235,7 +236,9 @@ class DevBuildsys:
 
                 format_data = {
                     'registry': 'candidate-registry.fedoraproject.org',
-                    'hash': 'sha256:2bd64a888...',
+                    # We make up a fake digest for the image manifest using a
+                    # digest of the version-release string
+                    'hash': hashlib.sha256(f"{version}-{release}".encode("UTF-8")).hexdigest(),
                     'version': version,
                     'release': release
                 }

--- a/bodhi-server/tests/tasks/test_composer.py
+++ b/bodhi-server/tests/tasks/test_composer.py
@@ -15,6 +15,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+import hashlib
 from http.client import IncompleteRead
 from unittest import mock
 from urllib.error import HTTPError, URLError
@@ -102,6 +103,24 @@ mock_absent_taskotron_results = {
     'target': 'bodhi.server.util.taskotron_results',
     'return_value': [],
 }
+
+
+def _expected_skopeo_args(config, source, dtag, extra_args=[]):
+    source_repository, source_version_release = source.split(':')
+    # Match how buildsys.py creates a fake digest
+    source_digest = hashlib.sha256(source_version_release.encode("UTF-8")).hexdigest()
+
+    return [config['skopeo.cmd'], 'copy'] + extra_args + [
+        'docker://{}/{}@sha256:{}'.format(config['container.source_registry'],
+                                          source_repository, source_digest),
+        'docker://{}/{}:{}'.format(config['container.destination_registry'],
+                                   source_repository, dtag)
+    ]
+
+
+def _expected_skopeo_call(config, source, dtag, extra_args=[]):
+    return mock.call(_expected_skopeo_args(config, source, dtag, extra_args=extra_args),
+                     shell=False, stderr=-1, stdout=-1, cwd=None)
 
 
 class TestTask:
@@ -2371,15 +2390,10 @@ class TestContainerComposerThread__compose_updates(ComposerThreadBaseTestCase):
         # Popen should have been called three times per build, once for each of the destination
         # tags. With two builds that is a total of 6 calls to Popen.
         expected_mock_calls = []
-        for source in ('testcontainer1:2.0.1-71.fc28container',
-                       'testcontainer2:1.0.1-1.fc28container'):
+        for source in ('f28/testcontainer1:2.0.1-71.fc28container',
+                       'f28/testcontainer2:1.0.1-1.fc28container'):
             for dtag in [source.split(':')[1], source.split(':')[1].split('-')[0], 'testing']:
-                mock_call = mock.call(
-                    [config['skopeo.cmd'], 'copy',
-                     'docker://{}/f28/{}'.format(config['container.source_registry'], source),
-                     'docker://{}/f28/{}:{}'.format(config['container.destination_registry'],
-                                                    source.split(':')[0], dtag)],
-                    shell=False, stderr=-1, stdout=-1, cwd=None)
+                mock_call = _expected_skopeo_call(config, source, dtag)
                 expected_mock_calls.append(mock_call)
                 expected_mock_calls.append(mock.call().communicate())
         assert Popen.mock_calls == expected_mock_calls
@@ -2400,15 +2414,10 @@ class TestContainerComposerThread__compose_updates(ComposerThreadBaseTestCase):
         # Popen should have been called three times per build, once for each of the destination
         # tags. With two builds that is a total of 6 calls to Popen.
         expected_mock_calls = []
-        for source in ('testcontainer1:2.0.1-71.fc28container',
-                       'testcontainer2:1.0.1-1.fc28container'):
+        for source in ('f28/testcontainer1:2.0.1-71.fc28container',
+                       'f28/testcontainer2:1.0.1-1.fc28container'):
             for dtag in [source.split(':')[1], source.split(':')[1].split('-')[0], 'latest']:
-                mock_call = mock.call(
-                    [config['skopeo.cmd'], 'copy',
-                     'docker://{}/f28/{}'.format(config['container.source_registry'], source),
-                     'docker://{}/f28/{}:{}'.format(config['container.destination_registry'],
-                                                    source.split(':')[0], dtag)],
-                    shell=False, stderr=-1, stdout=-1, cwd=None)
+                mock_call = _expected_skopeo_call(config, source, dtag)
                 expected_mock_calls.append(mock_call)
                 expected_mock_calls.append(mock.call().communicate())
         assert Popen.mock_calls == expected_mock_calls
@@ -2428,12 +2437,9 @@ class TestContainerComposerThread__compose_updates(ComposerThreadBaseTestCase):
             t._compose_updates()
 
         # Popen should have been called once.
-        skopeo_cmd = [
-            config['skopeo.cmd'], 'copy',
-            'docker://{}/f28/testcontainer1:2.0.1-71.fc28container'.format(
-                config['container.source_registry']),
-            'docker://{}/f28/testcontainer1:2.0.1-71.fc28container'.format(
-                config['container.destination_registry'])]
+        skopeo_cmd = _expected_skopeo_args(config,
+                                           "f28/testcontainer1:2.0.1-71.fc28container",
+                                           "2.0.1-71.fc28container")
         Popen.assert_called_once_with(skopeo_cmd, shell=False, stderr=-1, stdout=-1, cwd=None)
         assert f"{' '.join(skopeo_cmd)} returned a non-0 exit code: 1" in str(exc.value)
 
@@ -2453,15 +2459,11 @@ class TestContainerComposerThread__compose_updates(ComposerThreadBaseTestCase):
         # Popen should have been called three times per build, once for each of the destination
         # tags. With two builds that is a total of 6 calls to Popen.
         expected_mock_calls = []
-        for source in ('testcontainer1:2.0.1-71.fc28container',
-                       'testcontainer2:1.0.1-1.fc28container'):
+        for source in ('f28/testcontainer1:2.0.1-71.fc28container',
+                       'f28/testcontainer2:1.0.1-1.fc28container'):
             for dtag in [source.split(':')[1], source.split(':')[1].split('-')[0], 'testing']:
-                mock_call = mock.call(
-                    [config['skopeo.cmd'], 'copy', '--dest-tls-verify=false',
-                     'docker://{}/f28/{}'.format(config['container.source_registry'], source),
-                     'docker://{}/f28/{}:{}'.format(config['container.destination_registry'],
-                                                    source.split(':')[0], dtag)],
-                    shell=False, stderr=-1, stdout=-1, cwd=None)
+                mock_call = _expected_skopeo_call(config, source, dtag,
+                                                  extra_args=['--dest-tls-verify=false'])
                 expected_mock_calls.append(mock_call)
                 expected_mock_calls.append(mock.call().communicate())
         assert Popen.mock_calls == expected_mock_calls
@@ -2547,12 +2549,7 @@ class TestFlatpakComposerThread__compose_updates(ComposerThreadBaseTestCase):
         expected_mock_calls = []
         for source in ('testflatpak1:2.0.1-71.fc28flatpak', 'testflatpak2:1.0.1-1.fc28flatpak'):
             for dtag in [source.split(':')[1], source.split(':')[1].split('-')[0], 'testing']:
-                mock_call = mock.call(
-                    [config['skopeo.cmd'], 'copy',
-                     'docker://{}/{}'.format(config['container.source_registry'], source),
-                     'docker://{}/{}:{}'.format(config['container.destination_registry'],
-                                                source.split(':')[0], dtag)],
-                    shell=False, stderr=-1, stdout=-1, cwd=None)
+                mock_call = _expected_skopeo_call(config, source, dtag)
                 expected_mock_calls.append(mock_call)
                 expected_mock_calls.append(mock.call().communicate())
         assert Popen.mock_calls == expected_mock_calls

--- a/bodhi-server/tests/test_util.py
+++ b/bodhi-server/tests/test_util.py
@@ -1230,29 +1230,28 @@ class TestCMDFunctions:
         mock_debug.assert_called_with('subprocess output: output\nerror')
 
     @mock.patch('bodhi.server.buildsys.get_session')
-    def test__get_build_repository(self, session):
+    def test__get_build_repository_and_digest(self, session):
+        pull_specs = [
+            'candidate-registry.fedoraproject.org/f29/cockpit:176-5.fc28',
+            'candidate-registry.fedoraproject.org/myrepo@sha256:abcdefg123456'
+        ]
+
         session.return_value = mock.Mock()
-        session.return_value.getBuild.side_effect = [
-            {
-                'extra': {
-                    'typeinfo': {
-                        'image': {
-                            'index': {
-                                'pull': [pullspec]
-                            }
+        session.return_value.getBuild.return_value = {
+            'extra': {
+                'typeinfo': {
+                    'image': {
+                        'index': {
+                            'pull': pull_specs
                         }
                     }
                 }
             }
-            for pullspec in [
-                'candidate-registry.fedoraproject.org/f29/cockpit:176-5.fc28',
-                'candidate-registry.fedoraproject.org/myrepo@sha256:abcdefg123456'
-            ]
-        ]
+        }
+
         build = mock.Mock()
         build.nvr = 'cockpit-167-5'
-        assert util._get_build_repository(build) == 'f29/cockpit'
-        assert util._get_build_repository(build) == 'myrepo'
+        assert util._get_build_repository_and_digest(build) == ('myrepo', 'sha256:abcdefg123456')
         session.return_value.getBuild.assert_called_with('cockpit-167-5')
 
     def test_build_evr(self):
@@ -1266,8 +1265,11 @@ class TestCMDFunctions:
 
 
 @mock.patch('bodhi.server.util.cmd', autospec=True)
-@mock.patch('bodhi.server.util._container_image_url', new=lambda sr, r, st: f'{sr}:{r}:{st}')
-@mock.patch('bodhi.server.util._get_build_repository', new=lambda b: 'testrepo')
+@mock.patch('bodhi.server.util._container_image_url',
+            new=lambda sr, r, tag=None, digest=None:
+                f'{sr}:{r}:{tag}' if tag else f'{sr}:{r}@{digest}')
+@mock.patch('bodhi.server.util._get_build_repository_and_digest',
+            new=lambda b: ('testrepo', 'sha256:f00d00'))
 class TestCopyContainer(base.BasePyTestCase):
     """Test the copy_container() function."""
 
@@ -1286,21 +1288,24 @@ class TestCopyContainer(base.BasePyTestCase):
         """Test the default code path."""
         util.copy_container(self.build)
 
-        cmd.assert_called_once_with(['skopeo', 'copy', 'src:testrepo:1-1', 'dest:testrepo:1-1'],
+        cmd.assert_called_once_with(['skopeo', 'copy',
+                                     'src:testrepo@sha256:f00d00', 'dest:testrepo:1-1'],
                                     raise_on_error=True)
 
     def test_with_destination_registry(self, cmd):
         """Test with specified destination_registry."""
         util.copy_container(self.build, destination_registry='boo')
 
-        cmd.assert_called_once_with(['skopeo', 'copy', 'src:testrepo:1-1', 'boo:testrepo:1-1'],
+        cmd.assert_called_once_with(['skopeo', 'copy',
+                                     'src:testrepo@sha256:f00d00', 'boo:testrepo:1-1'],
                                     raise_on_error=True)
 
     def test_with_destination_tag(self, cmd):
         """Test with specified destination_tag."""
         util.copy_container(self.build, destination_tag='2-2')
 
-        cmd.assert_called_once_with(['skopeo', 'copy', 'src:testrepo:1-1', 'dest:testrepo:2-2'],
+        cmd.assert_called_once_with(['skopeo', 'copy',
+                                     'src:testrepo@sha256:f00d00', 'dest:testrepo:2-2'],
                                     raise_on_error=True)
 
     def test_with_extra_copy_flags(self, cmd):
@@ -1309,7 +1314,7 @@ class TestCopyContainer(base.BasePyTestCase):
         util.copy_container(self.build)
 
         cmd.assert_called_once_with(['skopeo', 'copy', '--quiet', '--remove-signatures',
-                                     'src:testrepo:1-1', 'dest:testrepo:1-1'],
+                                     'src:testrepo@sha256:f00d00', 'dest:testrepo:1-1'],
                                     raise_on_error=True)
 
 

--- a/bodhi-server/tests/test_util.py
+++ b/bodhi-server/tests/test_util.py
@@ -1264,6 +1264,21 @@ class TestCMDFunctions:
         assert util.build_evr(build) == ('2', '1', '2.fc30')
 
 
+class TestMakeValidContainerTag(base.BasePyTestCase):
+    """Test the make_valid_container_tag() function."""
+
+    def test_valid_tag(self):
+        def E(input, result):
+            assert util.make_valid_container_tag(input) == result
+
+        # Invalid characters turned to _
+        E("%{foo}-%{bar}", "__foo_-__bar_")
+        # . is only invalid when leading
+        E(".f-.g", "_f-.g")
+        # truncate to 128 characters
+        E("x" * 129, "x" * 128)
+
+
 @mock.patch('bodhi.server.util.cmd', autospec=True)
 @mock.patch('bodhi.server.util._container_image_url',
             new=lambda sr, r, tag=None, digest=None:

--- a/news/PR5497.bug
+++ b/news/PR5497.bug
@@ -1,0 +1,1 @@
+Fix handling container tags which aren't valid OCI tags


### PR DESCRIPTION
With the new Flatpak generation inside of Koji, we are versioning the containers based on their main packages. So,

  `ghex-45~beta-2.fc39` => `ghex-flatpak-45~beta-1`

But '45~beta-1' is not a valid registry tag, so pushing fails. This PR has two parts:

 1. Don't count on the tags in the candidate registry having any particular value - pull by digest instead
 2. Make sure the tags we create in the destination registry are valid
