### PR TITLE
Allow setting createrepo_c config per release

### DIFF
--- a/bodhi-server/bodhi/server/config.py
+++ b/bodhi-server/bodhi/server/config.py
@@ -351,6 +351,9 @@ class BodhiConfig(dict):
         'cors_origins_rw': {
             'value': 'https://bodhi.fedoraproject.org',
             'validator': str},
+        'createrepo_c_config': {
+            'value': '/etc/bodhi/createrepo_c.ini',
+            'validator': str},
         'critpath_pkgs': {
             'value': [],
             'validator': _generate_list_validator()},

--- a/bodhi-server/bodhi/server/metadata.py
+++ b/bodhi-server/bodhi/server/metadata.py
@@ -137,25 +137,10 @@ class UpdateInfoMetadata(object):
 
         self.uinfo = cr.UpdateInfo()
 
-        self.comp_type = cr.XZ
+        createrepo_c_settings = util.get_createrepo_config(release)
+        self.comp_type = getattr(cr, createrepo_c_settings.uinfo_comp)
+        self.zchunk = createrepo_c_settings.zchunk
 
-        # Some repos such as FEDORA-EPEL, are primarily targeted at
-        # distributions that use the yum client, which does not support zchunk metadata
-        self.legacy_repos = ['FEDORA-EPEL']
-        self.zchunk = True
-
-        if release.id_prefix in self.legacy_repos:
-            # FIXME: I'm not sure which versions of RHEL support xz metadata
-            # compression, so use the lowest common denominator for now.
-            self.comp_type = cr.BZ2
-
-            log.warning(
-                'Zchunk data is disabled for repo {release.id_prefix} until it moves to a client'
-                ' with Zchunk support'
-            )
-            self.zchunk = False
-
-        self.uinfo = cr.UpdateInfo()
         for update in self.updates:
             self.add_update(update)
 

--- a/bodhi-server/bodhi/server/tasks/composer.py
+++ b/bodhi-server/bodhi/server/tasks/composer.py
@@ -62,6 +62,7 @@ from bodhi.server.models import (
 from bodhi.server.tasks.clean_old_composes import main as clean_old_composes
 from bodhi.server.util import (
     copy_container,
+    get_createrepo_config,
     sanity_check_repodata,
     sorted_updates,
     transactional_session_maker,
@@ -991,6 +992,7 @@ class PungiComposerThread(ComposerThread):
     def _create_pungi_config(self):
         """Create a temp dir and render the Pungi config templates into the dir."""
         loader = jinja2.FileSystemLoader(searchpath=config.get('pungi.basepath'))
+        createrepo_c_settings = get_createrepo_config(self.compose.release)
         env = jinja2.Environment(loader=loader,
                                  autoescape=False,
                                  block_start_string='[%',
@@ -1004,6 +1006,7 @@ class PungiComposerThread(ComposerThread):
         env.globals['release'] = self.compose.release
         env.globals['request'] = self.compose.request
         env.globals['updates'] = self.compose.updates
+        env.globals['cr_config'] = createrepo_c_settings
 
         config_template = config.get(self.pungi_template_config_key)
         template = env.get_template(config_template)

--- a/bodhi-server/production.ini
+++ b/bodhi-server/production.ini
@@ -123,6 +123,7 @@ use = egg:bodhi-server
 #  * 'release': The Release being composed.
 #  * 'request': The request being composed.
 #  * 'updates': The Updates being composed.
+#  * 'cr_config': The createrepo_c settings loaded from config file.
 #
 # NOTE: The jinja2 configuration for these templates replaces the {'s and }'s with ['s and ]'.
 # e.g.: a block becomes [% if <something %], and a variable is [[ varname ]].
@@ -146,6 +147,9 @@ use = egg:bodhi-server
 
 # What to pass to Pungi's --label flag, which is metadata included in its composeinfo.json.
 # pungi.labeltype = Update
+
+# Path to the file with createrepo_c settings
+# createrepo_c_config = /etc/bodhi/createrepo_c.ini
 
 # The skopeo executable to use to copy container images.
 # You can put credentials for skopeo to use in $HOME/.docker/config.json

--- a/bodhi-server/tests/test_metadata.py
+++ b/bodhi-server/tests/test_metadata.py
@@ -353,7 +353,8 @@ class TestUpdateInfoMetadata(UpdateInfoMetadataTestCase):
             if record.title == title:
                 return record
 
-    def test___init___uses_bz2_for_epel(self):
+    @mock.patch('bodhi.server.util.log.info')
+    def test___init___uses_bz2_for_epel(self, info):
         """Assert that the __init__() method sets the comp_type attribute to cr.BZ2 for EPEL."""
         epel_7 = Release(id_prefix="FEDORA-EPEL", stable_tag='epel7')
 
@@ -361,8 +362,21 @@ class TestUpdateInfoMetadata(UpdateInfoMetadataTestCase):
 
         assert md.comp_type == createrepo_c.BZ2
         assert not md.zchunk
+        info.assert_any_call('Using custom createrepo_c config for FEDORA-EPEL.')
 
-    def test___init___uses_xz_for_fedora(self):
+    @mock.patch('bodhi.server.util.log.info')
+    def test___init___uses_xz_for_epel8(self, info):
+        """Assert that the __init__() method sets the comp_type attribute to cr.XZ for EPEL-8."""
+        epel_8 = Release(name="EPEL-8", id_prefix="FEDORA-EPEL", stable_tag='epel8')
+
+        md = UpdateInfoMetadata(epel_8, UpdateRequest.stable, self.db, self.tempdir)
+
+        assert md.comp_type == createrepo_c.XZ
+        assert not md.zchunk
+        info.assert_any_call('Using custom createrepo_c config for EPEL-8.')
+
+    @mock.patch('bodhi.server.util.log.info')
+    def test___init___uses_xz_for_fedora(self, info):
         """Assert that the __init__() method sets the comp_type attribute to cr.XZ for Fedora."""
         fedora = Release.query.one()
 
@@ -370,6 +384,7 @@ class TestUpdateInfoMetadata(UpdateInfoMetadataTestCase):
 
         assert md.comp_type == createrepo_c.XZ
         assert md.zchunk
+        info.assert_any_call('Using createrepo_c defaults config.')
 
     def test_extended_metadata_once(self):
         """Assert that a single call to update the metadata works as expected."""

--- a/bodhi-server/tests/testing.ini
+++ b/bodhi-server/tests/testing.ini
@@ -59,6 +59,7 @@ warm_cache_on_start = false
 celery_config = %(here)s/../celeryconfig.py
 compose_dir = /srv/composes/final
 compose_stage_dir = /srv/composes/stage
+createrepo_c_config = %(here)s/../../devel/ci/integration/bodhi/createrepo_c.ini
 pungi.basepath = %(here)s/../../devel/ci/integration/bodhi/
 pungi.cmd = /usr/bin/true
 pungi.conf.rpm = pungi.rpm.conf.j2

--- a/devel/ci/integration/bodhi/createrepo_c.ini
+++ b/devel/ci/integration/bodhi/createrepo_c.ini
@@ -1,0 +1,26 @@
+[DEFAULT]
+# updateinfo-compress-type is used to generate updateinfo file in metadata.py
+# set the value to an attribute which match the python constant
+# Supported options are: BZ2, GZ, ZSTD, XZ.
+updateinfo-compress-type = XZ
+# createrepo-compress-type is used in the CLI call to createrepo_c
+# set the value to match the `--compress-type=COMPRESSION_TYPE` option
+# Supported compressions are: bzip2, gzip, zck, zstd, xz.
+# Or leave empty for no compression.
+repodata-compress-type =
+# setting general-compress to True will switch usage of `--compress-type=COMPRESSION_TYPE`
+# to `--general-compress-type=COMPRESSION_TYPE`. See `man createrepo_c`.
+general-compress = False
+# zchunk is a boolean which enables zchunk on repodata
+zchunk = True
+
+# Here you can override default values by matching Release.prefix_id or Release.name
+# If a value is not overridden, those from DEFAULT are used
+# Each section only inherits from DEFAULT, so `release` will not inherit from `prefix`.
+[prefix.FEDORA-EPEL]
+updateinfo-compress-type = BZ2
+zchunk = False
+
+[release.EPEL-8]
+repodata-compress-type = xz
+zchunk = False

--- a/devel/ci/integration/bodhi/pungi.module.conf.j2
+++ b/devel/ci/integration/bodhi/pungi.module.conf.j2
@@ -104,7 +104,7 @@ check_deps = False
 
 # CREATEREPO
 createrepo_deltas = False
-[% if release.version_int >= 30 %]
+[% if cr_config.zchunk %]
 createrepo_extra_args = ['--zck', '--zck-dict-dir=/usr/share/fedora-repo-zdicts/f[[ release.version_int ]]']
 [% endif %]
 

--- a/devel/ci/integration/bodhi/pungi.module.conf.j2
+++ b/devel/ci/integration/bodhi/pungi.module.conf.j2
@@ -1,9 +1,14 @@
+# Import shared settings from pungi_general.conf
+from pungi_general import *
+# Import multilib settings from pungi_multilib.conf
+from pungi_multilib import *
+
 # PRODUCT INFO
-release_name = '[[ release.id_prefix.title() ]]'
-release_short = '[[ release.id_prefix.title() ]]'
 release_version = '[[ release.version ]]'
 release_type = 'updates[% if request.name == 'testing' %]-testing[% endif %]'
-release_is_layered = False
+release_name = '[[ release.id_prefix.title() ]]'
+release_short = '[[ release.id_prefix.title() ]]'
+
 
 # GENERAL SETTINGS
 bootable = False
@@ -12,49 +17,92 @@ variants_file='module-variants.xml'
 sigkeys = [
 [% if release.version_int == 28 %]
 	'9db62fb1',
-[% elif release.version_int == 29 %]
-	'429476b4',
 [% elif release.version_int == 30 %]
 	'cfc659b9',
+[% elif release.version_int == 31 %]
+	'3c3359c4',
+[% elif release.version_int == 32 %]
+	'12c944d0',
+[% elif release.version_int == 33 %]
+	'9570ff31',
+[% elif release.version_int == 34 %]
+    '45719a39',
+[% elif release.version_int == 35 %]
+    '9867c58f',
+[% elif release.version_int == 36 %]
+    '38ab71f4',
+[% elif release.version_int == 37 %]
+    '5323552a',
+[% elif release.version_int == 38 %]
+    'eb10b464',
+[% elif release.version_int == 39 %]
+    '18B8e74c',
+[% elif release.version_int == 40 %]
+    'a15B79cc',
+[% elif release.version_int == 8 %]
+    '2f86d6a1',
 [% endif %]
 {% if env == "staging" %}
-	None
+    [% if release.version_int == 8 %]
+        'd300e724',
+    [% endif %]
 {% endif %}
 ]
 
 module_defaults_dir = {
     'scm': 'git',
-    'repo': 'https://pagure.io/releng/fedora-module-defaults.git',
-    'branch': 'f[[ release.version_int ]]',
+    {% if env == "staging" %}
+        'repo': 'https://pagure.io/modularity/fedora-stg-module-defaults.git',
+        [% if release.version_int == 8 %]
+            'branch': 'el[[ release.version_int ]]',
+        [% else %]
+            'branch': 'f[[ release.version_int ]]',
+        [% endif %]
+    {% else %}
+        'repo': 'https://pagure.io/releng/fedora-module-defaults.git',
+        [% if release.version_int == 8 %]
+            'branch': 'el[[ release.version_int ]]',
+        [% else %]
+            'branch': 'f[[ release.version_int ]]',
+        [% endif %]
+    {% endif %}
     'dir': '.'
 }
 
-hashed_directories = True
+module_obsoletes_dir = {
+    'scm': 'git',
+    {% if env == "staging" %}
+        'repo': 'https://pagure.io/modularity/fedora-stg-module-defaults.git',
+        [% if release.version_int == 8 %]
+            'branch': 'el[[ release.version_int ]]',
+        [% else %]
+            'branch': 'f[[ release.version_int ]]',
+        [% endif %]
+    {% else %}
+        'repo': 'https://pagure.io/releng/fedora-module-defaults.git',
+        [% if release.version_int == 8 %]
+            'branch': 'el[[ release.version_int ]]',
+        [% else %]
+            'branch': 'f[[ release.version_int ]]',
+        [% endif %]
+    {% endif %}
+    'dir': 'obsoletes'
+}
 
 # RUNROOT settings
 runroot = False
 
-# PKGSET
-pkgset_source = 'koji' # koji, repos
-
-# PKGSET - KOJI
-# pkgset_koji_tag is not used by the modular compose, but Pungi needs this
-# option to appear in a config, otherwise it fails. Once this is fixed, we can
-# remove this option completely.
-pkgset_koji_tag = 'not-used'
-pkgset_koji_inherit = False
-
-filter_system_release_packages = False
+# PDC settings
+pdc_url = 'https://pdc{{ env_suffix }}.fedoraproject.org/rest_api/v1'
+pdc_insecure = False
+pdc_develop = True
 
 # GATHER
 gather_method = 'nodeps'
 gather_profiler = True
 check_deps = False
-greedy_method = 'build'
 
 # CREATEREPO
-createrepo_c = True
-createrepo_checksum = 'sha256'
 createrepo_deltas = False
 [% if release.version_int >= 30 %]
 createrepo_extra_args = ['--zck', '--zck-dict-dir=/usr/share/fedora-repo-zdicts/f[[ release.version_int ]]']
@@ -80,4 +128,13 @@ createiso_skip = [
             'src': True
         }),
 ]
+
+filter_modules = [
+    ('(Everything)$', {
+        '*': [
+        'perl*bootstrap:*',
+        ]
+    }),
+]
+
 koji_profile = 'bodhi_koji'

--- a/devel/ci/integration/bodhi/pungi.rpm.conf.j2
+++ b/devel/ci/integration/bodhi/pungi.rpm.conf.j2
@@ -1,17 +1,21 @@
+# Import shared settings from pungi_general.conf
+from pungi_general import *
+# Import multilib settings from pungi_multilib.conf
+from pungi_multilib import *
+
 # PRODUCT INFO
-skip_phases = ["buildinstall", "productimg", "extra_files"]
-release_name = '[[ release.id_prefix.title() ]]'
-release_short = '[[ release.id_prefix.title() ]]'
+skip_phases = ["buildinstall", "extra_files"]
 release_version = '[[ release.version_int ]]'
 release_type = 'updates[% if request.name == 'testing' %]-testing[% endif %]'
-release_is_layered = False
 old_composes_per_release_type = True
+release_name = '[[ release.id_prefix.title() ]]'
+release_short = '[[ release.id_prefix.title() ]]'
 
 # GENERAL SETTINGS
 comps_file = {
     'scm': 'git',
     'repo': 'https://pagure.io/fedora-comps.git',
-    'branch': 'master', # defaults to cvs/HEAD or git/master
+    'branch': 'main', # defaults to cvs/HEAD or git/main
     'file': 'comps-[[ release.branch ]].xml',
     'command': 'make',
 }
@@ -25,20 +29,41 @@ sigkeys = [
     'f5282ee4',
 [% elif release.version_int == 28 %]
     '9db62fb1',
-[% elif release.version_int == 29 %]
-    '429476b4',
 [% elif release.version_int == 30 %]
     'cfc659b9',
+[% elif release.version_int == 31 %]
+    '3c3359c4',
+[% elif release.version_int == 32 %]
+    '12c944d0',
+[% elif release.version_int == 33 %]
+    '9570ff31',
+[% elif release.version_int == 34 %]
+    '45719a39',
+[% elif release.version_int == 35 %]
+    '9867c58f',
+[% elif release.version_int == 36 %]
+    '38ab71f4',
+[% elif release.version_int == 37 %]
+    '5323552a',
+[% elif release.version_int == 38 %]
+    'eb10b464',
+[% elif release.version_int == 39 %]
+    '18B8e74c',
+[% elif release.version_int == 40 %]
+    'a15B79cc',
 [% elif release.version_int == 6 %]
     '0608b895',
 [% elif release.version_int == 7 %]
     '352C64E5',
+[% elif release.version_int == 8 %]
+    '2f86d6a1'
+[% elif release.version_int == 9 %]
+    '3228467c'
 [% endif %]
 {% if env == "staging" %}
     None
 {% endif %}
 ]
-hashed_directories = True
 comps_filter_environments = False
 
 # RUNROOT settings
@@ -47,27 +72,28 @@ runroot_channel = 'compose'
 runroot_tag = 'f[[ release.version_int ]]-build'
 
 # PKGSET
-pkgset_source = 'koji' # koji, repos
 pkgset_koji_tag = '[[ id ]]'
 pkgset_koji_inherit = False
-filter_system_release_packages = False
+pkgset_allow_reuse = False
 
 # GATHER
 gather_method = 'deps'
 gather_backend = 'dnf'
 check_deps = False
-greedy_method = 'build'
 repoclosure_backend = 'dnf'
 
 # CREATEREPO
-createrepo_c = True
-createrepo_checksum = 'sha256'
 createrepo_deltas = [
     ('^Everything$', {'*': True})
 ]
 createrepo_database = True
 [% if release.version_int >= 30 %]
 createrepo_extra_args = ['--zck', '--zck-dict-dir=/usr/share/fedora-repo-zdicts/f[[ release.version_int ]]']
+[% endif %]
+# For epel8 we want to use xz compression for repodata
+# https://pagure.io/epel/issue/71
+[% if release.version_int == 8 %]
+createrepo_extra_args = ['--xz']
 [% endif %]
 
 # CHECKSUMS
@@ -81,6 +107,7 @@ additional_packages = [
     ('^Everything$', {
         '*': [
             '*',
+            '*-debuginfo',
         ],
     }),
 ]
@@ -91,30 +118,7 @@ multilib = [
     })
 ]
 filter_packages = []
-# format: {arch|*: [packages]}
-multilib_blacklist = {
-    '*': ['kernel*', 'kernel-PAE*', 'kernel*debug*',
-        'dmraid-devel', 'kdeutils-devel', 'mkinitrd-devel',
-        'java-1.5.0-gcj-devel', 'java-1.7.0-icedtea-devel',
-        'php-devel', 'java-1.6.0-openjdk-devel',
-        'java-1.7.0-openjdk-devel', 'java-1.8.0-openjdk-devel',
-        'httpd-devel', 'tomcat-native', 'php*', 'httpd',
-        'krb5-server', 'krb5-server-ldap', 'mod_*', 'ghc-*'
-    ],
-}
-# format: {arch|*: [packages]}
-multilib_whitelist = {
-    '*': ['libgnat', 'wine*', 'lmms-vst', 'nspluginwrapper',
-        'libflashsupport', 'valgrind', 'perl-libs', 'redhat-lsb',
-        'yaboot', 'syslinux-extlinux-nonlinux', 'syslinux-nonlinux',
-        'syslinux-tftpboot', 'nosync', '*-static', 'apitrace-libs',
-        'fakeroot-libs', 'postgresql-odbc', 'mysql-connector-odbc',
-        'fakechroot-libs','mesa-vdpau-drivers', 'p11-kit-trust',
-        'mariadb-connector-odbc', 'compiler-rt',
-        'nvidia-query-resource-opengl-lib',
-        'ibus-libs', 'ibus-gtk2', 'ibus-gtk3'
-    ],
-}
+
 createiso_skip = [
         ('^Everything$', {
             '*': True,
@@ -126,43 +130,10 @@ createiso_skip = [
 [% if release.id_prefix == 'FEDORA' %]
 ostree = {
     "^Everything$": [
-        # Atomic Host
-        # Atomic Host will be avilable till F29 EOL
-        # See https://github.com/coreos/fedora-coreos-tracker/issues/145
-        [% if release.version_int <= 29 %]
-        {
-            "version": "!VERSION_FROM_VERSION_DATE_RESPIN",
-            "force_new_commit": True
-            "treefile": "fedora-atomic-host.json",
-            "config_url": "https://pagure.io/fedora-atomic.git",
-            "config_branch": "f[[ release.version ]]",
-            "repo": [
-                "Everything",
-                "https://kojipkgs{{ env_suffix }}.fedoraproject.org/compose/[[ release.version_int ]]/latest-Fedora-[[ release.version_int ]]/compose/Everything/$basearch/os/",
-                [% if request.name == 'testing' %]
-                    # In the case of testing, also inject the last stable updates
-                    "https://kojipkgs{{ env_suffix }}.fedoraproject.org/compose/updates/f[[ release.version_int ]]-updates/compose/Everything/$basearch/os/"
-                [% endif %]
-            ]
-            "ostree_repo": "/mnt/koji/compose/ostree/repo",
-            [% if request.name == 'stable' %]
-                "ostree_ref": "fedora/[[ release.version_int ]]/${basearch}/updates/atomic-host",
-            [% else %]
-                "ostree_ref": "fedora/[[ release.version_int ]]/${basearch}/testing/atomic-host",
-            [% endif %]
-            "tag_ref": False,
-            "arches": ["x86_64", "ppc64le", "aarch64" ],
-            "failable": ["ppc64le", "aarch64"],
-        },
-        [% endif %]
         # Fedora Silverblue
         {
             "version": "!VERSION_FROM_VERSION_DATE_RESPIN",
-            [% if release.version_int >= 29 %]
-                "treefile": "fedora-silverblue.yaml",
-            [% else %]
-                "treefile": "fedora-atomic-workstation-updates-[[ request.name ]].json",
-            [% endif %]
+            "treefile": "fedora-silverblue.yaml",
             "config_url": "https://pagure.io/workstation-ostree-config.git",
             "config_branch": "f[[ release.version ]]",
             "repo": [
@@ -171,139 +142,120 @@ ostree = {
                     # In the case of testing, also inject the last stable updates
                     "https://kojipkgs{{ env_suffix }}.fedoraproject.org/compose/updates/f[[ release.version_int ]]-updates/compose/Everything/$basearch/os/",
                 [% endif %]
-                # For f30 the compose location is going to be under /compose/branched/
-                [% if release.version_int == 30 %]
+                # For F39 the compose location is going to be under /compose/branched/
+                [% if release.version_int == 39 %]
                     "https://kojipkgs{{ env_suffix }}.fedoraproject.org/compose/branched/latest-Fedora-[[ release.version_int ]]/compose/Everything/$basearch/os/"
                 [% else %]
                     "https://kojipkgs{{ env_suffix }}.fedoraproject.org/compose/[[ release.version_int ]]/latest-Fedora-[[ release.version_int ]]/compose/Everything/$basearch/os/"
                 [% endif %]
             ]
             "ostree_repo": "/mnt/koji/compose/ostree/repo",
-            # For f29+ we are changing the ref to silverblue. For f28/f27 let the files
-            # still specify the workstation ref.
-            [% if release.version_int >= 29 %]
-                [% if request.name == 'stable' %]
-                    "ostree_ref": "fedora/[[ release.version_int ]]/${basearch}/updates/silverblue",
-                [% else %]
-                    "ostree_ref": "fedora/[[ release.version_int ]]/${basearch}/testing/silverblue",
+            [% if request.name == 'stable' %]
+                "ostree_ref": "fedora/[[ release.version_int ]]/${basearch}/updates/silverblue",
+            [% else %]
+                "ostree_ref": "fedora/[[ release.version_int ]]/${basearch}/testing/silverblue",
+            [% endif %]
+            "tag_ref": False,
+            "arches": ["x86_64", "ppc64le", "aarch64" ],
+            "failable": ["x86_64", "ppc64le", "aarch64" ]
+        },
+        # Fedora Kinoite
+        [% if release.version_int >= 35 %]
+        {
+            "version": "!VERSION_FROM_VERSION_DATE_RESPIN",
+            "treefile": "fedora-kinoite.yaml",
+            "config_url": "https://pagure.io/workstation-ostree-config.git",
+            "config_branch": "f[[ release.version ]]",
+            "repo": [
+                "Everything",
+                [% if request.name == 'testing' %]
+                    # In the case of testing, also inject the last stable updates
+                    "https://kojipkgs{{ env_suffix }}.fedoraproject.org/compose/updates/f[[ release.version_int ]]-updates/compose/Everything/$basearch/os/",
                 [% endif %]
+                # For F39 the compose location is going to be under /compose/branched/
+                [% if release.version_int == 39 %]
+                    "https://kojipkgs{{ env_suffix }}.fedoraproject.org/compose/branched/latest-Fedora-[[ release.version_int ]]/compose/Everything/$basearch/os/"
+                [% else %]
+                    "https://kojipkgs{{ env_suffix }}.fedoraproject.org/compose/[[ release.version_int ]]/latest-Fedora-[[ release.version_int ]]/compose/Everything/$basearch/os/"
+                [% endif %]
+            ]
+            "ostree_repo": "/mnt/koji/compose/ostree/repo",
+            [% if request.name == 'stable' %]
+                "ostree_ref": "fedora/[[ release.version_int ]]/${basearch}/updates/kinoite",
+            [% else %]
+                "ostree_ref": "fedora/[[ release.version_int ]]/${basearch}/testing/kinoite",
+            [% endif %]
+            "tag_ref": False,
+            "arches": ["x86_64", "ppc64le", "aarch64" ],
+            "failable": ["x86_64", "ppc64le", "aarch64" ]
+        },
+        [% endif %]
+        # Fedora Sericea
+        [% if release.version_int >= 38 %]
+        {
+            "version": "!VERSION_FROM_VERSION_DATE_RESPIN",
+            "treefile": "fedora-sericea.yaml",
+            "config_url": "https://pagure.io/workstation-ostree-config.git",
+            "config_branch": "f[[ release.version ]]",
+            "repo": [
+                "Everything",
+                [% if request.name == 'testing' %]
+                    # In the case of testing, also inject the last stable updates
+                    "https://kojipkgs{{ env_suffix }}.fedoraproject.org/compose/updates/f[[ release.version_int ]]-updates/compose/Everything/$basearch/os/",
+                [% endif %]
+                # For F39 the compose location is going to be under /compose/branched/
+                [% if release.version_int == 39 %]
+                    "https://kojipkgs{{ env_suffix }}.fedoraproject.org/compose/branched/latest-Fedora-[[ release.version_int ]]/compose/Everything/$basearch/os/"
+                [% else %]
+                    "https://kojipkgs{{ env_suffix }}.fedoraproject.org/compose/[[ release.version_int ]]/latest-Fedora-[[ release.version_int ]]/compose/Everything/$basearch/os/"
+                [% endif %]
+            ]
+            "ostree_repo": "/mnt/koji/compose/ostree/repo",
+            [% if request.name == 'stable' %]
+                "ostree_ref": "fedora/[[ release.version_int ]]/${basearch}/updates/sericea",
+            [% else %]
+                "ostree_ref": "fedora/[[ release.version_int ]]/${basearch}/testing/sericea",
             [% endif %]
             "tag_ref": False,
             "arches": ["x86_64"],
             "failable": ["x86_64"]
         },
+        [% endif %]
+        # Fedora Onyx
+        [% if release.version_int >= 39 %]
+        {
+            "version": "!VERSION_FROM_VERSION_DATE_RESPIN",
+            "treefile": "fedora-onyx.yaml",
+            "config_url": "https://pagure.io/workstation-ostree-config.git",
+            "config_branch": "f[[ release.version ]]",
+            "repo": [
+                "Everything",
+                [% if request.name == 'testing' %]
+                    # In the case of testing, also inject the last stable updates
+                    "https://kojipkgs{{ env_suffix }}.fedoraproject.org/compose/updates/f[[ release.version_int ]]-updates/compose/Everything/$basearch/os/",
+                [% endif %]
+                # For F39 the compose location is going to be under /compose/branched/
+                [% if release.version_int == 39 %]
+                    "https://kojipkgs{{ env_suffix }}.fedoraproject.org/compose/branched/latest-Fedora-[[ release.version_int ]]/compose/Everything/$basearch/os/"
+                [% else %]
+                    "https://kojipkgs{{ env_suffix }}.fedoraproject.org/compose/[[ release.version_int ]]/latest-Fedora-[[ release.version_int ]]/compose/Everything/$basearch/os/"
+                [% endif %]
+            ]
+            "ostree_repo": "/mnt/koji/compose/ostree/repo",
+            [% if request.name == 'stable' %]
+                "ostree_ref": "fedora/[[ release.version_int ]]/${basearch}/updates/onyx",
+            [% else %]
+                "ostree_ref": "fedora/[[ release.version_int ]]/${basearch}/testing/onyx",
+            [% endif %]
+            "tag_ref": False,
+            "arches": ["x86_64"],
+            "failable": ["x86_64"]
+        },
+        [% endif %]
     ]
 }
 [% endif %]
 
-[% if release.id_prefix == 'FEDORA' and release.version_int == 29 %]
-global_ksurl = 'git+https://pagure.io/fedora-kickstarts.git?#origin/f[[ release.version_int ]]'
-global_release = '!RELEASE_FROM_LABEL_DATE_TYPE_RESPIN'
-image_name_format = '%(release_short)s-%(variant)s-%(disc_type)s-%(arch)s-%(version)s-%(date)s%(type_suffix)s.%(respin)s.iso'
-image_volid_formats = [
-    '%(release_short)s-%(variant)s-%(disc_type)s-%(arch)s-%(version)s'
-    ]
-volume_id_substitutions = {
-    'AtomicHost': 'AH',
-    'Everything': 'E',
-}
-
-# Other ostree artifacts
-image_build = {
-    '^AtomicHost$': [
-        {
-            'image-build': {
-                'format': [('qcow2', 'qcow2'), ('raw-xz', 'raw.xz')],
-                'name': 'Fedora-AtomicHost',
-                [% if request.name == 'stable' %]
-                    # Use a different version string for the updates vs updates-testing
-                    # runs so that NVRs don't conflict
-                    'version': '!VERSION_FROM_VERSION'
-                [% endif %]
-                'release': '!RELEASE_FROM_DATE_RESPIN'
-                [% if request.name == 'stable' %]
-                    # Use updates ref to build updates images and testing ref to build
-                    # updates-testing images.
-                    # https://pagure.io/fedora-kickstarts/c/899bc45aa1d432ca67372ed112de16c0ea89251c?branch=f29
-                    'kickstart': 'fedora-atomic-updates.ks',
-                [% else %]
-                    'kickstart': 'fedora-atomic-testing.ks',
-                [% endif %]
-                'distro': 'Fedora-22',
-                'disk_size': 6,
-                'target': 'f[[ release.version_int ]]',
-                'arches': ['x86_64', 'aarch64', 'ppc64le'],
-                'install_tree_from': 'https://kojipkgs{{ env_suffix }}.fedoraproject.org/compose/[[ release.version_int ]]/latest-Fedora-[[ release.version_int ]]/compose/Everything/$arch/os/',
-                'subvariant': 'AtomicHost',
-                'failable': ['*'],
-            }
-        },
-        {
-            'image-build': {
-                'format': [('vagrant-libvirt','vagrant-libvirt.box'), ('vagrant-virtualbox','vagrant-virtualbox.box')],
-                'name': 'Fedora-AtomicHost-Vagrant',
-                [% if request.name == 'stable' %]
-                    # Use a different version string for the updates vs updates-testing
-                    # runs so that NVRs don't conflict
-                    'version': '!VERSION_FROM_VERSION'
-                [% endif %]
-                'release': '!RELEASE_FROM_DATE_RESPIN'
-                [% if request.name == 'stable' %]
-                    # Use updates ref to build updates images and testing ref to build
-                    # updates-testing images.
-                    # https://pagure.io/fedora-kickstarts/c/899bc45aa1d432ca67372ed112de16c0ea89251c?branch=f29
-                    'kickstart': 'fedora-atomic-vagrant-updates.ks',
-                [% else %]
-                    'kickstart': 'fedora-atomic-vagrant-testing.ks',
-                [% endif %]
-                'distro': 'Fedora-22',
-                'disk_size': 40,
-                'target': 'f[[ release.version_int ]]',
-                'arches': ['x86_64'],
-                'install_tree_from': 'https://kojipkgs{{ env_suffix }}.fedoraproject.org/compose/[[ release.version_int ]]/latest-Fedora-[[ release.version_int ]]/compose/Everything/$arch/os/',
-                'subvariant': 'AtomicHost',
-                'failable': ['*'],
-            },
-            'factory-parameters': {
-                'vagrant_sync_directory': '/home/vagrant/sync',
-            }
-        }
-    ]
-}
-
-ostree_installer = [
-    ('^AtomicHost$', {
-        [% for arch in ['x86_64', 'aarch64', 'ppc64le'] %]
-            '[[ arch ]]': {
-                "repo": [
-                    "Everything",
-                    "https://kojipkgs{{ env_suffix }}.fedoraproject.org/compose/[[ release.version_int ]]/latest-Fedora-[[ release.version_int ]]/compose/Everything/[[arch]]/os/",
-                    [% if request.name == 'testing' %]
-                        # In the case of testing, also inject the last stable updates
-                        "https://kojipkgs{{ env_suffix }}.fedoraproject.org/compose/updates/f[[ release.version_int ]]-updates/compose/Everything/[[arch]]/os/"
-                    [% endif %]
-                ],
-            'release': None,
-            'rootfs_size': '4',
-            'add_template': ['ostree-based-installer/lorax-configure-repo.tmpl',
-                             'ostree-based-installer/lorax-embed-repo.tmpl'],
-            'add_template_var': [
-                'ostree_install_repo=https://kojipkgs.fedoraproject.org/compose/ostree/repo/',
-                'ostree_update_repo=https://ostree.fedoraproject.org',
-                'ostree_osname=fedora-atomic',
-                'ostree_oskey=fedora-[[ release.version_int ]]-primary',
-                'ostree_contenturl=mirrorlist=https://ostree.fedoraproject.org/mirrorlist',
-                'ostree_install_ref=fedora/[[ release.version_int ]]/[[ arch ]]/[% if request.name == "testing" %]testing[% else %]updates[% endif %]/atomic-host',
-                'ostree_update_ref=fedora/[[ release.version_int ]]/[[ arch ]]/atomic-host',
-            ],
-            'template_repo': 'https://pagure.io/fedora-lorax-templates.git',
-            'template_branch': 'f[[ release.version_int ]]'
-            'failable': ['*'],
-        },
-        [% endfor %]
-    })
-]
-[% endif %]
 {% endif %}
 
 translate_paths = [

--- a/devel/ci/integration/bodhi/pungi.rpm.conf.j2
+++ b/devel/ci/integration/bodhi/pungi.rpm.conf.j2
@@ -87,14 +87,18 @@ createrepo_deltas = [
     ('^Everything$', {'*': True})
 ]
 createrepo_database = True
-[% if release.version_int >= 30 %]
-createrepo_extra_args = ['--zck', '--zck-dict-dir=/usr/share/fedora-repo-zdicts/f[[ release.version_int ]]']
+createrepo_extra_args = [
+[% if cr_config.zchunk %]
+    '--zck', '--zck-dict-dir=/usr/share/fedora-repo-zdicts/f[[ release.version_int ]]',
 [% endif %]
-# For epel8 we want to use xz compression for repodata
-# https://pagure.io/epel/issue/71
-[% if release.version_int == 8 %]
-createrepo_extra_args = ['--xz']
+[% if cr_config.repodata_comp %]
+[% if cr_config.general_comp %]
+    '--general-compress-type=[[ cr_config.repodata_comp ]]',
+[% else %]
+    '--compress-type=[[ cr_config.repodata_comp ]]',
 [% endif %]
+[% endif %]
+]
 
 # CHECKSUMS
 media_checksums = ['sha256']

--- a/devel/ci/integration/bodhi/pungi_general.conf
+++ b/devel/ci/integration/bodhi/pungi_general.conf
@@ -1,0 +1,15 @@
+# PRODUCT INFO
+release_is_layered = False
+
+hashed_directories = True
+
+# PKGSET
+pkgset_source = 'koji' # koji, repos
+filter_system_release_packages = False
+
+# GATHER
+greedy_method = 'build'
+
+# CREATEREPO
+createrepo_c = True
+createrepo_checksum = 'sha256'

--- a/devel/ci/integration/bodhi/pungi_multilib.conf
+++ b/devel/ci/integration/bodhi/pungi_multilib.conf
@@ -1,0 +1,84 @@
+# MULTILIB
+# Note: If you change something here (affects updates for stable releases), also
+# submit the same change to pungi-fedora (affects Rawhide/Branched composes),
+# we want to keep them in sync:
+# https://pagure.io/pungi-fedora/blob/main/f/multilib.conf
+#
+# format: {arch|*: [packages]}
+multilib_blacklist = {
+    '*': [
+        'dmraid-devel',
+        'ghc-*',
+        'httpd-core',
+        'httpd-devel',
+        'java-1.5.0-gcj-devel',
+        'java-1.6.0-openjdk-devel',
+        'java-1.7.0-icedtea-devel',
+        'java-1.7.0-openjdk-devel',
+        'java-1.8.0-openjdk-devel',
+        'kdeutils-devel',
+        'kernel*',
+        'kernel*debug*',
+        'kernel-PAE*',
+        'krb5-server',
+        'krb5-server-ldap',
+        'mkinitrd-devel',
+        'mod_*',
+        'mp',
+        'php*',
+        'php-devel',
+        'tomcat-native',
+        ],
+}
+
+# Note: If you change something here (affects updates for stable releases), also
+# submit the same change to pungi-fedora (affects Rawhide/Branched composes),
+# we want to keep them in sync:
+# https://pagure.io/pungi-fedora/blob/main/f/multilib.conf
+#
+# format: {arch|*: [packages]}
+multilib_whitelist = {
+    '*': [
+        '*-static',
+        'apitrace-libs',
+        'compiler-rt',
+        'dssi-vst-wine',
+        'fakechroot-libs',
+        'fakeroot-libs',
+        'glib-networking',
+        'glx-utils',
+        'ibus-gtk2',
+        'ibus-gtk3',
+        'ibus-libs',
+        'iptables',
+        'libflashsupport',
+        'libgnat',
+        'libomp',
+        'lmms-vst',
+        'mangohud',
+        'mariadb-connector-odbc',
+        'mesa-dri-drivers',
+        'mesa-va-drivers',
+        'mesa-vdpau-drivers',
+        'mesa-vulkan-drivers',
+        'mysql-connector-odbc',
+        'nosync',
+        'nspluginwrapper',
+        'nvidia-query-resource-opengl-lib',
+        'p11-kit-trust',
+        'pam',
+        'perl-libs',
+        'pipewire',
+        'postgresql-odbc',
+        'redhat-lsb',
+        'syslinux-extlinux-nonlinux',
+        'syslinux-nonlinux',
+        'syslinux-tftpboot',
+        'systemd-pam',
+        'valgrind',
+        'vkBasalt',
+        'wine',
+        'wine-*',
+        'yaboot',
+        ],
+}

--- a/news/5521.bic
+++ b/news/5521.bic
@@ -1,0 +1,1 @@
+Settings for repodata and updateinfo can now be set by an external config file and no more hardcoded. Custom settings can be applied per Release, see the `devel/ci/integration/bodhi/createrepo_c.ini` file for reference


### PR DESCRIPTION
Fixes #5517 
I've opted for defining per Release configuration or with a prefix based configuration like we do now using an external config file, rather than extending the database.