### PR TITLE
Automated tests: display openQA 'machine' rather than arch

### DIFF
--- a/bodhi-server/bodhi/server/templates/update.html
+++ b/bodhi-server/bodhi/server/templates/update.html
@@ -949,10 +949,14 @@ ${parent.javascript()}
         '</span>';
 
       var flavor;
+      var machine;
       if (scenario.includes("fedora.updates-")) {
         // this gets a correct flavor from an openQA scenario, e.g.
         // 'kde' from 'fedora.updates-kde.x86_64.64bit'
         flavor = scenario.split(".")[1].slice(8);
+        // this gets the 'machine', which distinguishes between e.g.
+        // BIOS and UEFI tests
+        machine = scenario.split(".")[3];
       }
 
       var required = '';
@@ -971,7 +975,12 @@ ${parent.javascript()}
           '</span>';
       }
 
-      if (arch != undefined) {
+      // for openQA tests, 'machine' tells us everything 'arch' does,
+      // so we don't need both
+      if (machine != undefined) {
+        testcase = testcase + "&nbsp;<span class='badge text-bg-secondary'>"
+          + machine + "</label>";
+      } else if (arch != undefined) {
         testcase = testcase + "&nbsp;<span class='badge text-bg-secondary'>"
           + arch + "</label>";
       }


### PR DESCRIPTION
In the little lozenges we show on the Automated Tests tab rows to differentiate multiple runs of the same test case, currently we show 'arch' and 'flavor' for openQA tests. However, this doesn't sufficiently distinguish some tests: e.g.
install_default_update_netinst, which is run on both BIOS and UEFI on x86_64. Both of these are listed as
"x86_64 everything-boot-iso" at present.

This makes us display the openQA "machine" instead of the arch, if we can determine it (from the scenario). As "machine" will always be more distinguishing than "arch" when present, we don't show "arch" if we can find "machine".

This will make the two install_default_update_netinst runs show as "64bit everything-boot-iso" and "uefi everything-boot-iso". Other tests will also now show "64bit" (the x86_64 BIOS 'machine' name in openQA) rather than "x86_64", which might be a bit more confusing I guess; if that's a problem, we can consider changing the machine names in openQA to something clearer like "x86_64-uefi" and "x86_64-bios" or something, I'd just have to think about what other things might need changing in that case.