### PR TITLE
webui: add 'For help debugging' message for FCOS tests

### DIFF
--- a/bodhi-server/bodhi/server/templates/update.html
+++ b/bodhi-server/bodhi/server/templates/update.html
@@ -638,8 +638,9 @@ if can_edit and update.release.composed_by_bodhi:
         <h3>Automated Test Results</h3>
         % if update.test_gating_status == models.TestGatingStatus.failed:
         <div class="alert alert-danger" role="alert">
-          For help debugging failed Fedora CI tests (fedora-ci.*), contact <a href="https://web.libera.chat/?channels=#fedora-ci" target="_blank">#fedora-ci on Libera.chat</a><br/>
-          For help debugging failed openQA tests (update.*), contact <a href="https://matrix.to/#/#quality:fedoraproject.org" target="_blank">the Fedora Quality team</a>, who will usually investigate and diagnose all failures within 24 hours
+          For help debugging failed Fedora CI tests (fedora-ci.*), contact <a href="https://web.libera.chat/?channels=#fedora-ci" target="_blank">#fedora-ci on Libera.chat</a>.<br/>
+          For help debugging failed Fedora CoreOS tests (coreos.*), contact <a href="https://matrix.to/#/#coreos:fedoraproject.org" target="_blank">the Fedora CoreOS team</a>.<br/>
+          For help debugging failed openQA tests (update.*), contact <a href="https://matrix.to/#/#quality:fedoraproject.org" target="_blank">the Fedora Quality team</a>, who will usually investigate and diagnose all failures within 24 hours.
         </div>
         % endif
         <div id="gating-summary-tab">

--- a/bodhi-server/bodhi/server/templates/update.html
+++ b/bodhi-server/bodhi/server/templates/update.html
@@ -638,7 +638,7 @@ if can_edit and update.release.composed_by_bodhi:
         <h3>Automated Test Results</h3>
         % if update.test_gating_status == models.TestGatingStatus.failed:
         <div class="alert alert-danger" role="alert">
-          For help debugging failed Fedora CI tests (fedora-ci.*), contact <a href="https://web.libera.chat/?channels=#fedora-ci" target="_blank">#fedora-ci on Libera.chat</a>.<br/>
+          For help debugging failed Fedora CI tests (fedora-ci.*), contact <a href="https://matrix.to/#/#fedora-ci:fedoraproject.org" target="_blank">the Fedora CI team</a>.<br/>
           For help debugging failed Fedora CoreOS tests (coreos.*), contact <a href="https://matrix.to/#/#coreos:fedoraproject.org" target="_blank">the Fedora CoreOS team</a>.<br/>
           For help debugging failed openQA tests (update.*), contact <a href="https://matrix.to/#/#quality:fedoraproject.org" target="_blank">the Fedora Quality team</a>, who will usually investigate and diagnose all failures within 24 hours.
         </div>


### PR DESCRIPTION
We've added new `coreos.*` tests that now show up in the Bodhi UI for
some packages. These tests are not yet gating, but to be ready for when
they are, let's be nice and link to the #coreos Matrix channel where
packagers can get debugging help like for the other ones.

While we're here, add final periods to each sentence.

