### PR TITLE
Add build NVRs (some) to the posted bugzilla comments

### DIFF
--- a/bodhi-server/bodhi/server/config.py
+++ b/bodhi-server/bodhi/server/config.py
@@ -404,7 +404,8 @@ class BodhiConfig(dict):
                       'bodhiadmin'],
             'validator': _generate_list_validator()},
         'initial_bug_msg': {
-            'value': '%s has been submitted as an update to %s. %s',
+            'value': ('{update_alias} ({update_beauty_title}) has been submitted as '
+                      'an update to {update_release}.\n{update_url}'),
             'validator': str},
         'greenwave_api_url': {
             'value': 'https://greenwave-web-greenwave.app.os.fedoraproject.org/api/v1.0',
@@ -568,7 +569,8 @@ class BodhiConfig(dict):
             'value': 'postgresql://localhost/bodhi',
             'validator': str},
         'stable_bug_msg': {
-            'value': ('{update_alias} has been pushed to the {repo} repository.\n'
+            'value': ('{update_alias} ({update_beauty_title}) has been pushed to '
+                      'the {repo} repository.\n'
                       'If problem still persists, please make note of it in this bug report.'),
             'validator': str},
         'stats_blacklist': {

--- a/bodhi-server/bodhi/server/models.py
+++ b/bodhi-server/bodhi/server/models.py
@@ -4756,7 +4756,7 @@ class Bug(Base):
                     'update_alias': update.alias,
                     'repo': f'{update.release.long_name} {update.status.description}',
                     'install_instructions': install_msg,
-                    'update_url': f'{config.get("base_address")}{update.get_url()}'}
+                    'update_url': update.abs_url()}
 
         if update.status is UpdateStatus.stable:
             message = config['stable_bug_msg'].format(**msg_data)

--- a/bodhi-server/bodhi/server/tasks/work_on_bugs.py
+++ b/bodhi-server/bodhi/server/tasks/work_on_bugs.py
@@ -76,8 +76,11 @@ def main(alias: str, bugs: typing.List[int]):
                     update.type = UpdateType.security
 
                 log.info(f'Commenting on {bug.bug_id}')
-                comment = config['initial_bug_msg'] % (
-                    update.alias, update.release.long_name, update.abs_url())
+                msg_data = {'update_alias': update.alias,
+                            'update_beauty_title': update.get_title(beautify=True, nvr=True),
+                            'update_release': update.release.long_name,
+                            'update_url': update.abs_url()}
+                comment = config['initial_bug_msg'].format(**msg_data)
 
                 log.info(f'Modifying {bug.bug_id}')
                 bug.modified(update, comment)

--- a/bodhi-server/production.ini
+++ b/bodhi-server/production.ini
@@ -331,15 +331,22 @@ use = egg:bodhi-server
 # bugtracker =
 
 # A template that Bodhi will use when commenting on Bugzilla tickets when Updates that reference
-# them are created. Positional substitution is used, and the three %%s's will be filled in with the
-# update title, the release's long name, and the URL to the update, respectively.
-# initial_bug_msg = %%s has been submitted as an update to %%s. %%s
+# them are created. These placeholders are available:
+# - {update_alias}
+# - {update_beauty_title}
+# - {update_release}
+# - {update_url}
+# initial_bug_msg = {update_alias} ({update_beauty_title}) has been submitted as an update to {update_release}.\n{update_url}
 
 # A template that Bodhi will use when commenting on Bugzilla tickets when Updates that reference
-# them are marked stable. Positional substitution is used, and the first %%s will be filled in with
-# the update title and the second will be filled in with the release's long name and the update
-# status.
-# stable_bug_msg = %%s has been pushed to the %%s repository. If problems still persist, please make note of it in this bug report.
+# them are marked stable. These placeholders are available:
+# - {update_title}
+# - {update_beauty_title}
+# - {update_alias}
+# - {repo}
+# - {install_instructions}
+# - {update_url}
+# stable_bug_msg = {update_alias} ({update_beauty_title}) has been pushed to the {repo} repository.\n. If problems still persists, please make note of it in this bug report.
 
 # The following two templates are used to comment on Bugzilla tickets. %%s will be substituted with
 # the update's URL. The first is used for all updates, unless the epel setting in defined, which

--- a/bodhi-server/tests/tasks/test_composer.py
+++ b/bodhi-server/tests/tasks/test_composer.py
@@ -1880,8 +1880,8 @@ testmodule:master:20172:2
         close.assert_called_with(
             12345,
             versions=dict(bodhi='bodhi-2.0-1.fc17'),
-            comment=(f'FEDORA-{time.strftime("%Y")}-a3bbe1a8f2 has been pushed to the '
-                     f'Fedora 17 stable repository.\nIf problem still persists, '
+            comment=(f'FEDORA-{time.strftime("%Y")}-a3bbe1a8f2 (bodhi-2.0-1.fc17) has been '
+                     f'pushed to the Fedora 17 stable repository.\nIf problem still persists, '
                      f'please make note of it in this bug report.'))
 
     @mock.patch(**mock_taskotron_results)

--- a/bodhi-server/tests/test_models.py
+++ b/bodhi-server/tests/test_models.py
@@ -325,7 +325,7 @@ class TestBugDefaultMessage(BasePyTestCase):
         message = bug.default_message(update)
 
         warning.assert_called_once_with("No 'testing_bug_epel_msg' found in the config.")
-        assert 'cool fedora stuff {}'.format(config['base_address'] + update.get_url()) == message
+        assert f'cool fedora stuff {update.abs_url()}' == message
 
 
 class TestBugModified(BasePyTestCase):

--- a/news/5513.bic
+++ b/news/5513.bic
@@ -1,0 +1,1 @@
+Build NVRs are added to the Bugzilla comment. Please adjust `initial_bug_msg` in Bodhi config during upgrade


### PR DESCRIPTION
Fixes #5513 
Build NVRs are added to the Bugzilla comment as the update title seen in webUI (max 2 NVRs + "and xx more")