### PR TITLE
bodhi-server test setup: read testing.ini only once

### DIFF
--- a/bodhi-server/tests/base.py
+++ b/bodhi-server/tests/base.py
@@ -46,6 +46,7 @@ from bodhi.server import (
 original_config = config.config.copy()
 engine = None
 _app = None
+_settings = None
 PROJECT_PATH = os.path.abspath(os.path.join(os.path.dirname(__file__), '../'))
 
 
@@ -225,7 +226,12 @@ class BaseTestCaseMixin:
     def _setup_method(self):
         """Set up Bodhi for testing."""
         self.config = testing.setUp()
-        self.app_settings = get_appsettings(os.environ["BODHI_CONFIG"])
+        # reading the settings is expensive and we run a lot of tests,
+        # so do it only once
+        global _settings
+        if _settings is None:
+            _settings = get_appsettings(os.environ["BODHI_CONFIG"])
+        self.app_settings = _settings
         config.config.clear()
         config.config.load_config(self.app_settings)
 


### PR DESCRIPTION
I ran the server test suite through cProfile and found it was spending a whole lot of time re-reading settings from testing.ini (that's where BODHI_CONFIG points) every time a test ran. This tweaks it to only read the settings from the file one time (but it will still *apply* them before every test runs, since some of the tests modify the config dict and we don't want those changes to leak into other tests).

In my test, this reduces the time to run the whole test suite from 727 seconds to 224 seconds.