### PR TITLE
Fix Automated Tests table rows for absent and error results

### DIFF
--- a/bodhi-server/bodhi/server/templates/update.html
+++ b/bodhi-server/bodhi/server/templates/update.html
@@ -1065,7 +1065,17 @@ ${parent.javascript()}
         // show missing tests and remote rule yaml problems first
         if (buildname in missing_tests) {
           $.each(missing_tests[buildname], function(i, result) {
+            // note the data structure is a bit different for
+            // test-result-missing than the other cases we handle at
+            // the end, so getting scenario and subject is a bit
+            // different. why? ask greenwave
+            var scenario = 'no_scenario';
+            if (result.scenario) {
+                scenario = result.scenario;
+            }
             table.append(make_row(
+              result.item[0],
+              scenario,
               'ABSENT',
               result.testcase,
               '',
@@ -1076,6 +1086,8 @@ ${parent.javascript()}
         }
         $.each(invalid_gating_repos, function (i, repo) {
           table.append(make_row(
+            'Remote policy errors',
+            'no_scenario',
             'FAILED',
             repo,
             'remote policy gating.yaml parsing failed',
@@ -1085,6 +1097,8 @@ ${parent.javascript()}
         });
         $.each(missing_gating_repos, function (i, repo) {
           table.append(make_row(
+            'Remote policy errors',
+            'no_scenario',
             'FAILED',
             repo,
             'remote policy gating.yaml missing',
@@ -1094,6 +1108,8 @@ ${parent.javascript()}
         });
         $.each(failed_fetch_gating_repos, function (i, repo) {
           table.append(make_row(
+            'Remote policy errors',
+            'no_scenario',
             'FAILED',
             repo,
             'remote policy gating.yaml retrieval failed',

--- a/news/PR5581.bug
+++ b/news/PR5581.bug
@@ -1,0 +1,1 @@
+Fixed Automated Tests table in the web UI not showing missing results or remote rule errors correctly


### PR DESCRIPTION
This fixes my own oversight from
https://github.com/fedora-infra/bodhi/pull/5480 . In changing the signature of make_row there, I did not remember to update all these other calls to it. This means make_row goes a bit crazy trying to treat 'FAILED' or 'ABSENT' as a subject and an error string or empty string as the outcome, and winds up rendering what looks to the user like an empty row. This should fix it so we actually get rows with sensible content again when a result is absent or there's some kind of remote rule error. Thanks to @decathorpe for finding this.