### PR TITLE
Add list_releases endpoint

### DIFF
--- a/bodhi-server/bodhi/server/services/releases.py
+++ b/bodhi-server/bodhi/server/services/releases.py
@@ -59,6 +59,9 @@ releases = Service(name='releases', path='/releases/',
                    # Note, this 'rw' is not a typo. The @releases service has
                    # a ``post`` section at the bottom.
                    cors_origins=bodhi.server.security.cors_origins_rw)
+list_releases = Service(name='list_releases', path='/list_releases/',
+                        description='Fedora Releases',
+                        cors_origins=bodhi.server.security.cors_origins_ro)
 
 
 @release.get(accept="text/html", renderer="release.html",
@@ -281,6 +284,10 @@ def query_releases_html(request):
             "active": active}
 
 
+@list_releases.get(accept=('application/json', 'text/json'),
+                   schema=bodhi.server.schemas.ListReleaseSchema(), renderer='json',
+                   error_handler=bodhi.server.services.errors.json_handler,
+                   validators=releases_get_validators)
 @releases.get(accept=('application/json', 'text/json'),
               schema=bodhi.server.schemas.ListReleaseSchema(), renderer='json',
               error_handler=bodhi.server.services.errors.json_handler,

--- a/bodhi-server/tests/services/test_releases.py
+++ b/bodhi-server/tests/services/test_releases.py
@@ -110,6 +110,9 @@ class TestReleasesService(base.BasePyTestCase):
         assert body['releases'][0]['name'] == 'F17'
         assert body['releases'][1]['name'] == 'F22'
 
+        res_list = self.app.get('/list_releases/')
+        assert res_list.json_body == body
+
     def test_list_releases_with_pagination(self):
         res = self.app.get('/releases/')
         body = res.json_body

--- a/news/5587.feature
+++ b/news/5587.feature
@@ -1,0 +1,1 @@
+A new `/list_releases/` GET endpoint is available to allow retrieving JSON data through ajax calls.


### PR DESCRIPTION
The `list_releases` endpoint will reuse the same method as `releases`, but since it only accepts the GET method we can make it use relaxed CORS, so that ajax queries will be able to fetch data from it.
Fixes #5587 