### PR TITLE
ensure build are tagged in the sidetag

### DIFF
--- a/bodhi-server/bodhi/server/buildsys.py
+++ b/bodhi-server/bodhi/server/buildsys.py
@@ -423,6 +423,11 @@ class DevBuildsys:
         if build in DevBuildsys.__tagged__:
             for tag in DevBuildsys.__tagged__[build]:
                 result += [{'name': tag}]
+        if build.startswith('gnome-backgrounds-3.0-'):
+            result += [{'maven_support': False, 'locked': False, 'name': 'f17-build-side-7777',
+                        'extra': {'sidetag_user': 'guest', 'sidetag': True},
+                        'perm': None, 'perm_id': None, 'arches': None, 'maven_include_all': False,
+                        'id': 7777}]
         return result
 
     @multicall_enabled

--- a/bodhi-server/bodhi/server/validators.py
+++ b/bodhi-server/bodhi/server/validators.py
@@ -363,6 +363,11 @@ def validate_build_tags(request, **kwargs):
                 'body', 'builds',
                 'Invalid tag: {} not tagged with any of the following tags {}'.format(
                     build, valid_tags))
+        if from_tag:
+            # The build MUST be tagged in the side tag
+            if from_tag not in tags:
+                request.errors.add(
+                    'body', 'builds', f'Invalid build: {build} not tagged in {from_tag}')
 
 
 @postschema_validator

--- a/bodhi-server/tests/services/test_updates.py
+++ b/bodhi-server/tests/services/test_updates.py
@@ -433,6 +433,23 @@ class TestNewUpdate(BasePyTestCase):
             "mattia does not own f17-build-side-7777 side-tag"
         )
 
+    @mock.patch('bodhi.server.services.updates.handle_side_and_related_tags_task')
+    @mock.patch.dict('bodhi.server.validators.config', {'acl_system': 'dummy'})
+    @unused_mock_patch(**mock_uuid4_version1)
+    def test_new_rpm_update_from_tag_build_missing_tag(self, handle_side_and_related_tags_task):
+        """Ensure build passed to a side-tag update are tagged in the side-tag."""
+        # We don't want the new update to obsolete the existing one.
+        self.db.delete(Update.query.one())
+
+        update = self.get_update(builds='bodhi-2.0-1.fc17', from_tag='f17-build-side-7777')
+
+        with mock.patch('bodhi.server.buildsys.DevBuildsys.getTag', self.mock_getTag):
+            with mock.patch('bodhi.server.models.Release.mandatory_days_in_testing', 0):
+                r = self.app.post_json('/updates/', update, status=400)
+        assert r.json_body['errors'][0]['description'] == (
+            "Invalid build: bodhi-2.0-1.fc17 not tagged in f17-build-side-7777"
+        )
+
     def test_koji_config_url(self, *args):
         """
         Test html rendering of default build link
@@ -3093,13 +3110,13 @@ class TestUpdatesService(BasePyTestCase):
         # We don't want an existing buildroot override to clutter the messages.
         self.db.delete(BuildrootOverride.query.one())
 
-        update = self.get_update(from_tag='f17-build-side-7777')
+        update = self.get_update(builds=None, from_tag='f17-build-side-7777')
         with mock.patch('bodhi.server.buildsys.DevBuildsys.getTag', self.mock_getTag):
             with fml_testing.mock_sends(update_schemas.UpdateReadyForTestingV3):
                 r = self.app.post_json('/updates/', update)
 
         update['edited'] = r.json['alias']
-        update['builds'] = 'bodhi-2.0.0-3.fc17'
+        update['builds'] = 'gnome-backgrounds-3.0-2.fc17'
 
         with mock.patch('bodhi.server.buildsys.DevBuildsys.getTag', self.mock_getTag):
             with fml_testing.mock_sends(update_schemas.UpdateEditV2,
@@ -3107,7 +3124,7 @@ class TestUpdatesService(BasePyTestCase):
                 r = self.app.post_json('/updates/', update)
 
         up = r.json_body
-        assert up['title'] == 'bodhi-2.0.0-3.fc17'
+        assert up['title'] == 'gnome-backgrounds-3.0-2.fc17'
         assert up['status'] == 'pending'
         assert up['request'] is None
         assert up['user']['name'] == 'guest'
@@ -3129,18 +3146,18 @@ class TestUpdatesService(BasePyTestCase):
 
         New build(s):
 
-        - bodhi-2.0.0-3.fc17
+        - gnome-backgrounds-3.0-2.fc17
 
         Removed build(s):
 
-        - bodhi-2.0-1.fc17
+        - gnome-backgrounds-3.0-1.fc17
 
         Karma has been reset.
         """).strip()
         assert_multiline_equal(up['comments'][-1]['text'], comment)
         assert len(up['builds']) == 1
-        assert up['builds'][0]['nvr'] == 'bodhi-2.0.0-3.fc17'
-        assert self.db.query(RpmBuild).filter_by(nvr='bodhi-2.0.0-2.fc17').first() is None
+        assert up['builds'][0]['nvr'] == 'gnome-backgrounds-3.0-2.fc17'
+        assert self.db.query(RpmBuild).filter_by(nvr='gnome-backgrounds-3.0-1.fc17').first() is None
 
     @mock.patch('bodhi.server.services.updates.handle_side_and_related_tags_task', mock.Mock())
     @mock.patch('bodhi.server.models.tag_update_builds_task')

--- a/news/PR5647.bug
+++ b/news/PR5647.bug
@@ -1,0 +1,1 @@
+Builds passed alongside a side-tag in update forms were not validated correctly against the side-tag


### PR DESCRIPTION
The update form in the web UI can mess up things, let's be sure that when passing both a list of builds and `from_tag`  all the builds are tagged in the sidetag.