### PR TITLE
Allow querying on multiple gating statuses simultaneously

### DIFF
--- a/bodhi-server/bodhi/server/schemas.py
+++ b/bodhi-server/bodhi/server/schemas.py
@@ -113,6 +113,13 @@ class Status(colander.SequenceSchema):
                                  validator=colander.OneOf(list(UpdateStatus.values())))
 
 
+class GatingStatus(colander.SequenceSchema):
+    """A SequenceSchema to validate a list of TestGatingStatus objects."""
+
+    status = colander.SchemaNode(colander.String(),
+                                 validator=colander.OneOf(list(TestGatingStatus.values())))
+
+
 class Tests(colander.SequenceSchema):
     """A SequenceSchema to validate a list of Test objects."""
 
@@ -653,11 +660,11 @@ class ListUpdateSchema(PaginatedSchema, SearchableSchema, Cosmetics):
         preparer=[util.splitter],
     )
 
-    gating = colander.SchemaNode(
-        colander.String(),
+    gating = GatingStatus(
+        colander.Sequence(accept_scalar=True),
         location="querystring",
         missing=None,
-        validator=colander.OneOf(list(TestGatingStatus.values())),
+        preparer=[util.splitter],
     )
 
 

--- a/bodhi-server/bodhi/server/services/updates.py
+++ b/bodhi-server/bodhi/server/services/updates.py
@@ -382,7 +382,7 @@ def query_updates(request):
 
     gating_status = data.get('gating')
     if gating_status is not None:
-        query = query.filter(Update.test_gating_status == gating_status)
+        query = query.filter(or_(*[Update.test_gating_status == s for s in gating_status]))
 
     user = data.get('user')
     if user is not None:

--- a/news/PR5658.feature
+++ b/news/PR5658.feature
@@ -1,0 +1,1 @@
+When searching updates, you can now specify multiple gating statuses by passing the 'gating' query arg more than once


### PR DESCRIPTION
I have a script that wants to find updates that are in waiting or failed gating status. It's annoying to have to run two searches.