### PR TITLE
tweak development.ini.example waitress to also listen on IPv6

### DIFF
--- a/devel/development.ini.example
+++ b/devel/development.ini.example
@@ -82,7 +82,7 @@ greenwave_api_url = http://localhost:6545/api/v1.0
 
 [server:main]
 use = egg:waitress#main
-host = 0.0.0.0
+host = localhost
 port = 6543
 trusted_proxy = 127.0.0.1
 trusted_proxy_count = 1

--- a/news/PR5659.bug
+++ b/news/PR5659.bug
@@ -1,0 +1,1 @@
+The development.ini.example config - on which the BCD config is based - is now set up to listen on both IPv4 and IPv6


### PR DESCRIPTION
Per https://docs.pylonsproject.org/projects/waitress/en/stable/usage.html host = 0.0.0.0 binds only to IPv4. This is a problem for BCD if your system is IPv6-enabled and resolves http://localhost.localdomain to IPv6, not IPv4 - accessing the development environment server from your host may not work.

Setting the host to 'localhost' instead listens on both IPv4 and IPv6, so let's do that.