### PR TITLE
Rename BugKarma to BugFeedback

### DIFF
--- a/bodhi-server/bodhi/server/migrations/versions/407335e56ccb_rename_bugkarma_to_bugfeedback.py
+++ b/bodhi-server/bodhi/server/migrations/versions/407335e56ccb_rename_bugkarma_to_bugfeedback.py
@@ -1,0 +1,44 @@
+# Copyright (c) 2024 Mattia Verga
+#
+# This file is part of Bodhi.
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+"""
+rename BugKarma to BugFeedback.
+
+Revision ID: 407335e56ccb
+Revises: 16864f8ff395
+Create Date: 2024-06-03 09:35:28.410462
+"""
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = '407335e56ccb'
+down_revision = '16864f8ff395'
+
+
+def upgrade():
+    """
+    Rename BugFeedback karma column to feedback.
+
+    We don't need to rename the table since it is named 'comment_bug_assoc'
+    """
+    op.alter_column('comment_bug_assoc', 'karma', nullable=False, new_column_name='feedback')
+
+
+def downgrade():
+    """Bring back the 'karma' name."""
+    op.alter_column('comment_bug_assoc', 'feedback', nullable=False, new_column_name='karma')

--- a/bodhi-server/bodhi/server/models.py
+++ b/bodhi-server/bodhi/server/models.py
@@ -49,7 +49,7 @@ from sqlalchemy import (
     UniqueConstraint,
 )
 from sqlalchemy.ext.hybrid import hybrid_property
-from sqlalchemy.orm import class_mapper, declarative_base, relationship, validates
+from sqlalchemy.orm import class_mapper, declarative_base, relationship, synonym, validates
 from sqlalchemy.orm.base import NEVER_SET
 from sqlalchemy.orm.exc import NoResultFound
 from sqlalchemy.orm.properties import RelationshipProperty
@@ -3014,15 +3014,15 @@ class Update(Base):
             val = ' '.join([str(bug.bug_id) for bug in self.bugs])
         return val
 
-    def get_bug_karma(self, bug):
+    def get_bug_feedback(self, bug):
         """
-        Return the karma for this update for the given bug.
+        Return the feedback for this update for the given bug.
 
         Args:
-            bug (Bug): The bug we want the karma about.
+            bug (Bug): The bug we want the feedback about.
         Returns:
-            tuple: A 2-tuple of integers. The first represents negative karma, the second represents
-            positive karma.
+            tuple: A 2-tuple of integers. The first represents negative feedback, the second
+            represents positive feedback.
         """
         good, bad, seen = 0, 0, set()
         for comment in self.comments_since_karma_reset:
@@ -3031,9 +3031,9 @@ class Update(Base):
             seen.add(comment.user.name)
             for feedback in comment.bug_feedback:
                 if feedback.bug == bug:
-                    if feedback.karma > 0:
+                    if feedback.feedback > 0:
                         good += 1
-                    elif feedback.karma < 0:
+                    elif feedback.feedback < 0:
                         bad += 1
         return bad * -1, good
 
@@ -3496,8 +3496,8 @@ class Update(Base):
         for bug in to_remove:
             self.bugs.remove(bug)
             if len(bug.updates) == 0:
-                # Don't delete the Bug instance if there is any associated BugKarma
-                if not session.query(BugKarma).filter_by(bug_id=bug.bug_id).count():
+                # Don't delete the Bug instance if there is any associated BugFeedback
+                if not session.query(BugFeedback).filter_by(bug_id=bug.bug_id).count():
                     log.debug("Destroying stray Bugzilla #%d" % bug.bug_id)
                     session.delete(bug)
         session.flush()
@@ -3534,7 +3534,7 @@ class Update(Base):
 
         got_feedback = False
         for feedback_dict in (bug_feedback + testcase_feedback):
-            if feedback_dict['karma'] != 0:
+            if feedback_dict['feedback'] != 0:
                 got_feedback = True
                 break
 
@@ -3595,7 +3595,7 @@ class Update(Base):
         session.flush()
 
         for feedback_dict in bug_feedback:
-            feedback = BugKarma(**feedback_dict)
+            feedback = BugFeedback(**feedback_dict)
             session.add(feedback)
             comment.bug_feedback.append(feedback)
 
@@ -4422,20 +4422,22 @@ class Compose(Base):
 event.listen(Compose.state, 'set', Compose.update_state_date, active_history=True)
 
 
-# Used for many-to-many relationships between karma and a bug
-class BugKarma(Base):
+# Used for one-to-one relationships between a comment and a bug
+class BugFeedback(Base):
     """
-    Karma for a bug associated with a comment.
+    Feedback for a bug associated with a comment.
 
     Attributes:
-        karma (int): The karma associated with this bug and comment.
-        comment (Comment): The comment this BugKarma is part of.
-        bug (Bug): The bug this BugKarma pertains to.
+        feedback (int): The feedback associated with this bug and comment.
+        comment (Comment): The comment this BugFeedback is part of.
+        bug (Bug): The bug this BugFeedback pertains to.
     """
 
     __tablename__ = 'comment_bug_assoc'
 
-    karma = Column(Integer, default=0)
+    feedback = Column(Integer, default=0)
+    # DEPRECATED this is only for temporary backwards compatibility
+    karma = synonym('feedback')
 
     # Many-to-one relationships
     comment_id = Column(Integer, ForeignKey('comments.id'))
@@ -4459,6 +4461,7 @@ class TestCaseKarma(Base):
     __tablename__ = 'comment_testcase_assoc'
 
     karma = Column(Integer, default=0)
+    feedback = synonym('karma')
 
     # Many-to-one relationships
     comment_id = Column(Integer, ForeignKey('comments.id'))
@@ -4493,7 +4496,7 @@ class Comment(Base):
     timestamp = Column(DateTime, default=datetime.utcnow)
 
     # One-to-many relationships
-    bug_feedback = relationship('BugKarma', back_populates='comment',
+    bug_feedback = relationship('BugFeedback', back_populates='comment',
                                 cascade="all,delete,delete-orphan")
 
     testcase_feedback = relationship('TestCaseKarma', back_populates='comment',
@@ -4616,7 +4619,7 @@ class Bug(Base):
     # Many-to-many relationships
     updates = relationship('Update', secondary=update_bug_table, back_populates='bugs')
 
-    feedback = relationship('BugKarma', back_populates='bug')
+    feedback = relationship('BugFeedback', back_populates='bug')
 
     @property
     def url(self) -> str:

--- a/bodhi-server/bodhi/server/schemas.py
+++ b/bodhi-server/bodhi/server/schemas.py
@@ -130,10 +130,16 @@ class BugFeedback(colander.MappingSchema):
     """A schema for BugFeedback to be provided via API parameters."""
 
     bug_id = colander.SchemaNode(colander.Integer())
-    karma = colander.SchemaNode(
+    feedback = colander.SchemaNode(
         colander.Integer(),
         validator=colander.Range(min=-1, max=1),
         missing=0,
+    )
+    # DEPRECATED this is only for temporary backwards compatibility
+    karma = colander.SchemaNode(
+        colander.Integer(),
+        validator=colander.Range(min=-1, max=1),
+        missing=None,
     )
 
 
@@ -147,10 +153,16 @@ class TestcaseFeedback(colander.MappingSchema):
     """A schema for TestcaseFeedback to be provided via API parameters."""
 
     testcase_name = colander.SchemaNode(colander.String())
-    karma = colander.SchemaNode(
+    feedback = colander.SchemaNode(
         colander.Integer(),
         validator=colander.Range(min=-1, max=1),
         missing=0,
+    )
+    # DEPRECATED this is only for temporary backwards compatibility
+    karma = colander.SchemaNode(
+        colander.Integer(),
+        validator=colander.Range(min=-1, max=1),
+        missing=None,
     )
 
 

--- a/bodhi-server/bodhi/server/templates/update.html
+++ b/bodhi-server/bodhi/server/templates/update.html
@@ -584,8 +584,8 @@ elif can_edit and update.status.value == 'testing' and update.test_gating_status
         <div class="list-group-item">
           <div class="row align-self-center">
             <div class="col fw-bold">${self.util.bug_link(bug) | n}</div>
-            <div class="col-auto ps-3 fw-bold">${self.fragments.karma(update.get_bug_karma(bug)[0], show_digit=True, zero_thumbsup=False)}</div>
-            <div class="col-auto ps-3 fw-bold">${self.fragments.karma(update.get_bug_karma(bug)[1], show_digit=True, zero_thumbsup=True)}</div>
+            <div class="col-auto ps-3 fw-bold">${self.fragments.karma(update.get_bug_feedback(bug)[0], show_digit=True, zero_thumbsup=False)}</div>
+            <div class="col-auto ps-3 fw-bold">${self.fragments.karma(update.get_bug_feedback(bug)[1], show_digit=True, zero_thumbsup=True)}</div>
           </div>
         </div>
         % endfor

--- a/bodhi-server/bodhi/server/validators.py
+++ b/bodhi-server/bodhi/server/validators.py
@@ -1073,6 +1073,9 @@ def validate_bug_feedback(request, **kwargs):
             bad_bugs.append(bug_id)
         else:
             item['bug'] = bug
+            if item['karma'] is not None:
+                # DEPRECATED this is only for temporary backwards compatibility
+                item['feedback'] = item.pop('karma')
             validated.append(item)
 
     if bad_bugs:
@@ -1132,6 +1135,8 @@ def validate_testcase_feedback(request, **kwargs):
             bad_testcases.append(name)
         else:
             item['testcase'] = testcase
+            if item['karma'] is not None:
+                item['feedback'] = item.pop('karma')
             validated.append(item)
 
     if bad_testcases:

--- a/bodhi-server/tests/test_models.py
+++ b/bodhi-server/tests/test_models.py
@@ -46,7 +46,7 @@ from bodhi.server.exceptions import (
     LockedUpdateException,
 )
 from bodhi.server.models import (
-    BugKarma,
+    BugFeedback,
     PackageManager,
     ReleaseState,
     TestGatingStatus,
@@ -2264,19 +2264,19 @@ class TestUpdateVersionHash(BasePyTestCase):
 
 
 class TestUpdateGetBugKarma(BasePyTestCase):
-    """Test the get_bug_karma() method."""
+    """Test the get_bug_feedback() method."""
 
     def test_feedback_wrong_bug(self):
         """Feedback for other bugs should be ignored."""
         update = model.Update.query.first()
-        # Let's add a bug karma to the existing comment on the bug.
-        bk = model.BugKarma(karma=1, comment=update.comments[0], bug=update.bugs[0])
+        # Let's add a bug feedback to the existing comment on the bug.
+        bk = model.BugFeedback(feedback=1, comment=update.comments[0], bug=update.bugs[0])
         self.db.add(bk)
         # Now let's associate a new bug with the update.
         bug = model.Bug(bug_id=12345, title='some title')
         update.bugs.append(bug)
 
-        bad, good = update.get_bug_karma(bug)
+        bad, good = update.get_bug_feedback(bug)
 
         assert bad == 0
         assert good == 0
@@ -2289,10 +2289,10 @@ class TestUpdateGetBugKarma(BasePyTestCase):
             comment = model.Comment(text='Test comment', karma=karma, user=user)
             self.db.add(comment)
             update.comments.append(comment)
-            bug_karma = model.BugKarma(karma=karma, comment=comment, bug=update.bugs[0])
+            bug_karma = model.BugFeedback(feedback=karma, comment=comment, bug=update.bugs[0])
             self.db.add(bug_karma)
 
-        bad, good = update.get_bug_karma(update.bugs[0])
+        bad, good = update.get_bug_feedback(update.bugs[0])
 
         assert bad == -1
         assert good == 2
@@ -2303,7 +2303,7 @@ class TestUpdateGetBugKarma(BasePyTestCase):
         self.db.add(comment)
         update.comments.append(comment)
 
-        bad, good = update.get_bug_karma(update.bugs[0])
+        bad, good = update.get_bug_feedback(update.bugs[0])
 
         assert bad == 0
         assert good == 0
@@ -3680,9 +3680,9 @@ class TestUpdate(ModelTest):
         assert update.bugs[0].bug_id == 4321
         assert self.db.query(model.Bug).filter_by(bug_id=1234).first() is None
 
-        # Try removing a bug when it already has BugKarma
-        karma = BugKarma(bug_id=4321, karma=1)
-        self.db.add(karma)
+        # Try removing a bug when it already has BugFeedback
+        bug_feedback = BugFeedback(bug_id=4321, feedback=1)
+        self.db.add(bug_feedback)
         self.db.flush()
         bugs = ['5678']
         update.update_bugs(bugs, session)

--- a/bodhi-server/tests/test_schemas.py
+++ b/bodhi-server/tests/test_schemas.py
@@ -26,7 +26,7 @@ class TestSchemas:
             'text': 'this is an update comment',
             'karma': -1,
             'karma_critpath': 1,
-            'bug_feedback': [{'bug_id': 1, 'karma': 1}],
+            'bug_feedback': [{'bug_id': 1, 'feedback': 1}],
             'testcase_feedback': [{'testcase_name': "wat", 'karma': -1}],
         }
         flat_structure = {
@@ -34,7 +34,7 @@ class TestSchemas:
             'karma': -1,
             'karma_critpath': 1,
             'bug_feedback.0.bug_id': 1,
-            'bug_feedback.0.karma': 1,
+            'bug_feedback.0.feedback': 1,
             'testcase_feedback.0.testcase_name': 'wat',
             'testcase_feedback.0.karma': -1,
         }

--- a/news/PR5668.bic
+++ b/news/PR5668.bic
@@ -1,0 +1,1 @@
+The `BugKarma` model has been renamed to `BugFeedback`. Also, its `karma` property has been renamed to `feedback`, therefore when posting a comment with feedback to a Bug, the new name should be used (`karma` will still work as compatibility layer for some time, but you should update any external code call ASAP)

--- a/news/summary.migration
+++ b/news/summary.migration
@@ -1,0 +1,1 @@
+The `karma` property of the `comment_bug_assoc` table has been renamed to `feedback`.


### PR DESCRIPTION
Fist step to drop the term 'karma' as requested in #4321 

Hopefully it should have a compatibility layer for a while, so external services referring to the old terminology should still work...