### PR TITLE
Add new BuildRequires python3dist(poetry-core) in spec file and Fix wrong python_version in bodhi server httpd conf

### DIFF
--- a/bodhi-client/bodhi-client.spec
+++ b/bodhi-client/bodhi-client.spec
@@ -20,6 +20,7 @@ BuildRequires:  python3-pytest
 BuildRequires:  python3-pytest-cov
 BuildRequires:  python3-pytest-mock
 BuildRequires:  python3-sphinx
+BuildRequires:  python3dist(poetry-core) >= 1
 
 Requires: koji
 

--- a/bodhi-messages/bodhi-messages.spec
+++ b/bodhi-messages/bodhi-messages.spec
@@ -19,6 +19,7 @@ BuildRequires:  python3-pytest
 BuildRequires:  python3-pytest-cov
 BuildRequires:  python3dist(fedora-messaging)
 BuildRequires:  python3dist(setuptools)
+BuildRequires:  python3dist(poetry-core) >= 1
 
 %description
 Bodhi Messages This package contains the schema for messages published by

--- a/bodhi-server/bodhi-server.spec
+++ b/bodhi-server/bodhi-server.spec
@@ -28,6 +28,7 @@ BuildRequires:  python3-responses
 BuildRequires:  python3-webtest
 BuildRequires:  python3-librepo
 BuildRequires:  python3dist(libcomps) >= 0.1.20
+BuildRequires:  python3dist(poetry-core) >= 1
 BuildRequires:  python3-createrepo_c
 BuildRequires:  python3-zstandard
 BuildRequires:  createrepo_c

--- a/bodhi-server/bodhi-server.spec
+++ b/bodhi-server/bodhi-server.spec
@@ -107,6 +107,7 @@ make %{?_smp_mflags} -C docs man
 
 install -m 644 apache/bodhi.conf %{buildroot}%{_sysconfdir}/httpd/conf.d/bodhi.conf
 sed -i -s 's/BODHI_VERSION/%{version}/g' %{buildroot}%{_sysconfdir}/httpd/conf.d/bodhi.conf
+sed -i -s 's/python3.7/python%{python3_version}/g' %{buildroot}%{_sysconfdir}/httpd/conf.d/bodhi.conf
 install -m 640 production.ini %{buildroot}%{_sysconfdir}/bodhi/production.ini
 install -m 640 alembic.ini %{buildroot}%{_sysconfdir}/bodhi/alembic.ini
 install apache/bodhi.wsgi %{buildroot}%{_datadir}/bodhi/bodhi.wsgi

--- a/news/PR5678.bug
+++ b/news/PR5678.bug
@@ -1,0 +1,1 @@
+build with spec false: build require python3dist(poetry-core) >= 1 but not in spec BuildRequires

--- a/news/PR5680.bug
+++ b/news/PR5680.bug
@@ -1,0 +1,1 @@
+bodhi server web Incorrect static resource path for httpd, always "python3.7" python3_version in /etc/httpd/conf.d/bodhi.conf, fix in bodhi-server.spec


### PR DESCRIPTION
fix issuse:
# https://github.com/fedora-infra/bodhi/issues/5678
# https://github.com/fedora-infra/bodhi/issues/5680