### PR TITLE
Do not reify releases list in pyramid request

### DIFF
--- a/bodhi-server/bodhi/server/__init__.py
+++ b/bodhi-server/bodhi/server/__init__.py
@@ -243,7 +243,7 @@ def main(global_config, testing=None, session=None, **settings):
     config.add_request_method(get_cacheregion, 'cache', reify=True)
     config.add_request_method(get_buildinfo, 'buildinfo', reify=True)
     config.add_request_method(get_from_tag_inherited, 'from_tag_inherited', reify=True)
-    config.add_request_method(get_releases, 'releases', reify=True)
+    config.add_request_method(get_releases, 'releases', property=True)
 
     # Templating
     config.add_mako_renderer('.html', settings_prefix='mako.')

--- a/news/PR5684.bug
+++ b/news/PR5684.bug
@@ -1,0 +1,1 @@
+Fixed the release list web page which was not updated after a release changed state


### PR DESCRIPTION
The `Release.all_releases()` method is already cached and set to be refreshed whenever a Release changes state. However, by having the `releases` request property reified makes that property never refreshed, thus is causing the releases list web page never updated with current changes until the server is restarted.