### PR TITLE
Remove wrong/outdated build validation condition

### DIFF
--- a/bodhi-server/bodhi/server/validators.py
+++ b/bodhi-server/bodhi/server/validators.py
@@ -204,17 +204,6 @@ def validate_build_nvrs(request, **kwargs):
     for build in request.validated.get('builds') or []:  # cope with builds being None
         try:
             cache_nvrs(request, build)
-            if request.validated.get('from_tag'):
-                n, v, r = request.buildinfo[build]['nvr']
-                release = request.db.query(Release).filter(or_(Release.name == r,
-                                                               Release.name == r.upper(),
-                                                               Release.version == r)).first()
-                if release and release.composed_by_bodhi:
-                    request.errors.add(
-                        'body', 'builds',
-                        f"Can't create update from tag for release"
-                        f" '{release.name}' composed by Bodhi.")
-
             if trusted_sources:
                 build_source = request.buildinfo[build]['info']['source']
                 if not any(build_source.startswith(source) for source in trusted_sources):

--- a/bodhi-server/tests/test_validators.py
+++ b/bodhi-server/tests/test_validators.py
@@ -968,25 +968,6 @@ class TestValidateBuildNvrs(BasePyTestCase):
         # We need release not composed by Bodhi
         self.release = models.Release.query.one()
 
-    @mock.patch('bodhi.server.validators.cache_nvrs')
-    def test_build_from_release_composed_by_bodhi(self, mock_cache_nvrs):
-        """Assert that release composed by Bodhi will not be validated when from_tag is provided."""
-        self.request.validated = {'from_tag': 'f17-build-side-7777',
-                                  'builds': ['foo-1-1.f17']}
-        self.request.buildinfo = {'foo-1-1.f17': {
-            'nvr': ('foo', '1-1', 'f17'),
-            'info': {'source': 'git+https://src.fedoraproject.org/rpms/foo.git#aabbccdd'}
-        }}
-        self.release.composed_by_bodhi = True
-        validators.validate_build_nvrs(self.request)
-
-        assert self.request.errors == [
-            {'location': 'body', 'name': 'builds',
-             'description':
-                 f"Can't create update from tag for release"
-                 f" '{self.release.name}' composed by Bodhi."}
-        ]
-
     @mock.patch.dict(
         'bodhi.server.validators.config',
         {'trusted_build_sources': ['git+https://src.fedoraproject.org/']})

--- a/news/5725.bug
+++ b/news/5725.bug
@@ -1,0 +1,1 @@
+Fixed a build validation issue which would prevent a sidetag update from being submitted in some circumstances


### PR DESCRIPTION
Fixes #5725 

As explained in the bug report, I think this validation condition is a leftover from the time when sidetag updates were first implemented and were only allowed in Rawhide. This also has never worked as intended because the `r` in `request.buildinfo[build]['nvr']` refers to the RPM release, not the distro release.