### PR TITLE
Validate side-tag update as regular one if the submitter is not side-tag creator

### DIFF
--- a/bodhi-server/tests/services/test_updates.py
+++ b/bodhi-server/tests/services/test_updates.py
@@ -430,7 +430,7 @@ class TestNewUpdate(BasePyTestCase):
             with mock.patch('bodhi.server.models.Release.mandatory_days_in_testing', 0):
                 r = app.post_json('/updates/', update, status=403)
         assert r.json_body['errors'][0]['description'] == (
-            "mattia does not own f17-build-side-7777 side-tag"
+            "mattia does not have commit access to gnome-backgrounds"
         )
 
     @mock.patch('bodhi.server.services.updates.handle_side_and_related_tags_task')

--- a/news/PR5764.feature
+++ b/news/PR5764.feature
@@ -1,0 +1,1 @@
+A packager can now edit a side-tag update even if the side-tag is not owned by them, provided they have commit rights on all packages included in the side-tag


### PR DESCRIPTION
The point of this change is to allow a user who has commit rights to all builds in an update to edit the update, even though the creator of the update and of the associated side-tag is a different user.

Users have been able to edit/waive test failures on regular updates created by Packit provided they had commit access to all the builds. This doesn't work with side-tag updates, where Packit is the creator of the side-tag. I don't see a reason why the validation couldn't allow both, the sidetag creator and the maintainer of all packages, to make changes.