### PR TITLE
Remove openid based authentication support

### DIFF
--- a/bodhi-server/bodhi/server/__init__.py
+++ b/bodhi-server/bodhi/server/__init__.py
@@ -220,8 +220,6 @@ def main(global_config, testing=None, session=None, **settings):
     for key in ('important_groups', 'admin_packager_groups', 'mandatory_packager_groups',
                 'admin_groups'):
         default.extend(bodhi_config.get(key))
-    # pyramid_fas_openid looks for this setting
-    bodhi_config['openid.groups'] = bodhi_config.get('openid.groups', default)
 
     config = Configurator(settings=bodhi_config, session_factory=session_factory)
 
@@ -268,7 +266,7 @@ def main(global_config, testing=None, session=None, **settings):
                         {'name': 'fedora-contributor'},
                         {'name': 'signed_fpca'},
                         {'name': 'fedorabugs'},],
-             'openid': bodhi_config['openid_template'].format(username=testing)}
+             }
         )
         config.testing_securitypolicy(userid=testing, identity=fake_identity, permissive=True)
     else:

--- a/bodhi-server/bodhi/server/auth/__init__.py
+++ b/bodhi-server/bodhi/server/auth/__init__.py
@@ -20,8 +20,6 @@ def includeme(config):
     config.add_view('bodhi.server.auth.views.login', route_name='login')
     config.add_route('logout', '/logout')
     config.add_view('bodhi.server.auth.views.logout', route_name='logout')
-    config.add_route('verify_openid', pattern='/dologin.html')
-    config.add_view('pyramid_fas_openid.verify_openid', route_name='verify_openid')
 
     # OIDC (OpenID Connect)
     oauth = OAuth()

--- a/bodhi-server/bodhi/server/auth/views.py
+++ b/bodhi-server/bodhi/server/auth/views.py
@@ -34,13 +34,6 @@ def login(request: 'pyramid.request.Request') -> HTTPFound:
         referrer = request.route_url('home')
     came_from = request.params.get('came_from', referrer)
     request.session['came_from'] = came_from
-    if request.GET.get("method", "oidc") == "openid":
-        oid_url = request.registry.settings['openid.url']
-        return HTTPFound(
-            location=request.route_url(
-                'verify_openid', _query=dict(openid=oid_url)
-            )
-        )
     # Use OIDC
     return HTTPFound(location=request.route_url('oidc_login'))
 

--- a/bodhi-server/bodhi/server/models.py
+++ b/bodhi-server/bodhi/server/models.py
@@ -4867,7 +4867,7 @@ class User(Base):
         if not request:
             return None
         context = dict(request=request)
-        return get_avatar(context=context, username=self.name, size=24)
+        return get_avatar(context=context, username=self.name, usermail=self.email, size=24)
 
     def openid(self, request: 'pyramid.request') -> str:
         """

--- a/bodhi-server/bodhi/server/templates/fragments.html
+++ b/bodhi-server/bodhi/server/templates/fragments.html
@@ -129,7 +129,7 @@ ${statusmap[status]}\
           <div class="col font-size-09">
           % if comment.user:
           <a href="${request.route_url('user', name=comment.user.name)}" class="fw-bold notblue">
-            <img src="${util.avatar(comment.user.name, size=16)}" alt="User Icon"/>
+            <img src="${util.avatar(comment.user.name, comment.user.email, size=16)}" alt="User Icon"/>
             ${comment.user.name}
           </a>
           % if comment.text:

--- a/bodhi-server/bodhi/server/templates/home.html
+++ b/bodhi-server/bodhi/server/templates/home.html
@@ -92,7 +92,7 @@
                 % for tester, count in top_testers:
                 <div class="list-group-item">
                     <a href="${request.route_url('user', name=tester['name'])}">
-                      <img class="rounded-circle" src="${self.util.avatar(tester['name'], size=24)}" alt="User Icon"/>
+                      <img class="rounded-circle" src="${self.util.avatar(tester['name'], tester['email'], size=24)}" alt="User Icon"/>
                       ${tester['name']}
                     </a>
                   <div class="float-end">${str(count)} comments</div>
@@ -106,7 +106,7 @@
               % for tester, count in top_packagers:
               <div class="list-group-item">
                   <a href="${request.route_url('user', name=tester['name'])}">
-                    <img class="rounded-circle" src="${self.util.avatar(tester['name'], size=24)}" alt="User Icon"/>
+                    <img class="rounded-circle" src="${self.util.avatar(tester['name'], tester['email'], size=24)}" alt="User Icon"/>
                     ${tester['name']}
                   </a>
                 <div class="float-end">${str(count)} updates</div>

--- a/bodhi-server/bodhi/server/templates/master.html
+++ b/bodhi-server/bodhi/server/templates/master.html
@@ -96,7 +96,7 @@
                     <li class="nav-item dropdown">
                         <a class="nav-link dropdown-toggle" href="#" data-bs-toggle="dropdown" role="button" aria-expanded="false">
                             <span class="glyphicon glyphicon-user"></span>
-                            <img src="${self.util.avatar(request.identity.name, size=24)}" alt="User Icon"/>
+                            <img src="${self.util.avatar(request.identity.name, request.identity.email, size=24)}" alt="User Icon"/>
                         </a>
                         <div class="dropdown-menu dropdown-menu-right">
                             <a class="dropdown-item" href="${request.route_url('home')}">
@@ -112,7 +112,7 @@
                             <a class="dropdown-item" href="${request.route_url('user', name=request.identity.name)}">
                                 Your Public Profile
                             </a>
-                            <a class="dropdown-item" href="${request.registry.settings.get('fmn_url')}${request.identity.openid}/">
+                            <a class="dropdown-item" href="${request.registry.settings.get('fmn_url')}/">
                                 Manage Alerts
                             </a>
                             % if request.identity:

--- a/bodhi-server/bodhi/server/templates/override.html
+++ b/bodhi-server/bodhi/server/templates/override.html
@@ -85,12 +85,12 @@ ${parent.css()}
           <div class="form-group">
             %if override is not UNDEFINED:
             <a href="${request.route_url('user', name=override.submitter.name)}">
-              <img src="${util.avatar(override.submitter.name, size=24)}" alt="User Icon"/>
+              <img src="${util.avatar(override.submitter.name, override.submitter.email, size=24)}" alt="User Icon"/>
               ${override.submitter.name}
             </a>
             %else:
             <a href="${request.route_url('user', name=request.identity.name)}">
-              <img src="${util.avatar(request.identity.name, size=24)}" alt="User Icon"/>
+              <img src="${util.avatar(request.identity.name, override.submitter.email, size=24)}" alt="User Icon"/>
               ${request.identity.name}
             </a>
             %endif
@@ -187,7 +187,7 @@ ${parent.css()}
             </h5>
           <div>
             <a href="${request.route_url('user', name=override.submitter.name)}">
-              <img src="${util.avatar(override.submitter.name, size=24)}" alt="User Icon"/>
+              <img src="${util.avatar(override.submitter.name, override.submitter.email, size=24)}" alt="User Icon"/>
               ${override.submitter.name}
             </a>
           </div>

--- a/bodhi-server/bodhi/server/templates/user.html
+++ b/bodhi-server/bodhi/server/templates/user.html
@@ -5,11 +5,11 @@
   <div class="col-md-12">
     <div class="float-start">
       % if request.identity and user['name'] == request.identity.name:
-        <a href="https://www.libravatar.org/openid/login/?openid_identifier=${request.identity.openid}">
-          <img class="img-thumbnail" src="${self.util.avatar(user['name'], size=128)}" width="128px" height="128px" alt="User Icon"/>
+        <a href="https://www.libravatar.org/accounts/login/">
+          <img class="img-thumbnail" src="${self.util.avatar(user['name'], user['email'], size=128)}" width="128px" height="128px" alt="User Icon"/>
         </a>
       % else:
-        <img class="img-thumbnail" src="${self.util.avatar(user['name'], size=128)}" alt="User Icon"/>
+        <img class="img-thumbnail" src="${self.util.avatar(user['name'], user['email'], size=128)}" alt="User Icon"/>
       % endif
     </div>
     <div class="float-start" style="margin-left: 15px">

--- a/bodhi-server/production.ini
+++ b/bodhi-server/production.ini
@@ -485,19 +485,6 @@ fedora_epel.mandatory_days_in_testing = 14
 ## Authentication & Authorization
 ##
 
-# pyramid.openid settings.
-# openid.success_callback = bodhi.server.auth.utils:remember_me
-# openid.provider = https://id.fedoraproject.org/openid/
-# openid.url = https://id.fedoraproject.org/
-# openid_template = {username}.id.fedoraproject.org
-# openid.sreg_required = email nickname
-# If this is undefined, Bodhi will concatenate the groups listed in the following other settings
-# from this file: important_groups, admin_packager_groups, mandatory_packager_groups, and
-# admin_groups. You likely want this default, but can override it here if you know what you are
-# doing. You can also override it here if you do not know what you are doing, but that would be
-# inadvisable.
-# openid.groups = DEFAULT_DOCUMENTED_ABOVE
-
 # OIDC (OpenID Connect)
 oidc.fedora.client_id = oidc-client_id
 oidc.fedora.client_secret = oidc-client_secret

--- a/bodhi-server/pyproject.toml
+++ b/bodhi-server/pyproject.toml
@@ -108,7 +108,6 @@ py3dns = ">=3.2.1" # Should be required by pyLibravatar https://bugs.launchpad.n
 pyLibravatar = ">=1.6"
 pymediawiki = "^0.7"
 pyramid = "~2.0.0"
-pyramid-fas-openid = "^0.4.0"
 pyramid-mako = "^1.1"
 python-bugzilla = ">=3.2.0"
 PyYAML = ">=5.4.1"

--- a/bodhi-server/tests/auth/test_views.py
+++ b/bodhi-server/tests/auth/test_views.py
@@ -20,11 +20,6 @@ class TestLogin(base.BasePyTestCase):
         resp = self.app.get('/login', status=302)
         assert resp.location == "http://localhost/oidc/login"
 
-    def test_login_openid(self):
-        """Test the login redirect for openid"""
-        resp = self.app.get('/login?method=openid', status=302)
-        assert 'dologin.html' in resp
-
 
 class TestLogout(base.BasePyTestCase):
     """Test the logout() function."""

--- a/bodhi-server/tests/base.py
+++ b/bodhi-server/tests/base.py
@@ -159,7 +159,7 @@ def populate(db):
     Args:
         db (sqlalchemy.orm.session.Session): The database session.
     """
-    user = models.User(name='guest')
+    user = models.User(name='guest', email='guest@bodhi-dev.example.com')
     db.add(user)
     anonymous = models.User(name='anonymous')
     db.add(anonymous)

--- a/bodhi-server/tests/functional/test_users.py
+++ b/bodhi-server/tests/functional/test_users.py
@@ -59,7 +59,9 @@ class TestUsersService(base.BasePyTestCase):
         assert res.json_body['user']['name'] == 'guest'
 
         base = 'https://seccdn.libravatar.org/avatar/'
-        h = 'eb48e08cc23bcd5961de9541ba5156c385cd39799e1dbf511477aa4d4d3a37e7'
+        # This is the hash of 'guest@bodhi-dev.example.com'
+        # see fake_identity set up for testing in server __init__.py
+        h = '4b9fbd26009562b568c44bba075c5df741647dd1255ff7a29e2cfe0cba28f509'
         tail = '?d=retro&s=24'
         url = base + h
 

--- a/bodhi-server/tests/scripts/test_sar.py
+++ b/bodhi-server/tests/scripts/test_sar.py
@@ -34,7 +34,7 @@ from ..base import BasePyTestCase
 EXPECTED_USER_DATA_OUTPUT = """\
 ==========> User account data for: guest <==========
 
-email: None
+email: guest@bodhi-dev.example.com
 groups: ['packager']
 
 ----> Comments: <----
@@ -72,7 +72,7 @@ user: guest
 EXPECTED_JSON_OUTPUT = (
     '{"guest": {"comments": [{"karma": 1, "karma_critpath": 0, "text":'
     ' "wow. amaze.", "timestamp": "1984-11-02 00:00:00", "update_alias": '
-    '"ALIAS", "username": "guest"}], "email": null, "groups": '
+    '"ALIAS", "username": "guest"}], "email": "guest@bodhi-dev.example.com", "groups": '
     '["packager"], "name": "guest", "updates": [{"alias": '
     '"ALIAS", "autokarma": true, "bugs": [12345], "builds": '
     '["bodhi-2.0-1.fc17"], "close_bugs": true, "date_submitted": "1984-11-02 00:00:00", '

--- a/devel/ci/Dockerfile-f40
+++ b/devel/ci/Dockerfile-f40
@@ -37,13 +37,11 @@ RUN dnf --best install -y \
     python3-librepo \
     python3-markdown \
     python3-munch \
-    python3-openid \
     python3-psycopg2 \
     python3-prometheus_client \
     python3-pylibravatar \
     python3-pymediawiki \
     python3-pyramid \
-    python3-pyramid-fas-openid \
     python3-pyramid-mako \
     python3-pytest \
     python3-pytest-cov \

--- a/devel/ci/Dockerfile-f41
+++ b/devel/ci/Dockerfile-f41
@@ -37,13 +37,11 @@ RUN dnf --best install -y \
     python3-librepo \
     python3-markdown \
     python3-munch \
-    python3-openid \
     python3-psycopg2 \
     python3-prometheus_client \
     python3-pylibravatar \
     python3-pymediawiki \
     python3-pyramid \
-    python3-pyramid-fas-openid \
     python3-pyramid-mako \
     python3-pytest \
     python3-pytest-cov \

--- a/devel/ci/Dockerfile-rawhide
+++ b/devel/ci/Dockerfile-rawhide
@@ -37,13 +37,11 @@ RUN dnf --best install -y \
     python3-librepo \
     python3-markdown \
     python3-munch \
-    python3-openid \
     python3-psycopg2 \
     python3-prometheus_client \
     python3-pylibravatar \
     python3-pymediawiki \
     python3-pyramid \
-    python3-pyramid-fas-openid \
     python3-pyramid-mako \
     python3-pytest \
     python3-pytest-cov \

--- a/devel/ci/integration/tests/test_bodhi.py
+++ b/devel/ci/integration/tests/test_bodhi.py
@@ -450,16 +450,16 @@ def test_get_user_view(bodhi_container, db_container):
         raise
 
 
-def create_avatar_url(username, size):
+def create_avatar_url(username, usermail, size):
     hardcoded_avatars = {
         'bodhi': f'https://apps.fedoraproject.org/img/icons/bodhi-{size}.png',
     }
     if username in hardcoded_avatars:
         return hardcoded_avatars[username]
 
-    openid = f"http://{username}.id.dev.fedoraproject.org/"
+    email = 'default' if not usermail else usermail
     query = urlencode({'s': size, 'd': 'retro'})
-    hash = hashlib.sha256(openid.encode('utf-8')).hexdigest()
+    hash = hashlib.sha256(email.lower().encode('utf-8')).hexdigest()
     return f"https://seccdn.libravatar.org/avatar/{hash}?{query}"
 
 
@@ -513,7 +513,7 @@ def test_get_users_json(bodhi_container, db_container):
         http_response = c.get("/users")
 
     for user in users:
-        user["avatar"] = create_avatar_url(user["name"], 24)
+        user["avatar"] = create_avatar_url(user["name"], user["email"], 24)
         user["openid"] = f"{user['name']}.id.dev.fedoraproject.org"
         # Python and SQL don't sort identically :(
         # Python: fedorabugs > fedora-contributor
@@ -588,7 +588,7 @@ def test_get_user_json(bodhi_container, db_container):
         "id": user_id,
         "name": user_name,
         "email": user_email,
-        "avatar": create_avatar_url(user_name, 24),
+        "avatar": create_avatar_url(user_name, user_email, 24),
         "openid": f"{user_name}.id.dev.fedoraproject.org",
         "groups": user_groups,
     }

--- a/news/5601.bug
+++ b/news/5601.bug
@@ -1,0 +1,1 @@
+Openid based login support has been removed from Bodhi. `python-openid` and `pyramid-fas-openid` are EOL and we moved to OIDC authentication.


### PR DESCRIPTION
This has been discussed in #5601 
`python-openid` and `pyramid-fas-openid` are EOL and we moved to OIDC authentication. I see no way to "fix" the openid endpoint, so I've removed it entirely and dropped a release note.

There are some `openid.*` config records which seems to be used for OIDC also, so I'm not sure they can be removed...