### PR TITLE
Correctly handle empty bugs when editing an update

### DIFF
--- a/bodhi-server/bodhi/server/models.py
+++ b/bodhi-server/bodhi/server/models.py
@@ -2797,7 +2797,9 @@ class Update(Base):
             for tag in tags:
                 tag_update_builds_task.delay(tag=tag, builds=builds_to_tag)
 
-        new_bugs = up.update_bugs(data['bugs'], db)
+        new_bugs = []
+        if data['bugs'] is not None:
+            new_bugs = up.update_bugs(data['bugs'], db)
         del data['bugs']
 
         req = data.pop("request", None)

--- a/news/5800.bug
+++ b/news/5800.bug
@@ -1,0 +1,1 @@
+When editing an update from APIs it is no more required to specify the old bug ids list in sent data if no change is required


### PR DESCRIPTION
When posting the data for creating a new update, the case where the `bugs` key was not present in data was already handled.
But when editing an update, that key was required, because the default to a None object would cause a `'NoneType' object is not iterable` error.

After this PR we will now consider the absence of the `bugs` key as "I don't want to change anything in the bugs attached to the update", but we still want to be sure that an empty string passed as `bugs` will cause all attached bugs to be removed.
Fixes #5800 