### PR TITLE
Separate critpath and non-critpath min_karma settings

### DIFF
--- a/bodhi-server/bodhi/server/config.py
+++ b/bodhi-server/bodhi/server/config.py
@@ -363,6 +363,9 @@ class BodhiConfig(dict):
         'critpath.mandatory_days_in_testing': {
             'value': 14,
             'validator': int},
+        'critpath.min_karma': {
+            'value': 2,
+            'validator': int},
         'critpath.type': {
             'value': None,
             'validator': _validate_none_or(str)},
@@ -447,6 +450,8 @@ class BodhiConfig(dict):
             'value': 'bodhi.server:templates',
             'validator': str},
         'min_karma': {
+            # 1 would be a closer match for Fedora's policy, but a lot
+            # of the tests expect 2
             'value': 2,
             'validator': int},
         'mandatory_packager_groups': {

--- a/bodhi-server/tests/services/test_updates.py
+++ b/bodhi-server/tests/services/test_updates.py
@@ -4029,7 +4029,7 @@ class TestUpdatesService(BasePyTestCase):
         up.request = None
         assert len(up.builds) == 1
         # just to set our base expectation
-        assert up.release.min_karma == 2
+        assert up.min_karma == 2
         up.test_gating_status = TestGatingStatus.passed
         # Clear pending messages
         self.db.info['messages'] = []
@@ -4873,7 +4873,7 @@ class TestUpdatesService(BasePyTestCase):
         status = up.status
         request = up.request
         # just for clarity that stable_karma is not lower and both are reached
-        assert up.release.min_karma == 2
+        assert up.min_karma == 2
         up.comment(self.db, "foo", 1, 'biz')
         # nothing should have changed yet, on any path. we don't need to test the
         # messages published so far here, either
@@ -4989,7 +4989,7 @@ class TestUpdatesService(BasePyTestCase):
         up.critpath = critpath
         up.status = status
         up.stable_karma = 1
-        assert up.release.min_karma == 2
+        assert up.min_karma == 2
         # we don't use _reach_autopush_threshold here because this is a bit different
         with mock.patch('bodhi.server.models.notifications.publish', autospec=True) as publish:
             _, caveats = up.comment(self.db, "foo", 1, 'biz')

--- a/news/PR5802.feature
+++ b/news/PR5802.feature
@@ -1,0 +1,1 @@
+Bodhi now allows setting the min_karma threshold for critical path and non-critical path updates separately


### PR DESCRIPTION
FESCo has decided to reinstate different minimum karma for critpath and non-critpath:
https://pagure.io/fesco/issue/3289
so we need to support this. This introduces critpath.min_karma, and makes min_karma work much like mandatory_days_in_testing, with the appropriate value for each update worked out at the level of the update based on whether it's critpath or not.

We leave the default value of min_karma at 2 even though 1 would be closer to the policy now, just because the tests were written around 2 and are hard to adjust, especially the
test_autopush_reached tests in test_updates.py. We'll set it to 1 in downstream config.