### PR TITLE
bcd: drop python3-ipdb from Bodhi container

### DIFF
--- a/devel/ansible-podman/containers/bodhi/Containerfile
+++ b/devel/ansible-podman/containers/bodhi/Containerfile
@@ -33,7 +33,6 @@ RUN set -exo pipefail \
         nano \
         nmap-ncat \
         pcp-system-tools \
-        python3-ipdb \
         python3-pydocstyle \
         screen \
         tmux \


### PR DESCRIPTION
It's retired in Fedora 41. It wasn't needed for anything, it was just there as part of an attempt to provide a 'nice' development environment.