### PR TITLE
bcd: introduce 'clean' subcommand for complete refresh

### DIFF
--- a/bcd
+++ b/bcd
@@ -69,6 +69,11 @@ def parse_args():
         aliases=["destroy"]
     )
     parser_remove.set_defaults(func=ansible)
+    parser_clean = subparsers.add_parser(
+        "clean",
+        description="Stop and remove all containers, remove built images, pull base images",
+    )
+    parser_clean.set_defaults(func=ansible)
     parser_cis = subparsers.add_parser(
         "cis",
         description="Clear Ipsilon sessions (to allow you to log in as a different user)"

--- a/devel/ansible-podman/roles/podman/tasks/clean.yml
+++ b/devel/ansible-podman/roles/podman/tasks/clean.yml
@@ -1,0 +1,20 @@
+- include_tasks: remove.yml
+
+- name: "Remove all built images"
+  containers.podman.podman_image:
+    name: "{{ item }}"
+    state: absent
+  with_items:
+    - "localhost/bodhi-dev-bodhi"
+    - "localhost/bodhi-dev-ipsilon"
+
+- name: "Update all base images"
+  containers.podman.podman_image:
+    name: "{{item }}"
+    force: true
+  with_items:
+    - "docker.io/library/postgres:latest"
+    - "factory2/waiverdb:latest"
+    - "quay.io/factory2/greenwave:latest"
+    - "docker.io/library/rabbitmq:4-management"
+    - "quay.io/fedora/fedora:latest"

--- a/devel/ansible-podman/roles/podman/tasks/main.yml
+++ b/devel/ansible-podman/roles/podman/tasks/main.yml
@@ -10,5 +10,8 @@
 - include_tasks: remove.yml
   when: "bodhi_dev_remove is defined"
 
+- include_tasks: clean.yml
+  when: "bodhi_dev_clean is defined"
+
 - include_tasks: clear_ipsilon_sessions.yml
   when: "bodhi_dev_cis is defined"

--- a/docs/developer/bcd.rst
+++ b/docs/developer/bcd.rst
@@ -27,11 +27,12 @@ Other commands
 ^^^^^^^^^^^^^^
 
 Other command commands are ``./bcd stop`` to stop all containers, ``./bcd remove`` to remove all
-containers, ``bcd logs (container)`` to view the logs for a container, ``bcd shell (container)``
-to shell into a container (the Bodhi container by default), and ``./bcd cis`` to clear Ipsilon's
-session cache. This is necessary to log in to Bodhi as a different user - first log out, then run
-``./bcd cis``, then log in again. If you don't clear the session cache Ipsilon will just keep
-logging you in as the same user. Run ``./bcd -h`` or ``./bcd (subcommand) -h`` for more help.
+containers, ``./bcd clean`` to do remove plus remove all built images and update all base images,
+``bcd logs (container)`` to view the logs for a container, ``bcd shell (container)`` to shell into
+a container (the Bodhi container by default), and ``./bcd cis`` to clear Ipsilon's session cache.
+This is necessary to log in to Bodhi as a different user - first log out, then run ``./bcd cis``,
+then log in again. If you don't clear the session cache Ipsilon will just keep logging you in as
+the same user. Run ``./bcd -h`` or ``./bcd (subcommand) -h`` for more help.
 
 Containers
 ^^^^^^^^^^
@@ -57,6 +58,22 @@ The server will automatically reload when any Python source file is changed.
 
 The Bodhi container uses systemd, so you can shell into it and stop or restart the bodhi service
 or any of the ancillary services it runs, if you need to.
+
+Refreshing the bcd environment
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Once you've set up a bcd environment, it's kind of frozen, aside from the bodhi code itself.
+All the containers will be built on whatever their 'latest' bases were are the time, but nothing
+ever rebuilds or updates them by default. So after a while, your environment will be stale and
+may not run newer Bodhi code correctly.
+
+To easily completely refresh the bcd environment, run ``./bcd clean`` then ``./bcd run`` again.
+This wipes all the existing containers and custom images, pulls the latest versions of all the
+base images, then rebuilds the custom images and the containers.
+
+Of course, any customizations, command history etc. within the containers will be lost. If you
+want to do something more granular, you'll have to do it 'behind the scenes' with normal podman
+commands to remove the container and/or images, pull base images, and rebuild.
 
 Authentication
 ^^^^^^^^^^^^^^

--- a/news/PR5804.feature
+++ b/news/PR5804.feature
@@ -1,0 +1,1 @@
+bcd has a new clean subcommand to completely refresh the bcd environment


### PR DESCRIPTION
This adds a new subcommand to bcd which you can use to completely refresh the environment. It removes all existing containers, removes the bodhi-dev-bodhi and bodhi-dev-ipsilon images (so they will be rebuilt on the next run), and pulls the latest versions of all the base images we use (so all the containers will be rebased on fresh versions of their base images at the next run). This should give you a completely clean and updated bcd environment the next time you do `./bcd run`.