### PR TITLE
expose (critpath_,)mandatory_days_in_testing and (critpath_,)min_karma

### DIFF
--- a/bodhi-client/docs/man_pages/bodhi.rst
+++ b/bodhi-client/docs/man_pages/bodhi.rst
@@ -680,6 +680,11 @@ The ``releases`` command allows users to manage update releases.
 
         Go to page number.
 
+``bodhi releases requirements RELEASE_NAME``
+
+    The ``requirements`` command prints information about the status of the given release
+    and the requirements needed by its updates for being pushed to stable.
+
 
 Examples
 ========

--- a/bodhi-client/tests/fixtures.py
+++ b/bodhi-client/tests/fixtures.py
@@ -915,7 +915,9 @@ EXAMPLE_RELEASE_MUNCH = Munch({
     'pending_testing_tag': 'f27-updates-testing-pending', 'stable_tag': 'f27-updates',
     'candidate_tag': 'f27-updates-candidate', 'mail_template': 'fedora_errata_template',
     'create_automatic_updates': False, 'package_manager': 'unspecified',
-    'testing_repository': None, 'released_on': None, 'eol': None, 'setting_status': None})
+    'testing_repository': None, 'released_on': None, 'eol': None,
+    'critpath_mandatory_days_in_testing': 0, 'mandatory_days_in_testing': 0,
+    'critpath_min_karma': 0, 'min_karma': 0, 'setting_status': None})
 
 
 EXPECTED_RELEASE_OUTPUT = """Saved release:
@@ -943,6 +945,16 @@ EXPECTED_RELEASE_OUTPUT = """Saved release:
   End of Life:              None
 """
 
+EXPECTED_RELEASE_REQUIREMENTS_OUTPUT = """Release F27 state is currently "pending"
+
+  - Requirements for critical path updates are:
+    0 days in testing OR +0 karma
+
+  - Requirements for non-critical path updates are:
+    0 days in testing OR +0 karma
+
+"""
+
 EXAMPLE_ARCHIVED_RELEASE_MUNCH = Munch({
     'composes': [], 'dist_tag': 'f26', 'name': 'F26',
     'testing_tag': 'f26-updates-testing', 'pending_stable_tag': 'f26-updates-pending',
@@ -953,7 +965,8 @@ EXAMPLE_ARCHIVED_RELEASE_MUNCH = Munch({
     'candidate_tag': 'f26-updates-candidate', 'stable_tag': 'f26-updates',
     'override_tag': 'f26-override', 'composed_by_bodhi': True,
     'package_manager': 'unspecified', 'testing_repository': None, 'released_on': None,
-    'eol': None, 'setting_status': None,
+    'eol': None, 'critpath_mandatory_days_in_testing': 14, 'mandatory_days_in_testing': 7,
+    'critpath_min_karma': 2, 'min_karma': 1, 'setting_status': None,
 })
 
 EXAMPLE_CURRENT_RELEASE_MUNCH = Munch({
@@ -966,7 +979,8 @@ EXAMPLE_CURRENT_RELEASE_MUNCH = Munch({
     'candidate_tag': 'f28-updates-candidate', 'stable_tag': 'f28-updates',
     'override_tag': 'f28-override', 'composed_by_bodhi': True,
     'package_manager': 'unspecified', 'testing_repository': None, 'released_on': None,
-    'eol': None, 'setting_status': None,
+    'eol': None, 'critpath_mandatory_days_in_testing': 14, 'mandatory_days_in_testing': 7,
+    'critpath_min_karma': 2, 'min_karma': 1, 'setting_status': None,
 })
 
 EXAMPLE_PENDING_RELEASE_MUNCH = Munch({
@@ -979,8 +993,19 @@ EXAMPLE_PENDING_RELEASE_MUNCH = Munch({
     'candidate_tag': 'f29-updates-candidate', 'stable_tag': 'f29-updates',
     'override_tag': 'f29-override', 'composed_by_bodhi': True,
     'package_manager': 'unspecified', 'testing_repository': None, 'released_on': None,
-    'eol': None, 'setting_status': None,
+    'eol': None, 'critpath_mandatory_days_in_testing': 3, 'mandatory_days_in_testing': 3,
+    'critpath_min_karma': 2, 'min_karma': 1, 'setting_status': 'prebeta',
 })
+
+EXPECTED_PENDING_RELEASE_REQUIREMENTS_OUTPUT = """Release F29 state is currently "pending prebeta"
+
+  - Requirements for critical path updates are:
+    3 days in testing OR +2 karma
+
+  - Requirements for non-critical path updates are:
+    3 days in testing OR +1 karma
+
+"""
 
 EXAMPLE_FROZEN_RELEASE_MUNCH = Munch({
     'composes': [], 'dist_tag': 'f30', 'name': 'F30',
@@ -992,7 +1017,8 @@ EXAMPLE_FROZEN_RELEASE_MUNCH = Munch({
     'candidate_tag': 'f30-updates-candidate', 'stable_tag': 'f30-updates',
     'override_tag': 'f30-override', 'composed_by_bodhi': True,
     'package_manager': 'unspecified', 'testing_repository': None, 'released_on': None,
-    'eol': None, 'setting_status': None,
+    'eol': None, 'critpath_mandatory_days_in_testing': 3, 'mandatory_days_in_testing': 3,
+    'critpath_min_karma': 2, 'min_karma': 1, 'setting_status': None,
 })
 
 EXAMPLE_RELEASE_MUNCH_NO_ARCHIVED = Munch({

--- a/bodhi-client/tests/test_cli.py
+++ b/bodhi-client/tests/test_cli.py
@@ -2510,6 +2510,58 @@ class TestInfo:
         assert result.output == "ERROR: an error was encountered... :(\n"
 
 
+class TestRequirements:
+    """
+    Test the requirements() function.
+    """
+    def test_url_flag(self, mocked_client_class):
+        """
+        Assert correct behavior with the --url flag.
+        """
+        mocked_client_class.send_request.return_value = \
+            client_test_data.EXAMPLE_RELEASE_MUNCH
+        runner = testing.CliRunner()
+
+        result = runner.invoke(cli.requirements_release, ['--url', 'http://localhost:6543', 'F27'])
+
+        assert result.exit_code == 0
+        assert result.output == \
+            client_test_data.EXPECTED_RELEASE_REQUIREMENTS_OUTPUT.replace('Saved r', 'R')
+        mocked_client_class.send_request.assert_called_once_with(
+            'releases/F27', verb='GET', auth=False)
+
+    def test_pending_release(self, mocked_client_class):
+        """
+        Assert correct output with a pensing prebeta release.
+        """
+        mocked_client_class.send_request.return_value = \
+            client_test_data.EXAMPLE_PENDING_RELEASE_MUNCH
+        runner = testing.CliRunner()
+
+        result = runner.invoke(cli.requirements_release, ['--url', 'http://localhost:6543', 'F29'])
+
+        assert result.exit_code == 0
+        assert result.output == \
+            client_test_data.EXPECTED_PENDING_RELEASE_REQUIREMENTS_OUTPUT.replace('Saved r', 'R')
+        mocked_client_class.send_request.assert_called_once_with(
+            'releases/F29', verb='GET', auth=False)
+
+    def test_requirements_with_errors(self, mocked_client_class):
+        """
+        Assert errors are printed if returned back in the request
+        """
+        mocked_client_class.send_request.return_value = {
+            "errors": [{"description": "an error was encountered... :("}]
+        }
+
+        runner = testing.CliRunner()
+
+        result = runner.invoke(cli.requirements_release, ['--url', 'http://localhost:6543', 'F27'])
+
+        assert result.exit_code == 1
+        assert result.output == "ERROR: an error was encountered... :(\n"
+
+
 class TestListReleases:
     """
     Test the list_releases() function.

--- a/bodhi-server/bodhi/server/models.py
+++ b/bodhi-server/bodhi/server/models.py
@@ -880,7 +880,8 @@ class Release(Base):
 
     __tablename__ = 'releases'
     __exclude_columns__ = ('id', 'builds', 'composes')
-    __include_extras__ = ('setting_status', )
+    __include_extras__ = ('critpath_mandatory_days_in_testing', 'mandatory_days_in_testing',
+                          'critpath_min_karma', 'min_karma', 'setting_status', )
     __get_by__ = ('name', 'long_name', 'dist_tag')
 
     name = Column(Unicode(10), unique=True, nullable=False)

--- a/devel/ci/integration/tests/test_bodhi.py
+++ b/devel/ci/integration/tests/test_bodhi.py
@@ -1127,8 +1127,15 @@ def test_get_compose_json(bodhi_container, db_container):
         compose['content_type'] = updates[0]['builds'][0]['content_type']
     else:
         compose['content_type'] = None
-    # We can't get this from db
+    # We can't get these from db
     release['setting_status'] = http_response.json()['compose']['release']['setting_status']
+    release['min_karma'] = http_response.json()['compose']['release']['min_karma']
+    release['critpath_min_karma'] = \
+        http_response.json()['compose']['release']['critpath_min_karma']
+    release['mandatory_days_in_testing'] = \
+        http_response.json()['compose']['release']['mandatory_days_in_testing']
+    release['critpath_mandatory_days_in_testing'] = \
+        http_response.json()['compose']['release']['critpath_mandatory_days_in_testing']
 
     compose['release'] = release
     compose['update_summary'] = []

--- a/news/PR5807.feature
+++ b/news/PR5807.feature
@@ -1,0 +1,1 @@
+The Release properties `min_karma`, `critpath_min_karma`, `mandatory_days_in_testing` and `critpath_mandatory_days_in_testing` are now expossed in JSON replies from bodhi-server and can be viewed in bodhi-client through the `release requirements` command


### PR DESCRIPTION
This exposes the `(critpath_,)mandatory_days_in_testing` and `(critpath_,)min_karma` Release properties to the JSON representation and to the CLI.