### PR TITLE
Remove libdnf5 dependency from pyproject.toml

### DIFF
--- a/bodhi-server/bodhi-server.spec
+++ b/bodhi-server/bodhi-server.spec
@@ -36,6 +36,9 @@ BuildRequires:  python3-zstandard
 BuildRequires:  createrepo_c
 BuildRequires:  skopeo
 BuildRequires:  dnf
+%if %{with libdnf5}
+BuildRequires:  python3dist(libdnf5)
+%endif
 
 Requires: bodhi-client >= %{client_min_version}
 Requires: python3-bodhi-messages >= %{messages_min_version}
@@ -69,10 +72,9 @@ Summary: Bodhi composer backend
 
 Requires: %{py3_dist jinja2}
 %if %{with libdnf5}
-Requires: python3-bodhi-server+libdnf5 == %{version}-%{release}
-%else
-Requires: bodhi-server == %{version}-%{release}
+Requires: python3dist(libdnf5)
 %endif
+Requires: bodhi-server == %{version}-%{release}
 Requires: pungi >= 4.1.20
 Requires: python3-createrepo_c
 Requires: skopeo
@@ -81,10 +83,6 @@ Requires: skopeo
 The Bodhi composer is the component that publishes Bodhi artifacts to
 repositories.
 
-%if %{with libdnf5}
-%pyproject_extras_subpkg -n python3-bodhi-server libdnf5
-%endif
-
 
 %prep
 %autosetup -n %{src_name}-%{pypi_version}
@@ -92,7 +90,7 @@ repositories.
 rm -rf %{pypi_name}.egg-info
 
 %generate_buildrequires
-%pyproject_buildrequires %{?_with_libdnf5:-x libdnf5}
+%pyproject_buildrequires
 
 # https://docs.fedoraproject.org/en-US/packaging-guidelines/UsersAndGroups/#_dynamic_allocation
 cat > %{name}.sysusers << EOF

--- a/bodhi-server/pyproject.toml
+++ b/bodhi-server/pyproject.toml
@@ -102,7 +102,6 @@ Markdown = ">=3.3.6"
 munch = ">=2.5.0"
 koji = ">=1.27.1"
 libcomps ="^0.1.20"
-libdnf5 = {version = "^5.2", optional = true}
 packaging = ">=21.3"
 prometheus-client = ">=0.13.1"
 psycopg2 = ">=2.8.6"
@@ -117,9 +116,6 @@ requests = ">=2.25.1"
 SQLAlchemy = ">=1.4, <2.1"
 waitress = ">=1.4.4"
 zstandard = "^0.21 || ^0.22.0 || ^0.23.0"
-
-[tool.poetry.extras]
-libdnf5 = ["libdnf5"]
 
 [tool.pytest.ini_options]
 addopts = "--cov-config .coveragerc --cov=bodhi --cov-report term --cov-report xml --cov-report html"


### PR DESCRIPTION
libdnf5 in Pypi is just a broken package, the version doesn't match the reality. So we just have to handle the requires manually in RPM specfile.