### PR TITLE
Ensure Update is in session before linking relationships

### DIFF
--- a/bodhi-server/bodhi/server/consumers/automatic_updates.py
+++ b/bodhi-server/bodhi/server/consumers/automatic_updates.py
@@ -191,20 +191,26 @@ class AutomaticUpdateHandler:
             except ValueError:
                 critpath_groups = None
                 critpath = Update.contains_critpath_component([build], rel.branch)
+            # Avoid sqlalchemy warnings about adding relationships before the Update is in session
             update = Update(
                 release=rel,
-                builds=[build],
-                bugs=closing_bugs,
                 notes=notes,
                 type=utype,
                 stable_karma=3,
                 unstable_karma=-3,
                 autokarma=False,
-                user=user,
                 status=UpdateStatus.pending,
                 critpath_groups=critpath_groups,
                 critpath=critpath,
             )
+
+            log.debug("Adding new update to the database.")
+            dbsession.add(update)
+
+            # Now add relationships
+            update.user = user
+            update.bugs = closing_bugs
+            update.builds = [build]
 
             # Comment on the update that it was automatically created.
             update.comment(
@@ -215,9 +221,6 @@ class AutomaticUpdateHandler:
 
             update.add_tag(update.release.pending_signing_tag)
 
-            log.debug("Adding new update to the database.")
-            dbsession.add(update)
-
             log.debug("Flushing changes to the database.")
             dbsession.flush()
 
@@ -227,6 +230,7 @@ class AutomaticUpdateHandler:
             except Exception as e:
                 log.error(f'Problem obsoleting older updates: {e}')
 
+            Update._ready_for_testing(update, None)
             alias = update.alias
             buglist = [b.bug_id for b in update.bugs]
 

--- a/bodhi-server/bodhi/server/models.py
+++ b/bodhi-server/bodhi/server/models.py
@@ -2085,8 +2085,6 @@ class Update(Base):
 
         log.debug('Set alias for %s to %s' % (self.get_title(), alias))
 
-        self._ready_for_testing(self, None)
-
     @property
     def version_hash(self):
         """
@@ -2547,7 +2545,6 @@ class Update(Base):
         """
         db = request.db
         user = User.get(request.identity.name)
-        data['user'] = user
         caveats = []
         try:
             data['critpath_groups'] = cls.get_critpath_groups(
@@ -2574,9 +2571,12 @@ class Update(Base):
                     db.add(bug)
                     db.flush()
                 bugs.append(bug)
-        data['bugs'] = bugs
 
         del data['edited']
+        # Avoid sqlalchemy warnings about adding relationships before the Update is in session
+        data.pop("bugs", None)
+        builds = data.pop("builds", None)
+        data.pop("user", None)
 
         req = data.pop("request", UpdateRequest.testing)
 
@@ -2591,7 +2591,15 @@ class Update(Base):
             data['stable_days'] = 0
             log.debug("Overriding autotime settings for rawhide update.")
 
+        # Add the update to session
         up = Update(**data, release=release)
+        log.debug(f"Adding new update to the db {up.alias}.")
+        db.add(up)
+
+        # Now add relationships
+        up.user = user
+        up.bugs = bugs
+        up.builds = builds
 
         # We want to make sure that the value of stable_days
         # will not be lower than the mandatory_days_in_testing.
@@ -2613,8 +2621,8 @@ class Update(Base):
                                f"release value of {up.min_karma}"
             })
 
-        log.debug(f"Adding new update to the db {up.alias}.")
-        db.add(up)
+        cls._ready_for_testing(up, None)
+
         log.debug(f"Triggering db commit for new update {up.alias}.")
         db.commit()
 
@@ -4251,7 +4259,7 @@ class Update(Base):
         """
         if old == NEVER_SET:
             # This is the object initialization phase. This instance is not ready, don't create
-            # the message now. This method will be called again at the end of __init__
+            # the message now. This method will be called again after the update is created
             return
         if target.content_type != ContentType.rpm:
             return

--- a/bodhi-server/tests/services/test_updates.py
+++ b/bodhi-server/tests/services/test_updates.py
@@ -5369,12 +5369,13 @@ class TestUpdatesService(BasePyTestCase):
                         request=UpdateRequest.testing, notes='second update',
                         user=update.user, release=update.release,
                         stable_karma=3, unstable_karma=-3)
+        self.db.add(update)
+        Update._ready_for_testing(update, None)
         update.comment(self.db, "foo1", 1, 'foo1')
         update.comment(self.db, "foo2", 1, 'foo2')
         # this is triggering a karma-autopush to get the newer update pushed stable
         with fml_testing.mock_sends(api.Message, api.Message, api.Message, api.Message):
             update.comment(self.db, "foo3", 1, 'foo3')
-        self.db.add(update)
         # Let's clear any messages that might get sent
         self.db.info['messages'] = []
 

--- a/news/PR5840.bug
+++ b/news/PR5840.bug
@@ -1,0 +1,1 @@
+When creating a new Update, do not add relationships before the Update object is in session. Fixes some SQLAlchemy 2.x warnings.


### PR DESCRIPTION
In production I have been seeing SQLAlchemy warnings like:
```
2025-01-06 08:12:34,735 INFO [bodhi.server][ThreadPoolExecutor-0_0] Creating new update: [<RpmBuild {'nvr': 'perl-Net-OAuth-0.30-1.el10_0', 'signed': False, 'release_id': 83, 'type': 'rpm', 'epoch': 0}>]
2025-01-06 08:12:34,736 WARNI [bodhi.server][ThreadPoolExecutor-0_0] No JSON file found for collection epel10
/usr/lib/python3.12/site-packages/bodhi/server/models.py:2134: SAWarning: Object of type <Update> not in session, add operation along 'User.updates' will not proceed (This warning originated from the Session 'autoflush' process, which was invoked automatically in response to a user-initiated operation.)
u = Update.query.filter(Update.release_id == release.id, Update.id != self.id).first()
/usr/lib/python3.12/site-packages/bodhi/server/models.py:2134: SAWarning: Object of type <Update> not in session, add operation along 'Bug.updates' won't proceed (This warning originated from the Session 'autoflush' process, which was invoked automatically in response to a user-initiated operation.)
u = Update.query.filter(Update.release_id == release.id, Update.id != self.id).first()
/usr/lib/python3.12/site-packages/bodhi/server/models.py:2134: SAWarning: Object of type <Update> not in session, add operation along 'Build.update' won't proceed (This warning originated from the Session 'autoflush' process, which was invoked automatically in response to a user-initiated operation.)
u = Update.query.filter(Update.release_id == release.id, Update.id != self.id).first()
2025-01-06 08:12:35,042 INFO [bodhi.server][ThreadPoolExecutor-0_0] Deferring working on bugs and fetching test cases to celery
```

This seems to happen for updates with bugs.
With this PR I'll try to add the relationships only after the update is added to the session. The tests seems happy with this, so let's try...