### PR TITLE
Apply correct tags upon signing rawhide updates

### DIFF
--- a/bodhi-server/bodhi/server/consumers/signed.py
+++ b/bodhi-server/bodhi/server/consumers/signed.py
@@ -130,6 +130,9 @@ class SignedHandler(object):
                 log.info("Every build in update is signed, set status to testing")
 
                 build.update.status = UpdateStatus.testing
+                from_tag = build.update.release.pending_testing_tag
+                to_tag = build.update.release.testing_tag
+                build.update.move_tags(from_tag, to_tag)
                 build.update.date_testing = func.current_timestamp()
                 build.update.request = None
                 build.update.pushed = True

--- a/bodhi-server/bodhi/server/models.py
+++ b/bodhi-server/bodhi/server/models.py
@@ -3375,6 +3375,26 @@ class Update(Base):
             koji.tagBuild(tag, build.nvr, force=True)
         return koji.multiCall()
 
+    def move_tags(self, from_tag, to_tag):
+        """
+        Move all :class:`Builds <Build>` in this update netween koji tags.
+
+        Args:
+            from_tag (str): The tag to be removed to the builds.
+            to_tag (str): The tag to be added to the builds.
+        """
+        log.debug(f'Moving tags from {from_tag} to {to_tag} for {self.title}')
+        if any([not from_tag, not to_tag]):
+            log.warning(f"Not moving builds of {self.title} because of empty tag: "
+                        f"from {from_tag} to {to_tag}")
+            return []  # An empty iterator in place of koji multicall
+
+        koji = buildsys.get_session()
+        koji.multicall = True
+        for build in self.builds:
+            koji.moveBuild(from_tag, to_tag, build.nvr, force=True)
+        return koji.multiCall()
+
     def remove_tag(self, tag, koji=None):
         """
         Remove the given koji tag from all builds in this update.

--- a/bodhi-server/tests/test_models.py
+++ b/bodhi-server/tests/test_models.py
@@ -3669,6 +3669,18 @@ class TestUpdate(ModelTest):
             self.obj.last_modified
         assert 'Update has no timestamps set:' in str(exc.value)
 
+    @pytest.mark.parametrize("from_tag,to_tag", [("f17-pending-testing", ""),
+                                                 ("", "f17-testing")])
+    @mock.patch('bodhi.server.models.log.warning')
+    def test_move_tags_emptystring(self, warning, from_tag, to_tag):
+        """Test move_tags() with a tag of ''."""
+        assert self.obj.move_tags(from_tag, to_tag) == []
+
+        warning.assert_called_once_with(
+            f"Not moving builds of {self.obj.title} because of empty tag: "
+            f"from {from_tag} to {to_tag}"
+        )
+
     @mock.patch('bodhi.server.models.log.warning')
     def test_remove_tag_emptystring(self, warning):
         """Test remove_tag() with a tag of ''."""

--- a/news/5830.bug
+++ b/news/5830.bug
@@ -1,0 +1,1 @@
+Builds for rawhide or branched updates are now moved from pending-testing to testing tag when the update is moved into testing. Despite being pointless, this ensure to not break update flow when a release enters Bodhi activation point


### PR DESCRIPTION
I believe moving rawhide/branched builds from pending_testing to testing tag could solve stuck updates after bodhi activation point and fix #5830 

This would introduce some more load on Koji, though, which is usefulness for 99%... but guarantees tags consistency.