### PR TITLE
Fix indicating waived failures when there is no scenario

### DIFF
--- a/bodhi-server/bodhi/server/templates/update.html
+++ b/bodhi-server/bodhi/server/templates/update.html
@@ -957,7 +957,11 @@ ${parent.javascript()}
                         if (!(requirement.subject_identifier in waived)) {
                             waived[requirement.subject_identifier] = {};
                         }
-                        var key = [requirement.testcase, requirement.scenario].join('##');
+                        var scenario = 'no_scenario';
+                        if (requirement.scenario) {
+                            scenario = requirement.scenario;
+                        }
+                        var key = [requirement.testcase, scenario].join('##');
                         waived[requirement.subject_identifier][key] = requirement.waiver_id;
                     }
                 });

--- a/news/PR5863.bug
+++ b/news/PR5863.bug
@@ -1,0 +1,1 @@
+The Automated Tests tab now correctly indicates when a required test failure was waived if the test case has no 'scenario'.


### PR DESCRIPTION
On the Automated Tests tab, when a required test failed but the failure has been waived, we intend to show a thumbs-up icon with a tooltip with details about the waiver. However, if the failed test has no 'scenario', this doesn't work, because there's a hash key mismatch (we store the waiver under key "testcase##null" but look it up under key "testcase##no_scenario").

This should fix that, and mean we correctly note waived failures for Fedora CI results (openQA ones always have a scenario).