### PR TITLE
Update Dockerfiles for integration tests

### DIFF
--- a/devel/ci/integration/greenwave/settings.py
+++ b/devel/ci/integration/greenwave/settings.py
@@ -8,7 +8,7 @@ KOJI_BASE_URL = 'https://koji.fedoraproject.org/kojihub'
 
 SECRET_KEY = 'this-is-only-for-integration-testing'
 WAIVERDB_API_URL = 'http://waiverdb:8080/api/v1.0'
-RESULTSDB_API_URL = 'http://resultsdb/resultsdb/api/v2.0'
+RESULTSDB_API_URL = 'http://resultsdb:5001/api/v2.0'
 CORS_URL = 'https://bodhi'
 CACHE = {
     "backend": "dogpile.cache.memory_pickle",

--- a/devel/ci/integration/ipsilon/Dockerfile
+++ b/devel/ci/integration/ipsilon/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/fedora/fedora:38
+FROM quay.io/fedora/fedora:latest
 # should be specified as hostname:port to listen on a non-standard port
 ARG hostname=id.dev.fedoraproject.org
 # can be a comma-separated list
@@ -22,7 +22,7 @@ RUN ipsilon-server-install --root-instance --secure no --testauth yes --testauth
 #     --subject-alt-name ipsilon.ci \
 #     --subject-alt-name ipsilon
 RUN \
-    dnf -y install openssl && \
+    dnf -y install gawk openssl && \
     cd /root && \
     curl -L -o easyrsa.tgz https://github.com/OpenVPN/easy-rsa/releases/download/v3.2.2/EasyRSA-3.2.2.tgz && \
     tar -xf /root/easyrsa.tgz && \

--- a/devel/ci/integration/rabbitmq/Dockerfile
+++ b/devel/ci/integration/rabbitmq/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/fedora/fedora:38
+FROM quay.io/fedora/fedora:41
 LABEL \
   name="rabbitmq" \
   vendor="Fedora Infrastructure" \

--- a/devel/ci/integration/resultsdb/Dockerfile
+++ b/devel/ci/integration/resultsdb/Dockerfile
@@ -1,22 +1,11 @@
-FROM quay.io/fedora/fedora:37
+FROM quay.io/factory2/resultsdb:prod-fedora
 LABEL \
   name="resultsdb" \
   vendor="Fedora Infrastructure" \
-  maintainer="Aurelien Bompard <abompard@fedoraproject.org>" \
+  maintainer="Mattia Verga <mattia@fedoraproject.org>" \
   license="MIT"
-
-# Install deps
-RUN dnf install -y \
-    httpd \
-    python3-mod_wsgi \
-    resultsdb \
-    python3-psycopg2 \
-    python3-fedora-messaging
 
 # Configuration
 COPY devel/ci/integration/resultsdb/settings.py /etc/resultsdb/settings.py
-COPY devel/ci/integration/resultsdb/httpd.conf /etc/httpd/conf.d/resultsdb.conf
 COPY devel/ci/integration/resultsdb/fedora-messaging.toml /etc/fedora-messaging/config.toml
 
-EXPOSE 80
-CMD ["/usr/sbin/httpd", "-DFOREGROUND"]

--- a/devel/ci/integration/resultsdb/settings.py
+++ b/devel/ci/integration/resultsdb/settings.py
@@ -1,5 +1,7 @@
 SECRET_KEY = 'this-is-only-for-integration-testing'
 SQLALCHEMY_DATABASE_URI = 'postgresql+psycopg2://resultsdb@db/resultsdb'
+HOST = '0.0.0.0'
+PORT = 5001
 FILE_LOGGING = False
 LOGFILE = '/var/log/resultsdb/resultsdb.log'
 SYSLOG_LOGGING = False

--- a/devel/ci/integration/tests/fixtures/resultsdb.py
+++ b/devel/ci/integration/tests/fixtures/resultsdb.py
@@ -50,8 +50,8 @@ def resultsdb_container(docker_backend, docker_network, db_container, rabbitmq_c
     container = image.run_via_binary(additional_opts=run_opts)
     container.start()
     # Add sample data in the database
-    container.execute(["resultsdb", "init_db"])
+    container.execute(["/venv/bin/resultsdb", "init_db"])
     # we need to wait for the webserver to start serving
-    container.wait_for_port(80, timeout=30)
+    container.wait_for_port(5001, timeout=30)
     yield container
     stop_and_delete(container)

--- a/devel/ci/integration/waiverdb/settings.py
+++ b/devel/ci/integration/waiverdb/settings.py
@@ -1,6 +1,6 @@
 DATABASE_URI = 'postgresql+psycopg2://waiverdb@db:5432/waiverdb'
 SECRET_KEY = 'this-is-only-for-integration-testing'
-RESULTSDB_API_URL = 'https://resultsdb:8080/api/v2.0'
+RESULTSDB_API_URL = 'http://resultsdb:5001/api/v2.0'
 CORS_URL = 'https://bodhi'
 
 # TODO: integration testing of published fedmsgs?


### PR DESCRIPTION
Upgrading:
- ipsilon to `fedora:latest`
- rabbitmq to `fedora:41`
- resultsdb to `quay.io/factory2/resultsdb:prod-fedora`

I had to pin rabbitmq to Fedora 41 because starting with Fedora 42 (or because rabbitmq in F42 has been upgraded to v4.0) it doesn't work right: https://bugzilla.redhat.com/show_bug.cgi?id=2362450

Resultsdb is not packaged anymore in Fedora, so we should just use upstream.
