### PR TITLE
Integration tests: use EasyRSA instead of sscg for now

### DIFF
--- a/bodhi-client/bodhi/client/cli.py
+++ b/bodhi-client/bodhi/client/cli.py
@@ -474,7 +474,7 @@ def new(url: str, id_provider: str, client_id: str, debug: bool, **kwargs):
         except bindings.BodhiClientException as e:
             click.echo(str(e), err=True)
         except Exception:
-            traceback.print_exc()
+            click.echo(traceback.format_exc(), err=True)
 
 
 def _validate_edit_update(

--- a/devel/ci/integration/ipsilon/Dockerfile
+++ b/devel/ci/integration/ipsilon/Dockerfile
@@ -14,13 +14,27 @@ RUN git clone https://pagure.io/fedora-infra/ipsilon-fedora.git /opt/ipsilon-fed
     && cd /opt/ipsilon-fedora \
     && ./install.sh
 RUN ipsilon-server-install --root-instance --secure no --testauth yes --testauth-groups "fedora-contributors,packager" --openid yes --openidc yes --hostname $hostname --openid-extensions "insecureAPI,Teams,CLAs,Simple Registration" --openidc-extensions "fedora-account,waiverdb" --openidc-default-attribute-mapping '[["*", "*"], ["_groups", "groups"], [["_extras", "cla"], "cla"], ["fullname", "name"], ["_username", "nickname"], ["_username", "preferred_username"], ["fasIRCNick", "ircnick"], ["fasLocale", "locale"], ["fasTimeZone", "zoneinfo"], ["fasTimeZone", "timezone"], ["fasWebsiteURL", "website"], ["fasGPGKeyId", "gpg_keyid"], ["ipaSshPubKey", "ssh_key"], ["fasIsPrivate", "privacy"], ["fullname", "human_name"]]'
-RUN sscg \
-    --ca-file /etc/pki/tls/certs/localhost-ca.crt \
-    --cert-file /etc/pki/tls/certs/localhost.crt \
-    --cert-key-file /etc/pki/tls/private/localhost.key \
-    --hostname $hostname \
-    --subject-alt-name ipsilon.ci \
-    --subject-alt-name ipsilon
+# RUN sscg \
+#     --ca-file /etc/pki/tls/certs/localhost-ca.crt \
+#     --cert-file /etc/pki/tls/certs/localhost.crt \
+#     --cert-key-file /etc/pki/tls/private/localhost.key \
+#     --hostname $hostname \
+#     --subject-alt-name ipsilon.ci \
+#     --subject-alt-name ipsilon
+RUN \
+    dnf -y install openssl && \
+    cd /root && \
+    curl -L -o easyrsa.tgz https://github.com/OpenVPN/easy-rsa/releases/download/v3.2.2/EasyRSA-3.2.2.tgz && \
+    tar -xf /root/easyrsa.tgz && \
+    mv EasyRSA* easyrsa && \
+    cd easyrsa && \
+    ./easyrsa init-pki && \
+    ./easyrsa --batch --bc-crit build-ca nopass && \
+    ./easyrsa --batch --bc-crit --san=DNS:ipsilon.ci --san=DNS:ipsilon --san=DNS:id.dev.fedoraproject.org build-server-full id.dev.fedoraproject.org nopass && \
+    cp ./pki/ca.crt /etc/pki/tls/certs/localhost-ca.crt && \
+    cp ./pki/issued/id.dev.fedoraproject.org.crt /etc/pki/tls/certs/localhost.crt && \
+    cp ./pki/private/id.dev.fedoraproject.org.key /etc/pki/tls/private/localhost.key && \
+    chmod 644 /etc/pki/tls/certs/localhost-ca.crt /etc/pki/tls/certs/localhost.crt
 COPY devel/ci/integration/ipsilon/setup-bodhi.py.tmpl /tmp/setup-bodhi.py.tmpl
 RUN sed -e "s|##REDIRECT##|$redirect|g" -e "s,##CLIENTURI##,$clienturi,g" /tmp/setup-bodhi.py.tmpl > /usr/local/bin/setup-bodhi.py && chmod ugo+x /usr/local/bin/setup-bodhi.py
 RUN python3 /usr/local/bin/setup-bodhi.py


### PR DESCRIPTION
This lets us set the critical flag on the CA's `basicConstraints`, which is necessary for Rawhide's Python.

Fixes: #5888 