### PR TITLE
Set waitress lower release bound to v3.0.1

### DIFF
--- a/bodhi-server/pyproject.toml
+++ b/bodhi-server/pyproject.toml
@@ -113,7 +113,7 @@ python-bugzilla = ">=3.2.0"
 PyYAML = ">=5.4.1"
 requests = ">=2.25.1"
 SQLAlchemy = ">=1.4, <2.1"
-waitress = ">=1.4.4"
+waitress = "^3.0.1"
 zstandard = "^0.21 || ^0.22.0 || ^0.23.0"
 
 [tool.pytest.ini_options]

--- a/news/PR5897.dependency
+++ b/news/PR5897.dependency
@@ -1,0 +1,1 @@
+bodhi-server: dependency on waitress now requires a version greater than 3.0.1


### PR DESCRIPTION
Addresses a couple of critical warnings raised by dependabot about CVEs on old waitress releases.