### PR TITLE
Frontend update page: notice all waivers, not just failures, show waived missing results in the results table, fix required test identification

### DIFF
--- a/bodhi-server/bodhi/server/templates/update.html
+++ b/bodhi-server/bodhi/server/templates/update.html
@@ -814,7 +814,7 @@ ${parent.javascript()}
     var builds = ${update.builds_json | n};
 
     // These are the required tests (from greenwave)
-    var requirements = [];
+    var requirements = {};
     // These are the known waivers of failed testcases (key - waiver id, value - waiver)
     var waivers = {};
     // These are waived test failures (key - subject, value - hash: key - testcase##scenario, value - waiver id)
@@ -844,6 +844,15 @@ ${parent.javascript()}
         }
     }
 
+    var add_to_requirements = function(subject, key) {
+        if (!(subject in requirements)) {
+            requirements[subject] = [];
+        }
+        if ($.inArray(key, requirements[subject]) == -1) {
+            requirements[subject].push(key);
+        }
+    }
+
     // handle Greenwave decision
     var handle_unsatisfied_requirements = function(data) {
         $.each(data['unsatisfied_requirements'], function(i, requirement) {
@@ -862,9 +871,12 @@ ${parent.javascript()}
                 if (requirement.type == 'failed-fetch-gating-yaml')
                     failed_fetch_gating_repos.push(requirement.subject_identifier);
             }
-            if ($.inArray(requirement.testcase, requirements) == -1) {
-                requirements.push(requirement.testcase);
+            var scenario = 'no_scenario';
+            if (requirement.scenario) {
+                scenario = requirement.scenario;
             }
+            var key = [requirement.testcase, scenario].join('##');
+            add_to_requirements(requirement.subject_identifier, key);
             $('#failed_requirements').append('<li class="list-group-item">' + requirement.testcase + '</li>');
 
             // there is at least one unsatisfied requirement, so show the button to be able to waive.
@@ -953,22 +965,20 @@ ${parent.javascript()}
                 });
                 handle_unsatisfied_requirements(data);
                 $.each(data['satisfied_requirements'], function(i, requirement) {
+                    var scenario = 'no_scenario';
+                    if (requirement.scenario) {
+                        scenario = requirement.scenario;
+                    }
+                    var key = [requirement.testcase, scenario].join('##');
                     if (requirement.type == 'test-result-missing-waived') {
                         populate_missing_result(requirement);
                     }
-                    if ($.inArray(requirement.testcase, requirements) == -1) {
-                        requirements.push(requirement.testcase);
-                    }
+                    add_to_requirements(requirement.subject_identifier, key);
                     // stash data about waived non-passes
                     if (requirement.type.endsWith("-waived")) {
                         if (!(requirement.subject_identifier in waived)) {
                             waived[requirement.subject_identifier] = {};
                         }
-                        var scenario = 'no_scenario';
-                        if (requirement.scenario) {
-                            scenario = requirement.scenario;
-                        }
-                        var key = [requirement.testcase, scenario].join('##');
                         waived[requirement.subject_identifier][key] = requirement.waiver_id;
                     }
                 });
@@ -1010,7 +1020,7 @@ ${parent.javascript()}
           'title="' + reason + '" ' +
           'class="fa fa-thumbs-up">' +
           '</span>';
-      } else if ($.inArray(testcase, requirements) != -1) {
+      } else if (subject in requirements && $.inArray(key, requirements[subject]) != -1) {
         required = '<span data-bs-toggle="tooltip" data-placement="top" ' +
           'title="' + testcase + ' is a required test" ' +
           'class="fa fa-asterisk">' +

--- a/bodhi-server/bodhi/server/templates/update.html
+++ b/bodhi-server/bodhi/server/templates/update.html
@@ -952,8 +952,8 @@ ${parent.javascript()}
                     if ($.inArray(requirement.testcase, requirements) == -1) {
                         requirements.push(requirement.testcase);
                     }
-                    // stash data about waived failures
-                    if (requirement.type == "test-result-failed-waived") {
+                    // stash data about waived non-passes
+                    if (requirement.type.endsWith("-waived")) {
                         if (!(requirement.subject_identifier in waived)) {
                             waived[requirement.subject_identifier] = {};
                         }

--- a/bodhi-server/bodhi/server/templates/update.html
+++ b/bodhi-server/bodhi/server/templates/update.html
@@ -832,20 +832,24 @@ ${parent.javascript()}
     var running_reqs_counter = 0;
     var greenwave_errors = 0;
 
+    var populate_missing_result = function(requirement) {
+        if (requirement.result_id) {
+            running_reqs_counter++;
+        }
+        else {
+            missing_reqs_counter++;
+            if (missing_tests[requirement.subject_identifier] === undefined)
+                missing_tests[requirement.subject_identifier] = [];
+            missing_tests[requirement.subject_identifier].push(requirement);
+        }
+    }
+
     // handle Greenwave decision
     var handle_unsatisfied_requirements = function(data) {
         $.each(data['unsatisfied_requirements'], function(i, requirement) {
             unsatisfied_reqs_counter++;
             if (requirement.type == 'test-result-missing') {
-                if (requirement.result_id) {
-                    running_reqs_counter++;
-                }
-                else {
-                    missing_reqs_counter++;
-                    if (missing_tests[requirement.subject_identifier] === undefined)
-                        missing_tests[requirement.subject_identifier] = [];
-                    missing_tests[requirement.subject_identifier].push(requirement);
-                }
+                populate_missing_result(requirement);
             }
             if (requirement.type.match('gating-yaml')) {
                 remoteerror_reqs_counter++;
@@ -949,6 +953,9 @@ ${parent.javascript()}
                 });
                 handle_unsatisfied_requirements(data);
                 $.each(data['satisfied_requirements'], function(i, requirement) {
+                    if (requirement.type == 'test-result-missing-waived') {
+                        populate_missing_result(requirement);
+                    }
                     if ($.inArray(requirement.testcase, requirements) == -1) {
                         requirements.push(requirement.testcase);
                     }
@@ -1099,16 +1106,17 @@ ${parent.javascript()}
         // show missing tests and remote rule yaml problems first
         if (buildname in missing_tests) {
           $.each(missing_tests[buildname], function(i, result) {
-            // note the data structure is a bit different for
-            // test-result-missing than the other cases we handle at
-            // the end, so getting scenario and subject is a bit
-            // different. why? ask greenwave
+            // note here we're dealing with a greenwave 'requirement'
+            // object from [un]satisfied_requirements, further down
+            // when we handle "results" we're dealing with the
+            // passed-through resultsdb results, they have different
+            // data structures
             var scenario = 'no_scenario';
             if (result.scenario) {
                 scenario = result.scenario;
             }
             table.append(make_row(
-              result.item[0],
+              result.subject_identifier,
               scenario,
               'ABSENT',
               result.testcase,


### PR DESCRIPTION
greenwave has several more requirement types indicating waived results - not just test-result-failed-waived, there's also test-result-missing-waived and test-result-errored-waived. Let's catch all of those too, otherwise things look weird when one of those is waived.

Also, we were not including waived missing results in the Results table, because we weren't looking for them, we were only looking for non-waived missing results. Second commit fixes that.

Also, our identification of "required" tests was too naive, based only on test case name. It needs to also take into consideration the subject and the scenario.