### PR TITLE
Fix test failures with authlib 1.6.2 and mysterious rss feed change

### DIFF
--- a/bodhi-server/tests/auth/test_oauth.py
+++ b/bodhi-server/tests/auth/test_oauth.py
@@ -171,7 +171,10 @@ class TestOAuth2(base.BasePyTestCase):
 
         with mock.patch('requests.sessions.Session.send') as send:
             send.return_value = mock_send_value(get_bearer_token())
-            request2 = testing.DummyRequest(path='/authorize', params={"state": state})
+            request2 = testing.DummyRequest(
+                path='/authorize',
+                params={"state": state, "code": "dummycode"}
+            )
             request2.session = request.session
 
             token = client.authorize_access_token(request2)
@@ -242,7 +245,7 @@ class TestOAuth2(base.BasePyTestCase):
         with mock.patch('requests.sessions.Session.send', fake_send):
             request2 = testing.DummyRequest(
                 path="/authorize",
-                params={"state": state}
+                params={"state": state, "code": "dummycode"}
             )
             request2.session = request.session
             token = client.authorize_access_token(request2)
@@ -276,7 +279,7 @@ class TestOAuth2(base.BasePyTestCase):
 
             request2 = testing.DummyRequest(
                 path='/authorize',
-                params={"state": state},
+                params={"state": state, "code": "dummycode"},
             )
             request2.session = request.session
 

--- a/bodhi-server/tests/auth/test_views.py
+++ b/bodhi-server/tests/auth/test_views.py
@@ -54,7 +54,10 @@ class TestOIDCLoginViews(base.BasePyTestCase):
 
     def test_authorize(self):
         """Test a user logging in."""
-        request = testing.DummyRequest(path="/oidc/authorize", params={"state": "STATE"})
+        request = testing.DummyRequest(
+            path="/oidc/authorize",
+            params={"state": "STATE", "code": "CODE"}
+        )
         set_session_data(request.session, "STATE", "state", "STATE", app_name="fedora")
         request.registry = self.registry
         request.db = self.db
@@ -76,7 +79,10 @@ class TestOIDCLoginViews(base.BasePyTestCase):
         user.groups = [models.Group(name="testgroup1"), models.Group(name="testgroup2")]
         self.db.commit()
 
-        request = testing.DummyRequest(path="/oidc/authorize", params={"state": "STATE"})
+        request = testing.DummyRequest(
+            path="/oidc/authorize",
+            params={"state": "STATE", "code": "CODE"}
+        )
         set_session_data(request.session, "STATE", "state", "STATE", app_name="fedora")
         request.registry = self.registry
         request.db = self.db

--- a/devel/ci/integration/tests/test_bodhi.py
+++ b/devel/ci/integration/tests/test_bodhi.py
@@ -885,7 +885,7 @@ def test_get_overrides_rss(bodhi_container, db_container):
             {
                 "tag": "link",
                 "attrib": {},
-                "text": f"http://{bodhi_ip}:8080/overrides/{quote(override['nvr'])}"
+                "text": f"http://{bodhi_ip}:8080/overrides/{quote(override['nvr'], safe='/+')}"
             },
             {"tag": "description", "attrib": {}, "text": override["notes"]},
             {"tag": "pubDate", "attrib": {}, "text": override["submission_date"]},


### PR DESCRIPTION
The authlib test failures are probably caused by this change in authlib:
https://github.com/authlib/authlib/commit/a4a9792bf371c7b1d2738bd0c9edda76b66eed41
in our tests, `code` was present in `kwargs` when checked but its value was
`None` (a default value set along the way); with the previous authlib code this was incorrectly
allowed, but now it is correctly rejected.

Somebody more familiar with OAuth should check this, but I *think*
it's correct to just fake the value. Looking at
https://docs.authlib.org/en/latest/client/oauth2.html , it seems
the code is supposed to be provided by the authorization server.
Once we've generated an authorization URL we're supposed to visit
it and "grant the authorization", and it should
"redirect you back to your site with a code and state arguments".
If I'm following things correctly, we're just faking this step
in the tests - we don't really have an authorization server,
we're just making up a response as if it came from one. So it
should be correct to include a dummy `code` value in the made-up
responses.

test_get_overrides_rss suddenly started failing on F41, F42 *and* Rawhide. The
difference appears to be that the "text" values in the generated
RSS feed are no longer escaped. I cannot figure out why this
changed; there's no obvious difference in the package sets or
pypi downloads between a failed and a succeeded run which would
explain this.

I think it's OK to just accept the new value - I don't think
there is a security issue - but it might be good to get a security
expert to check. I can't think of any reason *why* these fields
needed to be escaped, they're not part of a URI.