### PR TITLE
Make client `updates download` use koji --fallback-unsigned

### DIFF
--- a/bodhi-client/bodhi/client/cli.py
+++ b/bodhi-client/bodhi/client/cli.py
@@ -899,6 +899,7 @@ def download(url: str, id_provider: str, client_id: str, **kwargs):
                     args = ['koji', 'download-build']
                     if keyid:
                         args.append(f'--key={keyid}')
+                        args.append('--fallback-unsigned')
                     if debuginfo:
                         args.append('--debuginfo')
                     # subprocess is icky, but koji module doesn't

--- a/bodhi-client/tests/test_cli.py
+++ b/bodhi-client/tests/test_cli.py
@@ -381,7 +381,7 @@ class TestDownloadGPG:
             text=True
         )
         self.call.assert_called_once_with([
-            'koji', 'download-build', '--key=fdb19c98', '--arch=noarch',
+            'koji', 'download-build', '--key=fdb19c98', '--fallback-unsigned', '--arch=noarch',
             '--arch={}'.format(platform.machine()), 'nodejs-grunt-wrap-0.3.0-2.fc25'])
 
     def test_epel_good(self, mocked_client_class):
@@ -401,7 +401,7 @@ class TestDownloadGPG:
             text=True
         )
         self.call.assert_called_once_with([
-            'koji', 'download-build', '--key=fdb19c98', '--arch=noarch',
+            'koji', 'download-build', '--key=fdb19c98', '--fallback-unsigned', '--arch=noarch',
             '--arch={}'.format(platform.machine()), 'nodejs-grunt-wrap-0.3.0-2.fc25'])
 
     def test_gpg_fails(self, mocked_client_class):
@@ -539,7 +539,7 @@ kRFmBygMR6M/
             text=True
         )
         self.call.assert_called_once_with([
-            'koji', 'download-build', '--key=fdb19c98', '--arch=noarch',
+            'koji', 'download-build', '--key=fdb19c98', '--fallback-unsigned', '--arch=noarch',
             '--arch={}'.format(platform.machine()), 'nodejs-grunt-wrap-0.3.0-2.fc25'])
 
     def test_epel_good_remote(self, mocked_client_class):
@@ -556,7 +556,7 @@ kRFmBygMR6M/
         url += '/raw/epel7/f/RPM-GPG-KEY-EPEL-7'
         self.get.assert_called_once_with(url)
         self.call.assert_called_once_with([
-            'koji', 'download-build', '--key=fdb19c98', '--arch=noarch',
+            'koji', 'download-build', '--key=fdb19c98', '--fallback-unsigned', '--arch=noarch',
             '--arch={}'.format(platform.machine()), 'nodejs-grunt-wrap-0.3.0-2.fc25'])
 
     def test_gpg_noexist_remote(self, mocked_client_class):

--- a/news/PR6039.feature
+++ b/news/PR6039.feature
@@ -1,0 +1,1 @@
+client: when downloading packages use the --fallback-unsigned option to tell Koji to fall back to getting unsigned packages if it can't get signed ones


### PR DESCRIPTION
When we're trying to download signed packages, use the --fallback-unsigned option to tell Koji to fall back to getting unsigned packages if it can't get signed ones. This is just what we used to do anyway, and better than bailing out or downloading nothing at all.

This was always planned as a follow-up to
https://github.com/fedora-infra/bodhi/pull/5859 , but there was a delay in getting a Koji release with the feature. I've now backported the Koji feature to Fedora 42+ and EPEL 10+, so it should be reasonably safe to land this and send an update to the same branches.