### PR TITLE
Update automatically-created update test gating status on creation

### DIFF
--- a/bodhi-server/bodhi/server/consumers/automatic_updates.py
+++ b/bodhi-server/bodhi/server/consumers/automatic_updates.py
@@ -234,5 +234,9 @@ class AutomaticUpdateHandler:
             alias = update.alias
             buglist = [b.bug_id for b in update.bugs]
 
+            # Set an initial gating status
+            if config.get('test_gating.required'):
+                update.update_test_gating_status()
+
         # This must be run after dbsession is closed so changes are committed to db
         work_on_bugs_task.delay(alias, buglist)

--- a/bodhi-server/bodhi/server/consumers/signed.py
+++ b/bodhi-server/bodhi/server/consumers/signed.py
@@ -27,8 +27,7 @@ import logging
 import fedora_messaging
 from sqlalchemy import func
 
-from bodhi.server.config import config
-from bodhi.server.models import Build, UpdateRequest, UpdateStatus, TestGatingStatus
+from bodhi.server.models import Build, UpdateRequest, UpdateStatus
 from bodhi.server.util import transactional_session_maker
 
 log = logging.getLogger('bodhi')
@@ -136,11 +135,5 @@ class SignedHandler(object):
                 build.update.date_testing = func.current_timestamp()
                 build.update.request = None
                 build.update.pushed = True
-
-                if config.get("test_gating.required"):
-                    log.debug('Test gating is required, marking the update as waiting on test '
-                              'gating and updating it from Greenwave to get the real status.')
-                    build.update.test_gating_status = TestGatingStatus.waiting
-                    build.update.update_test_gating_status()
 
                 log.info(f"Update {build.update.alias} status has been set to testing")

--- a/bodhi-server/tests/consumers/test_automatic_updates.py
+++ b/bodhi-server/tests/consumers/test_automatic_updates.py
@@ -77,21 +77,45 @@ class TestAutomaticUpdateHandler(base.BasePyTestCase):
 
     # Test the main code paths.
 
+    @mock.patch.dict(config, [('test_gating.required', True)])
     @pytest.mark.parametrize('critpath', (True, False, "groups"))
     def test_consume(self, critpath, caplog):
         """Assert that messages about tagged builds create an update."""
         caplog.set_level(logging.DEBUG)
 
-        if critpath is True:
-            with mock.patch.dict(config, [('critpath_pkgs', ['colord'])]):
-                self.handler(self.sample_message)
-        elif critpath is False:
-            self.handler(self.sample_message)
-        elif critpath == "groups":
-            with mock.patch.dict(config, [('critpath.type', 'json')]):
-                with mock.patch('bodhi.server.util.read_critpath_json') as fakejson:
-                    fakejson.return_value = {'rpm': {'core': ['colord']}}
+        # mock a typical greenwave response to test initial
+        # gating status
+        with mock.patch('bodhi.server.models.util.greenwave_api_post') as mock_greenwave:
+            greenwave_response = {
+                'policies_satisfied': True,
+                'summary': "1 of 1 required test results missing",
+                'applicable_policies': [
+                    'kojibuild_bodhipush_no_requirements',
+                    'kojibuild_bodhipush_remoterule',
+                    'bodhiupdate_bodhipush_no_requirements',
+                    'bodhiupdate_bodhipush_openqa'
+                ],
+                'satisfied_requirements': [],
+                'unsatisfied_requirements': [
+                    {
+                        'scenario': 'fedora.updates-everything-boot-iso.x86_64.uefi',
+                        'subject_type': 'bodhi_update',
+                        'testcase': 'update.install_default_update_netinst',
+                        'type': 'test-result-missing'
+                    },
+                ]
+            }
+            mock_greenwave.return_value = greenwave_response
+            if critpath is True:
+                with mock.patch.dict(config, [('critpath_pkgs', ['colord'])]):
                     self.handler(self.sample_message)
+            elif critpath is False:
+                self.handler(self.sample_message)
+            elif critpath == "groups":
+                with mock.patch.dict(config, [('critpath.type', 'json')]):
+                    with mock.patch('bodhi.server.util.read_critpath_json') as fakejson:
+                        fakejson.return_value = {'rpm': {'core': ['colord']}}
+                        self.handler(self.sample_message)
 
         # check if the update exists...
         update = self.db.query(Update).join(Build).filter(
@@ -103,7 +127,7 @@ class TestAutomaticUpdateHandler(base.BasePyTestCase):
         assert update.type == UpdateType.newpackage
         assert update.status == UpdateStatus.pending
         assert update.autokarma is False
-        assert update.test_gating_status is None
+        assert update.test_gating_status == TestGatingStatus.waiting
         assert update.builds[0].release == self.release
         if critpath:
             assert update.critpath is True

--- a/bodhi-server/tests/consumers/test_signed.py
+++ b/bodhi-server/tests/consumers/test_signed.py
@@ -23,11 +23,9 @@ from fedora_messaging import api
 from fedora_messaging import testing as fml_testing
 
 from bodhi.messages.schemas import update as update_schemas
-from bodhi.server.config import config
 from bodhi.server.consumers import signed
 from bodhi.server.models import (
     Build,
-    TestGatingStatus,
     Update,
     UpdateRequest,
     UpdateStatus,
@@ -228,7 +226,6 @@ class TestSignedHandlerConsume(base.BasePyTestCase):
         assert build.signed is True
         assert update.status == UpdateStatus.pending
 
-    @mock.patch.dict(config, [('test_gating.required', True)])
     def test_consume_from_tag(self):
         """
         Assert that update created from tag is handled correctly when message
@@ -243,36 +240,13 @@ class TestSignedHandlerConsume(base.BasePyTestCase):
         update.pushed = False
 
         self.db.commit()
-        with mock.patch('bodhi.server.models.util.greenwave_api_post') as mock_greenwave:
-            greenwave_response = {
-                'policies_satisfied': True,
-                'summary': "All required tests passed",
-                'applicable_policies': [
-                    'kojibuild_bodhipush_no_requirements',
-                    'kojibuild_bodhipush_remoterule',
-                    'bodhiupdate_bodhipush_no_requirements',
-                    'bodhiupdate_bodhipush_openqa'
-                ],
-                'satisfied_requirements': [
-                    {
-                        'result_id': 39603316,
-                        'subject_type': 'bodhi_update',
-                        'testcase': 'update.install_default_update_netinst',
-                        'type': 'test-result-passed'
-                    },
-                ],
-                'unsatisfied_requirements': []
-            }
-            mock_greenwave.return_value = greenwave_response
-            self.handler(self.sample_side_tag_message)
+        self.handler(self.sample_side_tag_message)
 
         assert update.builds[0].signed is True
         assert update.builds[0].update.request is None
         assert update.status == UpdateStatus.testing
         assert update.pushed is True
-        assert update.test_gating_status == TestGatingStatus.passed
 
-    @mock.patch.dict(config, [('test_gating.required', True)])
     @mock.patch('bodhi.server.models.work_on_bugs_task', mock.Mock())
     @mock.patch('bodhi.server.models.fetch_test_cases_task', mock.Mock())
     @mock.patch('bodhi.server.models.Update.add_tag')
@@ -294,33 +268,11 @@ class TestSignedHandlerConsume(base.BasePyTestCase):
         update.pushed = False
 
         self.db.commit()
-        with mock.patch('bodhi.server.models.util.greenwave_api_post') as mock_greenwave:
-            greenwave_response = {
-                'policies_satisfied': True,
-                'summary': "All required tests passed",
-                'applicable_policies': [
-                    'kojibuild_bodhipush_no_requirements',
-                    'kojibuild_bodhipush_remoterule',
-                    'bodhiupdate_bodhipush_no_requirements',
-                    'bodhiupdate_bodhipush_openqa'
-                ],
-                'satisfied_requirements': [
-                    {
-                        'result_id': 39603316,
-                        'subject_type': 'bodhi_update',
-                        'testcase': 'update.install_default_update_netinst',
-                        'type': 'test-result-passed'
-                    },
-                ],
-                'unsatisfied_requirements': []
-            }
-            mock_greenwave.return_value = greenwave_response
-            with fml_testing.mock_sends(update_schemas.UpdateRequestTestingV1):
-                self.handler(self.sample_side_tag_message_2)
+        with fml_testing.mock_sends(update_schemas.UpdateRequestTestingV1):
+            self.handler(self.sample_side_tag_message_2)
 
         assert update.builds[0].signed is True
         assert update.builds[0].update.request == UpdateRequest.testing
         assert update.status == UpdateStatus.pending
         assert update.pushed is False
-        assert update.test_gating_status == TestGatingStatus.passed
         add_tag.assert_not_called()

--- a/news/PR6044.bug
+++ b/news/PR6044.bug
@@ -1,0 +1,1 @@
+server: avoid manually setting `TestGatingStatus.waiting` on Update before calling `update_test_gating_status()`


### PR DESCRIPTION
https://github.com/fedora-infra/bodhi/pull/3519 cleaned up the automatic update creation process a lot, but I think introduced a minor bug. It removed the setting of the update gating status at automatic creation time. Instead, the gating status would only be set to something other than `None` when the update was marked as 'testing' (or by any other process which happens to set it in the mean time).

We noticed this in https://github.com/fedora-infra/bodhi/issues/6000#issuecomment-3677952903
At first I was going to just drop the gating status update from SignedHandler, but on closer inspection I think it's actually correct to move it back to AutomaticUpdateHandler so we get an initial gating status immediately upon update creation. Right now it *usually* happens to get updated very quickly anyway - probably in response to a QUEUED test result being created, in most cases - but sometimes it doesn't, e.g. in
https://bodhi.fedoraproject.org/updates/FEDORA-2025-73c49c68e3 the initial gating status was set 36 minutes after the update was created.

We do drop the initial set to waiting before calling update_test_gating_status, because it's pointless and just causes the weird status churn that @mattiaverga noticed.