### PR TITLE
mail: add an X-Bodhi-Agent header

### DIFF
--- a/bodhi-server/bodhi/server/mail.py
+++ b/bodhi-server/bodhi/server/mail.py
@@ -429,6 +429,7 @@ def send(to: typing.Iterable[str], msg_type: str, update: 'Update',
             "X-Bodhi-Update-Title": update.get_title(nvr=True, beautify=True),
             "X-Bodhi-Update-Pushed": update.pushed,
             "X-Bodhi-Update-Submitter": update.user.name,
+            "X-Bodhi-Agent": agent,
         }
         if update.request:
             headers["X-Bodhi-Update-Request"] = update.request.description

--- a/bodhi-server/tests/test_mail.py
+++ b/bodhi-server/tests/test_mail.py
@@ -248,6 +248,7 @@ class TestSend(BasePyTestCase):
         assert sm.mock_calls[0][1][0] == 'updates@fedoraproject.org'
         assert sm.mock_calls[0][1][1] == ['fake@news.com']
         assert b'X-Bodhi-Update-Title: bodhi-2.0-1.fc17' in sm.mock_calls[0][1][2]
+        assert b'X-Bodhi-Agent: bowlofeggs' in sm.mock_calls[0][1][2]
         assert b'Subject: [Fedora Update] [comment] bodhi-2.0-1.fc17' in sm.mock_calls[0][1][2]
 
     @mock.patch.dict('bodhi.server.mail.config', {'smtp_server': 'smtp.example.com'})

--- a/news/PR6065.feature
+++ b/news/PR6065.feature
@@ -1,0 +1,1 @@
+server: added an X-Bodhi-Agent header to emails sent on update comments


### PR DESCRIPTION
This should be useful for filtering out mails caused by your own actions. e.g. I don't want to see notifications about my own comments.