### PR TITLE
Don't send a comment email notification to the comment author

### DIFF
--- a/bodhi-server/bodhi/server/models.py
+++ b/bodhi-server/bodhi/server/models.py
@@ -3733,7 +3733,7 @@ class Update(Base):
             else:
                 people.add(person.name)
         for comment in self.comments:
-            if comment.user.name in ['anonymous', 'bodhi']:
+            if comment.user.name in ['anonymous', 'bodhi', author]:
                 continue
             if comment.user.email:
                 people.add(comment.user.email)

--- a/news/PR6066.feature
+++ b/news/PR6066.feature
@@ -1,0 +1,1 @@
+server: don't send a comment email notification to the comment author


### PR DESCRIPTION
This has bugged me for years. I know I posted a comment. I don't need an email notification about it.