### PR TITLE
Allow querying updates by side tag name

### DIFF
--- a/bodhi-client/bodhi/client/bindings.py
+++ b/bodhi-client/bodhi/client/bindings.py
@@ -440,6 +440,7 @@ class BodhiClient:
             gating (str): filter by TestGatingStatus description.
             from_side_tag (bool): A boolean to filter updates created from side tag or from
                 normal workflow.
+            from_side_tag_name (str): Query for updates created from a certain side tag.
             user (str): Query for updates submitted by a specific user.
             rows_per_page (int): Limit the results to a certain number of rows per page
                 (min:1 max: 100 default: 20).

--- a/bodhi-server/bodhi/server/schemas.py
+++ b/bodhi-server/bodhi/server/schemas.py
@@ -539,6 +539,12 @@ class ListUpdateSchema(PaginatedSchema, SearchableSchema, Cosmetics):
         missing=None,
     )
 
+    from_side_tag_name = colander.SchemaNode(
+        colander.String(),
+        location="querystring",
+        missing=None,
+    )
+
     locked = colander.SchemaNode(
         colander.Boolean(true_choices=('true', '1')),
         location="querystring",

--- a/bodhi-server/bodhi/server/services/updates.py
+++ b/bodhi-server/bodhi/server/services/updates.py
@@ -403,6 +403,10 @@ def query_updates(request):
         else:
             query = query.filter(Update.from_tag.is_(None))
 
+    from_side_tag_name = data.get('from_side_tag_name')
+    if from_side_tag_name is not None:
+        query = query.filter(Update.from_tag == from_side_tag_name)
+
     query = query.order_by(Update.date_submitted.desc())
 
     # We can't use ``query.count()`` here because it is naive with respect to

--- a/bodhi-server/tests/services/test_updates.py
+++ b/bodhi-server/tests/services/test_updates.py
@@ -3081,6 +3081,33 @@ class TestUpdatesService(BasePyTestCase):
         assert up['alias'] == f'FEDORA-{YEAR}-a3bbe1a8f2'
         assert up['karma'] == 1
 
+    def test_list_updates_by_from_side_tag_name(self):
+        up = self.db.query(Build).filter_by(nvr='bodhi-2.0-1.fc17').one().update
+        up.from_tag = 'f33-side-tag'
+        self.db.commit()
+        res = self.app.get('/updates/', {"from_side_tag_name": "f33-side-tag"})
+        body = res.json_body
+        assert len(body['updates']) == 1
+
+        up = body['updates'][0]
+        assert up['title'] == 'bodhi-2.0-1.fc17'
+        assert up['status'] == 'pending'
+        assert up['request'] == 'testing'
+        assert up['user']['name'] == 'guest'
+        assert up['release']['name'] == 'F17'
+        assert up['type'] == 'bugfix'
+        assert up['severity'] == 'medium'
+        assert up['suggest'] == 'unspecified'
+        assert up['close_bugs'] is True
+        assert up['notes'] == 'Useful details!'
+        assert up['date_submitted'] == '1984-11-02 00:00:00'
+        assert up['date_modified'] is None
+        assert up['date_approved'] is None
+        assert up['date_pushed'] is None
+        assert up['locked'] is False
+        assert up['alias'] == f'FEDORA-{YEAR}-a3bbe1a8f2'
+        assert up['karma'] == 1
+
     def test_list_updates_by_multiple_usernames(self):
         another_user = User(name='aUser')
         self.db.add(another_user)

--- a/news/PR6078.feature
+++ b/news/PR6078.feature
@@ -1,0 +1,1 @@
+Bodhi query API now allows to query updates by Koji side tag name


### PR DESCRIPTION
Packit allows to automate creating multi-package updates by using side tags. However, since the lifecycle of a side tag doesn't necessarily correspond to the lifecycle of the update created from it, it is necessary for Packit, as side tag creator, to be able to query updates corresponding to a particular side tag so that it can act accordingly when an update has been obsoleted or unpushed.

In order not to break existing API, this commit adds a new field, `from_side_tag_name`, that allows to query for updates created from the specified side tag.

Alternatively, the existing `from_side_tag` field could be adjusted to accept both a boolean value and a string, but I'm not sure that's such a good idea.