### PR TITLE
update.html: tweak Automated Results table colors

### DIFF
--- a/bodhi-server/bodhi/server/templates/update.html
+++ b/bodhi-server/bodhi/server/templates/update.html
@@ -791,11 +791,11 @@ ${parent.javascript()}
     // Some handy lookups that map resultsdb states to bootstrap CSS classes.
     var classes = {
       PASSED: 'success',
-      INFO: 'info',
+      INFO: 'warning',
       FAILED: 'danger',
       NEEDS_INSPECTION: 'warning',
-      ABORTED: 'warning',
-      CRASHED: 'warning',
+      ABORTED: 'danger',
+      CRASHED: 'danger',
       ABSENT: 'danger',
       QUEUED: 'info',
       RUNNING: 'info',


### PR DESCRIPTION
The row colors in the Automated Results table are awkward because we have 9 known states but bootstrap only gives us 4 colored classes - success (green), danger (red), warning (orange), info (blue). But I think we can improve the mapping.

The most common states are QUEUED/RUNNING, INFO (which is used for openQA soft failures), FAILED and PASSED. But right now we use the info class for both INFO and QUEUED/RUNNING, so very often we have two somewhat different types of result both shown in blue.

Let's tweak that so we use warning (orange) for INFO. I'd prefer something like "light green" but we don't have that choice.

Let's also use danger (red) for both ABORTED and CRASHED, because both are effectively failures. It's especially important not to use warning now we're using it for INFO, because INFO is not a failure state.