### PR TITLE
Update page: Rebalance main columns

### DIFF
--- a/bodhi-server/bodhi/server/templates/update.html
+++ b/bodhi-server/bodhi/server/templates/update.html
@@ -164,7 +164,7 @@ elif can_edit and update.status.value == 'testing' and update.test_gating_status
   <div class="tab-content" id="updateTabContent">
     <div class="tab-pane show active" id="details-tab-pane" role="tabpanel" aria-labelledby="details-tab" tabindex="0">
       <div class="row">
-        <div class="col-md-9">
+        <div class="col-md-8 col-l-9">
 
           % if update.notes:
           ${self.util.markup(update.notes) | n}
@@ -325,7 +325,7 @@ elif can_edit and update.status.value == 'testing' and update.test_gating_status
           </div>
           %endif
         </div>
-        <div class="col-md-3 font-size-09">
+        <div class="col-md-4 col-l-3 font-size-09">
             <div>
               % if update.release.state == models.ReleaseState.frozen and (update.status == models.UpdateStatus.pending or update.status == models.UpdateStatus.testing):
               <div class="card border-info mb-1">


### PR DESCRIPTION
The two columns of the update page were sized `col-md-9` and `col-md-3`
(a 75/25 split), which made for ugly wrapping as the right column
squashed too narrow, at lower page widths.

To compensate, make the left column `col-md-8 col-lg-9`, and the right
column `col-md-4 col-lg-3`. That way, the right column will be given
slightly more of the total space when the page width is in the 'medium'
range (but go back to 25% once the width is 'large' or greater).

All of these screenshots are taken at the full 1920px screen width, for comparison purposes.

## Before, medium-breakpoint width

<img width="1920" height="1079" alt="Screenshot From 2026-03-25 04-32-45" src="https://github.com/user-attachments/assets/bba6775d-0b30-47ff-a6ee-5fc3cdef949f" />

## After, medium-breakpoint width

This is the only size actually affected by this change, and gives the right-hand column a bit more room to avoid the ugly wrapping (particularly the "Dates" section) seen in the previous image.

<img width="1920" height="1079" alt="Screenshot From 2026-03-25 04-35-28" src="https://github.com/user-attachments/assets/2b2023b7-0d85-4bce-a9f8-80646e015d5d" />


## Before, other sizes

<img width="1920" height="1079" alt="Screenshot From 2026-03-25 04-32-25" src="https://github.com/user-attachments/assets/e37db01a-6394-420b-a369-37172e8ffdc5" />
<img width="1920" height="1079" alt="Screenshot From 2026-03-25 04-32-34" src="https://github.com/user-attachments/assets/cde770d8-4649-4ed1-8c24-dbc7e5b30a05" />
<img width="1920" height="1079" alt="Screenshot From 2026-03-25 04-33-04" src="https://github.com/user-attachments/assets/23a7b16e-39ee-49e0-b457-03e013abbcf7" />

## After, other sizes (no meaningful differences)

<img width="1920" height="1079" alt="Screenshot From 2026-03-25 04-35-07" src="https://github.com/user-attachments/assets/df33bbf2-6363-48a7-bbac-5442ec3f66ef" />
<img width="1920" height="1079" alt="Screenshot From 2026-03-25 04-35-18" src="https://github.com/user-attachments/assets/41210da4-2c3e-48be-822e-8ee11998b975" />
<img width="1920" height="1079" alt="Screenshot From 2026-03-25 04-35-46" src="https://github.com/user-attachments/assets/8d0edd27-001e-4730-b962-52ea0816ba32" />
