### PR TITLE
Have 'ongoing freeze' text note that blockers/FEs may be pushed sooner

### DIFF
--- a/bodhi-server/bodhi/server/models.py
+++ b/bodhi-server/bodhi/server/models.py
@@ -3288,7 +3288,9 @@ class Update(Base):
         if self.release.state == ReleaseState.frozen and action == UpdateRequest.stable:
             comment_text += (
                 "\n\nThere is an ongoing freeze; this will be "
-                "pushed to stable after the freeze is over. "
+                "pushed to stable after the freeze is over, or "
+                "possibly sooner if a bug it fixes is an accepted "
+                "blocker or freeze exception. "
             )
         self.comment(db, comment_text, author=u'bodhi')
 

--- a/bodhi-server/bodhi/server/services/releases.py
+++ b/bodhi-server/bodhi/server/services/releases.py
@@ -454,7 +454,9 @@ def save_release(request):
                         u.comment(
                             request.db,
                             'There is an ongoing freeze; this will be pushed to'
-                            ' stable after the freeze is over.',
+                            ' stable after the freeze is over, or possibly'
+                            ' sooner if a bug it fixes is an accepted blocker'
+                            ' or freeze exception.',
                             author='bodhi',
                         )
                 setattr(r, k, v)

--- a/bodhi-server/tests/services/test_releases.py
+++ b/bodhi-server/tests/services/test_releases.py
@@ -517,7 +517,9 @@ class TestReleasesService(base.BasePyTestCase):
         python_test_update = self.db.query(Build).filter_by(
             nvr='python-test-update.fc22').one().update
         expected_comment = ('There is an ongoing freeze; this will be pushed to'
-                            ' stable after the freeze is over.')
+                            ' stable after the freeze is over, or possibly'
+                            ' sooner if a bug it fixes is an accepted blocker'
+                            ' or freeze exception.')
         assert python_test_update.comments[-1].text == expected_comment
 
     def test_get_single_release_html(self):

--- a/bodhi-server/tests/test_models.py
+++ b/bodhi-server/tests/test_models.py
@@ -4032,7 +4032,9 @@ class TestUpdate(ModelTest):
 
         # Check for information about frozen release in comment
         expected_info = ("There is an ongoing freeze; "
-                         "this will be pushed to stable after the freeze is over.")
+                         "this will be pushed to stable after the freeze is over, "
+                         "or possibly sooner if a bug it fixes is an accepted "
+                         "blocker or freeze exception.")
         assert expected_info in self.obj.comments[-1].text
 
     def test_set_request_stable_epel_requirements_not_met(self):


### PR DESCRIPTION
The "this will be pushed to stable after the freeze is over" text didn't take into account that an update might be pushed stable sooner if it fixes a blocker or FE.