### PR TITLE
Change greenwave product_version for ELN from fedora-eln to eln

### DIFF
--- a/bodhi-server/bodhi/server/models.py
+++ b/bodhi-server/bodhi/server/models.py
@@ -3874,7 +3874,12 @@ class Update(Base):
         Returns:
             str: The product version associated with this Update's Release.
         """
-        return self.release.long_name.lower().replace(' ', '-')
+        ret = self.release.long_name.lower().replace(' ', '-')
+        if ret == "fedora-eln":
+            # We call ELN something else so that "fedora-*" policies
+            # do not apply to it
+            ret = "eln"
+        return ret
 
     def check_requirements(self, session, settings):
         """

--- a/bodhi-server/tests/test_models.py
+++ b/bodhi-server/tests/test_models.py
@@ -3139,6 +3139,11 @@ class TestUpdate(ModelTest):
             ]
         )
 
+    def test_product_version_eln(self):
+        """Check the special product_version for ELN works."""
+        self.obj.release.long_name = "Fedora ELN"
+        assert self.obj.product_version == "eln"
+
     def test_mandatory_days_in_testing_critpath(self):
         """
         The Update.mandatory_days_in_testing method should be the configured value


### PR DESCRIPTION
Right now, almost all per-package gating policies specify the product_version as "fedora-*". This matches "fedora-eln", which is what Bodhi currently uses as the Greenwave product_version for ELN.

However, in the site-wide greenwave config, we do not currently apply the RemoteRule policy to ELN, so none of those policies actually applies to ELN updates as things stand.

We want to gate ELN kernels on openQA tests, via gating.yaml, but because RemoteRule is not applied to ELN it doesn't work. However, if we start applying the RemoteRule policy to "fedora-eln", suddenly all those pre-existing gating.yamls which specify "fedora-*" will also apply to ELN, which is probably an unexpected and undesired result (since many generic and package-specific tests still don't really work correctly against ELN).

To solve this, we can just change the product_version Bodhi uses for ELN when querying Greenwave. This should not break anything because, right now, we demonstrably do not apply *any* policies to "fedora-eln" in the site-wide config. Making the name just "eln" means that "fedora-*" policies do not apply to ELN; packages would have to add "eln" to the list to opt in to gating ELN updates. We can then do that for the kernel, and not disturb anything else.