### PR TITLE
Fix duplicate package names in search results

### DIFF
--- a/bodhi-server/bodhi/server/services/packages.py
+++ b/bodhi-server/bodhi/server/services/packages.py
@@ -74,7 +74,6 @@ def query_packages(request):
     search = data.get('search')
     if search is not None:
         query = query.filter(Package.name.ilike('%%%s%%' % search))
-        query = query.order_by(case((Package.name == search, Package.name)))
 
     # We can't use ``query.count()`` here because it is naive with respect to
     # all the joins that we're doing above.
@@ -82,6 +81,21 @@ def query_packages(request):
         .with_only_columns(func.count(distinct(Package.name)))\
         .order_by(None)
     total = db.execute(count_query).scalar()
+
+    if search is not None:
+        # We will first group by name, take a package id and then search for
+        # that package.This avoids duplicate results which differ on other parameters such as type
+        min_id_subq = (
+            query
+            .with_entities(func.min(Package.id).label('id'))
+            .group_by(Package.name)
+            .subquery()
+        )
+        query = (
+            db.query(Package)
+            .join(min_id_subq, Package.id == min_id_subq.c.id)
+            .order_by(case((Package.name == search, Package.name)))
+        )
 
     page = data.get('page')
     rows_per_page = data.get('rows_per_page')

--- a/bodhi-server/tests/functional/test_packages.py
+++ b/bodhi-server/tests/functional/test_packages.py
@@ -16,6 +16,7 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 from bodhi.server.models import (
+    ModulePackage,
     RpmPackage,
 )
 from .. import base
@@ -68,3 +69,27 @@ class TestRpmPackagesService(base.BasePyTestCase):
         resp = self.app.get('/packages/', dict(search='corebird'))
         body = resp.json_body
         assert len(body['packages']) == 0
+
+    def test_search_deduplicates_by_name(self):
+        """Packages with the same name but different types should appear only once."""
+        self.db.add(ModulePackage(name='bodhi'))
+        self.db.commit()
+
+        resp = self.app.get('/packages/', dict(search='bodhi'))
+        body = resp.json_body
+        assert body['total'] == 1
+        assert len(body['packages']) == 1
+        assert body['packages'][0]['name'] == 'bodhi'
+
+    def test_search_deduplicates_count_is_accurate(self):
+        """total should reflect distinct names, not total rows."""
+        self.db.add(ModulePackage(name='bodhi'))
+        self.db.add(RpmPackage(name='python'))
+        self.db.add(ModulePackage(name='python'))
+        self.db.commit()
+
+        resp = self.app.get('/packages/', dict(search='o'))
+        body = resp.json_body
+        # 'bodhi' and 'python' both contain 'o' — 2 distinct names despite 4 rows
+        assert body['total'] == 2
+        assert len(body['packages']) == 2

--- a/news/PR6130.bug
+++ b/news/PR6130.bug
@@ -1,0 +1,1 @@
+Fix duplicate package names in search results when a package exists as multiple content types.


### PR DESCRIPTION
Problem Statement  : 

This PR aims to solve the [issue](https://github.com/fedora-infra/bodhi/issues/6128).

RCA : 

The packages have two properties : name and type. Since we are only showing package names to the user and are navigating based on the package name too , it can lead to confusion ( specially for new users ). 

Changes made : 
Grouped the packages based on name and showing based on the package id. This ensures that a single package is shown to the user if there are multiple packages with exact same name. 