### PR TITLE
Add reading and API exposure of compose-critical component data

### DIFF
--- a/bodhi-server/bodhi/server/__init__.py
+++ b/bodhi-server/bodhi/server/__init__.py
@@ -312,6 +312,7 @@ def main(global_config, testing=None, session=None, **settings):
 
     # service endpoints
     config.add_route('get_critpath_components', '/get_critpath_components')
+    config.add_route('get_ccp_components', '/get_ccp_components')
 
     # Legacy: Redirect the previously self-hosted documentation
     # https://docs.pylonsproject.org/projects/pyramid/en/latest/narr/hybrid.html#using-subpath-in-a-route-pattern

--- a/bodhi-server/bodhi/server/util.py
+++ b/bodhi-server/bodhi/server/util.py
@@ -205,6 +205,46 @@ def get_critpath_components(collection='master', component_type='rpm', component
     return critpath_components
 
 
+def get_ccp_components(collection='rawhide', component_type='rpm', components=None):
+    """
+    Return a dictionary of compose-critical packages for a given collection.
+
+    Args:
+        collection (str): The collection/branch to search. Defaults to 'rawhide'.
+        component_type (str): The component type to search for. Defaults to 'rpm'. Only
+            has any effect when critpath_type is json.
+        components (frozenset or None): The list of components we are interested in. If None (the
+            default), all components for the given collection are returned.
+    Returns:
+        dict: The compose-critical components for the given collection and type, by variant, arch
+            and type ('buildroot' or 'image'). If components is specified, only elements of the
+            dict that contain any of the specified components will be present. Will be empty
+            if the underlying metadata is not available.
+    """
+    ccp_components = {}
+    try:
+        ccp_components = read_ccp_json(collection).get(component_type, {})
+    except FileNotFoundError:
+        log.warning(f'No JSON file found for collection {collection}')
+    except json.JSONDecodeError:
+        log.warning(f'JSON file for collection {collection} is invalid')
+    if components and ccp_components:
+        filtered_dict = {}
+        for variant in ccp_components:
+            for arch in ccp_components[variant]:
+                for (typ, packages) in ccp_components[variant][arch].items():
+                    filtered = [pkg for pkg in packages if pkg in components]
+                    if filtered:
+                        if variant not in filtered_dict:
+                            filtered_dict[variant] = {arch: {typ: filtered}}
+                        elif arch not in filtered_dict[variant]:
+                            filtered_dict[variant][arch] = {typ: filtered}
+                        else:
+                            filtered_dict[variant][arch][typ] = filtered
+        return filtered_dict
+    return ccp_components
+
+
 def sanity_check_repodata(myurl, repo_type, drpms=True):
     """
     Sanity check the repodata for a given repository.
@@ -910,6 +950,27 @@ def read_critpath_json(collection):
     """
     jsonpath = config.get('critpath.jsonpath')
     jsonfile = os.path.join(jsonpath, f'{collection}.json')
+    with open(jsonfile, 'r', encoding='utf-8') as jsonfh:
+        return json.load(jsonfh)
+
+
+def read_ccp_json(collection):
+    """
+    Read the JSON format compose critical package information for the collection.
+
+    Args:
+        collection (str): The collection to read information for.
+    Returns:
+        dict: A dict with variants as keys. The values are themselves dicts, with arches as
+            keys. The values are again dicts, each with two keys - "buildroot" and "image" -
+            and values as lists, containing the compose critical source package names of that
+            type, for that arch, for that variant.
+    Raises:
+        FileNotFoundError: If there is no file for the requested collection.
+        json.JSONDecodeError: If the file is not valid JSON.
+    """
+    jsonpath = config.get('critpath.jsonpath')
+    jsonfile = os.path.join(jsonpath, f'{collection}-ccp-source.json')
     with open(jsonfile, 'r', encoding='utf-8') as jsonfh:
         return json.load(jsonfh)
 

--- a/bodhi-server/bodhi/server/views/generic.py
+++ b/bodhi-server/bodhi/server/views/generic.py
@@ -645,3 +645,24 @@ def get_critpath_components(request):
         components = components.split(',')
     return bodhi.server.util.get_grouped_critpath_components(collection, component_type,
                                                              components)
+
+
+@view_config(route_name='get_ccp_components', renderer='json')
+def get_ccp_components(request):
+    """
+    Return compose-critical components configured in bodhi.
+
+    Args:
+        request (pyramid.request.Request): The current request.
+    Returns:
+        dict: The compose-critical components for the given collection and component type, by
+            variant, arch and type ('buildroot' or 'image'). If components is specified, only
+            elements of the dict that contain any of the specified components will be present.
+            Will be empty if the underlying metadata is not available.
+    """
+    collection = request.params.get('collection', 'rawhide')
+    component_type = request.params.get('component_type', 'rpm')
+    components = request.params.get('components')
+    if components is not None:
+        components = components.split(',')
+    return bodhi.server.util.get_ccp_components(collection, component_type, components)

--- a/bodhi-server/tests/conftest.py
+++ b/bodhi-server/tests/conftest.py
@@ -85,3 +85,48 @@ def critpath_json_config(request):
         json.dump(testdata, f36filefh)
     yield (tempdir.name, testdata)
     tempdir.cleanup()
+
+
+@pytest.fixture(scope="session")
+def ccp_json_config(request):
+    """
+    Compose-critical package JSON configuration fixture.
+
+    Set up one valid (f36) and one invalid (f35) configuration file
+    and yield the path, file names, and sample data.
+    """
+    tempdir = tempfile.TemporaryDirectory(suffix='bodhi')
+    f35file = os.path.join(tempdir.name, 'f35-ccp-source.json')
+    with open(f35file, 'w', encoding='utf-8') as f35filefh:
+        f35filefh.write("This is not JSON")
+    f36file = os.path.join(tempdir.name, 'f36-ccp-source.json')
+    testdata = {
+        'rpm': {
+            'Everything': {
+                'aarch64': {
+                    'buildroot': [
+                        'acl',
+                        'attr',
+                    ],
+                    'image': [
+                        'ModemManager',
+                        'NetworkManager',
+                    ],
+                },
+                'x86_64': {
+                    'buildroot': [
+                        'authselect',
+                        'bash',
+                    ],
+                    'image': [
+                        'abseil-cpp',
+                        'accountsservice'
+                    ],
+                },
+            },
+        },
+    }
+    with open(f36file, 'w', encoding='utf-8') as f36filefh:
+        json.dump(testdata, f36filefh)
+    yield (tempdir.name, testdata)
+    tempdir.cleanup()

--- a/bodhi-server/tests/test_util.py
+++ b/bodhi-server/tests/test_util.py
@@ -804,6 +804,55 @@ class TestUtils(base.BasePyTestCase):
         grouped = util.get_grouped_critpath_components('f35')
         assert grouped == {}
 
+    @mock.patch('bodhi.server.util.log')
+    def test_get_ccp_components_json_no_file(self, mock_log, ccp_json_config):
+        """Ensure we log a warning and return an empty list when
+        trying to retrieve ccp info from a non-existent JSON
+        file (from get_ccp_components).
+        """
+        pkgs = util.get_ccp_components('f34')
+        assert pkgs == {}
+        warning = 'No JSON file found for collection f34'
+        mock_log.warning.assert_called_once_with(warning)
+
+    @mock.patch('bodhi.server.util.log')
+    def test_get_ccp_components_json_bad_file(self, mock_log, ccp_json_config):
+        """Ensure we log a warning and return an empty list when
+        trying to retrieve ccp info from an invalid JSON
+        file (from get_ccp_components).
+        """
+        (tempdir, _) = ccp_json_config
+        config.update({
+            'critpath.jsonpath': tempdir
+        })
+        pkgs = util.get_ccp_components('f35')
+        assert pkgs == {}
+        warning = 'JSON file for collection f35 is invalid'
+        mock_log.warning.assert_called_once_with(warning)
+
+    def test_get_ccp_components_success(self, ccp_json_config):
+        """Ensure that get_ccp_components works when
+        using JSON files.
+        """
+        (tempdir, testdata) = ccp_json_config
+        config.update({
+            'critpath.jsonpath': tempdir
+        })
+        grouped = util.get_ccp_components('f36')
+        assert grouped == testdata['rpm']
+        # now test with components arg
+        filtered = util.get_ccp_components(
+            'f36', components=['ModemManager'])
+        assert filtered == {
+            'Everything': {
+                'aarch64': {
+                    'image': [
+                        'ModemManager',
+                    ],
+                },
+            },
+        }
+
     @mock.patch('bodhi.server.util.http_session')
     def test_pagure_api_get(self, session):
         """ Ensure that an API request to Pagure works as expected.

--- a/bodhi-server/tests/views/test_generic.py
+++ b/bodhi-server/tests/views/test_generic.py
@@ -603,3 +603,54 @@ class TestCritpathEndpoint(base.BasePyTestCase):
                 "errors": [{"location": "body", "name": "ValueError",
                             "description": "critpath.type (default) does not support groups"}]
             }
+
+
+class TestCcpEndpoint(base.BasePyTestCase):
+    """Test the ccp (compose-critical package) endpoint."""
+    @mock.patch('bodhi.server.util.get_ccp_components')
+    def test_defaults(self, mocked_get_ccp):
+        """Defaults should return rpms for rawhide."""
+        mocked_get_ccp.return_value = {}
+        self.app.get('/get_ccp_components')
+        mocked_get_ccp.assert_called_once_with('rawhide', 'rpm', None)
+
+    def test_collection(self, ccp_json_config):
+        """Collection parameter should look into the proper json file."""
+        (tempdir, testdata) = ccp_json_config
+        config.update({
+            'critpath.type': 'json',
+            'critpath.jsonpath': tempdir
+        })
+        res = self.app.get('/get_ccp_components', {'collection': 'f36'})
+        body = res.json_body
+        assert body == testdata['rpm']
+
+    def test_component_list(self, ccp_json_config):
+        """Components parameter is a comma separated values list."""
+        (tempdir, testdata) = ccp_json_config
+        config.update({
+            'critpath.type': 'json',
+            'critpath.jsonpath': tempdir
+        })
+        res = self.app.get('/get_ccp_components',
+                           {'collection': 'f36',
+                            'components': 'acl,attr,ModemManager,accountsservice'})
+        body = res.json_body
+        assert body == {
+            'Everything': {
+                'aarch64': {
+                    'buildroot': [
+                        'acl',
+                        'attr',
+                    ],
+                    'image': [
+                        'ModemManager',
+                    ],
+                },
+                'x86_64': {
+                    'image': [
+                        'accountsservice'
+                    ],
+                },
+            }
+        }

--- a/news/6142.feature
+++ b/news/6142.feature
@@ -1,0 +1,1 @@
+bodhi-server: added the `get_ccp_components` endpoint to expose compose-critical component data


### PR DESCRIPTION
This makes Bodhi read, and expose via the API, compose-critical component data produced by the ccp.py script that now lives with the critpath.py script. The code follows the existing critical path code very closely.