### PR TITLE
Replace several pagure.io links with forge.fedoraproject.org

### DIFF
--- a/bodhi-server/bodhi/server/consumers/automatic_updates.py
+++ b/bodhi-server/bodhi/server/consumers/automatic_updates.py
@@ -154,7 +154,7 @@ class AutomaticUpdateHandler:
                 changelog = build.get_changelog(lastupdate=True)
             except ValueError as e:
                 # Often due to bot-generated builds
-                # https://pagure.io/koji/issue/3178
+                # https://forge.fedoraproject.org/koji/koji/issues/3178
                 log.warning(str(e))
                 sleep(5)
                 # Re-raise exception, so that the message can be re-queued

--- a/bodhi-server/tests/tasks/test_check_policies.py
+++ b/bodhi-server/tests/tasks/test_check_policies.py
@@ -374,7 +374,7 @@ class TestCheckPolicies(BaseTaskTestCase):
         itemname = f'FEDORA-{datetime.now(timezone.utc).year}-a3bbe1a8f2'
         with patch('bodhi.server.models.util.greenwave_api_post') as mock_greenwave:
             # here, we're approximately mocking the scenario from
-            # https://pagure.io/fedora-ci/general/issue/263 , where
+            # https://forge.fedoraproject.org/ci/tickets/issues/263 , where
             # openQA tests passed, but a package in the update had a
             # local gating config that only specified the context
             # bodhi_update_push_stable (not _push_stable_critpath),

--- a/devel/ci/integration/bodhi/pungi_multilib.conf
+++ b/devel/ci/integration/bodhi/pungi_multilib.conf
@@ -2,7 +2,7 @@
 # Note: If you change something here (affects updates for stable releases), also
 # submit the same change to pungi-fedora (affects Rawhide/Branched composes),
 # we want to keep them in sync:
-# https://pagure.io/pungi-fedora/blob/main/f/multilib.conf
+# https://forge.fedoraproject.org/releng/pungi-fedora/src/branch/main/multilib.conf
 #
 # format: {arch|*: [packages]}
 multilib_blacklist = {
@@ -34,7 +34,7 @@ multilib_blacklist = {
 # Note: If you change something here (affects updates for stable releases), also
 # submit the same change to pungi-fedora (affects Rawhide/Branched composes),
 # we want to keep them in sync:
-# https://pagure.io/pungi-fedora/blob/main/f/multilib.conf
+# https://forge.fedoraproject.org/releng/pungi-fedora/src/branch/main/multilib.conf
 #
 # format: {arch|*: [packages]}
 multilib_whitelist = {

--- a/devel/ci/integration/ipsilon/api.py
+++ b/devel/ci/integration/ipsilon/api.py
@@ -1,5 +1,5 @@
 # Copyright (C) 2015 Patrick Uiterwijk, for license see Ipsilon's COPYING:
-# https://pagure.io/ipsilon/blob/main/f/COPYING
+# https://forge.fedoraproject.org/apps/ipsilon/src/branch/master/COPYING
 
 from __future__ import absolute_import
 

--- a/docs/user/2.x_release_notes.rst
+++ b/docs/user/2.x_release_notes.rst
@@ -187,7 +187,7 @@ Features
   (:commit:`431b9078`).
 * The graphs on the metrics page now have mouse hovers to indicate numerical values
   (:issue:`209`).
-* Bodhi now has support for using `Greenwave <https://pagure.io/greenwave/>`_ to gate updates based
+* Bodhi now has support for using `Greenwave <https://github.com/release-engineering/greenwave>`_ to gate updates based
   on test results. See the new ``test_gating.required``, ``test_gating.url``, and
   ``greenwave_api_url`` settings in ``production.ini`` for details on how to enable it. Note also
   that this feature introduces a new server CLI tool, ``bodhi-check-policies``, which is intended to

--- a/docs/user/5.x_release_notes.rst
+++ b/docs/user/5.x_release_notes.rst
@@ -39,7 +39,7 @@ Bug fixes
 ^^^^^^^^^
 
 * Bodhi will now retry to get a build changelog if Koji returns empty rpm
-  headers. See also https://pagure.io/koji/issue/3178 (:issue:`4316`).
+  headers. See also https://forge.fedoraproject.org/koji/koji/issues/3178 (:issue:`4316`).
 * Fixed an issue about some bug title never fetched from Bugzilla
   (:issue:`4317`).
 

--- a/docs/user/testing.rst
+++ b/docs/user/testing.rst
@@ -62,4 +62,4 @@ of 7 days and 3 karma respectively, it will be pushed stable as soon as it reach
 if 7 days have not yet passed; or it will be pushed stable after 7 days have passed, even if it
 has not yet reached +3 karma.
 
-.. _Greenwave: https://pagure.io/greenwave
+.. _Greenwave: https://github.com/release-engineering/greenwave


### PR DESCRIPTION
This does not address the config templates in devel/ci because they probably need more extensive changes.