### PR TITLE
Don't leak Pungi's pipes when a compose is aborted

### DIFF
--- a/bodhi-server/bodhi/server/tasks/composer.py
+++ b/bodhi-server/bodhi/server/tasks/composer.py
@@ -897,6 +897,8 @@ class PungiComposerThread(ComposerThread):
     """Compose update with Pungi."""
 
     pungi_template_config_key = None
+    #: Seconds to wait for an aborted Pungi to exit after SIGTERM before killing it.
+    pungi_abort_timeout = 60
 
     def __init__(self, max_concur_sem, compose, agent, db_factory, compose_dir, resume=False):
         """
@@ -951,29 +953,75 @@ class PungiComposerThread(ComposerThread):
 
         composedone = self._checkpoints.get('compose_done')
 
-        if not self.skip_compose and not composedone:
-            pungi_process = self._punge()
+        pungi_process = None
+        try:
+            if not self.skip_compose and not composedone:
+                pungi_process = self._punge()
 
-        # Things we can do while Pungi is running
-        self.generate_testing_digest()
+            # Things we can do while Pungi is running
+            self.generate_testing_digest()
 
-        if not self.skip_compose and not composedone:
-            uinfo = self._generate_updateinfo()
+            if not self.skip_compose and not composedone:
+                uinfo = self._generate_updateinfo()
 
-            self._wait_for_pungi(pungi_process)
+                self._wait_for_pungi(pungi_process)
+                pungi_process = None
 
-            uinfo.insert_updateinfo(self.path)
+                uinfo.insert_updateinfo(self.path)
 
-            self._sanity_check_repo()
-            self._wait_for_repo_signature()
-            self._stage_repo()
+                self._sanity_check_repo()
+                self._wait_for_repo_signature()
+                self._stage_repo()
 
-            self._checkpoints['compose_done'] = True
-            self.save_state()
+                self._checkpoints['compose_done'] = True
+                self.save_state()
 
-        if not self.skip_compose:
-            # Wait for the repo to hit the master mirror
-            self._wait_for_sync()
+            if not self.skip_compose:
+                # Wait for the repo to hit the master mirror
+                self._wait_for_sync()
+        finally:
+            # If we are leaving this method without having reaped Pungi (because
+            # something in between raised), we must not leak its stdout/stderr
+            # pipes. CPython keeps a still-running child alive in
+            # subprocess._active, which holds those file descriptors open. If
+            # Pungi has filled the 64kB pipe buffer it is blocked in write() and
+            # will never exit on its own, so the descriptors would be leaked for
+            # the lifetime of the worker process.
+            self._abandon_pungi(pungi_process)
+
+    def _abandon_pungi(self, pungi_process):
+        """
+        Terminate an unreaped Pungi child process and close its pipes.
+
+        This is a no-op if there is no process, or if it has already been reaped
+        by :meth:`_wait_for_pungi`.
+
+        Args:
+            pungi_process (subprocess.Popen or None): The Pungi process handle.
+        """
+        if pungi_process is None or pungi_process.returncode is not None:
+            return
+
+        log.warning('Compose aborted while Pungi (PID %s) was still running; '
+                    'terminating it and closing its pipes.', pungi_process.pid)
+        try:
+            pungi_process.terminate()
+        except OSError:
+            log.exception('Could not terminate Pungi process %s', pungi_process.pid)
+        try:
+            # Draining with a timeout both unblocks a Pungi that is stuck writing
+            # to a full pipe and reaps the child, so it cannot linger in
+            # subprocess._active.
+            pungi_process.communicate(timeout=self.pungi_abort_timeout)
+        except subprocess.TimeoutExpired:
+            log.error('Pungi process %s did not exit after SIGTERM; killing it.',
+                      pungi_process.pid)
+            pungi_process.kill()
+            pungi_process.communicate()
+        finally:
+            for stream in (pungi_process.stdout, pungi_process.stderr):
+                if stream is not None and not stream.closed:
+                    stream.close()
 
     def _copy_additional_pungi_files(self, pungi_conf_dir, template_env):
         """

--- a/bodhi-server/tests/tasks/test_composer.py
+++ b/bodhi-server/tests/tasks/test_composer.py
@@ -2506,6 +2506,8 @@ class TestPungiComposerThread__abandon_pungi(ComposerThreadBaseTestCase):
         pungi_process = mock.MagicMock()
         pungi_process.returncode = None
         pungi_process.pid = 1234
+        pungi_process.stdout.closed = False
+        pungi_process.stderr.closed = False
 
         t._abandon_pungi(pungi_process)
 
@@ -2521,6 +2523,8 @@ class TestPungiComposerThread__abandon_pungi(ComposerThreadBaseTestCase):
         pungi_process = mock.MagicMock()
         pungi_process.returncode = None
         pungi_process.pid = 1234
+        pungi_process.stdout.closed = False
+        pungi_process.stderr.closed = False
         pungi_process.communicate.side_effect = [
             subprocess.TimeoutExpired(cmd='pungi', timeout=t.pungi_abort_timeout),
             (b'', b''),
@@ -2539,6 +2543,8 @@ class TestPungiComposerThread__abandon_pungi(ComposerThreadBaseTestCase):
         pungi_process = mock.MagicMock()
         pungi_process.returncode = None
         pungi_process.pid = 1234
+        pungi_process.stdout.closed = False
+        pungi_process.stderr.closed = False
         pungi_process.terminate.side_effect = OSError('no such process')
 
         t._abandon_pungi(pungi_process)

--- a/bodhi-server/tests/tasks/test_composer.py
+++ b/bodhi-server/tests/tasks/test_composer.py
@@ -24,6 +24,7 @@ import errno
 import json
 import os
 import shutil
+import subprocess
 import tempfile
 import time
 import urllib.parse as urlparse
@@ -2349,6 +2350,58 @@ class TestPungiComposerThread__compose_updates(ComposerThreadBaseTestCase):
 
         assert os.path.exists(compose_dir)
 
+    def test_pungi_cleaned_up_on_exception(self):
+        """
+        Pungi must not be left unreaped if an exception is raised before it is waited on.
+
+        generate_testing_digest() talks to Koji and can raise, which used to leave the
+        Pungi Popen object -- and its two pipes -- referenced by subprocess._active for
+        as long as the child stayed alive.
+        """
+        task = self._make_task()
+        t = PungiComposerThread(self.semmock, task['composes'][0],
+                                'bowlofeggs', self.Session, self.tempdir)
+        t._checkpoints = {}
+        t.compose = Compose.from_dict(self.db, task['composes'][0])
+        t.skip_compose = False
+        pungi_process = mock.MagicMock()
+        pungi_process.returncode = None
+
+        with mock.patch.object(t, '_punge', return_value=pungi_process), \
+                mock.patch.object(t, 'generate_testing_digest',
+                                  side_effect=Exception('koji is sad')), \
+                mock.patch.object(t, '_abandon_pungi') as abandon:
+            with pytest.raises(Exception, match='koji is sad'):
+                t._compose_updates()
+
+        abandon.assert_called_once_with(pungi_process)
+
+    def test_pungi_not_cleaned_up_after_successful_wait(self):
+        """After _wait_for_pungi() succeeds, the cleanup must be a no-op."""
+        task = self._make_task()
+        t = PungiComposerThread(self.semmock, task['composes'][0],
+                                'bowlofeggs', self.Session, self.tempdir)
+        t._checkpoints = {}
+        t.compose = Compose.from_dict(self.db, task['composes'][0])
+        t.skip_compose = False
+        pungi_process = mock.MagicMock()
+
+        with mock.patch.object(t, '_punge', return_value=pungi_process), \
+                mock.patch.object(t, 'generate_testing_digest'), \
+                mock.patch.object(t, '_generate_updateinfo'), \
+                mock.patch.object(t, '_wait_for_pungi'), \
+                mock.patch.object(t, '_sanity_check_repo'), \
+                mock.patch.object(t, '_wait_for_repo_signature'), \
+                mock.patch.object(t, '_stage_repo'), \
+                mock.patch.object(t, 'save_state'), \
+                mock.patch.object(t, '_wait_for_sync'), \
+                mock.patch.object(t, '_abandon_pungi') as abandon:
+            t._compose_updates()
+
+        # pungi_process is cleared after a successful wait, so the finally block
+        # must be handed None rather than the live process.
+        abandon.assert_called_once_with(None)
+
 
 class TestFlatpakComposerThread__compose_updates(ComposerThreadBaseTestCase):
     """Test FlatpakComposerThread._compose_update()."""
@@ -2417,6 +2470,107 @@ class TestFlatpakComposerThread__compose_updates(ComposerThreadBaseTestCase):
                     expected_mock_calls.append(mock_call)
                     expected_mock_calls.append(mock.call().communicate())
         assert Popen.mock_calls == expected_mock_calls
+
+
+class TestPungiComposerThread__abandon_pungi(ComposerThreadBaseTestCase):
+    """This class contains tests for the PungiComposerThread._abandon_pungi() method."""
+
+    def _make_thread(self):
+        task = self._make_task()
+        t = PungiComposerThread(self.semmock, task['composes'][0],
+                                'bowlofeggs', self.Session, self.tempdir)
+        t.compose = Compose.from_dict(self.db, task['composes'][0])
+        return t
+
+    def test_no_process(self):
+        """The method should do nothing if there is no Pungi process."""
+        t = self._make_thread()
+
+        # This should not raise.
+        t._abandon_pungi(None)
+
+    def test_already_reaped(self):
+        """The method should not touch a process that has already exited."""
+        t = self._make_thread()
+        pungi_process = mock.MagicMock()
+        pungi_process.returncode = 0
+
+        t._abandon_pungi(pungi_process)
+
+        pungi_process.terminate.assert_not_called()
+        pungi_process.communicate.assert_not_called()
+
+    def test_terminates_and_drains(self):
+        """An unreaped Pungi should be terminated, drained, and its pipes closed."""
+        t = self._make_thread()
+        pungi_process = mock.MagicMock()
+        pungi_process.returncode = None
+        pungi_process.pid = 1234
+
+        t._abandon_pungi(pungi_process)
+
+        pungi_process.terminate.assert_called_once_with()
+        pungi_process.communicate.assert_called_once_with(timeout=t.pungi_abort_timeout)
+        pungi_process.kill.assert_not_called()
+        pungi_process.stdout.close.assert_called_once_with()
+        pungi_process.stderr.close.assert_called_once_with()
+
+    def test_kills_when_sigterm_ignored(self):
+        """A Pungi that does not exit after SIGTERM should be killed."""
+        t = self._make_thread()
+        pungi_process = mock.MagicMock()
+        pungi_process.returncode = None
+        pungi_process.pid = 1234
+        pungi_process.communicate.side_effect = [
+            subprocess.TimeoutExpired(cmd='pungi', timeout=t.pungi_abort_timeout),
+            (b'', b''),
+        ]
+
+        t._abandon_pungi(pungi_process)
+
+        pungi_process.kill.assert_called_once_with()
+        assert pungi_process.communicate.call_count == 2
+        pungi_process.stdout.close.assert_called_once_with()
+        pungi_process.stderr.close.assert_called_once_with()
+
+    def test_terminate_raises_oserror(self):
+        """The pipes must still be closed if terminate() raises OSError."""
+        t = self._make_thread()
+        pungi_process = mock.MagicMock()
+        pungi_process.returncode = None
+        pungi_process.pid = 1234
+        pungi_process.terminate.side_effect = OSError('no such process')
+
+        t._abandon_pungi(pungi_process)
+
+        pungi_process.stdout.close.assert_called_once_with()
+        pungi_process.stderr.close.assert_called_once_with()
+
+    def test_streams_already_closed(self):
+        """Streams that are already closed should not be closed a second time."""
+        t = self._make_thread()
+        pungi_process = mock.MagicMock()
+        pungi_process.returncode = None
+        pungi_process.pid = 1234
+        pungi_process.stdout.closed = True
+        pungi_process.stderr.closed = True
+
+        t._abandon_pungi(pungi_process)
+
+        pungi_process.stdout.close.assert_not_called()
+        pungi_process.stderr.close.assert_not_called()
+
+    def test_streams_are_none(self):
+        """The method should cope with a process that has no pipes."""
+        t = self._make_thread()
+        pungi_process = mock.MagicMock()
+        pungi_process.returncode = None
+        pungi_process.pid = 1234
+        pungi_process.stdout = None
+        pungi_process.stderr = None
+
+        # This should not raise.
+        t._abandon_pungi(pungi_process)
 
 
 class TestPungiComposerThread__get_master_repomd_url(ComposerThreadBaseTestCase):

--- a/news/PR6155.bug
+++ b/news/PR6155.bug
@@ -1,0 +1,1 @@
+The composer no longer leaves Pungi unreaped, with its stdout and stderr pipes still open, when a compose is aborted before Pungi is waited on


### PR DESCRIPTION
PungiComposerThread._compose_updates() started Pungi with stdout and stderr set to PIPE, then ran generate_testing_digest() and _generate_updateinfo() before reaching _wait_for_pungi(), which is what actually drains and closes those pipes.

Both of those intermediate calls talk to Koji and can raise -- in particular get_rpm_header() re-raises after three failed attempts -- so a slow or flaking Koji leaves _wait_for_pungi() unreached and the Popen object abandoned. CPython does not close the pipes in that situation: Popen.__del__ appends a still-running child to subprocess._active to keep it alive until it can be waited on, and that reference holds both file descriptors open. A garbage collection does not reclaim them.

If Pungi has written more than the 64kB pipe buffer by that point it is blocked in write() with nobody left to read, so it never exits, never gets reaped out of subprocess._active, and the descriptors are held for the remaining lifetime of the Celery worker. Composes that fail this way succeed on a retry, which is why this shows up as slow descriptor exhaustion rather than a reproducible failure.

Wrap the body of _compose_updates() in try/finally and add _abandon_pungi(), which terminates an unreaped Pungi, drains it with a timeout so a process stuck on a full pipe is unblocked and reaped, escalates to kill() if it ignores SIGTERM, and closes the streams. pungi_process is cleared after a successful _wait_for_pungi() so the cleanup is a no-op on the normal path.

Related to #5935

Assisted-by: Claude (Anthropic)