### PR TITLE
Opt into the hard file limit in the web server and celery tasks

### DIFF
--- a/bodhi-server/bodhi/server/__init__.py
+++ b/bodhi-server/bodhi/server/__init__.py
@@ -19,6 +19,7 @@
 from collections import defaultdict
 import importlib.metadata
 import logging as python_logging
+import resource
 
 from cornice.validators import DEFAULT_FILTERS
 from dogpile.cache import make_region
@@ -340,6 +341,15 @@ def main(global_config, testing=None, session=None, **settings):
         # the return value.
         generic._generate_home_page_stats()
 
+    raise_open_file_limit()
     log.info('Bodhi ready and at your service!')
     app = config.make_wsgi_app()
     return app
+
+
+def raise_open_file_limit() -> None:
+    """Set the soft limit on open files to the hard limit."""
+    soft_limit, hard_limit = resource.getrlimit(resource.RLIMIT_NOFILE)
+    if soft_limit < hard_limit:
+        resource.setrlimit(resource.RLIMIT_NOFILE, (hard_limit, hard_limit))
+        log.info(f'Raised open file limit from {soft_limit} to {hard_limit}')

--- a/bodhi-server/bodhi/server/consumers/__init__.py
+++ b/bodhi-server/bodhi/server/consumers/__init__.py
@@ -26,7 +26,7 @@ import logging
 
 import fedora_messaging
 
-from bodhi.server import bugs, buildsys, initialize_db
+from bodhi.server import bugs, buildsys, initialize_db, raise_open_file_limit
 from bodhi.server.config import config
 from bodhi.server.consumers.automatic_updates import AutomaticUpdateHandler
 from bodhi.server.consumers.signed import SignedHandler
@@ -49,6 +49,7 @@ class Consumer:
         initialize_db(config)
         buildsys.setup_buildsystem(config)
         bugs.set_bugtracker()
+        raise_open_file_limit()
 
         self.handler_infos = [
             HandlerInfo('.buildsys.tag', "Signed", SignedHandler()),

--- a/bodhi-server/bodhi/server/tasks/__init__.py
+++ b/bodhi-server/bodhi/server/tasks/__init__.py
@@ -23,7 +23,7 @@ import typing
 
 import celery
 
-from bodhi.server import bugs, buildsys, initialize_db
+from bodhi.server import bugs, buildsys, initialize_db, raise_open_file_limit
 from bodhi.server.config import config
 from bodhi.server.exceptions import ExternalCallException
 from bodhi.server.util import pyfile_to_module
@@ -47,6 +47,7 @@ def _do_init():
     initialize_db(config)
     buildsys.setup_buildsystem(config)
     bugs.set_bugtracker()
+    raise_open_file_limit()
 
 
 @app.task(name="compose", ignore_result=True)

--- a/bodhi-server/tests/test___init__.py
+++ b/bodhi-server/tests/test___init__.py
@@ -18,6 +18,7 @@
 """This test suite contains tests for bodhi.server.__init__."""
 from unittest import mock
 import collections
+import resource
 
 from pyramid import authentication, testing
 
@@ -193,3 +194,21 @@ class TestMain(base.BasePyTestCase):
             server.main({}, **self.app_settings)
 
         init_db.assert_called_once()
+
+
+class TestRaiseOpenFileLimit(base.BasePyTestCase):
+    @mock.patch('bodhi.server.log.info')
+    def test_raises_limit(self, info):
+        """The limit should be set to the hard limit."""
+        (original_soft, original_hard) = resource.getrlimit(resource.RLIMIT_NOFILE)
+        soft_limit = original_hard - 1
+        try:
+            resource.setrlimit(resource.RLIMIT_NOFILE, (soft_limit, original_hard))
+
+            server.raise_open_file_limit()
+
+            assert resource.getrlimit(resource.RLIMIT_NOFILE) == (original_hard, original_hard)
+            info.assert_called_once_with(
+                f'Raised open file limit from {soft_limit} to {original_hard}')
+        finally:
+            resource.setrlimit(resource.RLIMIT_NOFILE, (original_soft, original_hard))

--- a/news/PR6158.feature
+++ b/news/PR6158.feature
@@ -1,0 +1,2 @@
+The WSGI application and Celery tasks now opt into the process's hard file limit. Previously, both
+used the default soft limit, which for most platforms is 1024.


### PR DESCRIPTION
Resources have soft and hard limits. Processes are allowed to raise their soft limit up to the hard limit, but if they choose to not do that, the soft limit is the "real" limit.

The hard file limit in Fedora is ~500K, but for compatibility with old programs that use things like select() (which don't work with file descriptors above 1024) the soft limit is 1024.

This adjusts the Bodhi services to bump the soft limit to the hard limit. It's possible I missed some process entry-points.

See also: #5935