### PR TITLE
Don't let one failed compose block every other release

### DIFF
--- a/bodhi-server/bodhi/server/push.py
+++ b/bodhi-server/bodhi/server/push.py
@@ -108,6 +108,7 @@ def push(username, yes, **kwargs):
             resume_all = True
 
         # If we're resuming a push
+        existing_lanes = set()
         if resume:
             for compose in session.query(Compose).all():
                 if len(compose.updates) == 0:
@@ -131,7 +132,17 @@ def push(username, yes, **kwargs):
                 compose.error_message = ''
 
                 composes.append(compose)
-        else:
+                existing_lanes.add((compose.release_id, compose.request))
+
+            # Flush so that any Composes deleted above are removed from the database before we
+            # potentially create new Composes with the same compound primary key below.
+            session.flush()
+
+        # Queue up any other releases that do not already have a Compose in flight. A Compose that
+        # is being resumed owns its (release, request) lane until it succeeds, but it should not
+        # prevent unrelated lanes from being composed. An explicit --resume is left alone, since
+        # the operator asked for a resume and nothing else.
+        if not resume or resume_all:
             updates = []
             # Accept both comma and space separated request list
             requests = kwargs['request'].replace(',', ' ').split(' ')
@@ -175,7 +186,16 @@ def push(username, yes, **kwargs):
             if kwargs.get('updates'):
                 query = query.filter(Update.alias.in_(kwargs['updates'].split(',')))
 
+            skipped_lanes = set()
             for update in query.all():
+                # Updates in a lane that already has a Compose belong to that Compose. Adding them
+                # here would either collide with its compound primary key or silently attach them
+                # to a Compose that has already passed the checkpoints that would have tagged them.
+                lane = (update.release_id, update.request)
+                if lane in existing_lanes:
+                    skipped_lanes.add(lane)
+                    continue
+
                 # Skip unsigned updates (this checks that all builds in the update are signed)
                 update_sig_status(update)
 
@@ -187,9 +207,15 @@ def push(username, yes, **kwargs):
 
                 updates.append(update)
 
-            composes = Compose.from_updates(updates)
-            for c in composes:
+            if skipped_lanes:
+                click.echo(
+                    '\nSkipping {:d} release(s) with a Compose already in flight.'.format(
+                        len(skipped_lanes)))
+
+            new_composes = Compose.from_updates(updates)
+            for c in new_composes:
                 session.add(c)
+            composes.extend(new_composes)
 
             # We need to flush so the database knows about the new Compose objects, so the
             # Compose.updates relationship will work properly. This is due to us overriding the
@@ -197,7 +223,7 @@ def push(username, yes, **kwargs):
             session.flush()
 
             # Now we need to refresh the composes so their updates property will not be empty.
-            for compose in composes:
+            for compose in new_composes:
                 session.refresh(compose)
 
         # Now we need to sort the composes so their security property can be used to prioritize

--- a/bodhi-server/tests/test_push.py
+++ b/bodhi-server/tests/test_push.py
@@ -263,6 +263,8 @@ Requesting a compose
 TEST_LOCKED_UPDATES_EXPECTED_OUTPUT = (
     """Existing composes detected: <Compose: F17 testing>. Do you wish to resume them all? [y/N]: y
 
+Skipping 1 release(s) with a Compose already in flight.
+
 
 ===== <Compose: F17 testing> =====
 
@@ -279,6 +281,8 @@ Requesting a compose
 TEST_LOCKED_UPDATES_YES_FLAG_EXPECTED_OUTPUT = (
     """Existing composes detected: <Compose: F17 testing>. Resuming all.
 
+Skipping 1 release(s) with a Compose already in flight.
+
 
 ===== <Compose: F17 testing> =====
 
@@ -286,6 +290,29 @@ ejabberd-16.09-4.fc17
 
 
 Pushing 1 updates.
+
+Locking updates...
+
+Requesting a compose
+""")
+
+TEST_STUCK_LANE_EXPECTED_OUTPUT = (
+    """Existing composes detected: <Compose: F17 testing>. Resuming all.
+
+Skipping 1 release(s) with a Compose already in flight.
+
+
+===== <Compose: F25 testing> =====
+
+python-nose-1.3.7-11.fc25
+
+
+===== <Compose: F17 testing> =====
+
+ejabberd-16.09-4.fc17
+
+
+Pushing 2 updates.
 
 Locking updates...
 
@@ -824,6 +851,76 @@ class TestPush(base.BasePyTestCase):
         for u in [python_nose, python_paste_deploy]:
             assert not u.locked
             assert u.date_locked is None
+
+    def test_stuck_compose_does_not_block_other_releases(self):
+        """
+        Assert that a stuck Compose only holds up its own (release, request) lane.
+
+        A failed Compose keeps ownership of its lane until it succeeds, but it should be resumed
+        alongside newly created Composes for the other lanes rather than instead of them.
+        """
+        cli = CliRunner()
+        f25 = models.Release(
+            name='F25', long_name='Fedora 25',
+            id_prefix='FEDORA', version='25',
+            dist_tag='f25', stable_tag='f25-updates',
+            testing_tag='f25-updates-testing',
+            candidate_tag='f25-updates-candidate',
+            pending_signing_tag='f25-updates-testing-signing',
+            pending_testing_tag='f25-updates-testing-pending',
+            pending_stable_tag='f25-updates-pending',
+            override_tag='f25-override',
+            branch='f25', state=models.ReleaseState.current)
+        self.db.add(f25)
+        self.db.commit()
+        # ejabberd is stuck in a failed F17 testing compose.
+        ejabberd = self.create_update(['ejabberd-16.09-4.fc17'])
+        ejabberd.builds[0].signed = True
+        ejabberd.locked = True
+        compose = models.Compose(
+            release=ejabberd.release, request=ejabberd.request, state=models.ComposeState.failed,
+            error_message='y r u so mean nfs')
+        self.db.add(compose)
+        # python-nose is waiting on F25, which has no Compose of its own. It is a security update
+        # so we can also assert that it sorts ahead of the resumed Compose.
+        python_nose = self.create_update(['python-nose-1.3.7-11.fc25'], 'F25')
+        python_nose.type = models.UpdateType.security
+        python_nose.builds[0].signed = True
+        self.db.commit()
+
+        with mock.patch('bodhi.server.push.transactional_session_maker',
+                        return_value=base.TransactionalSessionMaker(self.Session)):
+            with mock.patch('bodhi.server.push.compose_task') as compose_task:
+                result = cli.invoke(push.push, ['--username', 'bowlofeggs', '--yes'])
+                compose_task.delay.assert_called_with(
+                    api_version=2, agent="bowlofeggs", resume=True,
+                    composes=[python_nose.compose.__json__(composer=True),
+                              ejabberd.compose.__json__(composer=True)],
+                )
+
+        assert result.exit_code == 0
+        assert result.output == TEST_STUCK_LANE_EXPECTED_OUTPUT
+        # The stuck lane is resumed, still holding exactly the update it started with.
+        ejabberd = self.db.query(models.Build).filter_by(nvr='ejabberd-16.09-4.fc17').one().update
+        assert ejabberd.locked
+        assert ejabberd.compose.state == models.ComposeState.requested
+        assert ejabberd.compose.error_message == ''
+        assert [u.alias for u in ejabberd.compose.updates] == [ejabberd.alias]
+        # F25 got a Compose of its own even though F17 is stuck.
+        python_nose = self.db.query(models.Build).filter_by(
+            nvr='python-nose-1.3.7-11.fc25').one().update
+        assert python_nose.locked
+        assert python_nose.date_locked <= datetime.now(timezone.utc)
+        assert python_nose.compose.release_id == f25.id
+        assert python_nose.compose.request == models.UpdateRequest.testing
+        assert python_nose.compose.state == models.ComposeState.requested
+        # The other F17 updates are left alone: their lane belongs to the stuck Compose, and
+        # quietly folding them into it would skip the tagging it has already checkpointed past.
+        for nvr in ('python-nose-1.3.7-11.fc17', 'python-paste-deploy-1.5.2-8.fc17'):
+            update = self.db.query(models.Build).filter_by(nvr=nvr).one().update
+            assert not update.locked
+            assert update.date_locked is None
+        assert self.db.query(models.Compose).count() == 2
 
     def test_no_updates_to_push(self):
         """

--- a/news/PR6160.bug
+++ b/news/PR6160.bug
@@ -1,0 +1,3 @@
+bodhi-push no longer treats any existing compose as evidence that a push is
+already running, so a single stuck compose can no longer block updates for
+every other release and content type


### PR DESCRIPTION
bodhi-push treats the presence of any Compose row as evidence that a push is already in flight:

    if not resume and session.query(Compose).count():
        ...
        resume = True
        resume_all = True

The count is unfiltered, so a single Compose left behind by a failure turns every later invocation into a resume of that compose and nothing else. The queries that find updates with a pending request live in the else branch and never run. A Compose row only survives when the compose did not finish, since remove_state() is the last statement of the success path, so the row persists for as long as the underlying problem does.

The practical effect is that one stuck lane, an F44 Flatpak compose say, stops updates for every release and every content type until someone clears the row by hand.

Nothing in the composer requires this. ComposerHandler.run() already starts one thread per Compose under a BoundedSemaphore and each thread catches its own exceptions, and the Compose primary key is (release_id, request), so lanes are independent by construction. The serialisation exists only in push.py's gate.

Collect resumable Composes and newly created ones in the same pass rather than choosing between them. A Compose being resumed keeps ownership of its (release, request) lane; every other lane is composed as usual. Updates belonging to an occupied lane are skipped before from_updates() sees them, which avoids a collision on the compound primary key and, more subtly, avoids quietly attaching a new update to a Compose that has already checkpointed past
determine_and_perform_tag_actions(). Such an update would never be tagged in Koji but would be treated as composed.

An explicit --resume is left alone. The additive behaviour applies only where resume_all was inferred from existing Composes.

Notes and caveats:

- The compose task message carries a single resume flag for the whole batch, and mixed batches are now possible. This is safe: Compose.checkpoints defaults to '{}', so load_state() on a freshly created Compose reads an empty dict and the checkpoint decorator skips nothing, and run() calls save_state(ComposeState.initializing) before work() regardless of the flag. The only visible effect is a misleading "Resuming push without any completed repos" log line for new Composes. No api_version bump is needed.

- Concurrency is unchanged. This still sends one compose task, so there is still one ComposerHandler and one semaphore, and max_concurrent_composes is still respected.

- The resume pass continues to resume every Compose regardless of --releases, while the new pass honours it. That asymmetry predates this change but becomes easier to notice: bodhi-push --releases F44 with a stuck F44F Compose will now resume F44F and create F44. It is not a regression, and fixing it seemed out of scope here.

- The first push after this is deployed will be large, since it flushes whatever accumulated behind the stuck lane. Better done deliberately than discovered from cron.

- Failed Composes are not aged out or retried differently. A failure is reported and resumed on the next run exactly as before. Resume semantics are untouched.

- Fedora's bodhi-automated-pushes.py in the infrastructure ansible repo needs a matching change to stop gating on /composes/ being empty. That change is only correct once this is deployed to the backends.

Adds test_stuck_compose_does_not_block_other_releases, covering a failed Compose on one release alongside a pending update on another and asserting that unlocked updates in the occupied lane stay out of it. Two existing expected-output fixtures gain the skip notice.

Assisted-by: Claude Opus 5 (Anthropic)