### PR TITLE
Fix duplicate package names in search results

### DIFF
--- a/bodhi-server/bodhi/server/static/js/search.js
+++ b/bodhi-server/bodhi/server/static/js/search.js
@@ -22,7 +22,7 @@ $(document).ready(function() {
         dropdownFilter: true,
         source: {
             packages: {
-                display: 'name',
+                display: ['name', 'type'],
                 ajax: {
                     url: 'packages/',
                     timeout: 10000,
@@ -31,9 +31,9 @@ $(document).ready(function() {
                     },
                     path: 'packages'
                 },
-                template: '{{name}}',
+                template: '<span class="badge text-bg-light border">{{type}}</span>&nbsp;{{name}}',
                 href: function (item) {
-                    return 'updates/?packages=' + encodeURIComponent(item.name)
+                    return 'updates/?packages=' + encodeURIComponent(item.name) + '&content_type=' +  encodeURIComponent(item.type)
                 }
             },
             updates: {


### PR DESCRIPTION
Package search showed identical names for different package types.
Added package type to the search result display.
Added content_type to the result URL.