### PR TITLE
Show package type in search results

### DIFF
--- a/bodhi-server/bodhi/server/static/js/search.js
+++ b/bodhi-server/bodhi/server/static/js/search.js
@@ -31,9 +31,9 @@ $(document).ready(function() {
                     },
                     path: 'packages'
                 },
-                template: '{{name}}',
+                template: '{{name}} <span class="text-muted font-size-09">({{type}})</span>',
                 href: function (item) {
-                    return 'updates/?packages=' + encodeURIComponent(item.name)
+                    return 'updates/?packages=' + encodeURIComponent(item.name)+ '&content_type=' + encodeURIComponent(item.type)
                 }
             },
             updates: {

--- a/news/6128.bug
+++ b/news/6128.bug
@@ -1,0 +1,2 @@
+Show the package type next to the package name in search results, so that packages
+sharing a name across content types can be told apart


### PR DESCRIPTION
[Fixes #6128 ](https://github.com/fedora-infra/bodhi/issues/6128)
 
**Problem Statement :** 
Currently on searching a package name, only package names show . These packages can be of different types but there is no way for user to know this or navigate to a specific package type. 

**Changes made :**  
1. added template level display of the package type 
2. updated navigation so that user navigates to correct package name + package type combination.

**Reference screenshot :** 

<img width="1329" height="225" alt="Screenshot From 2026-09-02 07-43-38" src="https://github.com/user-attachments/assets/8dd9036d-f540-43c5-8af8-99632b7546ec" />
