### PR TITLE
Fix search group hyperlink

### DIFF
--- a/bodhi-server/bodhi/server/static/css/site.css
+++ b/bodhi-server/bodhi/server/static/css/site.css
@@ -75,12 +75,12 @@ pre {
     border: none;
 }
 
-#bodhi-searchbar .typeahead__group > a {
+#bodhi-searchbar .typeahead__group {
     background: none;
     padding: 0 .5rem;
 }
 
-#bodhi-searchbar .typeahead__group > a > h3 {
+#bodhi-searchbar .typeahead__group > h3 {
     margin-top: .75rem;
     margin-bottom: 0;
     text-transform: capitalize;

--- a/bodhi-server/bodhi/server/static/js/search.js
+++ b/bodhi-server/bodhi/server/static/js/search.js
@@ -6,6 +6,7 @@ $(document).ready(function() {
         minLength: 2,
         dynamic: true,
         delay: 600,
+        groupTemplate: '<div class="typeahead__group-header"><h3>{{group}}</h3></div>',
         group: {
             template: function (item) {
                 if (item.group == "overrides") {


### PR DESCRIPTION
## Fix search result group headings linking to nothing (#6127)

Issue: https://github.com/fedora-infra/bodhi/issues/6127

### Problem

The search result group headings were rendered inside an `<a href="javascript:;">` element. The heading appeared to be a link, but selecting it did not perform any action.

### Fix

* Updated `groupTemplate` in `search.js` to render the group heading as a `<div>` containing an `<h3>`, instead of wrapping it in a non-functional hyperlink.
* Updated the related CSS selectors in `site.css` to target the new `<h3>` structure directly.
* This keeps the group heading semantic and non-clickable while preserving the existing styling.

### Technical change

Before:

```html
<a href="javascript:;">
    <h3>packages</h3>
</a>
```

After:

```html
<div class="typeahead__group-header">
    <h3>packages</h3>
</div>
```

### Result

Search result group headings are now displayed as headings rather than misleading hyperlinks, so clicking/selecting the heading no longer appears to trigger a link that does nothing.
